### PR TITLE
fix :: Color of selected item is black

### DIFF
--- a/apps/gauzy/src/app/@theme/styles/gauzy/_gauzy-overrides.scss
+++ b/apps/gauzy/src/app/@theme/styles/gauzy/_gauzy-overrides.scss
@@ -122,6 +122,7 @@ $default-box-shadow: var(--gauzy-shadow);
     display: block;
     overflow-x: hidden;
     text-overflow: ellipsis;
+    color: var(--gauzy-text-color-1);
   }
 }
 


### PR DESCRIPTION
# PR
Fixes #5195 
- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

The color is selected dropdown item is now black
## After
![Screenshot 2022-10-07 201422](https://user-images.githubusercontent.com/76220055/194581157-8ebfe40c-426b-4a16-ac2f-834e62ec9742.jpg)

## Before
![before](https://user-images.githubusercontent.com/76220055/194601279-30090131-b86f-481a-8d60-be516d06a339.jpg)


**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
