### PR TITLE
Bug/#4003 add employee modal

### DIFF
--- a/apps/gauzy/src/app/@core/services/error-handling.service.ts
+++ b/apps/gauzy/src/app/@core/services/error-handling.service.ts
@@ -35,7 +35,6 @@ export class ErrorHandlingService {
 					this.errorContent = 'Please try again later';
 					break;
 				default:
-          console.log(message);
 					this.errorTitle = 'Error';
 					this.errorContent = message;
 			}

--- a/apps/gauzy/src/app/@core/services/error-handling.service.ts
+++ b/apps/gauzy/src/app/@core/services/error-handling.service.ts
@@ -35,6 +35,7 @@ export class ErrorHandlingService {
 					this.errorContent = 'Please try again later';
 					break;
 				default:
+          console.log(message);
 					this.errorTitle = 'Error';
 					this.errorContent = message;
 			}

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
@@ -24,7 +24,7 @@
           </div>
         <ga-user-basic-info-form #userBasicInfo [isShowRole]="false" [isEmployee]="true"></ga-user-basic-info-form>
           <div class="text-right">
-            <button class="mr-2" status="primary" n *ngIf="employees.length" nbButton nbStepperNext>
+            <button class="mr-2" status="primary" (click)="nextStep()" *ngIf="employees.length"  nbButton >
               {{ 'BUTTONS.CANCEL' | translate }}
             </button>
             <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
@@ -9,7 +9,19 @@
         <ng-template #step1>{{
           'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_1' | translate
           }}</ng-template>
-
+          <div *ngFor="let employe of employees">
+            <button
+            nbButton
+            [size]="buttonSize || 'medium'"
+            (click)="delete(employe)"
+            status="danger"
+            class="mr-2 mb-2"
+          >
+            <nb-icon class="mr-1" icon="trash-2-outline"></nb-icon
+            >{{ 'BUTTONS.DELETE' | translate }}
+          </button>
+          {{employe.user.email}}
+          </div>
         <ga-user-basic-info-form #userBasicInfo [isShowRole]="false" [isEmployee]="true"></ga-user-basic-info-form>
         <div class="text-right">
           <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
@@ -1,72 +1,60 @@
 <nb-card>
-	<nb-card-header class="d-flex">
-		<h5>{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEE' | translate }}</h5>
-		<nb-icon
-			class="ml-auto mt-1 close"
-			icon="close-outline"
-			(click)="closeDialog()"
-		></nb-icon>
-	</nb-card-header>
-	<nb-card-body>
-		<nb-stepper orientation="horizontal" disableStepNavigation #stepper>
-			<nb-step [label]="step1">
-				<ng-template #step1>{{
-					'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_1' | translate
-				}}</ng-template>
-				<ga-user-basic-info-form
-					#userBasicInfo
-					[isShowRole]="false"
-					[isEmployee]="true"
-				></ga-user-basic-info-form>
-				<div class="text-right">
-					<button
-						status="success"
-						[disabled]="userBasicInfo.form.invalid"
-						nbButton
-						nbStepperNext
-					>
-						{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
-					</button>
-				</div>
-			</nb-step>
-			<nb-step [label]="step2">
-				<ng-template #step2>{{
-					'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_2' | translate
-				}}</ng-template>
+  <nb-card-header class="d-flex">
+    <h5>{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEE' | translate }}</h5>
+    <nb-icon class="ml-auto mt-1 close" icon="close-outline" (click)="closeDialog()"></nb-icon>
+  </nb-card-header>
+  <nb-card-body>
+    <nb-stepper [linear]="linear" orientation="horizontal" disableStepNavigation #stepper>
+      <nb-step [label]="step1">
+        <ng-template #step1>{{
+          'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_1' | translate
+          }}</ng-template>
 
