### PR TITLE
[Fix] language reset to default (en-english) on logout

### DIFF
--- a/apps/gauzy/src/app/@core/auth/auth-strategy.service.ts
+++ b/apps/gauzy/src/app/@core/auth/auth-strategy.service.ts
@@ -264,10 +264,12 @@ export class AuthStrategy extends NbAuthStrategy {
 	}
 
 	private async _logout(): Promise<NbAuthResult> {
+		const preferredLanguage = this.store.preferredLanguage;
 		this.logout$.next(true);
 
 		this.store.clear();
 		this.store.serverConnection = 200;
+		this.store.preferredLanguage = preferredLanguage;
 		if (this.electronService.isElectron) {
 			this.electronService.ipcRenderer.send('logout');
 		}


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

### Issue => #7121 

---

Fix the issue: when logging out, the language set while the user is logged in is being reset to default (en-english) so the user will see the auth pages in english.

