### PR TITLE
Fix :: move download apps icons from top to bottom menu

### DIFF
--- a/apps/gauzy/src/app/@theme/components/gauzy-logo/gauzy-logo.component.html
+++ b/apps/gauzy/src/app/@theme/components/gauzy-logo/gauzy-logo.component.html
@@ -19,38 +19,7 @@
 		<nb-accordion-item-body class="setting">
 			<ga-sidebar-menu [items]="[settings]"></ga-sidebar-menu>
 		</nb-accordion-item-body>
-		<nb-accordion-item-body class="item footer">
-			<div class="content">
-				<span>Download Apps:</span>
-				<span>
-					<a
-						target="_blank"
-						href="https://web.gauzy.co/downloads#desktop/apple"
-						><i class="fab fa-apple"></i
-					></a>
-					<a
-						target="_blank"
-						href="https://web.gauzy.co/downloads#desktop/windows"
-						><i class="fa-brands fa-windows"></i
-					></a>
-					<a
-						target="_blank"
-						href="https://web.gauzy.co/downloads#desktop/linux"
-						><i class="fa-brands fa-linux"></i
-					></a>
-					<a
-						target="_blank"
-						href=" https://web.gauzy.co/downloads#mobile"
-						><i class="fas fa-mobile"></i
-					></a>
-					<a
-						target="_blank"
-						href="https://web.gauzy.co/downloads#extensions"
-						><i class="fa-brands fa-chrome"></i
-					></a>
-				</span>
-			</div>
-		</nb-accordion-item-body>
+		<nb-accordion-item-body class="item footer"></nb-accordion-item-body>
 	</nb-accordion-item>
 </nb-accordion>
 

--- a/apps/gauzy/src/app/@theme/components/gauzy-logo/gauzy-logo.component.scss
+++ b/apps/gauzy/src/app/@theme/components/gauzy-logo/gauzy-logo.component.scss
@@ -34,10 +34,13 @@
   }
 
   .item.footer {
-    background-color: nb-theme(gauzy-card-2);
-    border-radius: 0 0 nb-theme(border-radius) nb-theme(border-radius);
     box-shadow: 0px 1px 1px 0px rgb(0 0 0 / 15%);
-    margin-top: 6px;
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    ::ng-deep{
+      .item-body {
+        padding: 5px;
+      }
+    }
   }
 }
 

--- a/apps/gauzy/src/app/@theme/components/gauzy-logo/gauzy-logo.component.scss
+++ b/apps/gauzy/src/app/@theme/components/gauzy-logo/gauzy-logo.component.scss
@@ -38,36 +38,6 @@
     border-radius: 0 0 nb-theme(border-radius) nb-theme(border-radius);
     box-shadow: 0px 1px 1px 0px rgb(0 0 0 / 15%);
     margin-top: 6px;
-
-    .content {
-      display: flex;
-      align-items: center;
-      color: #7e7e8f;
-      font-size: 12px;
-      font-weight: 500;
-      line-height: 13px;
-      letter-spacing: 0em;
-      text-align: left;
-      padding: 6px;
-
-      a {
-        margin: 0 0.2rem;
-        color: #7e7e8f;
-        transition: 0.2s;
-
-        i {
-          padding: 0;
-          margin: 0;
-        }
-
-        &:hover {
-          color: nb-theme(text-primary-color);
-          border: 1px solid nb-theme(text-primary-color);
-          border-radius: calc(nb-theme(border-radius) - 4px);
-          padding: 0.1rem 0.2rem;
-        }
-      }
-    }
   }
 }
 

--- a/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.html
+++ b/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.html
@@ -52,7 +52,7 @@
     <div class="download-apps-content">
       <span class="download-apps-label">Download Apps:</span>
       <span class="download-apps-icons">
-        <a *ngFor="let app of download_apps" target="_blank" [href]="app.link">
+        <a *ngFor="let app of downloadApps" target="_blank" [href]="app.link" rel="noopener">
           <i [class]="app.icon"></i>
         </a>
       </span>

--- a/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.html
+++ b/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.html
@@ -1,81 +1,84 @@
 <div gauzyOutside (clickOutside)="onClickOutside($event)" class="main-menu">
