### PR TITLE
fix: desktop server missing some dependencies in runtime

### DIFF
--- a/apps/desktop/src/package.json
+++ b/apps/desktop/src/package.json
@@ -53,7 +53,8 @@
 			"../../../dist/packages/plugins/camshot",
 			"../../../dist/packages/plugins/soundshot",
 			"../../../dist/packages/ui-config",
-			"../../../dist/packages/utils"
+			"../../../dist/packages/utils",
+			"../../../dist/packages/plugins/integration-activepieces"
 		]
 	},
 	"build": {
@@ -185,6 +186,7 @@
 		"@gauzy/plugin-posthog": "file:../../../dist/packages/plugins/posthog",
 		"@gauzy/plugin-camshot": "file:../../../dist/packages/plugins/camshot",
 		"@gauzy/plugin-soundshot": "file:../../../dist/packages/plugins/soundshot",
+		"@gauzy/plugin-integration-activepieces": "file:../../../dist/packages/plugins/integration-activepieces",
 		"@gauzy/ui-config": "file:../../../dist/packages/ui-config",
 		"@gauzy/utils": "file:../../../dist/packages/utils",
 		"@nestjs/platform-express": "^11.1.0",
@@ -218,7 +220,8 @@
 		"twing": "^5.0.2",
 		"underscore": "^1.13.3",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8"
+		"custom-electron-titlebar": "^4.2.8",
+		"@as-integrations/express5": "^1.1.2"
 	},
 	"optionalDependencies": {
 		"node-linux": "^0.1.12",

--- a/apps/server-api/src/package.json
+++ b/apps/server-api/src/package.json
@@ -43,7 +43,8 @@
 			"../../../dist/packages/plugins/soundshot",
 			"../../../dist/packages/plugins/registry",
 			"../../../dist/packages/ui-config",
-			"../../../dist/packages/utils"
+			"../../../dist/packages/utils",
+			"../../../dist/packages/plugins/integration-activepieces"
 		]
 	},
 	"build": {
@@ -178,6 +179,7 @@
 		"@gauzy/plugin-posthog": "file:../../../dist/packages/plugins/posthog",
 		"@gauzy/plugin-camshot": "file:../../../dist/packages/plugins/camshot",
 		"@gauzy/plugin-soundshot": "file:../../../dist/packages/plugins/soundshot",
+		"@gauzy/plugin-integration-activepieces": "file:../../../dist/packages/plugins/integration-activepieces",
 		"@gauzy/ui-config": "file:../../../dist/packages/ui-config",
 		"@gauzy/utils": "file:../../../dist/packages/utils",
 		"@sentry/electron": "6.9.0",
@@ -208,7 +210,8 @@
 		"twing": "^5.0.2",
 		"underscore": "^1.13.3",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8"
+		"custom-electron-titlebar": "^4.2.8",
+		"@as-integrations/express5": "^1.1.2"
 	},
 	"optionalDependencies": {
 		"node-linux": "^0.1.12",

--- a/apps/server/src/package.json
+++ b/apps/server/src/package.json
@@ -42,7 +42,8 @@
 			"../../../dist/packages/plugins/camshot",
 			"../../../dist/packages/plugins/soundshot",
 			"../../../dist/packages/ui-config",
-			"../../../dist/packages/utils"
+			"../../../dist/packages/utils",
+			"../../../dist/packages/plugins/integration-activepieces"
 		]
 	},
 	"build": {
@@ -177,6 +178,7 @@
 		"@gauzy/plugin-posthog": "file:../../../dist/packages/plugins/posthog",
 		"@gauzy/plugin-camshot": "file:../../../dist/packages/plugins/camshot",
 		"@gauzy/plugin-soundshot": "file:../../../dist/packages/plugins/soundshot",
+		"@gauzy/plugin-integration-activepieces": "file:../../../dist/packages/plugins/integration-activepieces",
 		"@gauzy/ui-config": "file:../../../dist/packages/ui-config",
 		"@gauzy/utils": "file:../../../dist/packages/utils",
 		"@sentry/electron": "6.9.0",
@@ -207,7 +209,8 @@
 		"twing": "^5.0.2",
 		"underscore": "^1.13.3",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8"
+		"custom-electron-titlebar": "^4.2.8",
+		"@as-integrations/express5": "^1.1.2"
 	},
 	"optionalDependencies": {
 		"node-linux": "^0.1.12",


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing runtime dependencies in desktop and server by adding the Activepieces integration plugin and the Express 5 adapter. Prevents startup errors and ensures the plugin loads in desktop, server-api, and server.

- **Dependencies**
  - Added @gauzy/plugin-integration-activepieces to desktop, server-api, and server (including workspace paths) so it’s bundled at runtime.
  - Added @as-integrations/express5 to ensure Express 5 compatibility.

<sup>Written for commit 026733f861a889d68101bb672dc620cfc3d9c82c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

