### PR TITLE
chore: set SNAPCRAFT_BUILD_ENVIRONMENT to host in all Linux workflows

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -160,6 +160,7 @@ jobs:
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_NO_CLOUD: true
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
   release-mac:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set SNAPCRAFT_BUILD_ENVIRONMENT=host across all Linux GitHub Actions workflows to run Snapcraft builds directly on the runner. This standardizes and stabilizes Linux builds for agent, desktop, and server pipelines.

- **Bug Fixes**
  - Removes LXD/Multipass dependency on runners, preventing snap build failures/timeouts.
  - Applied to stage and prod for: agent, desktop-app, desktop-timer-app, server, server-api, server-mcp.

<sup>Written for commit f02efe581df749258dfadeda2e855484961df821. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

