### PR TITLE
fix(auth): update refresh token during authentication refresh

### DIFF
--- a/packages/ui-core/core/src/lib/interceptors/auth-refresh.interceptor.ts
+++ b/packages/ui-core/core/src/lib/interceptors/auth-refresh.interceptor.ts
@@ -63,6 +63,8 @@ export class AuthRefreshInterceptor implements HttpInterceptor {
 							if (response?.token) {
 								// Update the token in the store
 								this.store.token = response.token;
+								// Update refresh token
+								this.store.refresh_token = response.refresh_token;
 								// Emit the new token to all waiting requests
 								this.refreshTokenSubject.next(response.token);
 								return next.handle(this.addToken(req, response.token));
@@ -99,7 +101,7 @@ export class AuthRefreshInterceptor implements HttpInterceptor {
 	 * Refreshes the access token by calling the AuthService.
 	 * @returns An Observable that emits the response of the token refresh request.
 	 */
-	private refreshAccessToken(): Observable<{ token: string } | null> {
+	private refreshAccessToken(): Observable<{ token: string, refresh_token: string } | null> {
 		const refresh_token = this.store.refresh_token;
 
 		if (!refresh_token) {

--- a/packages/ui-core/core/src/lib/services/auth/auth.service.ts
+++ b/packages/ui-core/core/src/lib/services/auth/auth.service.ts
@@ -144,7 +144,7 @@ export class AuthService {
 	 * @param refresh_token
 	 * @returns
 	 */
-	refreshToken(refresh_token: string): Promise<{ token: string } | null> {
+	refreshToken(refresh_token: string): Promise<{ token: string, refresh_token: string } | null> {
 		return firstValueFrom(this.http.post<any>(`${API_PREFIX}/auth/refresh-token`, { refresh_token }));
 	}
 


### PR DESCRIPTION
Update the store with the new refresh token received from the refresh endpoint. This ensures that rotating refresh tokens are correctly persisted, preventing authentication sessions from expiring.

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist rotating refresh tokens during the auth refresh flow to prevent sessions from expiring after a token rotation.

- **Bug Fixes**
  - Update store with the new refresh_token from /auth/refresh-token and use it for subsequent refreshes.
  - Update AuthService and interceptor types to handle { token, refresh_token } responses.

<sup>Written for commit 702cf94a1e47581ed045bd52d6313e98d63726ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

Resolves #9439
