### PR TITLE
Revert "fix: add more listerners to remove"

### DIFF
--- a/packages/desktop-libs/src/lib/desktop-ipc.ts
+++ b/packages/desktop-libs/src/lib/desktop-ipc.ts
@@ -818,12 +818,7 @@ export function removeMainListener() {
 		'get_last_screen_capture',
 		'update_app_setting',
 		'update_project_on',
-		'request_permission',
-		'update_locally',
-		'change_update_strategy',
-		'check_for_update',
-		'download_update',
-		'automatic_update_setting'
+		'request_permission'
 	];
 
 	mainListeners.forEach((listener) => {
@@ -851,15 +846,7 @@ export function removeTimerListener() {
 		'navigate_to_login',
 		'expand',
 		'timer_stopped',
-		'reset_permissions',
-		'failed_synced_timeslot',
-		'create-synced-interval',
-		'delete_time_slot',
-		'refresh-timer',
-		'aw_status',
-		'set_tp_aw',
-		'notify',
-		'update_session'
+		'reset_permissions'
 	];
 	timerListeners.forEach((listener) => {
 		ipcMain.removeAllListeners(listener);


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
### Tasks 🐊
This reverts partially commit 03d4a9836672028e113b6eb417bcb16c760cbaba.

`ipcMain extends EventEmitter`

https://nodejs.org/api/events.html#emitterremovealllistenerseventname

> It is bad practice to remove listeners added elsewhere in the code, particularly when the EventEmitter instance was created by some other component or module 