### PR TITLE
chore: upgrade node version from v20.18.1 to v24.12.0 (#9286)

### DIFF
--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -105,7 +105,7 @@ ARG REDIS_USER
 ARG REDIS_TLS
 ARG REDIS_URL
 
-FROM node:20.18.1-alpine3.19 AS dependencies
+FROM node:24.12.0-alpine3.23 AS dependencies
 
 LABEL maintainer="ever@ever.co"
 LABEL org.opencontainers.image.source="https://github.com/ever-co/ever-gauzy"
@@ -175,7 +175,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts && yarn postinstall.manual && yarn cache clean
 
-FROM node:20.18.1-alpine3.19 AS prodDependencies
+FROM node:24.12.0-alpine3.23 AS prodDependencies
 
 ENV CI=true
 
@@ -245,7 +245,7 @@ RUN rm -r node_modules/@angular
 # those within custom webpack in apps/api/config/custom-webpack.config.js
 # RUN rm -r node_modules/@gauzy
 
-FROM node:20.18.1-alpine3.19 AS development
+FROM node:24.12.0-alpine3.23 AS development
 
 USER node:node
 
@@ -255,7 +255,7 @@ COPY --chown=node:node --from=dependencies /wait /entrypoint.prod.sh /entrypoint
 COPY --chown=node:node --from=dependencies /srv/gauzy .
 COPY . .
 
-FROM node:20.18.1-alpine3.19 AS build
+FROM node:24.12.0-alpine3.23 AS build
 
 WORKDIR /srv/gauzy
 
@@ -295,7 +295,7 @@ RUN yarn build:api:prod:docker
 # those within custom webpack in apps/api/config/custom-webpack.config.js
 # RUN rm -r dist/apps/api/node_modules/@gauzy
 
-FROM node:20.18.1-alpine3.19 AS production
+FROM node:24.12.0-alpine3.23 AS production
 
 WORKDIR /srv/gauzy
 

--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -37,7 +37,7 @@ ARG DB_SYNCHRONIZE
 ARG MCP_TRUSTED_PROXIES
 
 
-FROM node:20.18.1-alpine3.19 AS dependencies
+FROM node:24.12.0-alpine3.23 AS dependencies
 
 LABEL maintainer="ever@ever.co"
 LABEL org.opencontainers.image.source="https://github.com/ever-co/ever-gauzy"
@@ -102,7 +102,7 @@ RUN rm -rf /srv/gauzy-mcp-auth/dist
 RUN yarn build:mcp-auth:prod
 
 # Only prod dependencies
-FROM node:20.18.1-alpine3.19 AS proddependencies
+FROM node:24.12.0-alpine3.23 AS proddependencies
 
 RUN apk add --no-cache python3 python3-dev py3-pip py3-setuptools build-base gcc g++ make autoconf automake git \
     && npm install --quiet node-gyp@10.2.0 -g \

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -83,7 +83,7 @@ ARG MCP_WS_SESSION_ENABLED
 ARG MCP_WS_SESSION_COOKIE_NAME
 ARG MCP_WS_TRUSTED_PROXIES
 
-FROM node:20.18.1-alpine3.19 AS dependencies
+FROM node:24.12.0-alpine3.23 AS dependencies
 
 LABEL maintainer="ever@ever.co"
 LABEL org.opencontainers.image.source="https://github.com/ever-co/ever-gauzy"
@@ -146,7 +146,7 @@ RUN rm -rf /srv/gauzy-mcp/dist
 RUN yarn build:mcp:prod
 
 # Only prod dependencies
-FROM node:20.18.1-alpine3.19 AS proddependencies
+FROM node:24.12.0-alpine3.23 AS proddependencies
 
 RUN apk add --no-cache python3 python3-dev py3-pip py3-setuptools build-base gcc g++ make autoconf automake git \
     && npm install --quiet node-gyp@10.2.0 -g \

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -61,7 +61,7 @@ ARG DESKTOP_APP_DOWNLOAD_LINK_LINUX
 ARG MOBILE_APP_DOWNLOAD_LINK
 ARG EXTENSION_DOWNLOAD_LINK
 
-FROM node:20.18.1-alpine3.19 AS dependencies
+FROM node:24.12.0-alpine3.23 AS dependencies
 
 LABEL maintainer="ever@ever.co"
 LABEL org.opencontainers.image.source="https://github.com/ever-co/ever-gauzy"
@@ -151,7 +151,7 @@ RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
 RUN yarn postinstall.manual
 RUN yarn cache clean
 
-FROM node:20.18.1-alpine3.19 AS development
+FROM node:24.12.0-alpine3.23 AS development
 
 USER node:node
 
@@ -161,7 +161,7 @@ COPY --chown=node:node --from=dependencies /wait /entrypoint.compose.sh /entrypo
 COPY --chown=node:node --from=dependencies /srv/gauzy .
 COPY . .
 
-FROM node:20.18.1-alpine3.19 AS build
+FROM node:24.12.0-alpine3.23 AS build
 
 WORKDIR /srv/gauzy
 

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: buildjet/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Change permissions
@@ -121,7 +121,7 @@ jobs:
         run: python3 -m pip install packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -180,14 +180,14 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Fix node-gyp and Python
         run: python3 -m pip install --break-system-packages packaging setuptools
 
       - name: Install latest version of NPM
-        run: 'sudo npm install -g npm@10.9.4'
+        run: 'sudo npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'sudo npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -246,7 +246,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools)
@@ -269,7 +269,7 @@ jobs:
           arch: x64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'
@@ -364,7 +364,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:
-          node-version: 22.21.1
+          node-version: 24.12.0
           cache: 'yarn'
 
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
@@ -387,7 +387,7 @@ jobs:
           arch: arm64
 
       - name: Install latest version of NPM
-        run: 'npm install -g npm@10.9.4'
+        run: 'npm install -g npm@11.6.2'
 
       - name: Install globally node-gyp, ts-node and nx packages
         run: 'npm install --quiet -g node-gyp@10.2.0 ts-node@10.9.2 nx@20.8.0'


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded Node.js to v24.12.0 across Docker images and CI workflows for a consistent, modern runtime. Also bumped npm to v11.6.2.

- **Dependencies**
  - Docker base images set to node:24.12.0-alpine3.23 for API, Webapp, MCP, and MCP Auth.
  - All GitHub Actions workflows now use Node.js 24.12.0 and npm 11.6.2.
  - No application code changes.

- **Migration**
  - Update local dev to Node.js 24.12.0 and npm 11.6.2, then reinstall packages.
  - Rebuild Docker images and clear CI caches to avoid mixed toolchain versions.

<sup>Written for commit f64ef578ad5568af155d472e45345df0aaeb3cf3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

