### PR TITLE
feat(redis): improve Redis connection configuration

### DIFF
--- a/packages/core/src/lib/app/app.module.ts
+++ b/packages/core/src/lib/app/app.module.ts
@@ -266,7 +266,7 @@ if (environment.THROTTLE_ENABLED) {
 									port: port,
 									passphrase: password,
 									keepAlive: 10_000, // enable TCP keepalive (initial delay in ms)
-									reconnectStrategy: (retries: number) => Math.min(1000 + retries * 200, 5000),
+									reconnectStrategy: (retries: number) => Math.min(1000 * Math.pow(2, retries), 5000),
 									connectTimeout: 10_000,
 									rejectUnauthorized: process.env.NODE_ENV === 'production'
 								},

--- a/packages/core/src/lib/bootstrap/redis-store.ts
+++ b/packages/core/src/lib/bootstrap/redis-store.ts
@@ -82,7 +82,7 @@ export async function configureRedisSession(app: any): Promise<void> {
 					port,
 					passphrase: password,
 					keepAlive: 10_000, // enable TCP keepalive (initial delay in ms)
-					reconnectStrategy: (retries: number) => Math.min(1000 + retries * 200, 5000),
+					reconnectStrategy: (retries: number) => Math.min(1000 * Math.pow(2, retries), 5000),
 					connectTimeout: 10_000,
 					rejectUnauthorized: process.env.NODE_ENV === 'production'
 				},

--- a/packages/core/src/lib/health/indicators/redis-health.indicator.ts
+++ b/packages/core/src/lib/health/indicators/redis-health.indicator.ts
@@ -97,7 +97,7 @@ export class RedisHealthIndicator extends HealthIndicator {
 					port: parseInt(port),
 					passphrase: password,
 					keepAlive: 10_000, // enable TCP keepalive (initial delay in ms)
-					reconnectStrategy: (retries: number) => Math.min(1000 + retries * 200, 5000),
+					reconnectStrategy: (retries: number) => Math.min(1000 * Math.pow(2, retries), 5000),
 					connectTimeout: 10_000,
 					rejectUnauthorized: process.env.NODE_ENV === 'production'
 				},


### PR DESCRIPTION
- Add pingInterval (30s) to prevent LB/firewall disconnections
- Add keepAlive (10s) for TCP keepalive
- Add reconnectStrategy with exponential backoff (1s-5s)
- Add connectTimeout (10s) for connection stability
- Apply improvements to session store, cache store, and health checks
- Optimize for DigitalOcean Valkey 8 compatibility

Resolves #9162 (step 4)

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
