### PR TITLE
chore: install Multipass in all Linux arm64 workflow builds

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
 
+      - name: Install Multipass
+        run: 'sudo snap install multipass'
+
       - name: Fix node-gyp and Python
         run: python3 -m pip install packaging setuptools
 


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install Multipass in all Linux arm64 GitHub Actions workflows so Snapcraft can provision build VMs. This fixes arm64 snap builds failing due to missing Multipass and aligns prod/stage configs across agent, desktop, timer, and server pipelines.

<sup>Written for commit f51b7ffc2781bc0e9b58f247dca98b85e39a6d1e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

