### PR TITLE
fix: remove tasks menu and set widget inactive as default

### DIFF
--- a/apps/agent/src/main/init/app.ts
+++ b/apps/agent/src/main/init/app.ts
@@ -167,14 +167,15 @@ async function appReady() {
 	await ensureScreenshotDir();
 	const configs: any = store.get('configs');
 	const settings = getAppSetting();
-	if (!settings) {
+	if (!settings || (!Object.keys(settings).length)) {
 		launchAtStartup(true, false);
 		LocalStore.setAllDefaultConfig();
 
 		/* Set default application setting for agent app. */
 		LocalStore.updateApplicationSetting({
 			screenshotNotification: false,
-			simpleScreenshotNotification: false
+			simpleScreenshotNotification: false,
+			alwaysOn: false
 		});
 	}
 

--- a/apps/agent/src/main/init/ipcMain.ts
+++ b/apps/agent/src/main/init/ipcMain.ts
@@ -190,7 +190,10 @@ export default function AppIpcMain() {
 			throw new AppError('GET_EMP_SETTING', error);
 		}
 		listenIO(false);
-		await handleAlwaysOnWindow(true);
+		const appSetting = getAppSetting();
+		if (appSetting?.alwaysOn) {
+			await handleAlwaysOnWindow(true);
+		}
 		await closeLoginWindow();
 	});
 

--- a/packages/desktop-ui-lib/src/lib/agent-dashboard/agent-dashboard-routing.module.ts
+++ b/packages/desktop-ui-lib/src/lib/agent-dashboard/agent-dashboard-routing.module.ts
@@ -10,10 +10,6 @@ export const agentDashboardRoutes: Routes = [
 		loadComponent: () => import('./activity-sync/activity-sync.component').then((m) => m.SyncPageComponent),
 	},
 	{
-		path: 'tasks',
-		loadChildren: () => import('../time-tracker/task-table/task-table.routing.module').then((m) => m.taskTableRoutes)
-	},
-	{
 		path: '',
 		redirectTo: 'logs',
 		pathMatch: 'full',

--- a/packages/desktop-ui-lib/src/lib/agent-dashboard/agent-dashboard.component.ts
+++ b/packages/desktop-ui-lib/src/lib/agent-dashboard/agent-dashboard.component.ts
@@ -15,12 +15,6 @@ import { TasksService } from './services/tasks-service';
 export class AgentDashboardComponent implements OnInit, OnDestroy {
 	menu: NbMenuItem[] = [
 		{
-			title: 'Tasks',
-			link: '/server-dashboard/tasks',
-			icon: 'checkmark-square-2-outline',
-			pathMatch: 'prefix'
-		},
-		{
 			title: 'Logs',
 			link: '/server-dashboard/logs', // Assuming this will be the route for logs
 			icon: 'file-text-outline'


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Tasks menu from the Agent Dashboard and disabled the Always-On widget by default. The widget now opens only when Always-On is enabled, and first-run defaults are set correctly.

- **Bug Fixes**
  - Removed the Tasks route and menu item from the Agent Dashboard.
  - Initialize defaults when settings are missing or empty; set alwaysOn to false.
  - Only open the Always-On window if appSetting.alwaysOn is true.

<sup>Written for commit 7947b8c8c0df2d2c5c94471c96fbc3fb47a1747a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

