### PR TITLE
fix(auth): reset selectedOrganization on login to prevent stale data

### DIFF
--- a/packages/ui-core/core/src/lib/services/auth/auth-strategy.service.ts
+++ b/packages/ui-core/core/src/lib/services/auth/auth-strategy.service.ts
@@ -312,6 +312,10 @@ export class AuthStrategy extends NbAuthStrategy {
 					return new NbAuthResult(false, res, false, AuthStrategy.config.login.defaultErrors);
 				}
 
+				// Reset selectedOrganization to prevent stale data from previous session.
+				// OrganizationSelectorComponent will set the correct organization after login.
+				this.store.selectedOrganization = user?.employee?.organization ?? null;
+
 				this.store.userId = user.id;
 				this.store.token = token;
 				this.store.refresh_token = refresh_token;
@@ -319,7 +323,7 @@ export class AuthStrategy extends NbAuthStrategy {
 				this.store.tenantId = user?.tenantId;
 				this.store.user = user;
 
-				this.electronAuthentication({ user, token, refresh_token  });
+				this.electronAuthentication({ user, token, refresh_token });
 
 				return new NbAuthResult(
 					true,


### PR DESCRIPTION
When switching between users (especially across different tenants), the persisted selectedOrganization from localStorage could belong to a different tenant, causing 400 errors from backend validators.

Reset to employee.organization if available, otherwise null. OrganizationSelectorComponent will set the correct organization after login.

Fixes #9226

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset selectedOrganization on login to prevent stale data and 400 errors when switching users or tenants.
Set it to employee.organization if available, otherwise null; OrganizationSelectorComponent will update it after login.

<sup>Written for commit 3b7a4a015d31c9f5b3add030b0325c08387c420c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

