### PR TITLE
[Fix] add missing await in JobProposalPlugin seed methods

### DIFF
--- a/packages/plugins/job-proposal/src/lib/job-proposal.plugin.ts
+++ b/packages/plugins/job-proposal/src/lib/job-proposal.plugin.ts
@@ -71,7 +71,7 @@ export class JobProposalPlugin implements IOnPluginBootstrap, IOnPluginDestroy, 
 	 */
 	async onPluginDefaultSeed() {
 		try {
-			this._proposalSeederService.createDefaultProposals();
+			await this._proposalSeederService.createDefaultProposals();
 
 			if (this.logEnabled) {
 				console.log(chalk.green(`Default data seeded successfully for ${JobProposalPlugin.name}.`));
@@ -86,7 +86,7 @@ export class JobProposalPlugin implements IOnPluginBootstrap, IOnPluginDestroy, 
 	 */
 	async onPluginRandomSeed() {
 		try {
-			this._proposalSeederService.createRandomProposals();
+			await this._proposalSeederService.createRandomProposals();
 
 			if (this.logEnabled) {
 				console.log(chalk.green(`Random data seeded successfully for ${JobProposalPlugin.name}.`));


### PR DESCRIPTION
- Add await to createDefaultProposals() in onPluginDefaultSeed()
- Add await to createRandomProposals() in onPluginRandomSeed()

This fixes the 'database connection is not open' error that occurred only with better-sqlite3 after seed completion. The error happened because the async seed operations were not awaited, causing them to continue executing after the database connection was destroyed.

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing awaits in JobProposalPlugin seed methods to ensure seeding finishes before shutdown. Fixes the "database connection is not open" error with better-sqlite3 after seed completion.

- **Bug Fixes**
  - Await createDefaultProposals() in onPluginDefaultSeed().
  - Await createRandomProposals() in onPluginRandomSeed().
  - Prevents async seed work from running after the DB connection is destroyed.

<sup>Written for commit a0947a5cbe386f2760f15041b34b60517737e6a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

