### PR TITLE
Fix/Option to run migrations in 1-transaction-per-migration mode

### DIFF
--- a/apps/api/src/plugin-config.ts
+++ b/apps/api/src/plugin-config.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import { TlsOptions } from 'tls';
 import {
 	IPluginConfig,
@@ -57,6 +56,7 @@ export const pluginConfig: IPluginConfig = {
 		}
 	},
 	dbConnectionOptions: {
+		migrationsTransactionMode: 'each', // Run migrations automatically in each transaction. i.e."all" | "none" | "each"
 		migrationsRun: !environment.production, // Run migrations automatically, you can disable this if you prefer running migration manually.
 		...getDbConfig(),
 	},

--- a/packages/core/src/dev-config.ts
+++ b/packages/core/src/dev-config.ts
@@ -21,6 +21,7 @@ export const devConfig: IPluginConfig = {
 		}
 	},
 	dbConnectionOptions: {
+		migrationsTransactionMode: 'each', // Run migrations automatically in each transaction. i.e."all" | "none" | "each"
 		migrationsRun: !environment.production, // Run migrations automatically, you can disable this if you prefer running migration manually.
 		...dbConnectionConfig
 	},


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

# Migration With Seeder

- [x] TypeORM auto migrations run, can't seed, becuase of `transaction mode`  [Fix By Typeorm](https://github.com/typeorm/typeorm/pull/7576)