### PR TITLE
[Feat]: Persist time slot id

### DIFF
--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -759,15 +759,16 @@ export function ipcTimer(
 
 	ipcMain.on('return_time_slot', async (event, arg) => {
 		try {
-			log.info(`Return To Timeslot Last Timeslot ID: ${arg.timeSlotId} and Timer ID: ${arg.timerId}`);
-
+			const { timeSlotId, timerId } = arg;
+			log.info(`Return To Timeslot Last Timeslot ID: ${timeSlotId} and Timer ID: ${timerId}`);
+			LocalStore.updateAdditionalSetting({ timeSlotId });
 			await timerHandler.processWithQueue(
 				`gauzy-queue`,
 				{
 					type: 'update-timer-time-slot',
 					data: {
-						id: arg.timerId,
-						timeSlotId: arg.timeSlotId
+						id: timerId,
+						timeSlotId
 					}
 				},
 				knex


### PR DESCRIPTION
Store the time slot ID in local storage when returning to a time slot.
Also destructure event arguments for clarity.

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
