### PR TITLE
[FIX] Use the correct rebuild process patterns for all native packages

### DIFF
--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -173,7 +173,7 @@ COPY --chown=node:node packages/plugins/registry/package.json ./packages/plugins
 COPY --chown=node:node decorate-angular-cli.js lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
-RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts && yarn postinstall.manual && yarn cache clean
+RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts && node ./.scripts/postinstall.js && npm rebuild bcrypt better-sqlite3 --build-from-source && yarn cache clean
 
 FROM node:20.18.1-alpine3.19 AS prodDependencies
 
@@ -236,7 +236,7 @@ COPY --chown=node:node packages/plugins/registry/package.json ./packages/plugins
 COPY --chown=node:node decorate-angular-cli.js lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
-RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts --production && yarn postinstall.manual && yarn cache clean
+RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts --production && node ./.scripts/postinstall.js && npm rebuild bcrypt better-sqlite3 --build-from-source && yarn cache clean
 
 # We remove Angular modules as it's not used in APIs
 RUN rm -r node_modules/@angular

--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -64,7 +64,8 @@ COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts \
-    && yarn postinstall.manual \
+    && node ./.scripts/postinstall.js \
+    && npm rebuild bcrypt better-sqlite3 --build-from-source \
     && yarn cache clean
 
 COPY --chown=node:node apps/mcp-auth ./apps/mcp-auth
@@ -114,7 +115,8 @@ COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts --production \
-    && yarn postinstall.manual \
+    && node ./.scripts/postinstall.js \
+    && npm rebuild bcrypt better-sqlite3 --build-from-source \
     && yarn cache clean
 
 # PROD

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -111,6 +111,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts \
     && node ./.scripts/postinstall.js \
+    && npm rebuild bcrypt --build-from-source \
     && yarn cache clean
 
 COPY --chown=node:node apps/mcp ./apps/mcp
@@ -159,7 +160,8 @@ COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts --production \
-    && yarn postinstall.manual \
+    && node ./.scripts/postinstall.js \
+    && npm rebuild bcrypt --build-from-source \
     && yarn cache clean
 
 # PROD


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker builds for api, mcp, and mcp-auth by running the unified postinstall script and the correct npm rebuild patterns for native modules. Ensures bcrypt and better-sqlite3 are compiled in both build and production layers.

- **Bug Fixes**
  - Use node ./.scripts/postinstall.js followed by npm rebuild bcrypt (and better-sqlite3 where needed) with --build-from-source.
  - Copy .scripts/postinstall.js into the image.
  - Apply changes in both build and production stages for all three Dockerfiles.

<sup>Written for commit bc1794b4b84a8e9d13f9608eac1818428a6c71bf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





