### PR TITLE
fix: desktop sentry bug report page

### DIFF
--- a/apps/agent/src/assets/styles/_overrides.scss
+++ b/apps/agent/src/assets/styles/_overrides.scss
@@ -744,3 +744,7 @@ nb-toastr-container {
 nb-toast {
 	width: 21rem !important;
 }
+
+.sentry-error-embed {
+  top: 30px !important;
+}

--- a/apps/desktop-timer/src/assets/styles/_overrides.scss
+++ b/apps/desktop-timer/src/assets/styles/_overrides.scss
@@ -745,3 +745,7 @@ nb-toastr-container {
 nb-toast {
 	width: 21rem !important;
 }
+
+.sentry-error-embed {
+  top: 30px !important;
+}

--- a/apps/desktop/src/assets/styles/_overrides.scss
+++ b/apps/desktop/src/assets/styles/_overrides.scss
@@ -757,3 +757,7 @@ angular2-smart-table>div {
 angular2-smart-table a:hover {
   text-decoration: auto !important;
 }
+
+.sentry-error-embed {
+  top: 30px !important;
+}

--- a/apps/server-api/src/assets/styles/_overrides.scss
+++ b/apps/server-api/src/assets/styles/_overrides.scss
@@ -722,3 +722,7 @@ angular2-smart-table table tr.angular2-smart-titles th a.sort {
 input {
   height: 2.625rem !important;
 }
+
+.sentry-error-embed {
+  top: 30px !important;
+}

--- a/apps/server/src/assets/styles/_overrides.scss
+++ b/apps/server/src/assets/styles/_overrides.scss
@@ -722,3 +722,7 @@ angular2-smart-table table tr.angular2-smart-titles th a.sort {
 input {
   height: 2.625rem !important;
 }
+
+.sentry-error-embed {
+  top: 30px !important;
+}


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Sentry bug report modal positioning so it shows correctly in all desktop apps. The modal no longer overlaps the header and is fully accessible.

- **Bug Fixes**
  - Added `.sentry-error-embed { top: 30px !important; }` to `*_overrides.scss` in agent, desktop, desktop-timer, server, and server-api.

<sup>Written for commit 7d639bb9448b2941d8853891fd18444a0268491e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

