### PR TITLE
fix: add expiration time to JWT access token in getJwtAccessToken()

### DIFF
--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -923,7 +923,9 @@ export class AuthService extends SocialAuthService {
 			};
 
 			// Generate the JWT access token using the payload
-			return sign(payload, environment.JWT_SECRET, {});
+			return sign(payload, environment.JWT_SECRET, {
+				expiresIn: `${environment.JWT_TOKEN_EXPIRATION_TIME}s`
+			});
 		} catch (error) {
 			// Log and rethrow any errors encountered during the process
 			console.log('Error while generating JWT access token:', error);


### PR DESCRIPTION
- Added expiresIn option to sign() method in getJwtAccessToken()
- Access tokens now expire after JWT_TOKEN_EXPIRATION_TIME (default: 1 day)
- This aligns with the behavior of generateToken() method
- Fixes issue where access tokens from /auth/login and /auth/refresh-token never expired

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
