### PR TITLE
[Chore](video-player): Remove preload metadata attribute

### DIFF
--- a/packages/plugins/videos-ui/src/lib/shared/ui/video-player/video-player.component.html
+++ b/packages/plugins/videos-ui/src/lib/shared/ui/video-player/video-player.component.html
@@ -1,6 +1,6 @@
 <div class="video-player">
 	@if(src) {
-	<video #video preload="metadata" controlsList="nodownload" [controls]="controls">
+	<video #video controlsList="nodownload" [controls]="controls">
 		<source [src]="src" type="video/mp4" />
 	</video>
 	} @else {


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

- [x] Allow browsers to determine the optimal preload strategy for the video element.