### PR TITLE
Fix: after adding the new category does not show Issue #3732

### DIFF
--- a/apps/gauzy/src/app/@shared/expenses/recurring-expense-mutation/recurring-expense-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/expenses/recurring-expense-mutation/recurring-expense-mutation.component.ts
@@ -187,7 +187,7 @@ export class RecurringExpenseMutationComponent
 		return { value: term, label: term };
 	}
 
-	addNewCustomCategoryName = (name: string): Promise<IExpenseCategory> => {
+	addNewCustomCategoryName = async (name: string): Promise<IExpenseCategory> => {
 		try {
 			this.toastrService.success(
 				'NOTES.ORGANIZATIONS.EDIT_ORGANIZATIONS_EXPENSE_CATEGORIES.ADD_EXPENSE_CATEGORY',
@@ -195,7 +195,18 @@ export class RecurringExpenseMutationComponent
 					name
 				}
 			);
-			return firstValueFrom(this.expenseCategoriesStore.create(name));
+
+      const createdCategory =  await firstValueFrom(this.expenseCategoriesStore.create(name));
+
+      this.defaultFilteredCategories = [
+        ...this.defaultFilteredCategories,
+        {
+          value: createdCategory.name,
+          label: createdCategory.name
+        }
+      ];
+
+			return createdCategory;
 		} catch (error) {
 			this.errorHandler.handleError(error);
 		}


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
This issue #3732 was caused because the state of rendered items(defaultFilteredCategories) wasn't updated when creating a new category. It was implemented to render only the default categories and add the new category on demand.

![2021-10-25 17_58_29-](https://user-images.githubusercontent.com/39434603/138721385-7f53dea9-ecbc-47aa-9f3a-d2a6f3c8ab26.jpg)
![2021-10-25 17_58_44-](https://user-images.githubusercontent.com/39434603/138721391-50880c8a-8af9-43c9-9057-f9793f5c931c.jpg)
![2021-10-25 17_58_55-](https://user-images.githubusercontent.com/39434603/138721394-0cbb9028-6873-4093-9d10-cc1b4b37cb26.jpg)


