### PR TITLE
Merge pull request #9425 from ever-co/fix/desktop-timer-stopping-timer

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -832,7 +832,8 @@
 		"reencoded",
 		"retryable",
 		"Retryable",
-		"pendings"
+		"pendings",
+		"SICO"
 	],
 	"useGitignore": true,
 	"ignorePaths": [

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -162,6 +162,7 @@ export * from './lib/camshot.model';
 export * from './lib/clone.model';
 export * from './lib/soundshot.model';
 export * from './lib/zapier.model';
+export * from './lib/desktop-timer.model';
 
 export {
 	ActorTypeEnum,

--- a/packages/contracts/src/lib/desktop-timer.model.ts
+++ b/packages/contracts/src/lib/desktop-timer.model.ts
@@ -1,0 +1,11 @@
+export enum TimerActionTypeEnum {
+	START_TIMER = 'startTimer',
+	STOP_TIMER = 'stopTimer'
+}
+
+export enum TimerSyncStateEnum {
+	PENDING = 'pending',
+	SYNCING = 'syncing',
+	SYNCED = 'synced',
+	FAILED = 'failed'
+}

--- a/packages/desktop-lib/src/lib/clean-timer.ts
+++ b/packages/desktop-lib/src/lib/clean-timer.ts
@@ -1,0 +1,31 @@
+import { ipcMain } from 'electron';
+import { TimerService, TimerTO, Timer } from './offline/index';
+export class CleanTimer {
+	private static instance: CleanTimer;
+	readonly timerService: TimerService;
+
+	private constructor() {
+		this.timerService = new TimerService();
+		ipcMain.handle('check-unfinished-sync', async () => {
+			const unfinishedSyncTimers = await this.timerService.findUnfinishedSync();
+			return unfinishedSyncTimers;
+		});
+
+		ipcMain.handle('set-to-offline', async (_, arg: TimerTO[]) => {
+			for (const timer of arg) {
+				await this.timerService.update(new Timer({
+					id: timer.id,
+					synced: false,
+					isStoppedOffline: true
+				}));
+			}
+		});
+	}
+
+	static getInstance(): CleanTimer {
+		if (!CleanTimer.instance) {
+			CleanTimer.instance = new CleanTimer();
+		}
+		return CleanTimer.instance;
+	}
+}

--- a/packages/desktop-lib/src/lib/offline/dao/timer.dao.ts
+++ b/packages/desktop-lib/src/lib/offline/dao/timer.dao.ts
@@ -10,8 +10,9 @@ import {
 	TABLE_NAME_INTERVALS,
 	TimerTO,
 	UserTO,
-	IntervalTO,
+	IntervalTO
 } from '../dto';
+import { TimerSyncStateEnum } from '@gauzy/contracts';
 import { TimerTransaction } from '../transactions';
 import { IntervalDAO } from './interval.dao';
 
@@ -196,5 +197,17 @@ export class TimerDAO implements DAO<TimerTO> {
 					"(stoppedAt/1000 - startedAt/1000)"
 				)
 			});
+	}
+
+	public async findUnfinishedSync(user: UserTO): Promise<TimerTO[]> {
+		return await this._provider
+			.connection<TimerTO>(TABLE_NAME_TIMERS)
+			.where('employeeId', user.employeeId)
+			.andWhere((qb) =>
+				qb
+					.where('stopSyncState', TimerSyncStateEnum.SYNCING)
+					.orWhere('startSyncState', TimerSyncStateEnum.SYNCING)
+			)
+			.andWhere('synced', true);
 	}
 }

--- a/packages/desktop-lib/src/lib/offline/databases/migrations/20260201065620_alter-table-timer-sync-state.ts
+++ b/packages/desktop-lib/src/lib/offline/databases/migrations/20260201065620_alter-table-timer-sync-state.ts
@@ -1,0 +1,24 @@
+import { Knex } from "knex";
+import { TABLE_NAME_TIMERS } from "../../dto";
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable(
+		TABLE_NAME_TIMERS,
+		(table: Knex.TableBuilder) => {
+			table.string('startSyncState').nullable();
+			table.string('stopSyncState').nullable();
+			table.integer('syncDuration').nullable();
+		}
+	);
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable(
+		TABLE_NAME_TIMERS,
+		(table: Knex.TableBuilder) => {
+			table.dropColumn('startSyncState');
+			table.dropColumn('stopSyncState');
+			table.dropColumn('syncDuration');
+		}
+	);
+}

