### PR TITLE
[fix] exclude workspaces with null tenantId from user workspaces

### DIFF
--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -1409,7 +1409,8 @@ export class AuthService extends SocialAuthService {
 						where: {
 							email,
 							isActive: true,
-							isArchived: false
+							isArchived: false,
+							tenantId: { $ne: null }
 						},
 						relations: { tenant: true },
 						order: { createdAt: 'DESC' }
@@ -1422,7 +1423,8 @@ export class AuthService extends SocialAuthService {
 						where: {
 							email,
 							isActive: true,
-							isArchived: false
+							isArchived: false,
+							tenantId: Not(IsNull())
 						},
 						relations: { tenant: true },
 						order: { createdAt: 'DESC' }


### PR DESCRIPTION
- Add tenantId IS NOT NULL condition to filter out invalid workspaces
- Apply filtering for both MikroORM and TypeORM implementations
- Ensure only workspaces with valid tenant associations are returned

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
