### PR TITLE
[fix] resolve PostgreSQL missing column error in unassignEmployeeFromT…

### DIFF
--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -743,14 +743,14 @@ export class TaskService extends TenantAwareCrudService<Task> {
 			const tenantId = RequestContext.currentTenantId();
 
 			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
-			query.leftJoinAndSelect(`${query.alias}.members`, 'members');
+			query.leftJoin(`${query.alias}.members`, 'members');
 
 			if (organizationTeamId) {
-				query.leftJoinAndSelect(`${query.alias}.teams`, 'teams', 'teams.id = :organizationTeamId', {
+				query.leftJoin(`${query.alias}.teams`, 'teams', 'teams.id = :organizationTeamId', {
 					organizationTeamId
 				});
 			} else {
-				query.leftJoinAndSelect(`${query.alias}.teams`, 'teams');
+				query.leftJoin(`${query.alias}.teams`, 'teams');
 			}
 
 			query.andWhere(p(`"${query.alias}"."tenantId" = :tenantId`), { tenantId });
@@ -761,8 +761,7 @@ export class TaskService extends TenantAwareCrudService<Task> {
 						const subQuery = qb.subQuery();
 						subQuery.select(p('"task_employee"."taskId"')).from(p('task_employee'), p('task_employee'));
 						subQuery.andWhere(p('"task_employee"."employeeId" = :employeeId'), { employeeId });
-
-						return p('"task_members"."taskId" IN ') + subQuery.distinct(true).getQuery();
+						return p('"members"."taskId" IN ') + subQuery.distinct(true).getQuery();
 					});
 					web.orWhere((qb: SelectQueryBuilder<Task>) => {
 						const subQuery = qb.subQuery();
@@ -774,8 +773,7 @@ export class TaskService extends TenantAwareCrudService<Task> {
 						);
 						subQuery.andWhere(p('"ote"."employeeId" = :employeeId'), { employeeId });
 						subQuery.andWhere(p(`"ote"."tenantId" = :tenantId`), { tenantId });
-
-						return p('"task_teams"."taskId" IN ') + subQuery.distinct(true).getQuery();
+						return p('"teams"."taskId" IN ') + subQuery.distinct(true).getQuery();
 					});
 				})
 			);
@@ -787,11 +785,11 @@ export class TaskService extends TenantAwareCrudService<Task> {
 						web.andWhere((qb: SelectQueryBuilder<Task>) => {
 							const subQuery = qb.subQuery();
 							subQuery.select(p('"task_team"."taskId"')).from(p('task_team'), p('task_team'));
-							subQuery.andWhere(p('"task_teams"."organizationTeamId" = :organizationTeamId'), {
+							subQuery.andWhere(p('"teams"."organizationTeamId" = :organizationTeamId'), {
 								organizationTeamId
 							});
-							subQuery.andWhere(p('"task_teams"."tenantId" = :tenantId'), { tenantId });
-							return p('"task_teams"."taskId" IN ') + subQuery.distinct(true).getQuery();
+							subQuery.andWhere(p('"teams"."tenantId" = :tenantId'), { tenantId });
+							return p('"teams"."taskId" IN ') + subQuery.distinct(true).getQuery();
 						});
 					})
 				);