--- a/packages/desktop-lib/src/lib/offline/dto/timer.dto.ts
+++ b/packages/desktop-lib/src/lib/offline/dto/timer.dto.ts
@@ -1,3 +1,5 @@
+import { TimerSyncStateEnum } from '@gauzy/contracts';
+
 export interface TimerTO {
 	id?: number;
 	day?: Date;
@@ -16,6 +18,9 @@ export interface TimerTO {
 	version?: string;
 	organizationTeamId?: string;
 	description?: string;
+	startSyncState?: TimerSyncStateEnum;
+	stopSyncState?: TimerSyncStateEnum;
+	syncDuration?: number;
 }
 
 export const TABLE_NAME_TIMERS: string = 'timers';

--- a/packages/desktop-lib/src/lib/offline/models/timer.model.ts
+++ b/packages/desktop-lib/src/lib/offline/models/timer.model.ts
@@ -1,5 +1,6 @@
 import { Serializable } from '../../interfaces';
 import { TimerTO } from '../dto';
+import { TimerSyncStateEnum } from '@gauzy/contracts';
 
 export class Timer implements TimerTO, Serializable<TimerTO> {
 	private _id?: number;
@@ -19,6 +20,9 @@ export class Timer implements TimerTO, Serializable<TimerTO> {
 	private _version: string;
 	private _organizationTeamId: string;
 	private _description: string;
+	private _startSyncState: TimerSyncStateEnum;
+	private _stopSyncState: TimerSyncStateEnum;
+	private _syncDuration: number;
 
 	constructor(timer: TimerTO) {
 		this._id = timer.id;
@@ -37,7 +41,10 @@ export class Timer implements TimerTO, Serializable<TimerTO> {
 		this._isStoppedOffline = timer.isStoppedOffline;
 		this._version = timer.version;
 		this._organizationTeamId = timer.organizationTeamId;
-		this._description  = timer.description;
+		this._description = timer.description;
+		this._startSyncState = timer.startSyncState;
+		this._stopSyncState = timer.stopSyncState;
+		this._syncDuration = timer.syncDuration;
 	}
 
 	public get isStoppedOffline(): boolean {
@@ -154,6 +161,30 @@ export class Timer implements TimerTO, Serializable<TimerTO> {
 		this._description = value;
 	}
 
+	public get startSyncState(): TimerSyncStateEnum {
+		return this._startSyncState;
+	}
+
+	public set startSyncState(value: TimerSyncStateEnum) {
+		this._startSyncState = value;
+	}
+
+	public get stopSyncState(): TimerSyncStateEnum {
+		return this._stopSyncState;
+	}
+
+	public set stopSyncState(value: TimerSyncStateEnum) {
+		this._stopSyncState = value;
+	}
+
+	public get syncDuration(): number {
+		return this._syncDuration;
+	}
+
+	public set syncDuration(value: number) {
+		this._syncDuration = value;
+	}
+
 	public toObject(): TimerTO {
 		return {
 			day: this._day,
@@ -171,7 +202,10 @@ export class Timer implements TimerTO, Serializable<TimerTO> {
 			isStoppedOffline: this._isStoppedOffline,
 			version: this._version,
 			organizationTeamId: this._organizationTeamId,
-			description: this._description
+			description: this._description,
+			startSyncState: this._startSyncState,
+			stopSyncState: this._stopSyncState,
+			syncDuration: this._syncDuration
 		};
 	}
 }

--- a/packages/desktop-lib/src/lib/offline/services/timer.service.ts
+++ b/packages/desktop-lib/src/lib/offline/services/timer.service.ts
@@ -153,4 +153,18 @@ export class TimerService implements ITimerService<TimerTO> {
 			return 0;
 		}
 	}
+
+	public async findUnfinishedSync(): Promise<TimerTO[]> {
+		try {
+			const user = await this._userService.retrieve();
+			if (user && user.employeeId) {
+				return await this._timerDAO.findUnfinishedSync(user);
+			} else {
+				return [];
+			}
+		} catch (error) {
+			console.error('Failed to get unfinished sync timer');
+			return [];
+		}
+	}
 }

--- a/packages/desktop-ui-lib/src/lib/interceptors/unauthorized.interceptor.ts
+++ b/packages/desktop-ui-lib/src/lib/interceptors/unauthorized.interceptor.ts
@@ -16,7 +16,7 @@ export class UnauthorizedInterceptor implements HttpInterceptor {
 		private router: Router,
 		private store: Store,
 		private _errorMapping: ErrorMapping
-	) {}
+	) { }
 
 	intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 		return next.handle(request).pipe(
@@ -52,7 +52,7 @@ export class UnauthorizedInterceptor implements HttpInterceptor {
 					}
 				}
 
-				return throwError(() => new Error(this._errorMapping.mapErrorMessage(error)));
+				return throwError(() => error);
 			})
 		);
 	}


### PR DESCRIPTION
Fix/desktop timer stopping timer

# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop timer “stuck/stopping” issues by tracking start/stop sync state end-to-end and guarding transitions in the UI. Improves reliability of online/offline sync and prevents duplicate API calls.

- **New Features**
  - Added start/stop sync state and syncDuration per timer (pending/syncing/synced/failed).
  - New IPC channel UPDATE_SYNC_STATE to persist sync progress from UI/queue to the main process.
  - CleanTimer utility with IPC handlers to detect unfinished sync and mark timers offline when needed.
  - Local DB migration: adds startSyncState, stopSyncState, syncDuration columns.

- **Bug Fixes**
  - Block start/stop while in transitional ignition states (STARTING/STOPPING/RESTARTING) and when the queue is active.
  - Sequence queue now marks timers SYNCED after successful start/stop and stores stop duration.
  - UI sets SYNCING/SYNCED/FAILED states around API calls, ensuring proper recovery on errors.
  - More consistent error handling during token refresh to avoid hidden failures.

<sup>Written for commit ccfff815a3a12e8003448f4688a9607a94f97814. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

