### PR TITLE
[FIX] Update environment variable for MCP deployment for both clusters and github actions

### DIFF
--- a/.deploy/k8s/k8s-manifest.mcp.demo.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.demo.yaml
@@ -56,6 +56,8 @@ spec:
 
             - name: MCP_AUTH_ENABLED
               value: '$MCP_AUTH_ENABLED'
+            - name: MCP_AUTH_BASE_URL
+              value: '$MCP_AUTH_BASE_URL'
             - name: MCP_AUTH_RESOURCE_URI
               value: '$MCP_AUTH_RESOURCE_URI'
             - name: MCP_AUTH_REQUIRED_SCOPES

--- a/.deploy/k8s/k8s-manifest.mcp.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.prod.yaml
@@ -56,6 +56,8 @@ spec:
 
             - name: MCP_AUTH_ENABLED
               value: '$MCP_AUTH_ENABLED'
+            - name: MCP_AUTH_BASE_URL
+              value: '$MCP_AUTH_BASE_URL'
             - name: MCP_AUTH_RESOURCE_URI
               value: '$MCP_AUTH_RESOURCE_URI'
             - name: MCP_AUTH_REQUIRED_SCOPES

--- a/.deploy/k8s/k8s-manifest.mcp.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.stage.yaml
@@ -56,6 +56,8 @@ spec:
 
             - name: MCP_AUTH_ENABLED
               value: '$MCP_AUTH_ENABLED'
+            - name: MCP_AUTH_BASE_URL
+              value: '$MCP_AUTH_BASE_URL'
             - name: MCP_AUTH_RESOURCE_URI
               value: '$MCP_AUTH_RESOURCE_URI'
             - name: MCP_AUTH_REQUIRED_SCOPES

--- a/.github/workflows/deploy-mcp-demo.yml
+++ b/.github/workflows/deploy-mcp-demo.yml
@@ -60,6 +60,7 @@ jobs:
 
           # OAuth 2.0 Authorization
           MCP_AUTH_ENABLED: "${{ secrets.MCP_AUTH_ENABLED }}"
+          MCP_AUTH_BASE_URL: "${{ secrets.MCP_AUTH_BASE_URL }}"
           MCP_AUTH_RESOURCE_URI: "${{ secrets.MCP_AUTH_RESOURCE_URI }}"
           MCP_AUTH_REQUIRED_SCOPES: "${{ secrets.MCP_AUTH_REQUIRED_SCOPES }}"
           MCP_AUTH_SERVERS: "${{ secrets.MCP_AUTH_SERVERS }}"

--- a/.github/workflows/deploy-mcp-prod.yml
+++ b/.github/workflows/deploy-mcp-prod.yml
@@ -60,6 +60,7 @@ jobs:
 
           # OAuth 2.0 Authorization
           MCP_AUTH_ENABLED: "${{ secrets.MCP_AUTH_ENABLED }}"
+          MCP_AUTH_BASE_URL: "${{ secrets.MCP_AUTH_BASE_URL }}"
           MCP_AUTH_RESOURCE_URI: "${{ secrets.MCP_AUTH_RESOURCE_URI }}"
           MCP_AUTH_REQUIRED_SCOPES: "${{ secrets.MCP_AUTH_REQUIRED_SCOPES }}"
           MCP_AUTH_SERVERS: "${{ secrets.MCP_AUTH_SERVERS }}"

--- a/.github/workflows/deploy-mcp-stage.yml
+++ b/.github/workflows/deploy-mcp-stage.yml
@@ -60,6 +60,7 @@ jobs:
 
           # OAuth 2.0 Authorization
           MCP_AUTH_ENABLED: "${{ secrets.MCP_AUTH_ENABLED }}"
+          MCP_AUTH_BASE_URL: "${{ secrets.MCP_AUTH_BASE_URL }}"
           MCP_AUTH_RESOURCE_URI: "${{ secrets.MCP_AUTH_RESOURCE_URI }}"
           MCP_AUTH_REQUIRED_SCOPES: "${{ secrets.MCP_AUTH_REQUIRED_SCOPES }}"
           MCP_AUTH_SERVERS: "${{ secrets.MCP_AUTH_SERVERS }}"


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated MCP deployments and GitHub Actions to include MCP_AUTH_BASE_URL for demo, stage, and prod. This fixes OAuth setup by providing the auth service base URL and keeps configuration consistent across environments.

- **Bug Fixes**
  - Added MCP_AUTH_BASE_URL to k8s manifests for all MCP clusters.
  - Passed MCP_AUTH_BASE_URL from GitHub Secrets in deploy workflows to prevent auth failures.

<sup>Written for commit 05d8e03a6c2d58c0718524dcbc0e9e0f23746cc3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

