### PR TITLE
[CI] Configure release workflows to default to patch

### DIFF
--- a/.github/workflows/release-demo.yml
+++ b/.github/workflows/release-demo.yml
@@ -21,6 +21,8 @@ jobs:
         id: tag_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_release_rules: ".*:patch"
+          default_bump: patch
           release_branches: master,main,develop,stage
           pre_release_branches: something_to_possible_use_later
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -21,6 +21,8 @@ jobs:
         id: tag_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_release_rules: ".*:patch"
+          default_bump: patch
           release_branches: master,main,develop,stage
           pre_release_branches: something_to_possible_use_later
 

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -21,6 +21,8 @@ jobs:
         id: tag_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_release_rules: ".*:patch"
+          default_bump: patch
           release_branches: master,main,develop,stage
           pre_release_branches: something_to_possible_use_later
 


### PR DESCRIPTION
Ensure all commits trigger at least a patch release by setting custom release rules and default bump to patch in the CI workflows. This simplifies commit message requirements for triggering version bumps.

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
