### PR TITLE
fix(core): export PasswordHashModule and PasswordHashService

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from './lib/tenant';
 export { RoleModule, RoleService } from './lib/role';
 export { RolePermissionModule, RolePermissionService } from './lib/role-permission';
 export { UserModule, UserService } from './lib/user';
+export { PasswordHashModule, PasswordHashService } from './lib/password-hash';
 
 export * from './lib/organization';
 export {


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose PasswordHashModule and PasswordHashService from core’s public API to unblock imports in other packages. Fixes missing exports in index.ts.

<sup>Written for commit 4d97050893b8c787837db1ce1cb78146b038eb02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

