### PR TITLE
fix: skip Redis auth when credentials are empty

### DIFF
--- a/packages/core/src/lib/app/app.module.ts
+++ b/packages/core/src/lib/app/app.module.ts
@@ -254,7 +254,7 @@ if (environment.THROTTLE_ENABLED) {
 								const parsedUrl = new URL(url);
 								const isTls = parsedUrl.protocol === 'rediss:';
 								const username = parsedUrl.username || REDIS_USER;
-								const password = parsedUrl.password || REDIS_PASSWORD;
+								const password = parsedUrl.password || REDIS_PASSWORD || undefined;
 								const host = parsedUrl.hostname || REDIS_HOST;
 								const port = parseInt(parsedUrl.port || REDIS_PORT || '6379', 10);
 

--- a/packages/core/src/lib/bootstrap/redis-store.ts
+++ b/packages/core/src/lib/bootstrap/redis-store.ts
@@ -57,7 +57,7 @@ export async function configureRedisSession(app: any): Promise<void> {
 			const parsedUrl = new URL(url);
 			const isTls = parsedUrl.protocol === 'rediss:';
 			const username = parsedUrl.username || REDIS_USER;
-			const password = parsedUrl.password || REDIS_PASSWORD;
+			const password = parsedUrl.password || REDIS_PASSWORD || undefined;
 			const host = parsedUrl.hostname || REDIS_HOST;
 			const port = parseInt(parsedUrl.port || REDIS_PORT || '6379', 10);
 

--- a/packages/core/src/lib/health/indicators/redis-health.indicator.ts
+++ b/packages/core/src/lib/health/indicators/redis-health.indicator.ts
@@ -96,7 +96,7 @@ export class RedisHealthIndicator extends HealthIndicator {
 			const parsedUrl = new URL(redisUrl);
 			const isTls = parsedUrl.protocol === 'rediss:';
 			const username = parsedUrl.username || REDIS_USER;
-			const password = parsedUrl.password || REDIS_PASSWORD;
+			const password = parsedUrl.password || REDIS_PASSWORD || undefined;
 			const host = parsedUrl.hostname || REDIS_HOST;
 			const port = parseInt(parsedUrl.port || REDIS_PORT || '6379', 10);
 


### PR DESCRIPTION
Prevent WRONGPASS error in local development by only adding authentication to Redis URL when both username and password are provided.

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Redis authentication when credentials are empty to prevent WRONGPASS errors in local setups. Also standardize Redis URL parsing and port handling across session bootstrap and health checks.

- **Bug Fixes**
  - Add auth to Redis URL only if both username and password are provided.
  - Parse Redis URL with the URL API instead of manual string splitting.
  - Consistently parse port as an integer and reuse in socket options.
  - Health check warns and skips client init when Redis is enabled but missing URL or host/port.

<sup>Written for commit b345efa12d25e5ec456101eff300023f8858a066. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



