### PR TITLE
fix: desktop translate not loaded

### DIFF
--- a/apps/desktop/project.json
+++ b/apps/desktop/project.json
@@ -25,7 +25,7 @@
 				"tsConfig": "apps/desktop/tsconfig.app.json",
 				"aot": true,
 				"stylePreprocessorOptions": {
-					"includePaths": ["apps/desktop-timer/src/assets/styles", "packages/ui-core/static/styles"]
+					"includePaths": ["apps/desktop/src/assets/styles", "packages/ui-core/static/styles"]
 				},
 				"assets": ["apps/desktop/src/favicon.ico", "apps/desktop/src/assets"],
 				"styles": [
@@ -40,7 +40,6 @@
 					"node_modules/leaflet/dist/leaflet.css",
 					"node_modules/@ng-select/ng-select/themes/default.theme.css",
 					"apps/desktop/src/assets/styles/styles.scss",
-					"apps/desktop/src/styles.css",
 					"packages/ui-core/static/styles/styles.scss"
 				],
 				"scripts": [],

--- a/apps/desktop/src/app/app.module.ts
+++ b/apps/desktop/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClient, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { ErrorHandler, inject, NgModule, provideAppInitializer } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -15,6 +15,7 @@ import {
 	ElectronService,
 	ErrorHandlerService,
 	GAUZY_ENV,
+	HttpLoaderFactory,
 	ImageViewerModule,
 	LanguageInterceptor,
 	LanguageModule,
@@ -53,6 +54,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { AppService } from './app.service';
 import { initializeSentry } from './sentry';
+import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 
 /**
  * Initializes Sentry based on the environment configuration.
@@ -90,6 +92,14 @@ if (environment.SENTRY_DSN) {
 		UpdaterModule,
 		ImageViewerModule,
 		NbDatepickerModule.forRoot(),
+		TranslateModule.forRoot({
+			extend: true,
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		}),
 		LanguageModule.forRoot(),
 		AboutModule,
 		AlwaysOnModule,
@@ -137,7 +147,7 @@ if (environment.SENTRY_DSN) {
 			deps: [Router]
 		},
 		provideAppInitializer(() => {
-			const initializerFn = ((trace: Sentry.TraceService) => () => {})(inject(Sentry.TraceService));
+			const initializerFn = ((trace: Sentry.TraceService) => () => { })(inject(Sentry.TraceService));
 			return initializerFn();
 		}),
 		{
@@ -181,4 +191,4 @@ if (environment.SENTRY_DSN) {
 	],
 	bootstrap: [AppComponent]
 })
-export class AppModule {}
+export class AppModule { }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,1 +1,0 @@
-/* You can add global styles to this file, and also import other style files */

--- a/apps/gauzy/project.json
+++ b/apps/gauzy/project.json
@@ -200,7 +200,6 @@
 					}
 				],
 				"styles": [
-					"apps/desktop/src/styles.css",
 					"node_modules/bootstrap/dist/css/bootstrap.css",
 					"node_modules/typeface-exo/index.css",
 					"node_modules/roboto-fontface/css/roboto/roboto-fontface.css",


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing translations in the desktop app by wiring up ngx-translate with an HTTP loader. Also corrects style paths and removes an unused stylesheet entry.

- **Bug Fixes**
  - Register TranslateModule with HttpLoaderFactory and HttpClient in AppModule to load i18n files.
  - Update includePaths to apps/desktop/src/assets/styles.
  - Remove unused apps/desktop/src/styles.css from desktop and gauzy build configs.

<sup>Written for commit f3e631d0c8e237051ff4acdd1a31007fa335873a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