-	<div class="left-menu">
-		<div class="sub-menu">
-			<span
-				><i class="far fa-smile"></i>
-				{{ 'USER_MENU.STATUS' | translate }}</span
-			>
-			<div class="status">
-				<div class="button selected">
-					{{ 'USER_MENU.AVAILABLE' | translate }}
-				</div>
-				<div class="button">
-					{{ 'USER_MENU.UNAVAILABLE' | translate }}
-				</div>
-			</div>
-		</div>
-		<div class="sub-menu">
-			<span>{{ 'USER_MENU.PAUSE_NOTIFICATIONS' | translate }}</span>
-			<div class="notifications">
-				<div class="button">
-					{{ 'USER_MENU.FOR_1_HOUR' | translate }}
-				</div>
-				<div class="button">
-					{{ 'USER_MENU.FOR_2_HOURS' | translate }}
-				</div>
-				<div class="button selected">
-					{{ 'USER_MENU.UNTIL_TOMORROW' | translate }}
-				</div>
-				<div class="button">{{ 'USER_MENU.CUSTOM' | translate }}</div>
-				<div class="button">
-					<i class="far fa-calendar"></i>
-					{{ 'USER_MENU.SET_AS_NOTIFICATION_SCHEDULE' | translate }}
-				</div>
-			</div>
-		</div>
-		<div class="links">
-			<p class="link" (click)="open(popup)">
-				{{ 'USER_MENU.SET_YOURSELF_AS_AWAY' | translate }}
-			</p>
-			<p class="link" routerLink="/pages/auth/profile">
-				{{ 'USER_MENU.PROFILE' | translate }}
-			</p>
-			<p class="link" routerLink="/auth/logout">
-				{{ 'USER_MENU.SIGN_OUT' | translate }}
-			</p>
-		</div>
-		<div class="sub-user-menu">
-			<gauzy-user
-				showIdentity="true"
-				[user]="user"
-				(clicked)="onClick()"
-			></gauzy-user>
-		</div>
-	</div>
-	<div class="right-menu">
-		<span><i (click)="onClick()" class="fas fa-times"></i></span>
-		<p>
-			<a target="_blank" href="https://gauzy.co">{{
-				'USER_MENU.HELP' | translate
-			}}</a>
-		</p>
-		<p class="link" (click)="open(popup)">
-			{{ 'USER_MENU.HOTKEYS' | translate }}
-		</p>
-		<p>
-			<ngx-theme-language-selector
-				class="theme"
-			></ngx-theme-language-selector>
-		</p>
-		<p><gauzy-switch-theme class="theme"></gauzy-switch-theme></p>
-		<p><gauzy-theme-selector class="theme"></gauzy-theme-selector></p>
-	</div>
+  <div class="left-menu">
+    <div class="sub-menu">
+      <span><i class="far fa-smile"></i>
+        {{ 'USER_MENU.STATUS' | translate }}</span>
+      <div class="status">
+        <div class="button selected">
+          {{ 'USER_MENU.AVAILABLE' | translate }}
+        </div>
+        <div class="button">
+          {{ 'USER_MENU.UNAVAILABLE' | translate }}
+        </div>
+      </div>
+    </div>
+    <div class="sub-menu">
+      <span>{{ 'USER_MENU.PAUSE_NOTIFICATIONS' | translate }}</span>
+      <div class="notifications">
+        <div class="button">
+          {{ 'USER_MENU.FOR_1_HOUR' | translate }}
+        </div>
+        <div class="button">
+          {{ 'USER_MENU.FOR_2_HOURS' | translate }}
+        </div>
+        <div class="button selected">
+          {{ 'USER_MENU.UNTIL_TOMORROW' | translate }}
+        </div>
+        <div class="button">{{ 'USER_MENU.CUSTOM' | translate }}</div>
+        <div class="button">
+          <i class="far fa-calendar"></i>
+          {{ 'USER_MENU.SET_AS_NOTIFICATION_SCHEDULE' | translate }}
+        </div>
+      </div>
+    </div>
+    <div class="links">
+      <p class="link" (click)="open(popup)">
+        {{ 'USER_MENU.SET_YOURSELF_AS_AWAY' | translate }}
+      </p>
+      <p class="link" routerLink="/pages/auth/profile">
+        {{ 'USER_MENU.PROFILE' | translate }}
+      </p>
+      <p class="link" routerLink="/auth/logout">
+        {{ 'USER_MENU.SIGN_OUT' | translate }}
+      </p>
+    </div>
+    <div class="sub-user-menu">
+      <gauzy-user showIdentity="true" [user]="user" (clicked)="onClick()"></gauzy-user>
+    </div>
+  </div>
+
+  <div class="right-menu">
+    <span><i (click)="onClick()" class="fas fa-times"></i></span>
+    <div class="download-apps-content">
+      <span class="download-apps-label">Download Apps:</span>
+      <span class="download-apps-icons">
+        <a *ngFor="let app of download_apps" target="_blank" [href]="app.link">
+          <i [class]="app.icon"></i>
+        </a>
+      </span>
+    </div>
+    <p>
+      <a target="_blank" href="https://gauzy.co">{{
+        'USER_MENU.HELP' | translate
+        }}</a>
+    </p>
+    <p class="link" (click)="open(popup)">
+      {{ 'USER_MENU.HOTKEYS' | translate }}
+    </p>
+    <p>
+      <ngx-theme-language-selector class="theme"></ngx-theme-language-selector>
+    </p>
+    <p>
+      <gauzy-switch-theme class="theme"></gauzy-switch-theme>
+    </p>
+    <p>
+      <gauzy-theme-selector class="theme"></gauzy-theme-selector>
+    </p>
+  </div>
 </div>
 
 <ng-template #popup let-ref="dialogRef">
