### PR TITLE
fix: invalid input syntax for type integer

### DIFF
--- a/packages/desktop-libs/src/lib/desktop-timer.ts
+++ b/packages/desktop-libs/src/lib/desktop-timer.ts
@@ -440,10 +440,15 @@ export default class Timerhandler {
 						activeWindow: detectActiveWindow(),
 						isAw: projectInfo.aw.isAw,
 						isAwConnected: appSetting.awIsConnected,
-						keyboard:
-							this.eventCounter.keyboardPercentage * durationNow,
-						mouse: this.eventCounter.mousePercentage * durationNow,
-						system: this.eventCounter.systemPercentage * durationNow
+						keyboard: Math.ceil(
+							this.eventCounter.keyboardPercentage * durationNow
+						),
+						mouse: Math.ceil(
+							this.eventCounter.mousePercentage * durationNow
+						),
+						system: Math.ceil(
+							this.eventCounter.systemPercentage * durationNow
+						)
 					}
 				);
 				break;


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
For some reason in production, database can't cast float value to integer
<img width="1440" alt="Screen Shot 2022-09-26 at 8 49 17 AM" src="https://user-images.githubusercontent.com/45813955/192212550-5486a117-864a-49b5-ba30-26124003d42e.png">
