### PR TITLE
(total, subtotal boxes) & (Save as Draft btn) in edit estimate aren't the same as the design

### DIFF
--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.scss
@@ -26,11 +26,11 @@
   float: right;
 
   &-item {
-    border: solid 2px gray;
+    border: solid 2px var(--button-filled-info-disabled-border-color);
     border-radius: 5px;
-    margin: 20px 20px 0px 10px;
+    margin: 20px 20px 20px 10px;
     padding: 5px;
-    font-size: 18px;
+    font-size: 14px;
   }
 }
 
@@ -138,6 +138,7 @@ div.button-action {
 :host button.gray {
   background-color: rgba(126, 126, 143, 1);
   color: nb-theme(text-control-color);
+  border-color: var(--button-filled-basic-border-color);
   [nbButton].appearance-filled.status-basic {
     background-color: nb-theme(button-filled-basic-background-color);
     border-color: nb-theme(button-filled-basic-border-color);


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
Issue -> #7026 

### design:
<img width="399" alt="image" src="https://github.com/ever-co/ever-gauzy/assets/78637183/028ed5ea-c9f4-47e9-9c81-bff5c155f4a9">


### Before:
![image](https://github.com/ever-co/ever-gauzy/assets/78637183/84fcd3fc-9b38-4e87-815b-9bfaacce193c)

---

### After:
<img width="722" alt="image" src="https://github.com/ever-co/ever-gauzy/assets/78637183/d0ee47f8-07dd-40d1-95ff-4b9f0e5e1a4f">



