### PR TITLE
[FIX] remove `strict`  and use only `lax` to avoid the oauth flow to be restrictive(Avoiding crsf issue)

### DIFF
--- a/packages/auth/src/lib/mcp/server/oauth-authorization-server.ts
+++ b/packages/auth/src/lib/mcp/server/oauth-authorization-server.ts
@@ -175,7 +175,7 @@ export class OAuth2AuthorizationServer {
 			cookieName: isHttps ? '__Host-mcp.x-csrf-token' : 'mcp-csrf-token',
 			cookieOptions: {
 				httpOnly: true,
-				sameSite: isHttps ? 'strict' : 'lax',
+				sameSite: 'lax',
 				secure: isHttps,
 				path: '/',
 			},


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
