### PR TITLE
chore(deps): bump better-sqlite3 from 12.2.0 to 12.6.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,7 +111,7 @@
 		"atlassian-connect-express": "^8.5.0",
 		"axios": "^1.9.0",
 		"bcrypt": "^5.1.1",
-		"better-sqlite3": "12.2.0",
+		"better-sqlite3": "12.6.2",
 		"cache-manager": "^6.4.2",
 		"cacheable": "^2.1.1",
 		"@keyv/redis": "^5.1.3",

--- a/packages/desktop-activity/package.json
+++ b/packages/desktop-activity/package.json
@@ -33,7 +33,7 @@
 		"underscore": "^1.13.3",
 		"get-windows": "^9.2.3",
 		"better-queue": "^3.8.12",
-		"better-sqlite3": "12.2.0",
+		"better-sqlite3": "12.6.2",
 		"is-online": "^9.0.1"
 	},
 	"devDependencies": {

--- a/packages/desktop-lib/package.json
+++ b/packages/desktop-lib/package.json
@@ -34,7 +34,7 @@
 		"@gauzy/desktop-window": "^0.1.0",
 		"@gauzy/desktop-activity": "^0.1.0",
 		"get-windows": "^9.2.3",
-		"better-sqlite3": "12.2.0",
+		"better-sqlite3": "12.6.2",
 		"electron-log": "^4.4.8",
 		"electron-store": "^8.1.0",
 		"electron-util": "^0.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16661,10 +16661,10 @@ better-sqlite3@11.10.0:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"
 
-better-sqlite3@12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.2.0.tgz#de7c3466074f2d1a5d260f510647e822e42684d2"
-  integrity sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==
+better-sqlite3@12.6.2:
+  version "12.6.2"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.6.2.tgz#770649f28a62e543a360f3dfa1afe4cc944b1937"
+  integrity sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump better-sqlite3 from 12.2.0 to 12.6.2 across core and desktop packages to improve stability and keep native bindings up to date.

- **Dependencies**
  - Updated better-sqlite3 to 12.6.2 in packages/core, packages/desktop-activity, and packages/desktop-lib.
  - Regenerated yarn.lock.

- **Migration**
  - Reinstall dependencies and rebuild native modules for Electron builds if needed.

<sup>Written for commit e85fd8b8c2d6039f1f8df2ac941d89fefdbfcc43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

