### PR TITLE
[FIX] Fix Gauzy MCP/MCP OAuth Server build related to missing critical dependencies to compile native nodejs modules

### DIFF
--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -42,7 +42,8 @@ FROM node:20.18.1-alpine3.19 AS dependencies
 LABEL maintainer="ever@ever.co"
 LABEL org.opencontainers.image.source="https://github.com/ever-co/ever-gauzy"
 
-RUN apk add --no-cache python3 make g++ \
+RUN apk add --no-cache python3 python3-dev py3-pip py3-setuptools build-base gcc g++ make autoconf automake git \
+    && npm install --quiet node-gyp@10.2.0 -g \
     && npm install yarn -g --force
 RUN mkdir /srv/gauzy-mcp-auth && chown -R node:node /srv/gauzy-mcp-auth
 
@@ -100,7 +101,8 @@ RUN yarn build:mcp-auth:prod
 # Only prod dependencies
 FROM node:20.18.1-alpine3.19 AS proddependencies
 
-RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache python3 python3-dev py3-pip py3-setuptools build-base gcc g++ make autoconf automake git \
+    && npm install --quiet node-gyp@10.2.0 -g
 
 USER node:node
 

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -88,7 +88,8 @@ FROM node:20.18.1-alpine3.19 AS dependencies
 LABEL maintainer="ever@ever.co"
 LABEL org.opencontainers.image.source="https://github.com/ever-co/ever-gauzy"
 
-RUN apk add --no-cache python3 make g++ \
+RUN apk add --no-cache python3 python3-dev py3-pip py3-setuptools build-base gcc g++ make autoconf automake git \
+    && npm install --quiet node-gyp@10.2.0 -g \
     && npm install yarn -g --force
 
 RUN mkdir /srv/gauzy-mcp && chown -R node:node /srv/gauzy-mcp
@@ -145,7 +146,8 @@ RUN yarn build:mcp:prod
 # Only prod dependencies
 FROM node:20.18.1-alpine3.19 AS proddependencies
 
-RUN apk add --no-cache python3 make g++
+RUN apk add --no-cache python3 python3-dev py3-pip py3-setuptools build-base gcc g++ make autoconf automake git \
+    && npm install --quiet node-gyp@10.2.0 -g
 
 USER node:node
 


### PR DESCRIPTION

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker builds for Gauzy MCP and MCP OAuth Server by adding missing native build dependencies and node-gyp. This ensures native Node modules compile and images build reliably.

- **Bug Fixes**
  - Install Python toolchain and build essentials (python3, python3-dev, pip, setuptools, build-base, gcc, g++, make, autoconf, automake, git) in Alpine images.
  - Add global node-gyp@10.2.0 to support native module compilation during install.
  - Apply changes to both dependency and production stages in mcp and mcp-auth Dockerfiles.

<sup>Written for commit 4d071a52f70c78768dc3c1dd1891a3c05db5ef0f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