--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -743,17 +743,21 @@ export class TaskService extends TenantAwareCrudService<Task> {
 			const tenantId = RequestContext.currentTenantId();
 
 			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
-			query.leftJoin(`${query.alias}.members`, 'members');
 
+			// Use unique alias to avoid conflict with 'teams' used later
 			if (organizationTeamId) {
-				query.leftJoin(`${query.alias}.teams`, 'teams', 'teams.id = :organizationTeamId', {
+				query.leftJoinAndSelect(`${query.alias}.teams`, 'teamFilter', 'teamFilter.id = :organizationTeamId', {
 					organizationTeamId
 				});
 			} else {
-				query.leftJoin(`${query.alias}.teams`, 'teams');
+				query.leftJoinAndSelect(`${query.alias}.teams`, 'teamFilter');
 			}
 
-			query.andWhere(p(`"${query.alias}"."tenantId" = :tenantId`), { tenantId });
+			query.andWhere(
+				new Brackets((qb: WhereExpressionBuilder) => {
+					qb.andWhere(p(`"${query.alias}"."tenantId" = :tenantId`), { tenantId });
+				})
+			);
 
 			query.andWhere(
 				new Brackets((web: WhereExpressionBuilder) => {
@@ -761,46 +765,48 @@ export class TaskService extends TenantAwareCrudService<Task> {
 						const subQuery = qb.subQuery();
 						subQuery.select(p('"task_employee"."taskId"')).from(p('task_employee'), p('task_employee'));
 						subQuery.andWhere(p('"task_employee"."employeeId" = :employeeId'), { employeeId });
-						return p('"members"."taskId" IN ') + subQuery.distinct(true).getQuery();
+						return p(`"${query.alias}"."id" IN (${subQuery.distinct(true).getQuery()})`);
 					});
 					web.orWhere((qb: SelectQueryBuilder<Task>) => {
 						const subQuery = qb.subQuery();
 						subQuery.select(p('"task_team"."taskId"')).from(p('task_team'), p('task_team'));
 						subQuery.leftJoin(
 							'organization_team_employee',
-							'ote',
-							p('"ote"."organizationTeamId" = "task_team"."organizationTeamId"')
+							'organization_team_employee',
+							p(
+								'"organization_team_employee"."organizationTeamId" = "task_team"."organizationTeamId" AND "organization_team_employee"."deletedAt" IS NULL'
+							)
 						);
-						subQuery.andWhere(p('"ote"."employeeId" = :employeeId'), { employeeId });
-						subQuery.andWhere(p(`"ote"."tenantId" = :tenantId`), { tenantId });
-						return p('"teams"."taskId" IN ') + subQuery.distinct(true).getQuery();
+						subQuery.andWhere(p('"organization_team_employee"."employeeId" = :employeeId'), { employeeId });
+						return p(`"${query.alias}"."id" IN (${subQuery.distinct(true).getQuery()})`);
 					});
 				})
 			);
 
 			// If unassigned for specific team
 			if (organizationTeamId) {
-				query.andWhere(
-					new Brackets((web: WhereExpressionBuilder) => {
-						web.andWhere((qb: SelectQueryBuilder<Task>) => {
-							const subQuery = qb.subQuery();
-							subQuery.select(p('"task_team"."taskId"')).from(p('task_team'), p('task_team'));
-							subQuery.andWhere(p('"teams"."organizationTeamId" = :organizationTeamId'), {
-								organizationTeamId
-							});
-							subQuery.andWhere(p('"teams"."tenantId" = :tenantId'), { tenantId });
-							return p('"teams"."taskId" IN ') + subQuery.distinct(true).getQuery();
-						});
-					})
-				);
+				query.andWhere((qb: SelectQueryBuilder<Task>) => {
+					const subQuery = qb.subQuery();
+					subQuery.select(p('"task_team"."taskId"')).from(p('task_team'), p('task_team'));
+					subQuery.andWhere(p('"task_team"."organizationTeamId" = :organizationTeamId'), {
+						organizationTeamId
+					});
+					return p(`"${query.alias}"."id" IN (${subQuery.distinct(true).getQuery()})`);
+				});
 			}
 
-			// Find all assigned tasks of employee
-			const tasks = await query.getMany();
+			// Find all assigned tasks of employee with relations
+			// Use different aliases to avoid conflicts
+			const tasks = await query
+				.leftJoinAndSelect(`${query.alias}.members`, 'taskMembers')
+				.leftJoinAndSelect(`${query.alias}.teams`, 'taskTeams')
+				.getMany();
+
+			console.log('Raw tasks data:', JSON.stringify(tasks, null, 2));
 
 			// Unassign member from All the Team Tasks
 			tasks.forEach((task) => {
-				if (task.teams.length) {
+				if (task.teams?.length) {
 					task.members = task.members.filter((member) => member.id !== employeeId);
 				}
 			});

--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -802,8 +802,6 @@ export class TaskService extends TenantAwareCrudService<Task> {
 				.leftJoinAndSelect(`${query.alias}.teams`, 'taskTeams')
 				.getMany();
 
-			console.log('Raw tasks data:', JSON.stringify(tasks, null, 2));
-
 			// Unassign member from All the Team Tasks
 			tasks.forEach((task) => {
 				if (task.teams?.length) {


### PR DESCRIPTION
…eamTasks

- Fix PostgreSQL error 42703 (errorMissingColumn) in unassignEmployeeFromTeamTasks method
- Replace incorrect alias references with proper query structure
- Use task.id directly in subquery conditions instead of non-existent column references
- Simplify query structure following patterns from findTeamTasks method
- Remove debug console.log statements
- Ensure proper loading of task members and teams relations

The method now correctly:
- Finds tasks assigned to employee via individual assignment or team membership
- Filters by specific team when organizationTeamId is provided
- Removes employee from individual task assignments while preserving team assignments
- Maintains consistent query patterns with rest of codebase

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
