### PR TITLE
[Fix] Employee Field Shows [Object Object] on Edit and Should Be Non-editable on Job Page 

### DIFF
--- a/packages/plugins/job-employee-ui/src/lib/components/job-employee/job-employee.component.ts
+++ b/packages/plugins/job-employee-ui/src/lib/components/job-employee/job-employee.component.ts
@@ -27,6 +27,7 @@ import {
 	EmployeeLinksComponent,
 	IPaginationBase,
 	NumberEditorComponent,
+	EmployeeLinkEditorComponent,
 	PaginationFilterBaseComponent,
 	SmartTableToggleComponent
 } from '@gauzy/ui-core/shared';
@@ -212,7 +213,7 @@ export class JobEmployeeComponent extends PaginationFilterBaseComponent implemen
 			type: 'custom', // The type of the column
 			width: '20%', // The width of the column
 			isSortable: true, // Indicates whether the column is sortable
-			isEditable: true, // Indicates whether the column is editable
+			isEditable: false, // Indicates whether the column is editable
 			renderComponent: EmployeeLinksComponent,
 			valuePrepareFunction: (_: any, cell: Cell) => this.prepareEmployeeValue(_, cell),
 			componentInitFunction: (instance: EmployeeLinksComponent, cell: Cell) => {
@@ -220,6 +221,10 @@ export class JobEmployeeComponent extends PaginationFilterBaseComponent implemen
 				instance.rowData = cell.getRow().getData();
 				// Get the value from the cell
 				instance.value = cell.getValue();
+			},
+			editor: {
+				type: 'custom',
+				component: EmployeeLinkEditorComponent // Use the custom component for display
 			}
 		});
 

--- a/packages/ui-core/shared/src/lib/table-components/editors/employee-link-editor.component.ts
+++ b/packages/ui-core/shared/src/lib/table-components/editors/employee-link-editor.component.ts
@@ -19,14 +19,8 @@ export class EmployeeLinkEditorComponent extends DefaultEditor implements OnInit
 	@Input() cell!: Cell; // Input to access the cell data
 	value!: IUser;
 
-	constructor() {
-		super();
-	}
-
 	ngOnInit() {
 		const employee: IEmployee | undefined = this.cell.getRow().getData();
-		if (employee.user) {
-			this.value = employee.user;
-		}
+		this.value = employee?.user ?? null;
 	}
 }

--- a/packages/ui-core/shared/src/lib/table-components/editors/employee-link-editor.component.ts
+++ b/packages/ui-core/shared/src/lib/table-components/editors/employee-link-editor.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { IEmployee, IUser } from '@gauzy/contracts';
+import { Cell, DefaultEditor } from 'angular2-smart-table';
+
+@Component({
+	template: `
+		<ng-container *ngIf="value">
+			<a *ngIf="value?.name">
+				<img *ngIf="value.imageUrl" width="18px" height="18px" [src]="value.imageUrl" />
+				<div class="names-wrapper">
+					{{ value.name }}
+				</div>
+			</a>
+		</ng-container>
+	`,
+	styleUrls: ['../employee-links/employee-links.component.scss']
+})
+export class EmployeeLinkEditorComponent extends DefaultEditor implements OnInit {
+	@Input() cell!: Cell; // Input to access the cell data
+	value!: IUser;
+
+	constructor() {
+		super();
+	}
+
+	ngOnInit() {
+		const employee: IEmployee | undefined = this.cell.getRow().getData();
+		if (employee.user) {
+			this.value = employee.user;
+		}
+	}
+}

--- a/packages/ui-core/shared/src/lib/table-components/index.ts
+++ b/packages/ui-core/shared/src/lib/table-components/index.ts
@@ -10,6 +10,7 @@ export * from './date-view/date-view.component';
 export * from './document-date/document-date.component';
 export * from './document-url/document-url.component';
 export * from './editors/number-editor.component';
+export * from './editors/employee-link-editor.component';
 export * from './email/email.component';
 export * from './employee-links/employee-links.component';
 export * from './employee-with-links/employee-with-links.component';

--- a/packages/ui-core/shared/src/lib/table-components/table-components.module.ts
+++ b/packages/ui-core/shared/src/lib/table-components/table-components.module.ts
@@ -47,6 +47,7 @@ import { ValueWithUnitComponent } from './value-with-units/value-with-units.comp
 import { VisibilityComponent } from './visibility/visibility.component';
 import { DirectivesModule } from '../directives/directives.module';
 import { TaskBadgeViewComponentModule } from '../tasks/task-badge-view/task-badge-view.module';
+import { EmployeeLinkEditorComponent } from '../public-api';
 
 @NgModule({
 	imports: [
@@ -86,6 +87,7 @@ import { TaskBadgeViewComponentModule } from '../tasks/task-badge-view/task-badg
 		InvoiceTotalValueComponent,
 		NotesWithTagsComponent,
 		NumberEditorComponent,
+		EmployeeLinkEditorComponent,
 		OrganizationWithTagsComponent,
 		PhoneUrlComponent,
 		PictureNameTagsComponent,


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `EmployeeLinkEditorComponent` for enhanced employee profile linking in data tables.
	- Updated data table configuration to include the new editor component for employee names.

- **Bug Fixes**
	- Made the `name` column non-editable to prevent unintended modifications.

- **Documentation**
	- Added comments for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->