### PR TITLE
[FIX] replace Facebook by Keycloak in keycloak OAUTH config file

### DIFF
--- a/packages/config/src/lib/config/keycloak.ts
+++ b/packages/config/src/lib/config/keycloak.ts
@@ -2,7 +2,7 @@ import { registerAs } from '@nestjs/config';
 import { IKeycloakConfig } from '@gauzy/common';
 
 /**
- * Register Facebook OAuth configuration using @nestjs/config
+ * Register Keycloak OAuth configuration using @nestjs/config
  */
 export default registerAs(
 	'keycloak',


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

---

This PR aims to replace a bad comment in the Keycloak OAUTH configuration file.
Replaces Facebook by Keycloak.