-				<div class="button-container">
-					<button status="primary" nbButton nbStepperPrevious>
-						{{
-							'EMPLOYEES_PAGE.ADD_EMPLOYEES.PREVIOUS' | translate
-						}}
-					</button>
-					<button
-						status="success"
-						[disabled]="userBasicInfo.form.invalid"
-						nbButton
-						nbStepperNext
-					>
-						{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
-					</button>
-				</div>
-			</nb-step>
-
-			<nb-step [label]="step2" [hidden]="true">
-				<div class="step-container button-container">
-					<button nbButton (click)="addEmployee()">
-						{{
-							'EMPLOYEES_PAGE.ADD_EMPLOYEES.ADD_ANOTHER_EMPLOYEE'
-								| translate
-						}}
-					</button>
-					<button status="success" (click)="add()" nbButton>
-						{{
-							'EMPLOYEES_PAGE.ADD_EMPLOYEES.FINISHED_ADDING'
-								| translate
-						}}
-					</button>
-				</div>
-			</nb-step>
-		</nb-stepper>
-	</nb-card-body>
+        <ga-user-basic-info-form #userBasicInfo [isShowRole]="false" [isEmployee]="true"></ga-user-basic-info-form>
+        <div class="text-right">
+          <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>
+            {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
+          </button>
+        </div>
+      </nb-step>
+      <nb-step [label]="step2">
+        <ng-template #step2>{{
+          'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_2' | translate
+          }}</ng-template>
+        <div class="step-container button-container">
+          <button status="primary" nbButton nbStepperPrevious>
+            {{
+            'EMPLOYEES_PAGE.ADD_EMPLOYEES.PREVIOUS' | translate
+            }}
+          </button>
+          <button nbButton (click)="addEmployee()">
+            {{
+            'EMPLOYEES_PAGE.ADD_EMPLOYEES.ADD_ANOTHER_EMPLOYEE'
+            | translate
+            }}
+          </button>
+          <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>
+            {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
+          </button>
+        </div>
+      </nb-step>
+      <nb-step [label]="step2" [hidden]="true">
+        <div class="step-container">
+          <div class="button-container">
+            <button status="primary" nbButton nbStepperPrevious>
+              {{
+              'EMPLOYEES_PAGE.ADD_EMPLOYEES.PREVIOUS' | translate
+              }}
+            </button>
+            <button status="success" (click)="add()" nbButton>
+              {{
+              'EMPLOYEES_PAGE.ADD_EMPLOYEES.FINISHED_ADDING'
+              | translate
+              }}
+            </button>
+          </div>
+        </div>
+      </nb-step>
+    </nb-stepper>
+  </nb-card-body>
 </nb-card>

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
@@ -9,28 +9,21 @@
         <ng-template #step1>{{
           'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_1' | translate
           }}</ng-template>
-          <div *ngFor="let employe of employees">
-            <button
-            nbButton
-            [size]="buttonSize || 'medium'"
-            (click)="delete(employe)"
-            status="danger"
-            class="mr-2 mb-2"
-          >
-            <nb-icon class="mr-1" icon="trash-2-outline"></nb-icon
-            >{{ 'BUTTONS.DELETE' | translate }}
+        <div *ngFor="let employe of employees">
+          <button nbButton [size]="buttonSize || 'medium'" (click)="delete(employe)" status="danger" class="mr-2 mb-2">
+            <nb-icon class="mr-1" icon="trash-2-outline"></nb-icon>{{ 'BUTTONS.DELETE' | translate }}
           </button>
           {{employe.user.email}}
-          </div>
+        </div>
         <ga-user-basic-info-form #userBasicInfo [isShowRole]="false" [isEmployee]="true"></ga-user-basic-info-form>
-          <div class="text-right">
-            <button class="mr-2" status="primary" (click)="nextStep()" *ngIf="employees.length"  nbButton >
-              {{ 'BUTTONS.CANCEL' | translate }}
-            </button>
-            <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>
-              {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
-            </button>
-          </div>
+        <div class="text-right">
+          <button class="mr-2" status="primary" (click)="nextStep()" *ngIf="employees.length" nbButton>
+            {{ 'BUTTONS.CANCEL' | translate }}
+          </button>
+          <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>
+            {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
+          </button>
+        </div>
       </nb-step>
       <nb-step [label]="step2">
         <ng-template #step2>{{
@@ -48,7 +41,7 @@
             | translate
             }}
           </button>
