### PR TITLE
[FEAT] Extend OAuth2 app flow for reusability with other platforms (Activepieces --> Gauzy)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -236,6 +236,7 @@
 		"gauzymcpserver",
 		"gauzyprodsess",
 		"gauzyserver",
+		"GETDEL",
 		"GHCUP",
 		"GHCUP",
 		"gitmodules",

--- a/.env.compose
+++ b/.env.compose
@@ -224,6 +224,12 @@ GAUZY_ACTIVEPIECES_CLIENT_SECRET=
 GAUZY_ACTIVEPIECES_CALLBACK_URL="${API_BASE_URL}/api/integration/activepieces/callback"
 GAUZY_ACTIVEPIECES_POST_INSTALL_URL="${CLIENT_BASE_URL}/#/pages/integrations/activepieces/callback"
 
+# Gauzy OAuth2 App (Activepieces -> Gauzy)
+GAUZY_OAUTH_APP_CLIENT_ID=
+GAUZY_OAUTH_APP_CLIENT_SECRET=
+GAUZY_OAUTH_APP_CODE_SECRET=
+GAUZY_OAUTH_APP_REDIRECT_URIS="http://localhost:4200/redirect,https://cloud.activepieces.com/redirect"
+
 # File System: LOCAL | S3 | WASABI | CLOUDINARY
 FILE_PROVIDER=LOCAL
 

--- a/.env.demo.compose
+++ b/.env.demo.compose
@@ -226,6 +226,12 @@ GAUZY_ACTIVEPIECES_CLIENT_SECRET=
 GAUZY_ACTIVEPIECES_CALLBACK_URL="${API_BASE_URL}/api/integration/activepieces/callback"
 GAUZY_ACTIVEPIECES_POST_INSTALL_URL="${CLIENT_BASE_URL}/#/pages/integrations/activepieces/callback"
 
+# Gauzy OAuth2 App (Activepieces -> Gauzy)
+GAUZY_OAUTH_APP_CLIENT_ID=
+GAUZY_OAUTH_APP_CLIENT_SECRET=
+GAUZY_OAUTH_APP_CODE_SECRET=
+GAUZY_OAUTH_APP_REDIRECT_URIS="http://localhost:4200/redirect,https://cloud.activepieces.com/redirect"
+
 # File System: LOCAL | S3 | WASABI | CLOUDINARY
 FILE_PROVIDER=LOCAL
 

--- a/.env.docker
+++ b/.env.docker
@@ -217,6 +217,12 @@ GAUZY_ACTIVEPIECES_CLIENT_SECRET=
 GAUZY_ACTIVEPIECES_CALLBACK_URL="${API_BASE_URL}/api/integration/activepieces/callback"
 GAUZY_ACTIVEPIECES_POST_INSTALL_URL="${CLIENT_BASE_URL}/#/pages/integrations/activepieces/callback"
 
+# Gauzy OAuth2 App (Activepieces -> Gauzy)
+GAUZY_OAUTH_APP_CLIENT_ID=
+GAUZY_OAUTH_APP_CLIENT_SECRET=
+GAUZY_OAUTH_APP_CODE_SECRET=
+GAUZY_OAUTH_APP_REDIRECT_URIS="http://localhost:4200/redirect,https://cloud.activepieces.com/redirect"
+
 # File System: LOCAL | S3 | WASABI | CLOUDINARY
 FILE_PROVIDER=LOCAL
 

--- a/.env.local
+++ b/.env.local
@@ -220,6 +220,12 @@ GAUZY_ACTIVEPIECES_CLIENT_SECRET=
 GAUZY_ACTIVEPIECES_CALLBACK_URL="${API_BASE_URL}/api/integration/activepieces/callback"
 GAUZY_ACTIVEPIECES_POST_INSTALL_URL="${CLIENT_BASE_URL}/#/pages/integrations/activepieces/callback"
 
+# Gauzy OAuth2 App (Activepieces -> Gauzy)
+GAUZY_OAUTH_APP_CLIENT_ID=
+GAUZY_OAUTH_APP_CLIENT_SECRET=
+GAUZY_OAUTH_APP_CODE_SECRET=
+GAUZY_OAUTH_APP_REDIRECT_URIS="http://localhost:4200/redirect,https://cloud.activepieces.com/redirect"
+
 # File System: LOCAL | S3 | WASABI | CLOUDINARY
 FILE_PROVIDER=LOCAL
 

--- a/.env.sample
+++ b/.env.sample
@@ -39,6 +39,11 @@ GAUZY_ACTIVEPIECES_CLIENT_SECRET=
 GAUZY_ACTIVEPIECES_CALLBACK_URL="${API_BASE_URL}/api/integration/activepieces/callback"
 GAUZY_ACTIVEPIECES_POST_INSTALL_URL="${CLIENT_BASE_URL}/#/pages/integrations/activepieces/callback"
 
+# Gauzy OAuth2 App (Activepieces -> Gauzy)
+GAUZY_OAUTH_APP_CLIENT_ID=
+GAUZY_OAUTH_APP_CLIENT_SECRET=
+GAUZY_OAUTH_APP_CODE_SECRET=
+GAUZY_OAUTH_APP_REDIRECT_URIS="http://localhost:4200/redirect,https://cloud.activepieces.com/redirect"
 
 # Set true if running as a Demo
 DEMO=false

--- a/packages/auth/src/lib/auth0/auth0.controller.ts
+++ b/packages/auth/src/lib/auth0/auth0.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, HttpException, HttpStatus, Req, Res, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Response, Request } from 'express';
 import { Public } from '@gauzy/common';
