### PR TITLE
[Fix] Fixed the employee data serialization before and after entity load

### DIFF
--- a/packages/core/src/lib/employee-setting/employee-setting.subscriber.ts
+++ b/packages/core/src/lib/employee-setting/employee-setting.subscriber.ts
@@ -29,11 +29,17 @@ export class EmployeeSettingSubscriber extends BaseEntityEventSubscriber<Employe
 				if (typeof entity.data === 'object') {
 					entity.data = JSON.stringify(entity.data);
 				}
+
+				// serialize the `defaultData` field if it's an object
+				if (typeof entity.defaultData === 'object') {
+					entity.defaultData = JSON.stringify(entity.defaultData);
+				}
 			}
 		} catch (error) {
 			// Log the error and reset the data to an empty object if JSON parsing fails
 			console.error('Error stringify data:', error);
 			entity.data = '{}';
+			entity.defaultData = '{}';
 		}
 	}
 
@@ -76,11 +82,17 @@ export class EmployeeSettingSubscriber extends BaseEntityEventSubscriber<Employe
 				if (entity.data && typeof entity.data === 'string') {
 					entity.data = JSON.parse(entity.data);
 				}
+
+				// Parse the `defaultData` field if it's a string
+				if (entity.defaultData && typeof entity.defaultData === 'string') {
+					entity.defaultData = JSON.parse(entity.defaultData);
+				}
 			}
 		} catch (error) {
 			// Log the error and reset the data to an empty object if JSON parsing fails
 			console.error('Error parsing JSON data:', error);
 			entity.data = {};
+			entity.defaultData = {};
 		}
 	}
 }


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures employee settings data and defaultData are correctly serialized before save and parsed after load, preventing type mismatches and JSON errors (notably in SQLite).

- **Bug Fixes**
  - Serialize defaultData when saving (JSON.stringify if object).
  - Parse defaultData when loading (JSON.parse if string).
  - Add error handling: on failure, fallback to '{}' on save and {} on load for both data and defaultData.

<sup>Written for commit 8d04efb41972e06ca4809028dbb6997fd8c87cc1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

