### PR TITLE
[Fix] Product Name Not Displayed During Estimate Editing

### DIFF
--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.ts
@@ -311,9 +311,8 @@ export class InvoiceEditComponent extends PaginationFilterBaseComponent implemen
 						component: InvoiceProductsSelectorComponent
 					},
 					valuePrepareFunction: (product: IProduct) => {
-						return product?.name
-							? `${this.translatableService.getTranslatedProperty(product, 'name')}`
-							: '';
+						const translatedName = this.translatableService.getTranslatedProperty(product, 'name');
+						return translatedName || '';
 					}
 				};
 				break;


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of product names in the invoice editing feature, ensuring an empty string is returned when no translated name is available.
  
- **Style**
	- Minor adjustments made to comments and formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->