@@ -27,8 +27,53 @@ export class Auth0Controller {
 	 * @returns {Promise<void>} - A promise that resolves after redirecting the user.
 	 */
 	@Get('/auth0/callback')
-	async auth0LoginCallback(@RequestCtx() context: IIncomingRequest, @Res() res: Response): Promise<any> {
+	async auth0LoginCallback(
+		@RequestCtx() context: IIncomingRequest,
+		@Req() req: Request,
+		@Res() res: Response
+	): Promise<any> {
 		const { user } = context;
+
+		const session = (req as any).session;
+		const oauthRequest = session?.oauthApp as
+			| { clientId: string; redirectUri: string; scope?: string; state?: string }
+			| undefined;
+
+		if (oauthRequest) {
+			const oauthUser = await this.service.getOAuthLoginUser(user.emails);
+			if (!oauthUser) {
+				const errorParams = new URLSearchParams({
+					error: 'access_denied',
+					...(oauthRequest.state ? { state: oauthRequest.state } : {})
+				});
+				const redirectUrl = `${oauthRequest.redirectUri}?${errorParams.toString()}`;
+				session.oauthApp = undefined;
+				return res.redirect(redirectUrl);
+			}
+
+			try {
+				const code = await this.service.createOAuthAppAuthorizationCode({
+					userId: oauthUser.id,
+					tenantId: oauthUser.tenantId,
+					clientId: oauthRequest.clientId,
+					redirectUri: oauthRequest.redirectUri,
+					scope: oauthRequest.scope,
+					state: oauthRequest.state
+				});
+
+				const params = new URLSearchParams({
+					code,
+					...(oauthRequest.state ? { state: oauthRequest.state } : {})
+				});
+
+				const redirectUrl = `${oauthRequest.redirectUri}?${params.toString()}`;
+				session.oauthApp = undefined;
+				return res.redirect(redirectUrl);
+			} catch (error: any) {
+				throw new HttpException(error?.message || 'OAuth authorization failed', HttpStatus.INTERNAL_SERVER_ERROR);
+			}
+		}
+
 		const { success, authData } = await this.service.validateOAuthLoginEmail(user.emails);
 		return this.service.routeRedirect(success, authData, res);
 	}

--- a/packages/auth/src/lib/auth0/auth0.controller.ts
+++ b/packages/auth/src/lib/auth0/auth0.controller.ts
@@ -38,15 +38,21 @@ export class Auth0Controller {
 		const oauthRequest = session?.oauthApp as OAuthAppSessionData | undefined;
 
 		if (oauthRequest) {
+			// Always clear OAuth session data before any redirect to prevent replay
+			session.oauthApp = undefined;
+
+			// Re-validate redirect_uri against the allowlist (defense-in-depth against session tampering)
+			if (!this.service.isOAuthAppRedirectUriAllowed(oauthRequest.redirectUri)) {
+				throw new HttpException('Invalid redirect_uri', HttpStatus.BAD_REQUEST);
+			}
+
 			const oauthUser = await this.service.getOAuthLoginUser(user.emails);
 			if (!oauthUser) {
 				const errorParams = new URLSearchParams({
 					error: 'access_denied',
 					...(oauthRequest.state ? { state: oauthRequest.state } : {})
 				});
-				const redirectUrl = `${oauthRequest.redirectUri}?${errorParams.toString()}`;
-				session.oauthApp = undefined;
-				return res.redirect(redirectUrl);
+				return res.redirect(`${oauthRequest.redirectUri}?${errorParams.toString()}`);
 			}
 
 			try {
@@ -63,18 +69,13 @@ export class Auth0Controller {
 					code,
 					...(oauthRequest.state ? { state: oauthRequest.state } : {})
 				});
-
-				const redirectUrl = `${oauthRequest.redirectUri}?${params.toString()}`;
-				session.oauthApp = undefined;
-				return res.redirect(redirectUrl);
+				return res.redirect(`${oauthRequest.redirectUri}?${params.toString()}`);
 			} catch (error: any) {
 				const errorParams = new URLSearchParams({
 					error: 'server_error',
 					...(oauthRequest.state ? { state: oauthRequest.state } : {})
 				});
-				const redirectUrl = `${oauthRequest.redirectUri}?${errorParams.toString()}`;
-				session.oauthApp = undefined;
-				return res.redirect(redirectUrl);
+				return res.redirect(`${oauthRequest.redirectUri}?${errorParams.toString()}`);
 			}
 		}
 

--- a/packages/auth/src/lib/auth0/auth0.controller.ts
+++ b/packages/auth/src/lib/auth0/auth0.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, HttpException, HttpStatus, Req, Res, UseGuards } from 
 import { AuthGuard } from '@nestjs/passport';
 import { Response, Request } from 'express';
 import { Public } from '@gauzy/common';
-import { SocialAuthService } from './../social-auth.service';
+import { OAuthAppSessionData, SocialAuthService } from './../social-auth.service';
 import { IIncomingRequest, RequestCtx } from './../request-context.decorator';
 
 @UseGuards(AuthGuard('auth0'))
@@ -35,9 +35,7 @@ export class Auth0Controller {
 		const { user } = context;
 
 		const session = (req as any).session;
-		const oauthRequest = session?.oauthApp as
-			| { clientId: string; redirectUri: string; scope?: string; state?: string }
-			| undefined;
+		const oauthRequest = session?.oauthApp as OAuthAppSessionData | undefined;
 
 		if (oauthRequest) {
 			const oauthUser = await this.service.getOAuthLoginUser(user.emails);
@@ -70,7 +68,13 @@ export class Auth0Controller {
 				session.oauthApp = undefined;
 				return res.redirect(redirectUrl);
 			} catch (error: any) {
-				throw new HttpException(error?.message || 'OAuth authorization failed', HttpStatus.INTERNAL_SERVER_ERROR);
+				const errorParams = new URLSearchParams({
+					error: 'server_error',
+					...(oauthRequest.state ? { state: oauthRequest.state } : {})
+				});
+				const redirectUrl = `${oauthRequest.redirectUri}?${errorParams.toString()}`;
+				session.oauthApp = undefined;
+				return res.redirect(redirectUrl);
 			}
 		}
 

--- a/packages/auth/src/lib/auth0/auth0.controller.ts
+++ b/packages/auth/src/lib/auth0/auth0.controller.ts
@@ -38,24 +38,32 @@ export class Auth0Controller {
 		const oauthRequest = session?.oauthApp as OAuthAppSessionData | undefined;
 
 		if (oauthRequest) {
-			// Always clear OAuth session data before any redirect to prevent replay
-			session.oauthApp = undefined;
+			// Regenerate the session to prevent session fixation and clear OAuth
+			// state atomically. The old session (including oauthApp) is destroyed
+			// and a new session ID is issued. We already captured oauthRequest above.
+			try {
+				await new Promise<void>((resolve, reject) => {
+					session.regenerate((err: any) => (err ? reject(err) : resolve()));
+				});
+			} catch {
+				throw new HttpException('Failed to initialize secure session', HttpStatus.INTERNAL_SERVER_ERROR);
+			}
 
 			// Re-validate redirect_uri against the allowlist (defense-in-depth against session tampering)
 			if (!this.service.isOAuthAppRedirectUriAllowed(oauthRequest.redirectUri)) {
 				throw new HttpException('Invalid redirect_uri', HttpStatus.BAD_REQUEST);
 			}
 
-			const oauthUser = await this.service.getOAuthLoginUser(user.emails);
-			if (!oauthUser) {
-				const errorParams = new URLSearchParams({
-					error: 'access_denied',
-					...(oauthRequest.state ? { state: oauthRequest.state } : {})
-				});
-				return res.redirect(`${oauthRequest.redirectUri}?${errorParams.toString()}`);
-			}
-
 			try {
+				const oauthUser = await this.service.getOAuthLoginUser(user.emails);
+				if (!oauthUser) {
+					const errorParams = new URLSearchParams({
+						error: 'access_denied',
+						...(oauthRequest.state ? { state: oauthRequest.state } : {})
+					});
+					return res.redirect(`${oauthRequest.redirectUri}?${errorParams.toString()}`);
+				}
+
 				const code = await this.service.createOAuthAppAuthorizationCode({
 					userId: oauthUser.id,
 					tenantId: oauthUser.tenantId,

--- a/packages/auth/src/lib/internal.ts
+++ b/packages/auth/src/lib/internal.ts
@@ -7,6 +7,7 @@ import { KeycloakStrategy, KeycloakAuthGuard } from './keycloak';
 import { LinkedinStrategy, LinkedinController } from './linkedin';
 import { MicrosoftStrategy, MicrosoftController, MicrosoftAuthGuard } from './microsoft';
 import { TwitterStrategy, TwitterController } from './twitter';
+import { OAuthAppController } from './oauth-app';
 
 export const Strategies = [
 	Auth0Strategy,
@@ -27,7 +28,8 @@ export const Controllers = [
 	GoogleController,
 	LinkedinController,
 	TwitterController,
-	MicrosoftController
+	MicrosoftController,
+	OAuthAppController
 ];
 
 export const AuthGuards = [MicrosoftAuthGuard, KeycloakAuthGuard];

--- a/packages/auth/src/lib/oauth-app/index.ts
+++ b/packages/auth/src/lib/oauth-app/index.ts
@@ -1,0 +1,1 @@
+export * from './oauth-app.controller';

--- a/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
+++ b/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
@@ -1,7 +1,7 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Post, Query, Req, Res } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Logger, Post, Query, Req, Res } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { Public } from '@gauzy/common';
-import { SocialAuthService } from '../social-auth.service';
+import { OAuthAppSessionData, SocialAuthService } from '../social-auth.service';
 
 interface OAuthAppAuthorizeQuery {
 	client_id?: string;
@@ -22,6 +22,8 @@ interface OAuthAppTokenRequest {
 @Public()
 @Controller('/integration/ever-gauzy/oauth')
 export class OAuthAppController {
+	private readonly logger = new Logger(OAuthAppController.name);
+
 	constructor(private readonly service: SocialAuthService) {}
 
 	@Get('/authorize')
@@ -57,12 +59,13 @@ export class OAuthAppController {
 			throw new HttpException('OAuth session is not available', HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 
-		session.oauthApp = {
+		const oauthAppSession: OAuthAppSessionData = {
 			clientId: query.client_id,
 			redirectUri: query.redirect_uri,
 			scope: query.scope,
 			state: query.state
 		};
+		session.oauthApp = oauthAppSession;
 
 		return res.redirect('/api/auth/auth0');
 	}
@@ -73,8 +76,8 @@ export class OAuthAppController {
 			throw new HttpException('Missing token request parameters', HttpStatus.BAD_REQUEST);
 		}
 
-		if (body.grant_type && body.grant_type !== 'authorization_code') {
-			throw new HttpException('Unsupported grant_type', HttpStatus.BAD_REQUEST);
+		if (!body.grant_type || body.grant_type !== 'authorization_code') {
+			throw new HttpException('Missing or unsupported grant_type', HttpStatus.BAD_REQUEST);
 		}
 
 		try {
@@ -92,7 +95,10 @@ export class OAuthAppController {
 				scope: token.scope
 			};
 		} catch (error: any) {
-			throw new HttpException(error?.message || 'OAuth token exchange failed', HttpStatus.BAD_REQUEST);
+			const message = error?.message || 'OAuth token exchange failed';
+			const isServerError = message.includes('not configured') || message.includes('not implemented');
+			const status = isServerError ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.BAD_REQUEST;
+			throw new HttpException(message, status);
 		}
 	}
 }

--- a/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
+++ b/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
@@ -103,7 +103,7 @@ export class OAuthAppController {
 			}
 
 			// Never forward raw error.message to the client to avoid leaking internals
-			throw new HttpException('OAuth token exchange failed', HttpStatus.BAD_REQUEST);
+			throw new HttpException('OAuth token exchange failed', HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
 }

--- a/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
+++ b/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
@@ -67,6 +67,12 @@ export class OAuthAppController {
 		};
 		session.oauthApp = oauthAppSession;
 
+		// Explicitly persist the session before redirecting to ensure async stores
+		// (e.g. Redis) finish writing before the browser follows the redirect.
+		await new Promise<void>((resolve, reject) => {
+			session.save((err: any) => (err ? reject(err) : resolve()));
+		});
+
 		return res.redirect('/api/auth/auth0');
 	}
 

--- a/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
+++ b/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
@@ -95,10 +95,15 @@ export class OAuthAppController {
 				scope: token.scope
 			};
 		} catch (error: any) {
-			const message = error?.message || 'OAuth token exchange failed';
-			const isServerError = message.includes('not configured') || message.includes('not implemented');
-			const status = isServerError ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.BAD_REQUEST;
-			throw new HttpException(message, status);
+			this.logger.error('OAuth token exchange failed', error?.stack);
+
+			// Re-throw NestJS HTTP exceptions (they already have safe messages)
+			if (error instanceof HttpException) {
+				throw error;
+			}
+
+			// Never forward raw error.message to the client to avoid leaking internals
+			throw new HttpException('OAuth token exchange failed', HttpStatus.BAD_REQUEST);
 		}
 	}
 }

--- a/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
+++ b/packages/auth/src/lib/oauth-app/oauth-app.controller.ts
@@ -1,0 +1,98 @@
+import { Body, Controller, Get, HttpException, HttpStatus, Post, Query, Req, Res } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { Public } from '@gauzy/common';
+import { SocialAuthService } from '../social-auth.service';
+
+interface OAuthAppAuthorizeQuery {
+	client_id?: string;
+	redirect_uri?: string;
+	response_type?: string;
+	scope?: string;
+	state?: string;
+}
+
+interface OAuthAppTokenRequest {
+	grant_type?: string;
+	code?: string;
+	client_id?: string;
+	client_secret?: string;
+	redirect_uri?: string;
+}
+
+@Public()
+@Controller('/integration/ever-gauzy/oauth')
+export class OAuthAppController {
+	constructor(private readonly service: SocialAuthService) {}
+
+	@Get('/authorize')
+	async authorize(
+		@Query() query: OAuthAppAuthorizeQuery,
+		@Req() req: Request,
+		@Res() res: Response
+	) {
+		const config = this.service.getOAuthAppConfig();
+
+		if (!config.clientId || !config.clientSecret || !config.redirectUris.length || !config.codeSecret) {
+			throw new HttpException('OAuth app is not configured', HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+
+		if (!query.client_id || !query.redirect_uri || !query.response_type) {
+			throw new HttpException('Missing OAuth parameters', HttpStatus.BAD_REQUEST);
+		}
+
+		if (query.response_type !== 'code') {
+			throw new HttpException('Unsupported response_type', HttpStatus.BAD_REQUEST);
+		}
+
+		if (query.client_id !== config.clientId) {
+			throw new HttpException('Invalid client_id', HttpStatus.BAD_REQUEST);
+		}
+
+		if (!this.service.isOAuthAppRedirectUriAllowed(query.redirect_uri, config)) {
+			throw new HttpException('Invalid redirect_uri', HttpStatus.BAD_REQUEST);
+		}
+
+		const session = (req as any).session;
+		if (!session) {
+			throw new HttpException('OAuth session is not available', HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+
+		session.oauthApp = {
+			clientId: query.client_id,
+			redirectUri: query.redirect_uri,
+			scope: query.scope,
+			state: query.state
+		};
+
+		return res.redirect('/api/auth/auth0');
+	}
+
+	@Post('/token')
+	async token(@Body() body: OAuthAppTokenRequest) {
+		if (!body.code || !body.client_id || !body.client_secret || !body.redirect_uri) {
+			throw new HttpException('Missing token request parameters', HttpStatus.BAD_REQUEST);
+		}
+
+		if (body.grant_type && body.grant_type !== 'authorization_code') {
+			throw new HttpException('Unsupported grant_type', HttpStatus.BAD_REQUEST);
+		}
+
+		try {
+			const token = await this.service.exchangeOAuthAppAuthorizationCode({
+				code: body.code,
+				clientId: body.client_id,
+				clientSecret: body.client_secret,
+				redirectUri: body.redirect_uri
+			});
+
+			return {
+				access_token: token.accessToken,
+				token_type: token.tokenType,
+				expires_in: token.expiresIn,
+				scope: token.scope
+			};
+		} catch (error: any) {
+			throw new HttpException(error?.message || 'OAuth token exchange failed', HttpStatus.BAD_REQUEST);
+		}
+	}
+}

--- a/packages/auth/src/lib/social-auth.service.ts
+++ b/packages/auth/src/lib/social-auth.service.ts
@@ -1,6 +1,37 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService, IEnvironment } from '@gauzy/config';
 import { hashPassword } from '@gauzy/utils';
+import { IUser } from '@gauzy/contracts';
+
+export interface OAuthAppConfig {
+	clientId: string;
+	clientSecret: string;
+	redirectUris: string[];
+	codeSecret: string;
+}
+
+export interface OAuthAppAuthorizationRequest {
+	userId: string;
+	tenantId: string;
+	clientId: string;
+	redirectUri: string;
+	scope?: string;
+	state?: string;
+}
+
+export interface OAuthAppTokenRequest {
+	code: string;
+	clientId: string;
+	clientSecret: string;
+	redirectUri: string;
+}
+
+export interface OAuthAppTokenResponse {
+	accessToken: string;
+	expiresIn: number;
+	tokenType: string;
+	scope: string;
+}
 
 /**
  * Base class for social authentication.
@@ -27,6 +58,43 @@ export class SocialAuthService extends BaseSocialAuth {
 	}
 
 	public validateOAuthLoginEmail(args: []): any {}
+
+	public getOAuthAppConfig(): OAuthAppConfig {
+		const redirectUris = (process.env.GAUZY_OAUTH_APP_REDIRECT_URIS ?? '')
+			.split(',')
+			.map((uri) => uri.trim())
+			.filter(Boolean);
+
+		return {
+			clientId: process.env.GAUZY_OAUTH_APP_CLIENT_ID ?? '',
+			clientSecret: process.env.GAUZY_OAUTH_APP_CLIENT_SECRET ?? '',
+			redirectUris,
+			codeSecret: process.env.GAUZY_OAUTH_APP_CODE_SECRET ?? ''
+		};
+	}
+
+	public isOAuthAppRedirectUriAllowed(redirectUri: string, config?: OAuthAppConfig): boolean {
+		const resolved = config ?? this.getOAuthAppConfig();
+		return resolved.redirectUris.includes(redirectUri);
+	}
+
+	public async getOAuthLoginUser(
+		_emails: Array<{ value: string; verified: boolean }>
+	): Promise<IUser | null> {
+		return null;
+	}
+
+	public async createOAuthAppAuthorizationCode(
+		_request: OAuthAppAuthorizationRequest
+	): Promise<string> {
+		throw new Error('OAuth app authorization is not implemented');
+	}
+
+	public async exchangeOAuthAppAuthorizationCode(
+		_request: OAuthAppTokenRequest
+	): Promise<OAuthAppTokenResponse> {
+		throw new Error('OAuth app token exchange is not implemented');
+	}
 
 	/**
 	 * Generate a hash for the provided password using scrypt.

--- a/packages/auth/src/lib/social-auth.service.ts
+++ b/packages/auth/src/lib/social-auth.service.ts
@@ -68,15 +68,11 @@ export class SocialAuthService extends BaseSocialAuth {
 
 	public getOAuthAppConfig(): OAuthAppConfig {
 		const oauthApp = this.configService.get('oauthApp');
-		const redirectUris = (oauthApp?.redirectUris ?? '')
-			.split(',')
-			.map((uri) => uri.trim())
-			.filter(Boolean);
 
 		return {
 			clientId: oauthApp?.clientId ?? '',
 			clientSecret: oauthApp?.clientSecret ?? '',
-			redirectUris,
+			redirectUris: oauthApp?.redirectUris ?? [],
 			codeSecret: oauthApp?.codeSecret ?? ''
 		};
 	}

--- a/packages/auth/src/lib/social-auth.service.ts
+++ b/packages/auth/src/lib/social-auth.service.ts
@@ -10,6 +10,13 @@ export interface OAuthAppConfig {
 	codeSecret: string;
 }
 
+export interface OAuthAppSessionData {
+	clientId: string;
+	redirectUri: string;
+	scope?: string;
+	state?: string;
+}
+
 export interface OAuthAppAuthorizationRequest {
 	userId: string;
 	tenantId: string;
@@ -60,16 +67,17 @@ export class SocialAuthService extends BaseSocialAuth {
 	public validateOAuthLoginEmail(args: []): any {}
 
 	public getOAuthAppConfig(): OAuthAppConfig {
-		const redirectUris = (process.env.GAUZY_OAUTH_APP_REDIRECT_URIS ?? '')
+		const oauthApp = this.configService.get('oauthApp');
+		const redirectUris = (oauthApp?.redirectUris ?? '')
 			.split(',')
 			.map((uri) => uri.trim())
 			.filter(Boolean);
 
 		return {
-			clientId: process.env.GAUZY_OAUTH_APP_CLIENT_ID ?? '',
-			clientSecret: process.env.GAUZY_OAUTH_APP_CLIENT_SECRET ?? '',
+			clientId: oauthApp?.clientId ?? '',
+			clientSecret: oauthApp?.clientSecret ?? '',
 			redirectUris,
-			codeSecret: process.env.GAUZY_OAUTH_APP_CODE_SECRET ?? ''
+			codeSecret: oauthApp?.codeSecret ?? ''
 		};
 	}
 
@@ -81,7 +89,7 @@ export class SocialAuthService extends BaseSocialAuth {
 	public async getOAuthLoginUser(
 		_emails: Array<{ value: string; verified: boolean }>
 	): Promise<IUser | null> {
-		return null;
+		throw new Error('OAuth app user lookup is not implemented');
 	}
 
 	public async createOAuthAppAuthorizationCode(

--- a/packages/common/src/lib/interfaces/IOAuthAppConfig.ts
+++ b/packages/common/src/lib/interfaces/IOAuthAppConfig.ts
@@ -1,0 +1,6 @@
+export interface IOAuthAppConfig {
+	readonly clientId: string;
+	readonly clientSecret: string;
+	readonly codeSecret: string;
+	readonly redirectUris: string;
+}

--- a/packages/common/src/lib/interfaces/IOAuthAppConfig.ts
+++ b/packages/common/src/lib/interfaces/IOAuthAppConfig.ts
@@ -2,5 +2,5 @@ export interface IOAuthAppConfig {
 	readonly clientId: string;
 	readonly clientSecret: string;
 	readonly codeSecret: string;
-	readonly redirectUris: string;
+	readonly redirectUris: string[];
 }

--- a/packages/common/src/lib/interfaces/index.ts
+++ b/packages/common/src/lib/interfaces/index.ts
@@ -18,6 +18,7 @@ export * from './IKeycloakConfig';
 export * from './ILinkedinIConfig';
 export * from './IMakeComConfig';
 export * from './IMicrosoftConfig';
+export * from './IOAuthAppConfig';
 export * from './IPosthogConfig';
 export * from './ISMTPConfig';
 export * from './ITwitterConfig';

--- a/packages/config/src/lib/environments/environment.prod.ts
+++ b/packages/config/src/lib/environments/environment.prod.ts
@@ -167,6 +167,13 @@ export const environment: IEnvironment = {
 		domain: process.env.AUTH0_DOMAIN
 	},
 
+	oauthApp: {
+		clientId: process.env.GAUZY_OAUTH_APP_CLIENT_ID,
+		clientSecret: process.env.GAUZY_OAUTH_APP_CLIENT_SECRET,
+		codeSecret: process.env.GAUZY_OAUTH_APP_CODE_SECRET,
+		redirectUris: process.env.GAUZY_OAUTH_APP_REDIRECT_URIS
+	},
+
 	activepieces: {
 		clientId: process.env.GAUZY_ACTIVEPIECES_CLIENT_ID,
 		clientSecret: process.env.GAUZY_ACTIVEPIECES_CLIENT_SECRET,

--- a/packages/config/src/lib/environments/environment.prod.ts
+++ b/packages/config/src/lib/environments/environment.prod.ts
@@ -171,7 +171,10 @@ export const environment: IEnvironment = {
 		clientId: process.env.GAUZY_OAUTH_APP_CLIENT_ID,
 		clientSecret: process.env.GAUZY_OAUTH_APP_CLIENT_SECRET,
 		codeSecret: process.env.GAUZY_OAUTH_APP_CODE_SECRET,
-		redirectUris: process.env.GAUZY_OAUTH_APP_REDIRECT_URIS
+		redirectUris: (process.env.GAUZY_OAUTH_APP_REDIRECT_URIS ?? '')
+			.split(',')
+			.map((uri) => uri.trim())
+			.filter(Boolean)
 	},
 
 	activepieces: {

--- a/packages/config/src/lib/environments/environment.ts
+++ b/packages/config/src/lib/environments/environment.ts
@@ -167,6 +167,13 @@ export const environment: IEnvironment = {
 		domain: process.env.AUTH0_DOMAIN
 	},
 
+	oauthApp: {
+		clientId: process.env.GAUZY_OAUTH_APP_CLIENT_ID,
+		clientSecret: process.env.GAUZY_OAUTH_APP_CLIENT_SECRET,
+		codeSecret: process.env.GAUZY_OAUTH_APP_CODE_SECRET,
+		redirectUris: process.env.GAUZY_OAUTH_APP_REDIRECT_URIS
+	},
+
 	activepieces: {
 		clientId: process.env.GAUZY_ACTIVEPIECES_CLIENT_ID,
 		clientSecret: process.env.GAUZY_ACTIVEPIECES_CLIENT_SECRET,

--- a/packages/config/src/lib/environments/environment.ts
+++ b/packages/config/src/lib/environments/environment.ts
@@ -171,7 +171,10 @@ export const environment: IEnvironment = {
 		clientId: process.env.GAUZY_OAUTH_APP_CLIENT_ID,
 		clientSecret: process.env.GAUZY_OAUTH_APP_CLIENT_SECRET,
 		codeSecret: process.env.GAUZY_OAUTH_APP_CODE_SECRET,
-		redirectUris: process.env.GAUZY_OAUTH_APP_REDIRECT_URIS
+		redirectUris: (process.env.GAUZY_OAUTH_APP_REDIRECT_URIS ?? '')
+			.split(',')
+			.map((uri) => uri.trim())
+			.filter(Boolean)
 	},
 
 	activepieces: {

--- a/packages/config/src/lib/environments/ienvironment.ts
+++ b/packages/config/src/lib/environments/ienvironment.ts
@@ -19,6 +19,7 @@ import {
 	IJiraIntegrationConfig,
 	IDigitalOceanConfig,
 	IMakeComConfig,
+	IOAuthAppConfig,
 	IPosthogConfig,
 	IZapierConfig
 } from '@gauzy/common';
@@ -107,6 +108,7 @@ export interface IEnvironment {
 	jira: IJiraIntegrationConfig /** Jira Configuration */;
 	fiverrConfig: IFiverrConfig;
 	auth0Config: IAuth0Config;
+	oauthApp?: IOAuthAppConfig;
 
 	sentry?: {
 		dsn: string;

--- a/packages/core/src/lib/app/app.module.ts
+++ b/packages/core/src/lib/app/app.module.ts
@@ -6,6 +6,7 @@ import { ServeStaticModule, ServeStaticModuleOptions } from '@nestjs/serve-stati
 import { CacheModule as NestCacheModule } from '@nestjs/cache-manager';
 import { Cacheable, CacheableMemory } from 'cacheable';
 import { createKeyvNonBlocking } from '@keyv/redis';
+import { RedisModule } from '../redis/redis.module';
 import { Keyv } from 'keyv';
 import { ClsModule, ClsService } from 'nestjs-cls';
 import { HeaderResolver, I18nModule } from 'nestjs-i18n';
@@ -336,6 +337,8 @@ if (environment.THROTTLE_ENABLED) {
 					})
 			  ]
 			: [NestCacheModule.register({ isGlobal: true })]),
+		// Redis client for atomic operations (e.g. GETDEL for single-use OAuth codes)
+		RedisModule,
 		// Serve Static Module Configuration
 		ServeStaticModule.forRootAsync({
 			useFactory: async (config: ConfigService): Promise<ServeStaticModuleOptions[]> => {

--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -34,11 +34,14 @@ import { wrap } from '@mikro-orm/core';
 import { HttpService } from '@nestjs/axios';
 import {
 	BadRequestException,
+	Inject,
 	Injectable,
 	InternalServerErrorException,
 	NotFoundException,
 	UnauthorizedException
 } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 import { CommandBus } from '@nestjs/cqrs';
 import { JsonWebTokenError, JwtPayload, sign, verify } from 'jsonwebtoken';
 import * as moment from 'moment';
@@ -70,9 +73,7 @@ import {
 	verifyGoogleToken,
 	verifyTwitterToken
 } from './social-account/token-verification/verify-oauth-tokens';
-import { SocialAccountService } from './social-account/social-account.service';
-import { PasswordHashService } from '../password-hash/password-hash.service';
-import { createHmac, randomBytes } from 'node:crypto';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import {
 	OAuthAppAuthorizationRequest,
 	OAuthAppTokenRequest,
@@ -83,8 +84,8 @@ import {
 export class AuthService extends SocialAuthService {
 	// Get the type of the Object-Relational Mapping (ORM) used in the application.
 	private readonly ormType: MultiORM = getORMType();
-	private readonly oauthAppCodeState = new Map<string, { used: boolean; expiresAt: number }>();
-	private readonly oauthAppCodeTtlSeconds = 10 * 60;
+	private static readonly OAUTH_CODE_CACHE_PREFIX = 'oauth_app_code:';
+	private static readonly OAUTH_CODE_TTL_MS = 10 * 60 * 1000;
 
 	constructor(
 		private readonly typeOrmUserRepository: TypeOrmUserRepository,
@@ -101,7 +102,8 @@ export class AuthService extends SocialAuthService {
 		private readonly httpService: HttpService,
 		private readonly socialAccountService: SocialAccountService,
 		private readonly eventBus: EventBus,
-		private readonly passwordHashService: PasswordHashService
+		private readonly passwordHashService: PasswordHashService,
+		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache
 	) {
 		super();
 	}
@@ -120,15 +122,6 @@ export class AuthService extends SocialAuthService {
 		return entity;
 	}
 
-	private cleanupOAuthAppCodes(): void {
-		const now = Math.floor(Date.now() / 1000);
-		for (const [key, value] of this.oauthAppCodeState.entries()) {
-			if (value.expiresAt <= now) {
-				this.oauthAppCodeState.delete(key);
-			}
-		}
-	}
-
 	private signOAuthAppPayload(payload: string, secret: string): string {
 		return createHmac('sha256', secret).update(payload).digest('base64url');
 	}
@@ -144,12 +137,14 @@ export class AuthService extends SocialAuthService {
 	} {
 		const [version, payloadB64, sig] = code.split('.');
 		if (version !== 'v1' || !payloadB64 || !sig) {
-			throw new Error('Invalid authorization code');
+			throw new UnauthorizedException('Invalid authorization code');
 		}
 
 		const expectedSig = this.signOAuthAppPayload(payloadB64, secret);
-		if (sig !== expectedSig) {
-			throw new Error('Invalid authorization code signature');
+		const sigBuf = Buffer.from(sig, 'base64url');
+		const expectedBuf = Buffer.from(expectedSig, 'base64url');
+		if (sigBuf.length !== expectedBuf.length || !timingSafeEqual(sigBuf, expectedBuf)) {
+			throw new UnauthorizedException('Invalid authorization code signature');
 		}
 
 		const payloadJson = Buffer.from(payloadB64, 'base64url').toString();
@@ -164,7 +159,7 @@ export class AuthService extends SocialAuthService {
 		};
 
 		if (!payload.jti || !payload.userId || !payload.tenantId || !payload.clientId || !payload.redirectUri) {
-			throw new Error('Invalid authorization code payload');
+			throw new UnauthorizedException('Invalid authorization code payload');
 		}
 
 		return payload;
@@ -185,24 +180,23 @@ export class AuthService extends SocialAuthService {
 	public async createOAuthAppAuthorizationCode(
 		request: OAuthAppAuthorizationRequest
 	): Promise<string> {
-		this.cleanupOAuthAppCodes();
 		const config = this.getOAuthAppConfig();
 
 		if (!config.clientId || !config.clientSecret || !config.redirectUris.length || !config.codeSecret) {
-			throw new Error('OAuth app is not configured');
+			throw new InternalServerErrorException('OAuth app is not configured');
 		}
 
 		if (request.clientId !== config.clientId) {
-			throw new Error('Invalid client_id');
+			throw new BadRequestException('Invalid client_id');
 		}
 
 		if (!this.isOAuthAppRedirectUriAllowed(request.redirectUri, config)) {
-			throw new Error('Invalid redirect_uri');
+			throw new BadRequestException('Invalid redirect_uri');
 		}
 
 		const now = Math.floor(Date.now() / 1000);
 		const jti = randomBytes(32).toString('base64url');
-		const exp = now + this.oauthAppCodeTtlSeconds;
+		const exp = now + AuthService.OAUTH_CODE_TTL_MS / 1000;
 		const scope = request.scope ?? '';
 
 		const payload = {
@@ -218,7 +212,8 @@ export class AuthService extends SocialAuthService {
 		const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
 		const signature = this.signOAuthAppPayload(payloadB64, config.codeSecret);
 
-		this.oauthAppCodeState.set(jti, { used: false, expiresAt: exp });
+		const cacheKey = `${AuthService.OAUTH_CODE_CACHE_PREFIX}${jti}`;
+		await this.cacheManager.set(cacheKey, 'valid', AuthService.OAUTH_CODE_TTL_MS);
 
 		return `v1.${payloadB64}.${signature}`;
 	}
@@ -226,38 +221,39 @@ export class AuthService extends SocialAuthService {
 	public async exchangeOAuthAppAuthorizationCode(
 		request: OAuthAppTokenRequest
 	): Promise<OAuthAppTokenResponse> {
-		this.cleanupOAuthAppCodes();
 		const config = this.getOAuthAppConfig();
 
 		if (!config.clientId || !config.clientSecret || !config.redirectUris.length || !config.codeSecret) {
-			throw new Error('OAuth app is not configured');
+			throw new InternalServerErrorException('OAuth app is not configured');
 		}
 
 		if (request.clientId !== config.clientId || request.clientSecret !== config.clientSecret) {
-			throw new Error('Invalid client credentials');
+			throw new UnauthorizedException('Invalid client credentials');
 		}
 
 		if (!this.isOAuthAppRedirectUriAllowed(request.redirectUri, config)) {
-			throw new Error('Invalid redirect_uri');
+			throw new BadRequestException('Invalid redirect_uri');
 		}
 
 		const payload = this.parseOAuthAppCode(request.code, config.codeSecret);
 		const now = Math.floor(Date.now() / 1000);
 
 		if (payload.exp <= now) {
-			throw new Error('Authorization code expired');
+			throw new UnauthorizedException('Authorization code expired');
 		}
 
 		if (payload.clientId !== request.clientId || payload.redirectUri !== request.redirectUri) {
-			throw new Error('Authorization code mismatch');
+			throw new UnauthorizedException('Authorization code mismatch');
 		}
 
-		const state = this.oauthAppCodeState.get(payload.jti);
-		if (!state || state.used || state.expiresAt <= now) {
-			throw new Error('Authorization code already used');
+		// Atomic check-and-delete: get the code state then immediately delete it.
+		// If the key is absent the code was already redeemed or expired (TTL).
+		const cacheKey = `${AuthService.OAUTH_CODE_CACHE_PREFIX}${payload.jti}`;
+		const codeState = await this.cacheManager.get<string>(cacheKey);
+		if (!codeState) {
+			throw new UnauthorizedException('Authorization code already used');
 		}
-
-		state.used = true;
+		await this.cacheManager.del(cacheKey);
 
 		const accessToken = await this.getJwtAccessToken({
 			id: payload.userId,

--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -1,4 +1,9 @@
-import { SocialAuthService } from '@gauzy/auth';
+import {
+	SocialAuthService,
+	OAuthAppAuthorizationRequest,
+	OAuthAppTokenRequest,
+	OAuthAppTokenResponse
+} from '@gauzy/auth';
 import { IAppIntegrationConfig } from '@gauzy/common';
 import { environment } from '@gauzy/config';
 import { DEMO_PASSWORD_LESS_MAGIC_CODE } from '@gauzy/constants';
@@ -74,11 +79,6 @@ import {
 	verifyTwitterToken
 } from './social-account/token-verification/verify-oauth-tokens';
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
-import {
-	OAuthAppAuthorizationRequest,
-	OAuthAppTokenRequest,
-	OAuthAppTokenResponse
-} from '@gauzy/auth';
 
 @Injectable()
 export class AuthService extends SocialAuthService {
@@ -147,8 +147,7 @@ export class AuthService extends SocialAuthService {
 			throw new UnauthorizedException('Invalid authorization code signature');
 		}
 
-		const payloadJson = Buffer.from(payloadB64, 'base64url').toString();
-		const payload = JSON.parse(payloadJson) as {
+		let payload: {
 			jti: string;
 			userId: string;
 			tenantId: string;
@@ -157,6 +156,12 @@ export class AuthService extends SocialAuthService {
 			scope: string;
 			exp: number;
 		};
+		try {
+			const payloadJson = Buffer.from(payloadB64, 'base64url').toString();
+			payload = JSON.parse(payloadJson);
+		} catch {
+			throw new UnauthorizedException('Invalid authorization code payload');
+		}
 
 		if (!payload.jti || !payload.userId || !payload.tenantId || !payload.clientId || !payload.redirectUri) {
 			throw new UnauthorizedException('Invalid authorization code payload');

--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -70,11 +70,21 @@ import {
 	verifyGoogleToken,
 	verifyTwitterToken
 } from './social-account/token-verification/verify-oauth-tokens';
+import { SocialAccountService } from './social-account/social-account.service';
+import { PasswordHashService } from '../password-hash/password-hash.service';
+import { createHmac, randomBytes } from 'node:crypto';
+import {
+	OAuthAppAuthorizationRequest,
+	OAuthAppTokenRequest,
+	OAuthAppTokenResponse
+} from '@gauzy/auth';
 
 @Injectable()
 export class AuthService extends SocialAuthService {
 	// Get the type of the Object-Relational Mapping (ORM) used in the application.
 	private readonly ormType: MultiORM = getORMType();
+	private readonly oauthAppCodeState = new Map<string, { used: boolean; expiresAt: number }>();
+	private readonly oauthAppCodeTtlSeconds = 10 * 60;
 
 	constructor(
 		private readonly typeOrmUserRepository: TypeOrmUserRepository,
@@ -108,6 +118,160 @@ export class AuthService extends SocialAuthService {
 		}
 		// If using other ORM types, return the entity as is
 		return entity;
+	}
+
+	private cleanupOAuthAppCodes(): void {
+		const now = Math.floor(Date.now() / 1000);
+		for (const [key, value] of this.oauthAppCodeState.entries()) {
+			if (value.expiresAt <= now) {
+				this.oauthAppCodeState.delete(key);
+			}
+		}
+	}
+
+	private signOAuthAppPayload(payload: string, secret: string): string {
+		return createHmac('sha256', secret).update(payload).digest('base64url');
+	}
+
+	private parseOAuthAppCode(code: string, secret: string): {
+		jti: string;
+		userId: string;
+		tenantId: string;
+		clientId: string;
+		redirectUri: string;
+		scope: string;
+		exp: number;
+	} {
+		const [version, payloadB64, sig] = code.split('.');
+		if (version !== 'v1' || !payloadB64 || !sig) {
+			throw new Error('Invalid authorization code');
+		}
+
+		const expectedSig = this.signOAuthAppPayload(payloadB64, secret);
+		if (sig !== expectedSig) {
+			throw new Error('Invalid authorization code signature');
+		}
+
+		const payloadJson = Buffer.from(payloadB64, 'base64url').toString();
+		const payload = JSON.parse(payloadJson) as {
+			jti: string;
+			userId: string;
+			tenantId: string;
+			clientId: string;
+			redirectUri: string;
+			scope: string;
+			exp: number;
+		};
+
+		if (!payload.jti || !payload.userId || !payload.tenantId || !payload.clientId || !payload.redirectUri) {
+			throw new Error('Invalid authorization code payload');
+		}
+
+		return payload;
+	}
+
+	public async getOAuthLoginUser(
+		emails: Array<{ value: string; verified: boolean }>
+	): Promise<IUser | null> {
+		for (const { value } of emails) {
+			const userExist = await this.userService.checkIfExistsEmail(value);
+			if (userExist) {
+				return await this.userService.getOAuthLoginEmail(value);
+			}
+		}
+		return null;
+	}
+
+	public async createOAuthAppAuthorizationCode(
+		request: OAuthAppAuthorizationRequest
+	): Promise<string> {
+		this.cleanupOAuthAppCodes();
+		const config = this.getOAuthAppConfig();
+
+		if (!config.clientId || !config.clientSecret || !config.redirectUris.length || !config.codeSecret) {
+			throw new Error('OAuth app is not configured');
+		}
+
+		if (request.clientId !== config.clientId) {
+			throw new Error('Invalid client_id');
+		}
+
+		if (!this.isOAuthAppRedirectUriAllowed(request.redirectUri, config)) {
+			throw new Error('Invalid redirect_uri');
+		}
+
+		const now = Math.floor(Date.now() / 1000);
+		const jti = randomBytes(32).toString('base64url');
+		const exp = now + this.oauthAppCodeTtlSeconds;
+		const scope = request.scope ?? '';
+
+		const payload = {
+			jti,
+			userId: request.userId,
+			tenantId: request.tenantId,
+			clientId: request.clientId,
+			redirectUri: request.redirectUri,
+			scope,
+			exp
+		};
+
+		const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+		const signature = this.signOAuthAppPayload(payloadB64, config.codeSecret);
+
+		this.oauthAppCodeState.set(jti, { used: false, expiresAt: exp });
+
+		return `v1.${payloadB64}.${signature}`;
+	}
+
+	public async exchangeOAuthAppAuthorizationCode(
+		request: OAuthAppTokenRequest
+	): Promise<OAuthAppTokenResponse> {
+		this.cleanupOAuthAppCodes();
+		const config = this.getOAuthAppConfig();
+
+		if (!config.clientId || !config.clientSecret || !config.redirectUris.length || !config.codeSecret) {
+			throw new Error('OAuth app is not configured');
+		}
+
+		if (request.clientId !== config.clientId || request.clientSecret !== config.clientSecret) {
+			throw new Error('Invalid client credentials');
+		}
+
+		if (!this.isOAuthAppRedirectUriAllowed(request.redirectUri, config)) {
+			throw new Error('Invalid redirect_uri');
+		}
+
+		const payload = this.parseOAuthAppCode(request.code, config.codeSecret);
+		const now = Math.floor(Date.now() / 1000);
+
+		if (payload.exp <= now) {
+			throw new Error('Authorization code expired');
+		}
+
+		if (payload.clientId !== request.clientId || payload.redirectUri !== request.redirectUri) {
+			throw new Error('Authorization code mismatch');
+		}
+
+		const state = this.oauthAppCodeState.get(payload.jti);
+		if (!state || state.used || state.expiresAt <= now) {
+			throw new Error('Authorization code already used');
+		}
+
+		state.used = true;
+
+		const accessToken = await this.getJwtAccessToken({
+			id: payload.userId,
+			tenantId: payload.tenantId
+		});
+
+		const expiresIn = Number(environment.JWT_TOKEN_EXPIRATION_TIME) || 3600;
+
+		return {
+			accessToken,
+			expiresIn,
+			tokenType: 'Bearer',
+			scope: payload.scope ?? ''
+		};
 	}
 
 	/**

--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -43,6 +43,7 @@ import {
 	Injectable,
 	InternalServerErrorException,
 	NotFoundException,
+	Optional,
 	UnauthorizedException
 } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
@@ -79,6 +80,7 @@ import {
 	verifyTwitterToken
 } from './social-account/token-verification/verify-oauth-tokens';
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { EVER_REDIS_CLIENT } from '../redis/redis.module';
 
 @Injectable()
 export class AuthService extends SocialAuthService {
@@ -103,7 +105,8 @@ export class AuthService extends SocialAuthService {
 		private readonly socialAccountService: SocialAccountService,
 		private readonly eventBus: EventBus,
 		private readonly passwordHashService: PasswordHashService,
-		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache
+		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+		@Optional() @Inject(EVER_REDIS_CLIENT) private readonly redisClient: any
 	) {
 		super();
 	}
@@ -221,7 +224,11 @@ export class AuthService extends SocialAuthService {
 		const signature = this.signOAuthAppPayload(payloadB64, config.codeSecret);
 
 		const cacheKey = `${AuthService.OAUTH_CODE_CACHE_PREFIX}${jti}`;
-		await this.cacheManager.set(cacheKey, 'valid', AuthService.OAUTH_CODE_TTL_MS);
+		if (this.redisClient) {
+			await this.redisClient.set(cacheKey, 'valid', { PX: AuthService.OAUTH_CODE_TTL_MS });
+		} else {
+			await this.cacheManager.set(cacheKey, 'valid', AuthService.OAUTH_CODE_TTL_MS);
+		}
 
 		return `v1.${payloadB64}.${signature}`;
 	}
@@ -260,11 +267,19 @@ export class AuthService extends SocialAuthService {
 			throw new UnauthorizedException('Authorization code mismatch');
 		}
 
-		// Single-use enforcement: delete first, then verify the key existed.
-		// requests could both read 'valid' before either deletes.
+		// Single-use enforcement via atomic GETDEL (Redis) or get-then-del fallback
 		const cacheKey = `${AuthService.OAUTH_CODE_CACHE_PREFIX}${payload.jti}`;
-		const codeState = await this.cacheManager.get<string>(cacheKey);
-		await this.cacheManager.del(cacheKey);
+		let codeState: string | null;
+
+		if (this.redisClient) {
+			// Atomic get-and-delete: prevents race conditions in multi-instance deployments
+			codeState = await this.redisClient.getDel(cacheKey);
+		} else {
+			// Non-Redis fallback (single-instance safe)
+			codeState = (await this.cacheManager.get<string>(cacheKey)) ?? null;
+			await this.cacheManager.del(cacheKey);
+		}
+
 		if (!codeState) {
 			throw new UnauthorizedException('Authorization code already used');
 		}

--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -233,7 +233,7 @@ export class AuthService extends SocialAuthService {
 		if (request.clientId !== config.clientId) {
 			throw new UnauthorizedException('Invalid client credentials');
 		}
-		
+
 		const secretBuf = Buffer.from(request.clientSecret, 'utf8');
 		const expectedBuf = Buffer.from(config.clientSecret, 'utf8');
 		if (secretBuf.length !== expectedBuf.length || !timingSafeEqual(secretBuf, expectedBuf)) {
@@ -256,7 +256,6 @@ export class AuthService extends SocialAuthService {
 		}
 
 		// Single-use enforcement: delete first, then verify the key existed.
-		// Deleting before checking minimises the race window where two concurrent
 		// requests could both read 'valid' before either deletes.
 		const cacheKey = `${AuthService.OAUTH_CODE_CACHE_PREFIX}${payload.jti}`;
 		const codeState = await this.cacheManager.get<string>(cacheKey);

--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -168,7 +168,10 @@ export class AuthService extends SocialAuthService {
 	public async getOAuthLoginUser(
 		emails: Array<{ value: string; verified: boolean }>
 	): Promise<IUser | null> {
-		for (const { value } of emails) {
+		for (const { value, verified } of emails) {
+			// Skip unverified emails to prevent account takeover via unverified OAuth addresses
+			if (!verified) continue;
+
 			const userExist = await this.userService.checkIfExistsEmail(value);
 			if (userExist) {
 				return await this.userService.getOAuthLoginEmail(value);
@@ -227,7 +230,13 @@ export class AuthService extends SocialAuthService {
 			throw new InternalServerErrorException('OAuth app is not configured');
 		}
 
-		if (request.clientId !== config.clientId || request.clientSecret !== config.clientSecret) {
+		if (request.clientId !== config.clientId) {
+			throw new UnauthorizedException('Invalid client credentials');
+		}
+		
+		const secretBuf = Buffer.from(request.clientSecret, 'utf8');
+		const expectedBuf = Buffer.from(config.clientSecret, 'utf8');
+		if (secretBuf.length !== expectedBuf.length || !timingSafeEqual(secretBuf, expectedBuf)) {
 			throw new UnauthorizedException('Invalid client credentials');
 		}
 
@@ -246,14 +255,15 @@ export class AuthService extends SocialAuthService {
 			throw new UnauthorizedException('Authorization code mismatch');
 		}
 
-		// Atomic check-and-delete: get the code state then immediately delete it.
-		// If the key is absent the code was already redeemed or expired (TTL).
+		// Single-use enforcement: delete first, then verify the key existed.
+		// Deleting before checking minimises the race window where two concurrent
+		// requests could both read 'valid' before either deletes.
 		const cacheKey = `${AuthService.OAUTH_CODE_CACHE_PREFIX}${payload.jti}`;
 		const codeState = await this.cacheManager.get<string>(cacheKey);
+		await this.cacheManager.del(cacheKey);
 		if (!codeState) {
 			throw new UnauthorizedException('Authorization code already used');
 		}
-		await this.cacheManager.del(cacheKey);
 
 		const accessToken = await this.getJwtAccessToken({
 			id: payload.userId,
@@ -1021,7 +1031,10 @@ export class AuthService extends SocialAuthService {
 			authData: { jwt: null, userId: null }
 		};
 		try {
-			for (const { value } of emails) {
+			for (const { value, verified } of emails) {
+				// Skip unverified emails to prevent account takeover via unverified OAuth addresses
+				if (!verified) continue;
+
 				const userExist = await this.userService.checkIfExistsEmail(value);
 				if (userExist) {
 					const user = await this.userService.getOAuthLoginEmail(value);

--- a/packages/core/src/lib/redis/redis.module.ts
+++ b/packages/core/src/lib/redis/redis.module.ts
@@ -1,0 +1,40 @@
+import { Global, Logger, Module } from '@nestjs/common';
+import { createClient } from 'redis';
+
+export const EVER_REDIS_CLIENT = 'EVER_REDIS_CLIENT';
+
+@Global()
+@Module({
+	providers: [
+		{
+			provide: EVER_REDIS_CLIENT,
+			useFactory: async () => {
+				if (process.env.REDIS_ENABLED !== 'true') return null;
+
+				const { REDIS_URL, REDIS_HOST, REDIS_PORT, REDIS_USER, REDIS_PASSWORD, REDIS_TLS } = process.env;
+				if (!REDIS_URL && (!REDIS_HOST || !REDIS_PORT)) return null;
+
+				const url =
+					REDIS_URL ||
+					(() => {
+						const proto = REDIS_TLS === 'true' ? 'rediss' : 'redis';
+						const auth = REDIS_USER && REDIS_PASSWORD ? `${REDIS_USER}:${REDIS_PASSWORD}@` : '';
+						return `${proto}://${auth}${REDIS_HOST}:${REDIS_PORT}`;
+					})();
+
+				try {
+					const client = createClient({ url });
+					client.on('error', (err) => Logger.error('Redis client error', err, 'RedisModule'));
+					await client.connect();
+					Logger.log('Redis client connected for atomic operations', 'RedisModule');
+					return client;
+				} catch (error) {
+					Logger.warn('Redis client connection failed, falling back to cache-manager', 'RedisModule');
+					return null;
+				}
+			}
+		}
+	],
+	exports: [EVER_REDIS_CLIENT]
+})
+export class RedisModule {}


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends Gauzy’s OAuth2 authorization code flow so third‑party apps (e.g., Activepieces) can securely obtain Gauzy JWTs via standard authorize/token endpoints. Adds verified‑email login, stronger validation, single‑use HMAC codes, session fixation protection, and atomic Redis‑backed code invalidation with cache‑manager fallback.

- **New Features**
  - OAuth endpoints: GET /integration/ever-gauzy/oauth/authorize and POST /integration/ever-gauzy/oauth/token.
  - Authorize validates client_id, response_type=code, and allowlisted redirect_uri; stores {clientId, redirectUri, scope, state}; explicitly saves session; redirects to Auth0.
  - Auth0 callback regenerates the session to prevent fixation, revalidates redirect_uri, preserves state, requires verified emails, and redirects with code or error.
  - Codes are HMAC‑signed “v1” with a 10‑min TTL; single‑use is enforced via Redis GETDEL when available, with cache‑manager fallback.
  - Token exchange uses timing‑safe client_secret compare, verifies code signature/payload and clientId/redirectUri match, and returns a Bearer token with expires_in and scope.

- **Migration**
  - Set GAUZY_OAUTH_APP_CLIENT_ID, GAUZY_OAUTH_APP_CLIENT_SECRET, GAUZY_OAUTH_APP_CODE_SECRET, GAUZY_OAUTH_APP_REDIRECT_URIS (comma‑separated). JWT_TOKEN_EXPIRATION_TIME controls expires_in.
  - Ensure session middleware persists across redirects.
  - Optional: enable Redis for atomic single‑use codes (set REDIS_ENABLED=true and REDIS_URL or REDIS_HOST/PORT[/TLS/USER/PASSWORD]). Flow: authorize then exchange token as before.

<sup>Written for commit f62c9d9f1222b0dada1050c68628a09aa4907f3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

