### PR TITLE
fix: screenshot item date label text transform

### DIFF
--- a/apps/gauzy/src/app/@shared/timesheet/screenshots/screenshots-item/screenshots-item.component.scss
+++ b/apps/gauzy/src/app/@shared/timesheet/screenshots/screenshots-item/screenshots-item.component.scss
@@ -127,7 +127,6 @@
   line-height: 11px;
   letter-spacing: 0em;
   text-align: left;
-  text-transform: lowercase;
 }
 
 ::ng-deep {


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
`Now`
<img width="582" alt="Screenshot 2023-12-26 at 12 41 02 PM" src="https://github.com/ever-co/ever-gauzy/assets/45813955/caf866b5-8f72-4332-981c-ab1f14474322">

`Before`
<img width="588" alt="Screenshot 2023-12-26 at 12 43 14 PM" src="https://github.com/ever-co/ever-gauzy/assets/45813955/4834cd38-0808-44e1-9bf2-a180ce236d02">
