### PR TITLE
fix: login page style & handle close window on logout

### DIFF
--- a/packages/desktop-lib/src/lib/tray/auth/authentication-handler.ts
+++ b/packages/desktop-lib/src/lib/tray/auth/authentication-handler.ts
@@ -2,6 +2,7 @@ import { RegisteredWindow } from '@gauzy/desktop-core';
 import { getApiBaseUrl } from '@gauzy/desktop-window';
 import { User } from '../../offline';
 import { IConfigStore, IUserRepository, IWindowService } from '../interfaces';
+import { AppWindowManager } from '../../app-window-manager';
 
 export class AuthenticationHandler {
 	constructor(
@@ -82,8 +83,9 @@ export class AuthenticationHandler {
 	}
 
 	private closeWindows(): void {
-		this.windowService.getOne(RegisteredWindow.SETTINGS)?.close?.();
-		this.windowService.getOne(RegisteredWindow.WIDGET)?.close?.();
+		const appWindowManager = AppWindowManager.getInstance();
+		appWindowManager.settingWindow?.close?.();
+		appWindowManager.alwaysOnWindow?.browserWindow?.close?.();
 	}
 
 	private async clearUserData(): Promise<void> {

--- a/packages/desktop-ui-lib/src/lib/login/_reusable.scss
+++ b/packages/desktop-ui-lib/src/lib/login/_reusable.scss
@@ -190,7 +190,7 @@ $register-background-light-color: var(--gauzy-card-1);
 
 ::ng-deep {
   nb-card-body {
-    padding: 44px 1rem 1rem;
+    padding: 40px 1rem 1rem;
   }
 
   nb-card-header {

--- a/packages/desktop-ui-lib/src/lib/login/login.component.html
+++ b/packages/desktop-ui-lib/src/lib/login/login.component.html
@@ -153,7 +153,6 @@
       @if (!isAgent) {
         <ngx-social-links></ngx-social-links>
       }
-      <div class="hr-div-soft"></div>
       @if (!isAgent) {
         <section class="another-action" aria-label="Sign In Workspace">
           {{ 'WORKSPACES.UNKNOWN_WORKSPACE' | translate }}

--- a/packages/desktop-ui-lib/src/lib/login/login.component.scss
+++ b/packages/desktop-ui-lib/src/lib/login/login.component.scss
@@ -20,8 +20,8 @@
     height: 100%;
 
     & > * {
-      padding-left: 15px;
-      padding-right: 15px;
+      padding-left: 13px;
+      padding-right: 13px;
     }
 
     & .svg-wrapper {


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure logout reliably closes the Settings and Always-on widget windows using AppWindowManager. Clean up login page spacing: reduce card top padding (44px → 40px), tighten horizontal padding (15px → 13px), and remove the extra divider.

<sup>Written for commit 06261416efd0d12d98397959de73cf567d6d693e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

