### PR TITLE
fix: table name plugins conflict in desktop with integrated and sqlit…

### DIFF
--- a/packages/desktop-lib/src/lib/plugin-system/shared/constant.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/shared/constant.ts
@@ -1,1 +1,1 @@
-export const TABLE_PLUGINS = 'plugins';
+export const TABLE_PLUGINS = 'desktop_plugins';


### PR DESCRIPTION
…e as the database provider

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the desktop plugin table from 'plugins' to 'desktop_plugins' to prevent name collisions in integrated mode and with SQLite. This avoids conflicts with other modules that also use a 'plugins' table.

<sup>Written for commit 8678aa2e1f6e92b97ad1d93db5cfeae948571aab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

