### PR TITLE
[feat] separate project status from task status

### DIFF
--- a/packages/contracts/src/lib/organization-projects.model.ts
+++ b/packages/contracts/src/lib/organization-projects.model.ts
@@ -11,10 +11,20 @@ import { IOrganizationTeam } from './organization-team.model';
 import { IOrganizationProjectModule } from './organization-project-module.model';
 import { CrudActionEnum, ProjectBillingEnum, ProjectOwnerEnum } from './organization.model';
 import { CurrenciesEnum } from './currency.model';
-import { TaskStatusEnum } from './task-status.model';
 import { IRelationalRole } from './role.model';
 import { IBasePerTenantAndOrganizationEntityModel, ID } from './base-entity.model'; // Base Entities
 import { CustomFieldsObject } from './shared-types'; // Shared Types
+
+/**
+ * Project status enum
+ */
+export enum ProjectStatusEnum {
+	OPEN = 'open',
+	IN_PROGRESS = 'in-progress',
+	COMPLETED = 'completed',
+	CANCELLED = 'cancelled',
+	CUSTOM = 'custom'
+}
 
 // Base interface with optional properties
 export interface IRelationalOrganizationProject {
@@ -56,7 +66,7 @@ export interface IOrganizationProjectBase
 	budgetType?: OrganizationProjectBudgetTypeEnum;
 	membersCount?: number;
 	imageUrl?: string;
-	status?: TaskStatusEnum;
+	status?: ProjectStatusEnum;
 	icon?: string;
 	archiveTasksIn?: number;
 	closeTasksIn?: number;

--- a/packages/core/src/lib/organization-project/organization-project.entity.ts
+++ b/packages/core/src/lib/organization-project/organization-project.entity.ts
@@ -28,8 +28,8 @@ import {
 	OrganizationProjectBudgetTypeEnum,
 	ProjectBillingEnum,
 	ProjectOwnerEnum,
-	TaskListTypeEnum,
-	TaskStatusEnum
+	ProjectStatusEnum,
+	TaskListTypeEnum
 } from '@gauzy/contracts';
 import { isMySQL } from '@gauzy/config';
 import {
@@ -206,12 +206,12 @@ export class OrganizationProject
 	icon?: string;
 
 	// Specifies the status of the project, if provided.
-	@ApiPropertyOptional({ type: () => String, enum: TaskStatusEnum })
+	@ApiPropertyOptional({ type: () => String, enum: ProjectStatusEnum, default: ProjectStatusEnum.OPEN })
 	@IsOptional()
-	@IsEnum(TaskStatusEnum)
+	@IsEnum(ProjectStatusEnum)
 	@ColumnIndex()
-	@MultiORMColumn({ nullable: true })
-	status?: TaskStatusEnum;
+	@MultiORMColumn({ nullable: true, default: ProjectStatusEnum.OPEN })
+	status?: ProjectStatusEnum;
 
 	// Auto-sync tasks property
 	@ApiPropertyOptional({ type: () => Boolean })

--- a/packages/core/src/lib/organization-project/organization-project.seed.ts
+++ b/packages/core/src/lib/organization-project/organization-project.seed.ts
@@ -6,8 +6,8 @@ import {
 	IOrganizationProject,
 	ITenant,
 	OrganizationProjectBudgetTypeEnum,
-	TaskListTypeEnum,
-	TaskStatusEnum
+	ProjectStatusEnum,
+	TaskListTypeEnum
 } from '@gauzy/contracts';
 import { DatabaseTypeEnum } from '@gauzy/config';
 import { DEFAULT_ORGANIZATION_PROJECTS } from './default-organization-projects';
@@ -74,7 +74,7 @@ export const createDefaultOrganizationProjects = async (
 			// Create a new OrganizationProject instance
 			const project = new OrganizationProject();
 			project.name = projectName;
-			project.status = faker.helpers.arrayElement(Object.values(TaskStatusEnum));
+			project.status = faker.helpers.arrayElement(Object.values(ProjectStatusEnum));
 			project.tags = tags;
 			project.organizationContact = faker.helpers.arrayElement(organizationContacts);
 			project.organization = organization;
@@ -169,7 +169,7 @@ export const createRandomOrganizationProjects = async (
 				const project = new OrganizationProject();
 				project.tags = [tags[Math.floor(Math.random() * tags.length)]];
 				project.name = faker.company.name();
-				project.status = faker.helpers.arrayElement(Object.values(TaskStatusEnum));
+				project.status = faker.helpers.arrayElement(Object.values(ProjectStatusEnum));
 				project.organization = organization;
 				project.tenant = tenant;
 				project.budgetType = budgetType;


### PR DESCRIPTION
- Create dedicated ProjectStatusEnum for organization projects
- Remove dependency on TaskStatusEnum for project status management
- Update entities, interfaces, and seeders accordingly

# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
