### PR TITLE
chore(cache-manager):support Cacheable instance for nonBloking mode

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
 		"@mikro-orm/postgresql": "^6.4.13",
 		"@nestjs/apollo": "^13.1.0",
 		"@nestjs/axios": "github:ever-co/nestjs-axios#master",
-		"@nestjs/cache-manager": "^3.0.1",
+		"@nestjs/cache-manager": "^3.1.0",
 		"@nestjs/common": "^11.1.10",
 		"@nestjs/core": "^11.1.10",
 		"@nestjs/cqrs": "^11.0.3",

--- a/packages/core/src/lib/app/app.module.ts
+++ b/packages/core/src/lib/app/app.module.ts
@@ -318,7 +318,7 @@ if (environment.THROTTLE_ENABLED) {
 								// This provides proper type safety without 'as any' cast
 
 								return {
-									stores: [cacheable.primary, cacheable.secondary]
+									stores: cacheable
 								};
 							} catch (error) {
 								console.error(
@@ -345,8 +345,13 @@ if (environment.THROTTLE_ENABLED) {
 		I18nModule.forRoot({
 			fallbackLanguage: LanguagesEnum.ENGLISH,
 			loaderOptions: {
-				path: environment.isElectron && environment.electronResourcesPath ? path.resolve(environment.electronResourcesPath, 'app.asar.unpacked/node_modules/@gauzy/core/src/lib/i18n')
-				: path.resolve(__dirname, '../i18n/'),
+				path:
+					environment.isElectron && environment.electronResourcesPath
+						? path.resolve(
+								environment.electronResourcesPath,
+								'app.asar.unpacked/node_modules/@gauzy/core/src/lib/i18n'
+						  )
+						: path.resolve(__dirname, '../i18n/'),
 				watch: !environment.production
 			},
 			resolvers: [new HeaderResolver(['language'])]

--- a/packages/plugins/integration-ai/package.json
+++ b/packages/plugins/integration-ai/package.json
@@ -32,7 +32,7 @@
 		"@gauzy/core": "^0.1.0",
 		"@gauzy/utils": "^0.1.0",
 		"@nestjs/axios": "github:ever-co/nestjs-axios#master",
-		"@nestjs/cache-manager": "^3.0.1",
+		"@nestjs/cache-manager": "^3.1.0",
 		"@nestjs/common": "^11.1.10",
 		"@nestjs/config": "^4.0.2",
 		"@nestjs/cqrs": "^11.0.3",

--- a/packages/plugins/integration-github/package.json
+++ b/packages/plugins/integration-github/package.json
@@ -35,7 +35,7 @@
 		"@gauzy/utils": "^0.1.0",
 		"@mikro-orm/nestjs": "^6.1.1",
 		"@nestjs/axios": "github:ever-co/nestjs-axios#master",
-		"@nestjs/cache-manager": "^3.0.1",
+		"@nestjs/cache-manager": "^3.1.0",
 		"@nestjs/common": "^11.1.10",
 		"@nestjs/core": "^11.1.10",
 		"@nestjs/cqrs": "^11.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7208,10 +7208,10 @@
   version "4.0.0"
   resolved "https://codeload.github.com/ever-co/nestjs-axios/tar.gz/9cac09cfcbc1a6fe973b1feb8baedbb39715468e"
 
-"@nestjs/cache-manager@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@nestjs/cache-manager/-/cache-manager-3.0.1.tgz#893abd4fb8450d2fe6c6692bd71688c45b2d5128"
-  integrity sha512-4UxTnR0fsmKL5YDalU2eLFVnL+OBebWUpX+hEduKGncrVKH4PPNoiRn1kXyOCjmzb0UvWgqubpssNouc8e0MCw==
+"@nestjs/cache-manager@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/cache-manager/-/cache-manager-3.1.0.tgz#65f3be68154e48557790c0a58a55aadb92439dd0"
+  integrity sha512-pEIqYZrBcE8UdkJmZRduurvoUfdU+3kRPeO1R2muiMbZnRuqlki5klFFNllO9LyYWzrx98bd1j0PSPKSJk1Wbw==
 
 "@nestjs/cli@^11.0.7":
   version "11.0.7"


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables non-blocking cache configuration by switching to a Cacheable instance and upgrading @nestjs/cache-manager to 3.1.0. This simplifies store setup and aligns with the latest NestJS cache API.

- **Refactors**
  - Use Cacheable instance for cache stores in app.module (replace array with the instance) for non-blocking mode and better typing.
  - Minor i18n loader path formatting cleanup.

- **Dependencies**
  - Bump @nestjs/cache-manager to ^3.1.0 in core and integration packages.
  - Update yarn.lock accordingly.

<sup>Written for commit 800863179beda7b5957334ad24dd8a6ae4af7485. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

