### PR TITLE
[Fix] Avoid calling stop timer endpoint if the timer is already stopped

### DIFF
--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -488,19 +488,29 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			} else {
 				if (!this._isOffline) {
 					try {
-						timelog =
+						// Combine all conditions into a single descriptive boolean
+						const isRetrieveRemoteLog =
+							!isRemoteTimerRunning ||
 							isRemote ||
 							this._remoteSleepLock ||
-							(this.isRemoteTimer && (this._isSpecialLogout || this.quitApp))
-								? this._timeTrackerStatus.remoteTimer.lastLog
-								: await this.preventDuplicateApiRequest(
-										{
-											...params,
-											...lastTimer
-										},
-										(payload) => this.timeTrackerService.toggleApiStop(payload)
-								  );
+							(this.isRemoteTimer && (this._isSpecialLogout || this.quitApp));
+
+						if (isRetrieveRemoteLog) {
+							// Retrieve remote timer log
+							timelog = this._timeTrackerStatus.remoteTimer.lastLog;
+						} else {
+							// Create request parameters only when necessary
+							const requestParams = {
+								...params,
+								...lastTimer
+							};
+							// Execute API request to stop timer and store the result in timelog
+							timelog = await this.preventDuplicateApiRequest(requestParams, (payload) =>
+								this.timeTrackerService.toggleApiStop(payload)
+							);
+						}
 					} catch (error) {
+						// Handle any error during the process
 						lastTimer.isStoppedOffline = true;
 						await this.electronService.ipcRenderer.invoke('MARK_AS_STOPPED_OFFLINE');
 						this._loggerService.error(error);


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user feedback with toast notifications during timer operations.
	- Enhanced error handling for time slot deletion.

- **Bug Fixes**
	- Fixed issues related to timer state handling and API request parameters.

- **Refactor**
	- Simplified conditional logic in timer methods for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->