### PR TITLE
[Fix] Attach a Receipt Pop-up Disappears on Outside Clickbug

### DIFF
--- a/packages/ui-core/shared/src/lib/expenses/expenses-mutation/expenses-mutation.component.ts
+++ b/packages/ui-core/shared/src/lib/expenses/expenses-mutation/expenses-mutation.component.ts
@@ -262,7 +262,9 @@ export class ExpensesMutationComponent extends TranslationBaseComponent implemen
 			.open(AttachReceiptComponent, {
 				context: {
 					currentReceipt: this.form.value.receipt
-				}
+				},
+				closeOnBackdropClick: false,
+				closeOnEsc: false
 			})
 			.onClose.pipe(
 				tap((receipt) => {


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved dialog behavior during expense receipt operations. The dialog now remains open when clicking outside or pressing the Escape key, reducing accidental dismissals.

- **Style**
  - Adjusted configuration formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->