### PR TITLE
[fix] undefined passwords labels in accept invitation page

### DIFF
--- a/apps/gauzy/src/app/auth/accept-invite/accept-invite-form/accept-invite-form.component.html
+++ b/apps/gauzy/src/app/auth/accept-invite/accept-invite-form/accept-invite-form.component.html
@@ -25,6 +25,7 @@
 			<ngx-password-form-field
 				[id]="'passwordInput'"
 				[placeholder]="'ACCEPT_INVITE.ACCEPT_INVITE_FORM.PASSWORD' | translate"
+				[label]="'ACCEPT_INVITE.ACCEPT_INVITE_FORM.PASSWORD' | translate"
 				[ctrl]="form.get('password')"
 				formControlName="password"
 				[fieldSize]="'large'"
@@ -40,6 +41,7 @@
 			<ngx-password-form-field
 				[id]="'repeatPasswordInput'"
 				[placeholder]="'ACCEPT_INVITE.ACCEPT_INVITE_FORM.REPEAT_PASSWORD' | translate"
+				[label]="'ACCEPT_INVITE.ACCEPT_INVITE_FORM.REPEAT_PASSWORD' | translate"
 				[ctrl]="form.get('repeatPassword')"
 				formControlName="repeatPassword"
 				[fieldSize]="'large'"


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

### Issue => #7281

---

### Before:
![image](https://github.com/ever-co/ever-gauzy/assets/78637183/ebd72044-b16c-4228-a6e2-8922485d7d5c)

### After:
#### Note: I broken the code to test and fix, so I didn't use a real invitation link that's why we see no (ORG name, Email)
![image](https://github.com/ever-co/ever-gauzy/assets/78637183/b18e2057-6b67-48b4-918f-f353ef3fe056)