-	<ng-container
-		><gauzy-popup
-			(onClosed)="ref.close()"
-		></gauzy-popup
-	></ng-container>
+  <ng-container>
+    <gauzy-popup (onClosed)="ref.close()"></gauzy-popup>
+  </ng-container>
 </ng-template>

--- a/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.scss
+++ b/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.scss
@@ -77,4 +77,46 @@
     display: flex;
     flex-direction: column;
   }
+
+  .right-menu {
+    .download-apps-content {
+      display: flex;
+      align-items: center;
+      font-size: 12px;
+      font-weight: 500;
+      line-height: 15px;
+      letter-spacing: 0em;
+      text-align: left;
+      min-height: 20px;
+      margin-top: 0.5rem;
+      margin-bottom: 1rem;
+
+      .download-apps-label {
+        color: #7e7e8f;
+      }
+
+      .download-apps-icons {
+        margin-left: 0.3rem;
+        a {
+          margin: 0 0.2rem;
+          transition: 0.2s;
+          padding: 0.1rem 0.2rem;
+          border: 1px solid transparent;
+
+          i {
+            padding: 0;
+            margin: 0;
+            color: #7e7e8f;
+          }
+
+          &:hover {
+            color: nb-theme(text-primary-color);
+            border: 1px solid nb-theme(text-primary-color);
+            border-radius: calc(nb-theme(border-radius) - 4px);
+            transform: scale(1.5);
+          }
+        }
+      }
+    }
+  }
 }

--- a/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.ts
+++ b/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.ts
@@ -20,7 +20,7 @@ export class UserMenuComponent implements OnInit {
 
 	clicks: boolean[] = [];
 
-	download_apps = [
+	downloadApps = [
 		{
 			link: 'https://web.gauzy.co/downloads#desktop/apple',
 			icon: 'fab fa-apple'

--- a/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.ts
+++ b/apps/gauzy/src/app/@theme/components/user-menu/user-menu.component.ts
@@ -20,10 +20,32 @@ export class UserMenuComponent implements OnInit {
 
 	clicks: boolean[] = [];
 
+	download_apps = [
+		{
+			link: 'https://web.gauzy.co/downloads#desktop/apple',
+			icon: 'fab fa-apple'
+		},
+		{
+			link: 'https://web.gauzy.co/downloads#desktop/windows',
+			icon: 'fa-brands fa-windows'
+		},
+		{
+			link: 'https://web.gauzy.co/downloads#desktop/linux',
+			icon: 'fa-brands fa-linux'
+		},
+		{
+			link: 'https://web.gauzy.co/downloads#mobile',
+			icon: 'fas fa-mobile'
+		},
+		{
+			link: 'https://web.gauzy.co/downloads#extensions',
+			icon: 'fa-brands fa-chrome'
+		}
+	];
+
 	constructor(private dialogService: NbDialogService) {}
 
-	ngOnInit(): void {
-  }
+	ngOnInit(): void {}
 
 	onClick() {
 		this.close.emit();


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
We have to move "Download Apps" from menu at top to bottom menu.

![image (29)](https://user-images.githubusercontent.com/41804588/174964886-815d44a8-8d30-43d9-86c4-a8933fc8b95e.png)

**To**

![image (30)](https://user-images.githubusercontent.com/41804588/174964924-e9f88227-359d-4396-a2a4-879546af2dce.png)

Here is the final result:
<img width="1203" alt="Screen Shot 2022-06-22 at 20 57 46" src="https://user-images.githubusercontent.com/35149259/175115511-f1721640-aee5-4de7-9115-fe92f4625a03.png">


Fix #4806

Cc @evereq 