### PR TITLE
fix: avoid circular dependecies

### DIFF
--- a/apps/desktop-timer/src/main.ts
+++ b/apps/desktop-timer/src/main.ts
@@ -191,11 +191,12 @@ bootstrapApplication(AppComponent, {
 			useClass: ErrorHandlerService
 		},
 		provideAppInitializer(() => {
+			const injector = inject(Injector);
 			const initializerFn = serverConnectionFactory(
-				inject(ServerConnectionService),
-				inject(Store),
-				inject(Router),
-				inject(Injector)
+				injector.get(ServerConnectionService),
+				injector.get(Store),
+				injector.get(Router),
+				injector
 			);
 			return initializerFn();
 		}),

--- a/packages/desktop-ui-lib/src/lib/auth/services/auth.service.ts
+++ b/packages/desktop-ui-lib/src/lib/auth/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
+import { Inject, Injectable, Injector } from '@angular/core';
 import {
 	IAuthResponse,
 	IUser,
@@ -20,12 +20,21 @@ import { ElectronService } from '../../electron/services';
 
 @Injectable()
 export class AuthService {
+	private _http: HttpClient;
+
 	constructor(
-		private http: HttpClient,
+		private readonly injector: Injector,
 		private readonly electronService: ElectronService,
 		@Inject(GAUZY_ENV)
 		private readonly _environment: any
 	) {}
+
+	private get http(): HttpClient {
+		if (!this._http) {
+			this._http = this.injector.get(HttpClient);
+		}
+		return this._http;
+	}
 
 	isAuthenticated(): Promise<boolean> {
 		return firstValueFrom(this.http.get<boolean>(`${API_PREFIX}/auth/authenticated`));

--- a/packages/desktop-ui-lib/src/lib/interceptors/language.interceptor.ts
+++ b/packages/desktop-ui-lib/src/lib/interceptors/language.interceptor.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Store } from './../services/store.service';
@@ -7,25 +7,44 @@ import { LanguagesEnum } from '@gauzy/contracts';
 
 @Injectable()
 export class LanguageInterceptor implements HttpInterceptor {
-	constructor(
-		private _store: Store,
-		private _translateService: TranslateService
-	) { }
+	private _translateService: TranslateService;
 
-	intercept(
-		request: HttpRequest<any>,
-		next: HttpHandler
-	): Observable<HttpEvent<any>> {
+	constructor(private _store: Store, private _injector: Injector) {}
+
+	intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+		// Skip this interceptor for translation file requests to avoid circular dependency
+		// Translation files don't need the Language header anyway
+		if (this.isTranslationRequest(request.url)) {
+			return next.handle(request);
+		}
+
+		// Lazy-load TranslateService to avoid circular dependency
+		if (!this._translateService) {
+			try {
+				this._translateService = this._injector.get(TranslateService);
+			} catch (error) {
+				// TranslateService not available yet, skip adding Language header
+				return next.handle(request);
+			}
+		}
+
 		const language: LanguagesEnum =
 			this._store && this._store.preferredLanguage
 				? this._store.preferredLanguage
-				: this._translateService.getBrowserLang();
+				: this._translateService?.getBrowserLang() || LanguagesEnum.ENGLISH;
+
 		request = request.clone({
 			setHeaders: {
-				Language: language,
-			},
+				Language: language
+			}
 		});
 
 		return next.handle(request);
+	}
+
+	private isTranslationRequest(url: string): boolean {
+		// Check if this is a request for translation files
+		// Translation files are typically loaded from /assets/i18n/*.json
+		return url.includes('/assets/i18n/') || (url.includes('/i18n/') && url.endsWith('.json'));
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/interceptors/refresh-token.interceptor.ts
+++ b/packages/desktop-ui-lib/src/lib/interceptors/refresh-token.interceptor.ts
@@ -6,7 +6,7 @@ import {
 	HttpRequest,
 	HttpStatusCode
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { NbAuthResult } from '@nebular/auth';
 import { BehaviorSubject, Observable, throwError } from 'rxjs';
 import { catchError, filter, finalize, switchMap, take } from 'rxjs/operators';
@@ -16,18 +16,20 @@ import { Store, ErrorMapping } from '../services';
 
 /**
  * Interceptor that handles automatic token refresh when receiving 401 Unauthorized responses.
+ * Uses lazy injection of AuthStrategy to avoid circular dependency issues.
  * */
 
 @Injectable()
 export class RefreshTokenInterceptor implements HttpInterceptor {
 	private isRefreshing = false;
 	private refreshTokenSubject: BehaviorSubject<string | null> = new BehaviorSubject<string | null>(null);
+	private authStrategy: AuthStrategy;
 
 	constructor(
-		private readonly authStrategy: AuthStrategy,
+		private readonly injector: Injector,
 		private readonly store: Store,
 		private _errorMapping: ErrorMapping
-	) { }
+	) {}
 
 	intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 		return next.handle(request).pipe(
@@ -62,6 +64,11 @@ export class RefreshTokenInterceptor implements HttpInterceptor {
 			if (!refreshToken) {
 				this.isRefreshing = false;
 				return throwError(() => new Error('No refresh token available'));
+			}
+
+			// Lazy-load AuthStrategy to avoid circular dependency
+			if (!this.authStrategy) {
+				this.authStrategy = this.injector.get(AuthStrategy);
 			}
 
 			return this.authStrategy.refreshToken().pipe(

--- a/packages/desktop-ui-lib/src/lib/interceptors/unauthorized.interceptor.ts
+++ b/packages/desktop-ui-lib/src/lib/interceptors/unauthorized.interceptor.ts
@@ -1,5 +1,5 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpStatusCode } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { Router } from '@angular/router';
 import { concatMap, Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -10,13 +10,15 @@ import { ErrorMapping, Store } from '../services';
 
 @Injectable()
 export class UnauthorizedInterceptor implements HttpInterceptor {
+	private authStrategy: AuthStrategy;
+
 	constructor(
-		private authStrategy: AuthStrategy,
+		private injector: Injector,
 		private electronService: ElectronService,
 		private router: Router,
 		private store: Store,
 		private _errorMapping: ErrorMapping
-	) { }
+	) {}
 
 	intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 		return next.handle(request).pipe(
@@ -39,6 +41,11 @@ export class UnauthorizedInterceptor implements HttpInterceptor {
 					// Only force logout if it's an auth endpoint failure or no refresh token
 					// The RefreshTokenInterceptor will handle other 401s
 					if (isAuthEndpoint || !hasRefreshToken) {
+						// Lazy-load AuthStrategy to avoid circular dependency
+						if (!this.authStrategy) {
+							this.authStrategy = this.injector.get(AuthStrategy);
+						}
+
 						// Log out the user
 						this.authStrategy.logout();
 						// logout from desktop

--- a/packages/desktop-ui-lib/src/lib/language/language.module.ts
+++ b/packages/desktop-ui-lib/src/lib/language/language.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders, NgModule, provideAppInitializer, inject } from '@angular/core';
+import { ModuleWithProviders, NgModule, APP_INITIALIZER } from '@angular/core';
 import { NbSelectModule } from '@nebular/theme';
 import { I18nModule } from '@gauzy/ui-core/i18n';
 import { TranslateService } from '@ngx-translate/core';
@@ -26,10 +26,14 @@ export class LanguageModule {
 				Store,
 				LanguageSelectorService,
 				LanguageElectronService,
-				provideAppInitializer(() => {
-					const initializerFn = LanguageInitializerFactory(inject(TranslateService), inject(ElectronService));
-					return initializerFn();
-				})
+				{
+					provide: APP_INITIALIZER,
+					useFactory: (translateService: TranslateService, electronService: ElectronService) => {
+						return LanguageInitializerFactory(translateService, electronService);
+					},
+					deps: [TranslateService, ElectronService],
+					multi: true
+				}
 			]
 		};
 	}

--- a/packages/desktop-ui-lib/src/lib/services/error-mapping.service.ts
+++ b/packages/desktop-ui-lib/src/lib/services/error-mapping.service.ts
@@ -1,16 +1,24 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 @Injectable({
 	providedIn: 'root',
 })
 export class ErrorMapping {
+	private _translateService: TranslateService;
+
 	constructor(
-		private readonly _translateService: TranslateService
-	) {}
+		private readonly injector: Injector
+	) { }
 	public mapErrorMessage(error: HttpErrorResponse): string {
+		if (!this._translateService) {
+			this._translateService = this.injector.get(TranslateService);
+		}
+
 		if (error.error instanceof ErrorEvent) {
-			return this._translateService.instant('TIMER_TRACKER.TOASTR.NETWORK_ERROR', { message: error.error.message });
+			return this._translateService.instant('TIMER_TRACKER.TOASTR.NETWORK_ERROR', {
+				message: error.error.message
+			});
 		}
 
 		switch (error.status) {
@@ -33,10 +41,12 @@ export class ErrorMapping {
 			case 503:
 				return this._translateService.instant('TIMER_TRACKER.TOASTR.SERVICE_UNAVAILABLE');
 			default:
-				return this.extractMessage(error, this._translateService.instant('TIMER_TRACKER.TOASTR.UNEXPECTED_ERROR'));
+				return this.extractMessage(
+					error,
+					this._translateService.instant('TIMER_TRACKER.TOASTR.UNEXPECTED_ERROR')
+				);
 		}
 	}
-
 
 	private extractMessage(error: HttpErrorResponse, fallback: string): string {
 		if (error.error?.message) return error.error.message;


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes circular dependency crashes that broke the desktop timer UI after the ngx-translate v17 upgrade. Uses lazy injection and safer app initialization to stabilize auth, language, and error handling.

- **Bug Fixes**
  - Lazy-load HttpClient in AuthService; TranslateService in LanguageInterceptor and ErrorMapping; AuthStrategy in RefreshToken and Unauthorized interceptors.
  - LanguageInterceptor skips requests for i18n JSON files and falls back to English when needed.
  - Replace provideAppInitializer with APP_INITIALIZER in LanguageModule; use Injector in main bootstrap initializer to avoid early injection.
  - Keep token refresh and 401 handling stable without forcing unintended logouts.

<sup>Written for commit 5fc4afbc10492a28cfbcb02b4860b6039889fda6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

