### PR TITLE
[Feat(auth)] Return new refresh token along with access token on refresh

### DIFF
--- a/packages/core/src/lib/auth/auth.controller.ts
+++ b/packages/core/src/lib/auth/auth.controller.ts
@@ -1,18 +1,4 @@
-import {
-	Controller,
-	Post,
-	HttpStatus,
-	HttpCode,
-	Body,
-	Get,
-	Headers,
-	Query,
-	UseGuards,
-	BadRequestException
-} from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiOkResponse, ApiBadRequestResponse } from '@nestjs/swagger';
-import { CommandBus } from '@nestjs/cqrs';
-import { I18nLang } from 'nestjs-i18n';
+import { Public } from '@gauzy/common';
 import {
 	IAuthResponse,
 	ISocialAccount,
@@ -21,31 +7,45 @@ import {
 	LanguagesEnum,
 	PermissionsEnum
 } from '@gauzy/contracts';
-import { Public } from '@gauzy/common';
 import { parseToBoolean } from '@gauzy/utils';
-import { AuthService } from './auth.service';
+import {
+	BadRequestException,
+	Body,
+	Controller,
+	Get,
+	Headers,
+	HttpCode,
+	HttpStatus,
+	Post,
+	Query,
+	UseGuards
+} from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import { ApiBadRequestResponse, ApiOkResponse, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { I18nLang } from 'nestjs-i18n';
+import { RequestContext } from '../core/context';
+import { UseValidationPipe } from '../shared/pipes';
 import { User as IUser } from '../user/user.entity';
+import { ChangePasswordRequestDTO, ResetPasswordRequestDTO } from './../password-reset/dto';
+import { Permissions } from './../shared/decorators';
+import { AuthRefreshGuard, PermissionGuard, TenantPermissionGuard } from './../shared/guards';
+import { RegisterUserDTO, UserEmailDTO, UserLoginDTO, UserSigninWorkspaceDTO } from './../user/dto';
+import { UserService } from './../user/user.service';
+import { AuthService } from './auth.service';
 import {
 	AuthLoginCommand,
 	AuthRegisterCommand,
 	WorkspaceSigninSendCodeCommand,
 	WorkspaceSigninVerifyTokenCommand
 } from './commands';
-import { RequestContext } from '../core/context';
-import { AuthRefreshGuard, PermissionGuard, TenantPermissionGuard } from './../shared/guards';
-import { Permissions } from './../shared/decorators';
-import { UseValidationPipe } from '../shared/pipes';
-import { ChangePasswordRequestDTO, ResetPasswordRequestDTO } from './../password-reset/dto';
-import { RegisterUserDTO, UserEmailDTO, UserLoginDTO, UserSigninWorkspaceDTO } from './../user/dto';
-import { UserService } from './../user/user.service';
 import {
 	HasPermissionsQueryDTO,
 	HasRoleQueryDTO,
 	RefreshTokenDto,
-	WorkspaceSigninEmailVerifyDTO,
-	WorkspaceSigninDTO,
 	SwitchOrganizationDTO,
-	SwitchWorkspaceDTO
+	SwitchWorkspaceDTO,
+	WorkspaceSigninDTO,
+	WorkspaceSigninEmailVerifyDTO
 } from './dto';
 import { FindUserBySocialLoginDTO, SocialLoginBodyRequestDTO } from './social-account/dto';
 
@@ -304,7 +304,7 @@ export class AuthController {
 	@UseGuards(AuthRefreshGuard)
 	@Post('/refresh-token')
 	@UseValidationPipe()
-	async refreshToken(@Body() input: RefreshTokenDto): Promise<{ token: string } | null> {
+	async refreshToken(@Body() input: RefreshTokenDto): Promise<{ token: string; refresh_token: string } | null> {
 		return await this.authService.getAccessTokenFromRefreshToken();
 	}
 


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns a new refresh token along with the access token when calling /auth/refresh-token, enabling token rotation and better session security. Aligns with GP-780.

- **New Features**
  - /auth/refresh-token now returns { token, refresh_token }.
  - AuthService issues and persists a new refresh token on each refresh while keeping the current organization context.

- **Migration**
  - Update clients to read and store the new refresh_token from the refresh response.

<sup>Written for commit 86c2db16d1d2bbb58c4a43a08e4fa7c6afe0913b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

