### PR TITLE
fix: agent build release path

### DIFF
--- a/apps/agent/src/package.json
+++ b/apps/agent/src/package.json
@@ -39,14 +39,14 @@
 		"publish": [
 			{
 				"provider": "github",
-				"repo": "ever-agent",
+				"repo": "ever-gauzy-agent",
 				"releaseType": "release"
 			},
 			{
 				"provider": "spaces",
 				"name": "ever",
 				"region": "sfo3",
-				"path": "/ever-agent",
+				"path": "/ever-gauzy-agent",
 				"acl": "public-read"
 			}
 		],


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Agent release config so builds publish to the correct targets. Updates the GitHub repo to ever-gauzy-agent and the DigitalOcean Spaces path to /ever-gauzy-agent to prevent releases going to the wrong location.

<sup>Written for commit dde1ba10742e3e74fcdbda69b13c6c91a52e373b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

