### PR TITLE
Merge pull request #9346 from ever-co/feat/monitoring-i18n-settings

### DIFF
--- a/packages/ui-core/i18n/assets/i18n/ach.json
+++ b/packages/ui-core/i18n/assets/i18n/ach.json
@@ -4192,6 +4192,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Neno ki kwano ngec",
+		"SERVICES": "Tic",
+		"SCOPE": "Wel",
+		"GLOBAL": "Piny weng",
+		"TENANT": "Lobo",
+		"POSTHOG": {
+			"TITLE": "Kwano ngec me PostHog",
+			"ENABLED": "Mi PostHog tii",
+			"API_KEY": "Lagony API",
+			"API_KEY_PLACEHOLDER": "Ket lagony API pa projek me PostHog mamegi",
+			"HOST": "URL me lacoo (host)",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Kare me cwalo dwoko (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Kare i millisekond ikare ma ki cwalo ngec mapolo i dwoko"
+		},
+		"SENTRY": {
+			"TITLE": "Luboo marac me Sentry",
+			"ENABLED": "Mi Sentry tii",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Kwano ngec me Jitsu",
+			"ENABLED": "Mi Jitsu tii",
+			"HOST": "URL me lacoo (host)",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Lagony me cono (write key)",
+			"WRITE_KEY_PLACEHOLDER": "Ket lagony me cono pa Jitsu mamegi"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "crwdns9914:0{{ name }}crwdne9914:0",
 		"HOST": "crwdns8392:0crwdne8392:0",

--- a/packages/ui-core/i18n/assets/i18n/ar.json
+++ b/packages/ui-core/i18n/assets/i18n/ar.json
@@ -4791,6 +4791,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "المراقبة والتحليلات",
+		"SERVICES": "الخدمات",
+		"SCOPE": "النطاق",
+		"GLOBAL": "عام",
+		"TENANT": "مستأجر",
+		"POSTHOG": {
+			"TITLE": "تحليلات PostHog",
+			"ENABLED": "تفعيل PostHog",
+			"API_KEY": "مفتاح API",
+			"API_KEY_PLACEHOLDER": "أدخل مفتاح API لمشروع PostHog الخاص بك",
+			"HOST": "عنوان URL للمضيف",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "فاصل الإرسال (ملِّي ثانية)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "الوقت بالملِّي ثانية بين إرسال الدُفعات من الأحداث"
+		},
+		"SENTRY": {
+			"TITLE": "تتبُّع أخطاء Sentry",
+			"ENABLED": "تفعيل Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "تحليلات Jitsu",
+			"ENABLED": "تفعيل Jitsu",
+			"HOST": "عنوان URL للمضيف",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "مفتاح الكتابة",
+			"WRITE_KEY_PLACEHOLDER": "أدخل مفتاح الكتابة الخاص بك لـ Jitsu"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "إدارة SMTP لـ '{{ name }}'",
 		"FROM_ADDRESS": "عنوان البريد الإلكتروني مرسل منه",

--- a/packages/ui-core/i18n/assets/i18n/bg.json
+++ b/packages/ui-core/i18n/assets/i18n/bg.json
@@ -4835,6 +4835,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Мониторинг и анализ",
+		"SERVICES": "Услуги",
+		"SCOPE": "Обхват",
+		"GLOBAL": "Глобален",
+		"TENANT": "Наемател",
+		"POSTHOG": {
+			"TITLE": "PostHog аналитика",
+			"ENABLED": "Активирай PostHog",
+			"API_KEY": "API ключ",
+			"API_KEY_PLACEHOLDER": "Въведете API ключа на вашия PostHog проект",
+			"HOST": "URL на хоста",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Интервал на изпращане (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Време в милисекунди между изпращането на групирани събития"
+		},
+		"SENTRY": {
+			"TITLE": "Следене на грешки със Sentry",
+			"ENABLED": "Активирай Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Jitsu аналитика",
+			"ENABLED": "Активирай Jitsu",
+			"HOST": "URL на хоста",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Ключ за запис",
+			"WRITE_KEY_PLACEHOLDER": "Въведете вашия Jitsu ключ за запис"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Управление на SMTP за '{{ name }}'",
 		"HOST": "Хост",

--- a/packages/ui-core/i18n/assets/i18n/de.json
+++ b/packages/ui-core/i18n/assets/i18n/de.json
@@ -4802,6 +4802,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Überwachung & Analysen",
+		"SERVICES": "Dienste",
+		"SCOPE": "Geltungsbereich",
+		"GLOBAL": "Global",
+		"TENANT": "Mieter",
+		"POSTHOG": {
+			"TITLE": "PostHog-Analytik",
+			"ENABLED": "PostHog aktivieren",
+			"API_KEY": "API-Schlüssel",
+			"API_KEY_PLACEHOLDER": "Geben Sie den API-Schlüssel Ihres PostHog-Projekts ein",
+			"HOST": "Host-URL",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Sendeintervall (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Zeit in Millisekunden zwischen dem Senden gebündelter Ereignisse"
+		},
+		"SENTRY": {
+			"TITLE": "Sentry-Fehlerverfolgung",
+			"ENABLED": "Sentry aktivieren",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Jitsu-Analytik",
+			"ENABLED": "Jitsu aktivieren",
+			"HOST": "Host-URL",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Schreibschlüssel",
+			"WRITE_KEY_PLACEHOLDER": "Geben Sie Ihren Jitsu-Schreibschlüssel ein"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Verwalte SMTP für '{{ name }}'",
 		"FROM_ADDRESS": "Von E-Mail-Adresse",

--- a/packages/ui-core/i18n/assets/i18n/es.json
+++ b/packages/ui-core/i18n/assets/i18n/es.json
@@ -4808,6 +4808,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Supervisión y analítica",
+		"SERVICES": "Servicios",
+		"SCOPE": "Ámbito",
+		"GLOBAL": "Global",
+		"TENANT": "Inquilino",
+		"POSTHOG": {
+			"TITLE": "Analítica de PostHog",
+			"ENABLED": "Habilitar PostHog",
+			"API_KEY": "Clave API",
+			"API_KEY_PLACEHOLDER": "Introduce la clave API de tu proyecto PostHog",
+			"HOST": "URL del host",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Intervalo de envío (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Tiempo en milisegundos entre el envío de eventos en lotes"
+		},
+		"SENTRY": {
+			"TITLE": "Seguimiento de errores de Sentry",
+			"ENABLED": "Habilitar Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Analítica de Jitsu",
+			"ENABLED": "Habilitar Jitsu",
+			"HOST": "URL del host",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Clave de escritura",
+			"WRITE_KEY_PLACEHOLDER": "Introduce tu clave de escritura de Jitsu"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Administrar SMTP para '{{ name }}'",
 		"FROM_ADDRESS": "Desde la dirección de correo electrónico",

--- a/packages/ui-core/i18n/assets/i18n/fr.json
+++ b/packages/ui-core/i18n/assets/i18n/fr.json
@@ -4797,6 +4797,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Supervision & analytique",
+		"SERVICES": "Services",
+		"SCOPE": "Portée",
+		"GLOBAL": "Global",
+		"TENANT": "Locataire",
+		"POSTHOG": {
+			"TITLE": "Analyse PostHog",
+			"ENABLED": "Activer PostHog",
+			"API_KEY": "Clé API",
+			"API_KEY_PLACEHOLDER": "Saisissez la clé API de votre projet PostHog",
+			"HOST": "URL de l’hôte",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Intervalle de vidage (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Temps en millisecondes entre l’envoi des événements groupés"
+		},
+		"SENTRY": {
+			"TITLE": "Suivi des erreurs Sentry",
+			"ENABLED": "Activer Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Analyse Jitsu",
+			"ENABLED": "Activer Jitsu",
+			"HOST": "URL de l’hôte",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Clé d’écriture",
+			"WRITE_KEY_PLACEHOLDER": "Saisissez votre clé d’écriture Jitsu"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Gérer le SMTP pour '{{ name }}'",
 		"FROM_ADDRESS": "De Adresse Email",

--- a/packages/ui-core/i18n/assets/i18n/he.json
+++ b/packages/ui-core/i18n/assets/i18n/he.json
@@ -4798,6 +4798,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "ניטור וניתוח",
+		"SERVICES": "שירותים",
+		"SCOPE": "טווח",
+		"GLOBAL": "גלובלי",
+		"TENANT": "טננט",
+		"POSTHOG": {
+			"TITLE": "PostHog אנליטיקה",
+			"ENABLED": "הפעל PostHog",
+			"API_KEY": "מפתח API",
+			"API_KEY_PLACEHOLDER": "הזן את מפתח ה‑API של פרויקט ה‑PostHog שלך",
+			"HOST": "כתובת URL של המארח",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "מרווח שליחה (מילישניות)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "הזמן במילישניות בין שליחת אירועים במנות"
+		},
+		"SENTRY": {
+			"TITLE": "ניטור שגיאות Sentry",
+			"ENABLED": "הפעל Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "אנליטיקת Jitsu",
+			"ENABLED": "הפעל Jitsu",
+			"HOST": "כתובת URL של המארח",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "מפתח כתיבה",
+			"WRITE_KEY_PLACEHOLDER": "הזן את מפתח הכתיבה שלך עבור Jitsu"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Manage SMTP for '{{ name }}'",
 		"HOST": "Host",

--- a/packages/ui-core/i18n/assets/i18n/it.json
+++ b/packages/ui-core/i18n/assets/i18n/it.json
@@ -4806,6 +4806,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Monitoraggio e analitica",
+		"SERVICES": "Servizi",
+		"SCOPE": "Ambito",
+		"GLOBAL": "Globale",
+		"TENANT": "Inquilino",
+		"POSTHOG": {
+			"TITLE": "Analitica PostHog",
+			"ENABLED": "Abilita PostHog",
+			"API_KEY": "Chiave API",
+			"API_KEY_PLACEHOLDER": "Inserisci la chiave API del tuo progetto PostHog",
+			"HOST": "URL host",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Intervallo di invio (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Tempo in millisecondi tra l’invio degli eventi in batch"
+		},
+		"SENTRY": {
+			"TITLE": "Monitoraggio errori Sentry",
+			"ENABLED": "Abilita Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Analitica Jitsu",
+			"ENABLED": "Abilita Jitsu",
+			"HOST": "URL host",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Chiave di scrittura",
+			"WRITE_KEY_PLACEHOLDER": "Inserisci la tua chiave di scrittura Jitsu"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Gestisci SMTP per '{{ name }}'",
 		"FROM_ADDRESS": "Dall'indirizzo email",

--- a/packages/ui-core/i18n/assets/i18n/nl.json
+++ b/packages/ui-core/i18n/assets/i18n/nl.json
@@ -4806,6 +4806,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Monitoring en analyse",
+		"SERVICES": "Diensten",
+		"SCOPE": "Bereik",
+		"GLOBAL": "Globaal",
+		"TENANT": "Huurder",
+		"POSTHOG": {
+			"TITLE": "PostHog-analyse",
+			"ENABLED": "PostHog inschakelen",
+			"API_KEY": "API-sleutel",
+			"API_KEY_PLACEHOLDER": "Voer de API-sleutel van je PostHog-project in",
+			"HOST": "Host-URL",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Verzendinterval (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Tijd in milliseconden tussen het verzenden van gebundelde events"
+		},
+		"SENTRY": {
+			"TITLE": "Sentry-foutopsporing",
+			"ENABLED": "Sentry inschakelen",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Jitsu-analyse",
+			"ENABLED": "Jitsu inschakelen",
+			"HOST": "Host-URL",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Schrijfsleutel",
+			"WRITE_KEY_PLACEHOLDER": "Voer je Jitsu-schrijfsleutel in"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "SMTP beheren voor '{{ name }}'",
 		"FROM_ADDRESS": "Van e-mailadres",

--- a/packages/ui-core/i18n/assets/i18n/pl.json
+++ b/packages/ui-core/i18n/assets/i18n/pl.json
@@ -4805,6 +4805,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Monitorowanie i analityka",
+		"SERVICES": "Usługi",
+		"SCOPE": "Zakres",
+		"GLOBAL": "Globalny",
+		"TENANT": "Tenant",
+		"POSTHOG": {
+			"TITLE": "Analityka PostHog",
+			"ENABLED": "Włącz PostHog",
+			"API_KEY": "Klucz API",
+			"API_KEY_PLACEHOLDER": "Wprowadź klucz API swojego projektu PostHog",
+			"HOST": "Adres URL hosta",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Interwał wysyłania (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Czas w milisekundach między wysyłaniem zgrupowanych zdarzeń"
+		},
+		"SENTRY": {
+			"TITLE": "Śledzenie błędów Sentry",
+			"ENABLED": "Włącz Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Analityka Jitsu",
+			"ENABLED": "Włącz Jitsu",
+			"HOST": "Adres URL hosta",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Klucz zapisu",
+			"WRITE_KEY_PLACEHOLDER": "Wprowadź swój klucz zapisu Jitsu"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Zarządzaj SMTP dla '{{ name }}'",
 		"FROM_ADDRESS": "Adres email nadawcy",

--- a/packages/ui-core/i18n/assets/i18n/pt.json
+++ b/packages/ui-core/i18n/assets/i18n/pt.json
@@ -4806,6 +4806,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Monitoramento e análise",
+		"SERVICES": "Serviços",
+		"SCOPE": "Escopo",
+		"GLOBAL": "Global",
+		"TENANT": "Inquilino",
+		"POSTHOG": {
+			"TITLE": "Análise do PostHog",
+			"ENABLED": "Ativar PostHog",
+			"API_KEY": "Chave de API",
+			"API_KEY_PLACEHOLDER": "Insira a chave de API do seu projeto PostHog",
+			"HOST": "URL do host",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Intervalo de envio (ms)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Tempo em milissegundos entre o envio de eventos em lote"
+		},
+		"SENTRY": {
+			"TITLE": "Monitoramento de erros do Sentry",
+			"ENABLED": "Ativar Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Análise do Jitsu",
+			"ENABLED": "Ativar Jitsu",
+			"HOST": "URL do host",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Chave de escrita",
+			"WRITE_KEY_PLACEHOLDER": "Insira sua chave de escrita do Jitsu"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Gerenciar o SMTP para '{{ name }}'",
 		"FROM_ADDRESS": "Do endereço de e-mail",

--- a/packages/ui-core/i18n/assets/i18n/ru.json
+++ b/packages/ui-core/i18n/assets/i18n/ru.json
@@ -4805,6 +4805,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "Мониторинг и аналитика",
+		"SERVICES": "Сервисы",
+		"SCOPE": "Область действия",
+		"GLOBAL": "Глобальный",
+		"TENANT": "Владелец",
+		"POSTHOG": {
+			"TITLE": "Аналитика PostHog",
+			"ENABLED": "Включить PostHog",
+			"API_KEY": "API‑ключ",
+			"API_KEY_PLACEHOLDER": "Введите API‑ключ вашего проекта PostHog",
+			"HOST": "URL хоста",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "Интервал отправки (мс)",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "Время в миллисекундах между отправкой пакетных событий"
+		},
+		"SENTRY": {
+			"TITLE": "Отслеживание ошибок Sentry",
+			"ENABLED": "Включить Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Аналитика Jitsu",
+			"ENABLED": "Включить Jitsu",
+			"HOST": "URL хоста",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "Ключ записи",
+			"WRITE_KEY_PLACEHOLDER": "Введите ваш ключ записи Jitsu"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "Управление SMTP для '{{ name }}'",
 		"HOST": "Хост",

--- a/packages/ui-core/i18n/assets/i18n/zh.json
+++ b/packages/ui-core/i18n/assets/i18n/zh.json
@@ -4806,6 +4806,38 @@
 			}
 		}
 	},
+	"SETTINGS_MONITORING": {
+		"HEADER": "监控与分析",
+		"SERVICES": "服务",
+		"SCOPE": "范围",
+		"GLOBAL": "全局",
+		"TENANT": "租户",
+		"POSTHOG": {
+			"TITLE": "PostHog 分析",
+			"ENABLED": "启用 PostHog",
+			"API_KEY": "API 密钥",
+			"API_KEY_PLACEHOLDER": "输入你 PostHog 项目的 API 密钥",
+			"HOST": "主机 URL",
+			"HOST_PLACEHOLDER": "https://app.posthog.com",
+			"FLUSH_INTERVAL": "批量发送间隔（毫秒）",
+			"FLUSH_INTERVAL_PLACEHOLDER": "10000",
+			"FLUSH_INTERVAL_HINT": "批量事件发送之间的时间（毫秒）"
+		},
+		"SENTRY": {
+			"TITLE": "Sentry 错误跟踪",
+			"ENABLED": "启用 Sentry",
+			"DSN": "DSN",
+			"DSN_PLACEHOLDER": "https://xxx@sentry.io/xxx"
+		},
+		"JITSU": {
+			"TITLE": "Jitsu 分析",
+			"ENABLED": "启用 Jitsu",
+			"HOST": "主机 URL",
+			"HOST_PLACEHOLDER": "https://your-jitsu-host.com",
+			"WRITE_KEY": "写入密钥",
+			"WRITE_KEY_PLACEHOLDER": "输入你的 Jitsu 写入密钥"
+		}
+	},
 	"CUSTOM_SMTP_PAGE": {
 		"HEADER": "管理SMTP邮件服务器的 '{{ name }}'",
 		"FROM_ADDRESS": "发件人电子邮件地址",


### PR DESCRIPTION
Feat/monitoring i18n settings

# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds translations for the new Monitoring & Analytics settings across 13 locales. Localizes PostHog, Sentry, and Jitsu configuration fields and scope labels.

- **New Features**
  - New namespace: SETTINGS_MONITORING with header, services, scope (Global, Tenant).
  - Providers: PostHog (enable, API key, host, flush interval + hint), Sentry (enable, DSN), Jitsu (enable, host, write key + placeholders).
  - Locales updated: ach, ar, bg, de, es, fr, he, it, nl, pl, pt, ru, zh.

<sup>Written for commit 9ae122339f3cbdd868e67689de38ac72694b1b47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