-          <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>
+          <button status="success" nbButton nbStepperNext>
             {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
           </button>
         </div>

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
@@ -1,68 +1,113 @@
 <nb-card>
-  <nb-card-header class="d-flex">
-    <h5>{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEE' | translate }}</h5>
-    <nb-icon class="ml-auto mt-1 close" icon="close-outline" (click)="closeDialog()"></nb-icon>
-  </nb-card-header>
-  <nb-card-body>
-    <nb-stepper [linear]="linear" orientation="horizontal" disableStepNavigation #stepper>
-      <nb-step [label]="step1">
-        <ng-template #step1>{{
-          'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_1' | translate
-          }}</ng-template>
-        <div *ngFor="let employe of employees">
-          <button nbButton [size]="buttonSize || 'medium'" (click)="delete(employe)" status="danger" class="mr-2 mb-2">
-            <nb-icon class="mr-1" icon="trash-2-outline"></nb-icon>{{ 'BUTTONS.DELETE' | translate }}
-          </button>
-          {{employe.user.email}}
-        </div>
-        <ga-user-basic-info-form #userBasicInfo [isShowRole]="false" [isEmployee]="true"></ga-user-basic-info-form>
-        <div class="text-right">
-          <button class="mr-2" status="primary" (click)="nextStep()" *ngIf="employees.length" nbButton>
-            {{ 'BUTTONS.CANCEL' | translate }}
-          </button>
-          <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>
-            {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
-          </button>
-        </div>
-      </nb-step>
-      <nb-step [label]="step2">
-        <ng-template #step2>{{
-          'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_2' | translate
-          }}</ng-template>
-        <div class="step-container button-container">
-          <button status="primary" nbButton nbStepperPrevious>
-            {{
-            'EMPLOYEES_PAGE.ADD_EMPLOYEES.PREVIOUS' | translate
-            }}
-          </button>
-          <button nbButton (click)="addEmployee()">
-            {{
-            'EMPLOYEES_PAGE.ADD_EMPLOYEES.ADD_ANOTHER_EMPLOYEE'
-            | translate
-            }}
-          </button>
-          <button status="success" nbButton nbStepperNext>
-            {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
-          </button>
-        </div>
-      </nb-step>
-      <nb-step [label]="step2" [hidden]="true">
-        <div class="step-container">
-          <div class="button-container">
-            <button status="primary" nbButton nbStepperPrevious>
-              {{
-              'EMPLOYEES_PAGE.ADD_EMPLOYEES.PREVIOUS' | translate
-              }}
-            </button>
-            <button status="success" (click)="add()" nbButton>
-              {{
-              'EMPLOYEES_PAGE.ADD_EMPLOYEES.FINISHED_ADDING'
-              | translate
-              }}
-            </button>
-          </div>
-        </div>
-      </nb-step>
-    </nb-stepper>
-  </nb-card-body>
+  	<nb-card-header class="d-flex">
+    	<h5>
+			{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEE' | translate }}
+		</h5>
+   	 	<nb-icon
+			class="ml-auto mt-1 close"
+			icon="close-outline"
+			(click)="closeDialog()">
+		</nb-icon>
+  	</nb-card-header>
+  	<nb-card-body>
+    	<nb-stepper 
+			[linear]="linear"
+			orientation="horizontal"
+			disableStepNavigation
+			#stepper
+		>
+			<nb-step [label]="step1">
+				<ng-template #step1>
+					{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_1' | translate }}
+				</ng-template>
+				<ng-container *ngIf="employees.length > 0">
+					<div class="row">
+						<div class="col">
+							<nb-tag-list (tagRemove)="onEmployeeRemove($event)">
+								<nb-tag
+									removable
+									*ngFor="let employee of employees"
+									[text]="employee?.user?.email">
+								</nb-tag>
+							</nb-tag-list>
+						</div>
+					</div>
+				</ng-container>
+				<ga-user-basic-info-form
+					#userBasicInfo
+					[isShowRole]="false"
+					[isEmployee]="true">
+				</ga-user-basic-info-form>
+				<div class="text-right">
+					<button
+						class="mr-2"
+						status="primary"
+						(click)="nextStep()"
+						*ngIf="employees.length"
+						nbButton
+					>
+						{{ 'BUTTONS.CANCEL' | translate }}
+					</button>
+					<button
+						status="success"
+						[disabled]="userBasicInfo.form.invalid"
+						nbButton
+						nbStepperNext
+					>
+						{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
+					</button>
+				</div>
+			</nb-step>
+			<nb-step [label]="step2">
+				<ng-template #step2>
+					{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_2' | translate }}
+				</ng-template>
+				<div class="step-container button-container">
+				<button
+					status="primary"
+					nbButton
+					nbStepperPrevious
+				>
+					{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.PREVIOUS' | translate }}
+				</button>
+				<button
+					nbButton
+					(click)="addEmployee()"
+				>
+					{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.ADD_ANOTHER_EMPLOYEE' | translate }}
+				</button>
+				<button
+					status="success"
+					nbButton
+					nbStepperNext
+				>
+					{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
+				</button>
+				</div>
+			</nb-step>
+			<nb-step [label]="step3">
+				<ng-template #step3>
+					{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_3' | translate }}
+				</ng-template>
+				<div class="step-container">
+					<div class="button-container">
+						<button
+							status="primary"
+							nbButton
+							nbStepperPrevious
+						> 
+							{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.PREVIOUS' | translate }}
+						</button>
+						<button
+							status="success"
+							(click)="add()"
+							nbButton
+						>
+							{{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.FINISHED_ADDING' | translate }}
+						</button>
+					</div>
+				</div>
+			</nb-step>
+    	</nb-stepper>
+  	</nb-card-body>
 </nb-card>

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
@@ -23,11 +23,14 @@
           {{employe.user.email}}
           </div>
         <ga-user-basic-info-form #userBasicInfo [isShowRole]="false" [isEmployee]="true"></ga-user-basic-info-form>
-        <div class="text-right">
-          <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>
-            {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
-          </button>
-        </div>
+          <div class="text-right">
+            <button class="mr-2" status="primary" n *ngIf="employees.length" nbButton nbStepperNext>
+              {{ 'BUTTONS.CANCEL' | translate }}
+            </button>
+            <button status="success" [disabled]="userBasicInfo.form.invalid" nbButton nbStepperNext>
+              {{ 'EMPLOYEES_PAGE.ADD_EMPLOYEES.NEXT' | translate }}
+            </button>
+          </div>
       </nb-step>
       <nb-step [label]="step2">
         <ng-template #step2>{{

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.html
@@ -8,7 +8,7 @@
 		></nb-icon>
 	</nb-card-header>
 	<nb-card-body>
-		<nb-stepper #stepper>
+		<nb-stepper orientation="horizontal" disableStepNavigation #stepper>
 			<nb-step [label]="step1">
 				<ng-template #step1>{{
 					'EMPLOYEES_PAGE.ADD_EMPLOYEES.STEP_1' | translate

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.scss
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.scss
@@ -7,6 +7,9 @@
 				cursor: pointer;
 			}
 		}
+		nb-tag-list nb-tag::ng-deep {
+			text-transform: initial;
+		}
 	}
 }
 

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
@@ -30,13 +30,12 @@ import {
 	styleUrls: ['employee-mutation.component.scss']
 })
 export class EmployeeMutationComponent implements OnInit, AfterViewInit {
-
 	@ViewChild('userBasicInfo')
 	userBasicInfo: BasicInfoFormComponent;
 
 	@ViewChild('stepper')
 	stepper: NbStepperComponent;
-  linear = true;
+	linear = true;
 	form: FormGroup;
 	role: IRole;
 	employees: IEmployeeCreateInput[] = [];
@@ -57,7 +56,7 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			.pipe(
 				distinctUntilChange(),
 				filter((organization) => !!organization),
-				tap((organization) => this.organization = organization),
+				tap((organization) => (this.organization = organization)),
 				untilDestroyed(this)
 			)
 			.subscribe();
@@ -80,8 +79,21 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 
 	addEmployee() {
 		this.form = this.userBasicInfo.form;
-		const { firstName, lastName, email, username, password, tags, imageUrl } = this.form.getRawValue();
-		const { offerDate = null, acceptDate = null, rejectDate = null, startedWorkOn = null } = this.form.getRawValue();
+		const {
+			firstName,
+			lastName,
+			email,
+			username,
+			password,
+			tags,
+			imageUrl
+		} = this.form.getRawValue();
+		const {
+			offerDate = null,
+			acceptDate = null,
+			rejectDate = null,
+			startedWorkOn = null
+		} = this.form.getRawValue();
 		const user: IUser = {
 			firstName: firstName,
 			lastName: lastName,
@@ -102,7 +114,7 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			rejectDate,
 			tags: tags
 		};
-		if(this.form.valid) this.employees.push(employee);
+		if (this.form.valid) this.employees.push(employee);
 		this.form.reset();
 		this.stepper.reset();
 	}
@@ -110,7 +122,7 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 	async add() {
 		this.addEmployee();
 		try {
-			const employees =  await firstValueFrom(
+			const employees = await firstValueFrom(
 				this.employeesService.createBulk(this.employees)
 			);
 			this._employeeStore.employeeAction = {
@@ -122,12 +134,12 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			this.errorHandler.handleError(error);
 		}
 	}
-   delete(employe: IEmployeeCreateInput): void{
-     this.employees = this.employees.filter(x => x!== employe);
-   }
+	delete(employe: IEmployeeCreateInput): void {
+		this.employees = this.employees.filter((x) => x !== employe);
+	}
 
-   nextStep(){
-     this.form.reset();
-     this.stepper.next();
-   }
+	nextStep() {
+		this.form.reset();
+		this.stepper.next();
+	}
 }

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { NbDialogRef, NbStepperComponent } from '@nebular/theme';
+import { NbDialogRef, NbStepperComponent, NbTagComponent } from '@nebular/theme';
 import { BasicInfoFormComponent } from '../../user/forms/basic-info/basic-info-form.component';
 import {
 	RolesEnum,
@@ -55,8 +55,8 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 		this.store.selectedOrganization$
 			.pipe(
 				distinctUntilChange(),
-				filter((organization) => !!organization),
-				tap((organization) => (this.organization = organization)),
+				filter((organization: IOrganization) => !!organization),
+				tap((organization: IOrganization) => (this.organization = organization)),
 				untilDestroyed(this)
 			)
 			.subscribe();
@@ -114,9 +114,9 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			rejectDate,
 			tags: tags
 		};
-    // Check form validity before to add an employe to the array of employees.
+   		// Check form validity before to add an employe to the array of employees.
 		if (this.form.valid) this.employees.push(employee);
-    // Reset form and stepper.
+    	// Reset form and stepper.
 		this.form.reset();
 		this.stepper.reset();
 	}
@@ -136,11 +136,20 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			this.errorHandler.handleError(error);
 		}
 	}
-  // Removed one employe in the array of employees.
-	delete(employe: IEmployeeCreateInput): void {
-		this.employees = this.employees.filter((x) => x !== employe);
+
+	/**
+	 * Removed one employe in the array of employees.
+	 * @param tag 
+	 */
+	onEmployeeRemove(tag: NbTagComponent): void {
+		this.employees = this.employees.filter(
+			(t: IEmployeeCreateInput) => t.user.email !== tag.text
+		);
 	}
-  // Go to the next step without saving the data even if the form is valid.
+
+	/**
+	 * Go to the next step without saving the data even if the form is valid.
+	 */
 	nextStep() {
 		this.form.reset();
 		this.stepper.next();

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
@@ -114,7 +114,9 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			rejectDate,
 			tags: tags
 		};
+    // Check form validity before to add an employe to the array of employees.
 		if (this.form.valid) this.employees.push(employee);
+    // Reset form and stepper.
 		this.form.reset();
 		this.stepper.reset();
 	}
@@ -134,10 +136,11 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			this.errorHandler.handleError(error);
 		}
 	}
+  // Removed one employe in the array of employees.
 	delete(employe: IEmployeeCreateInput): void {
 		this.employees = this.employees.filter((x) => x !== employe);
 	}
-
+  // Go to the next step without saving the data even if the form is valid.
 	nextStep() {
 		this.form.reset();
 		this.stepper.next();

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
@@ -30,18 +30,18 @@ import {
 	styleUrls: ['employee-mutation.component.scss']
 })
 export class EmployeeMutationComponent implements OnInit, AfterViewInit {
-	
+
 	@ViewChild('userBasicInfo')
 	userBasicInfo: BasicInfoFormComponent;
-	
+
 	@ViewChild('stepper')
 	stepper: NbStepperComponent;
-
+  linear = true;
 	form: FormGroup;
 	role: IRole;
 	employees: IEmployeeCreateInput[] = [];
 	organization: IOrganization;
-	
+
 	constructor(
 		protected readonly dialogRef: NbDialogRef<EmployeeMutationComponent>,
 		protected readonly organizationsService: OrganizationsService,
@@ -80,7 +80,7 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 
 	addEmployee() {
 		this.form = this.userBasicInfo.form;
-		
+
 		const { firstName, lastName, email, username, password, tags, imageUrl } = this.form.getRawValue();
 		const { offerDate = null, acceptDate = null, rejectDate = null, startedWorkOn = null } = this.form.getRawValue();
 		const user: IUser = {

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
@@ -124,4 +124,7 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			this.errorHandler.handleError(error);
 		}
 	}
+   delete(employe: IEmployeeCreateInput): void{
+     this.employees = this.employees.filter(x => x!== employe);
+   }
 }

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
@@ -75,13 +75,11 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 	}
 
 	closeDialog(employee: IEmployee[] = null) {
-    this.stepper.reset();
 		this.dialogRef.close(employee);
 	}
 
 	addEmployee() {
 		this.form = this.userBasicInfo.form;
-
 		const { firstName, lastName, email, username, password, tags, imageUrl } = this.form.getRawValue();
 		const { offerDate = null, acceptDate = null, rejectDate = null, startedWorkOn = null } = this.form.getRawValue();
 		const user: IUser = {
@@ -104,7 +102,7 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 			rejectDate,
 			tags: tags
 		};
-		this.employees.push(employee);
+		if(this.form.valid) this.employees.push(employee);
 		this.form.reset();
 		this.stepper.reset();
 	}

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
@@ -125,4 +125,9 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
    delete(employe: IEmployeeCreateInput): void{
      this.employees = this.employees.filter(x => x!== employe);
    }
+
+   nextStep(){
+     this.form.reset();
+     this.stepper.next();
+   }
 }

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.component.ts
@@ -75,6 +75,7 @@ export class EmployeeMutationComponent implements OnInit, AfterViewInit {
 	}
 
 	closeDialog(employee: IEmployee[] = null) {
+    this.stepper.reset();
 		this.dialogRef.close(employee);
 	}
 

--- a/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.module.ts
+++ b/apps/gauzy/src/app/@shared/employee/employee-mutation/employee-mutation.module.ts
@@ -1,17 +1,16 @@
-import { ThemeModule } from '../../../@theme/theme.module';
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 import {
 	NbCardModule,
 	NbButtonModule,
 	NbIconModule,
-	NbStepperModule
+	NbStepperModule,
+	NbTagModule
 } from '@nebular/theme';
 import { EmployeeMutationComponent } from './employee-mutation.component';
 import { UserFormsModule } from '../../user/forms/user-forms.module';
-import { OrganizationsService } from '../../../@core/services/organizations.service';
-import { EmployeesService } from '../../../@core/services/employees.service';
-import { RoleService } from '../../../@core/services/role.service';
+import { EmployeesService, OrganizationsService, RoleService } from '../../../@core/services';
+import { ThemeModule } from '../../../@theme/theme.module';
 import { TranslateModule } from '../../translate/translate.module';
 
 @NgModule({
@@ -19,10 +18,11 @@ import { TranslateModule } from '../../translate/translate.module';
 		ThemeModule,
 		FormsModule,
 		NbCardModule,
-		UserFormsModule,
 		NbButtonModule,
 		NbIconModule,
 		NbStepperModule,
+		NbTagModule,
+		UserFormsModule,
 		TranslateModule
 	],
 	exports: [EmployeeMutationComponent],

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -1212,6 +1212,7 @@
 		"ADD_EMPLOYEES": {
 			"STEP_1": "Step 1",
 			"STEP_2": "Step 2",
+			"STEP_3": "Step 3",
 			"ADD_ANOTHER_EMPLOYEE": "Add Another Employee",
 			"FINISHED_ADDING": "I’ve Added All Current Employees",
 			"NEXT": "Next",


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
## Description
- [x] Disabled steps Navigation
- [x] Why 2nd step is blank? By doing this, the developer wanted, i think, to make sense of the use of stepper. In fact, removing this part would create a one-step stepper. To overcome this, i update the second step to make it more relevant.

<img width="1440" alt="Screen Shot 2022-01-20 at 9 44 54 PM" src="https://user-images.githubusercontent.com/45813955/150426612-d72c0c00-cb3b-47c4-8500-7d83102093ea.png">

<img width="1440" alt="Screen Shot 2022-01-20 at 9 45 09 PM" src="https://user-images.githubusercontent.com/45813955/150426817-c2bb8033-ef86-496f-89b7-863a8bcb79c3.png">


- [x] Added an option that allows to get back without add another employee
- [x] Display all added employees in  the modal

<img width="1440" alt="Screen Shot 2022-01-20 at 9 44 25 PM" src="https://user-images.githubusercontent.com/45813955/150427876-6a51b20b-e0ef-44d8-9036-6e6d7f0786f6.png">

- [x] Modal is not directly closing after add employees. In fact, the `await`  expression causes `async` function to pause until a `Promise` is settled and resume execution of the `async` function after fulfillment. When resumed, the value of the `await` expression is that of fulfilled `Promise`. That's why the small delay in closing.
- [x] Employees list is refreshed when new employees are added.

 Check the [Demo](https://www.loom.com/share/1b492159648b4e6a81b5b005c2c1bcf7)  