### PR TITLE
[Feat] Add missing `version` property to timer objects in SequenceQueue and TimeTrackerComponent

### DIFF
--- a/packages/desktop-ui-lib/src/lib/offline-sync/concretes/sequence-queue.ts
+++ b/packages/desktop-ui-lib/src/lib/offline-sync/concretes/sequence-queue.ts
@@ -41,7 +41,8 @@ export class SequenceQueue extends OfflineQueue<ISequence> {
 				taskId: timer.taskId,
 				projectId: timer.projectId,
 				organizationId: this._store.organizationId,
-				tenantId: this._store.tenantId
+				tenantId: this._store.tenantId,
+				version: timer.version
 			};
 
 			let latest = null;

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2328,6 +2328,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			taskId: timer.taskId,
 			organizationTeamId: timer.organizationTeamId,
 			description: timer.description,
+			version: timer.version,
 			startedAt: timer.startedAt,
 			stoppedAt: new Date(),
 			...(session?.params && { ...session.params })


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced synchronization capabilities with the addition of a `version` property for improved context during timer operations.
	- Updated timer management to include versioning in the restart sequence, improving data handling with the backend service.

- **Bug Fixes**
	- No specific bug fixes were mentioned, but overall improvements to timer functionality may enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

resolves #8377