### PR TITLE
refactor(mcp-auth): use `PasswordHashModule` from @gauzy/core

### DIFF
--- a/apps/mcp-auth/src/app.module.ts
+++ b/apps/mcp-auth/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@gauzy/config';
+import { PasswordHashModule } from '@gauzy/core';
 import { McpOAuthModule } from './mcp-oauth/mcp-oauth.module';
 
 /**
@@ -11,6 +12,8 @@ import { McpOAuthModule } from './mcp-oauth/mcp-oauth.module';
 @Module({
 	imports: [
 		ConfigModule,
+		// Password hashing module - global, available throughout the app
+		PasswordHashModule,
 		// TypeORM configuration - use autoLoadEntities to automatically load entities from feature modules
 		TypeOrmModule.forRootAsync({
 			useFactory: (configService: ConfigService) => ({

--- a/apps/mcp-auth/src/user/oauth-user.service.ts
+++ b/apps/mcp-auth/src/user/oauth-user.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { User, PasswordHashService } from '@gauzy/core';
+import { PasswordHashService, User } from '@gauzy/core';
 import { IUser } from '@gauzy/contracts';
 
 /**
@@ -14,6 +14,7 @@ import { IUser } from '@gauzy/contracts';
 @Injectable()
 export class OAuthUserService {
 	private readonly logger = new Logger(OAuthUserService.name);
+
 	constructor(
 		@InjectRepository(User)
 		private readonly typeOrmRepository: Repository<User>,


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored MCP Auth to use PasswordHashModule from @gauzy/core, making password hashing available app-wide. No functional changes; this simplifies dependency management and ensures consistent hashing.

- **Refactors**
  - Added PasswordHashModule to app.module imports for global access.
  - Cleaned up OAuthUserService imports to use PasswordHashService from @gauzy/core.

<sup>Written for commit bcf69754597e48039a017602ac90153286758f8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

