### PR TITLE
feat(workflows): add FPM installation and USE_SYSTEM_FPM for arm64 Li…

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:agent:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:agent:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:desktop:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:desktop:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:desktop-timer:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:desktop-timer:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:gauzy-api-server:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:gauzy-api-server:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:gauzy-mcp-server:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:gauzy-mcp-server:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:gauzy-server:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -106,7 +106,10 @@ jobs:
         run: 'sudo chown -R $(whoami) ./*'
 
       - name: Install system dependencies
-        run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev'
+        run: |
+          sudo apt-get update
+          sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick libx11-dev libxtst-dev libxt-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxrandr-dev ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -148,6 +151,7 @@ jobs:
         run: 'yarn build:gauzy-server:linux:release:gh:arm64'
         env:
           USE_HARD_LINKS: false
+          USE_SYSTEM_FPM: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}


### PR DESCRIPTION
…nux builds

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable system FPM for arm64 Linux builds and install FPM via RubyGems across all CI workflows. This fixes arm64 packaging failures and stabilizes DEB/RPM releases.

- **Bug Fixes**
  - Set USE_SYSTEM_FPM=true for arm64 build steps so electron-builder uses system FPM.
  - Install FPM in Linux jobs to resolve missing fpm errors.
  - Applied to agent, desktop, desktop-timer, server, server-api, and server-mcp (stage and prod).

- **Dependencies**
  - Add apt packages: ruby, ruby-dev, rubygems, build-essential.
  - Install fpm gem with --no-document.

<sup>Written for commit 0a606e5c9c9ddd167169112c2a98fb2c194446a8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

