### PR TITLE
Fix/ Email content empty on email history page

### DIFF
--- a/apps/gauzy/src/app/pages/settings/email-history/email-history.component.ts
+++ b/apps/gauzy/src/app/pages/settings/email-history/email-history.component.ts
@@ -85,6 +85,10 @@ export class EmailHistoryComponent
 
 	selectEmail(email: IEmail) {
 		this.selectedEmail = email;
+    this.selectedEmail.content =
+      email.content ?
+        email.content :
+        email.emailTemplate.hbs;
 	}
 
 	async openFiltersDialog() {


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
## 🔨 Task (#3608)
- [x] when invitation sent, email should be visible in email history page.
Before([demo](https://demo.gauzy.co/#/pages/settings/email-history))
<img width="1440" alt="Screen Shot 2022-02-09 at 4 24 39 PM" src="https://user-images.githubusercontent.com/45813955/153220968-85a1856a-ce92-497c-90ee-502b91de4107.png">

After
<img width="1440" alt="Screen Shot 2022-02-09 at 4 25 10 PM" src="https://user-images.githubusercontent.com/45813955/153221099-99bd6fa4-4842-4a49-b8de-e09a967080e1.png">

