### PR TITLE
fix(ci): prevent NX daemon deadlock on Windows CI and add NX cache

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -325,11 +325,11 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
+          # Stop NX daemon first to release file locks before cleanup
+          npx nx daemon --stop 2>$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }
-          # Stop NX daemon from previous runs to prevent deadlocks
-          npx nx daemon --stop 2>$null
           exit 0
 
       - name: Install Node.js, NPM and Yarn


### PR DESCRIPTION
## Summary
- **Disable NX Daemon in CI** (`NX_DAEMON=false`) across all 60 jobs in 12 workflow files to prevent the daemon process from hanging indefinitely on Windows self-hosted runners after builds complete
- **Add `.nx/cache` to `actions/cache`** for all jobs (Linux, macOS, Windows, ARM64) to persist NX build cache between runs, significantly reducing rebuild times for unchanged projects
- **Selective cleanup on Windows self-hosted runners**: Use `clean: false` on checkout + explicit cleanup step that removes `dist/` and `node_modules/` but preserves `.nx/cache`, and stops any leftover NX daemon from previous runs

## Context
GitHub Actions run [#22040806051](https://github.com/ever-co/ever-gauzy/actions/runs/22040806051/job/63681294113) hung for 4+ hours on a Windows self-hosted runner. Log analysis showed all 54 NX project builds completed successfully, but the NX Daemon process stayed alive, blocking the parent yarn/node process chain from exiting until the 300-minute job timeout.

## Changes
All changes applied consistently across **12 workflow files** (desktop-app, desktop-timer-app, server, server-api, server-mcp, agent — both prod and stage):

| Change | Scope | Count |
|--------|-------|-------|
| `NX_DAEMON: false` in build env | All 5 jobs per file | 60 |
| `.nx/cache` in cache paths | All 6 cache steps per file | 72 |
| `yarn-nx-` cache key prefix | All cache keys | 120 |
| `clean: false` on checkout | release-windows only | 12 |
| Selective cleanup step | release-windows only | 12 |

## Test plan
- [ ] Verify a Windows self-hosted runner build completes without hanging
- [ ] Verify NX cache is properly saved and restored between runs
- [ ] Verify Linux/macOS/ARM64 jobs still work correctly with new cache keys
- [ ] Confirm no YAML syntax errors in any workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled Nx daemon in CI and enabled Nx build caching across all 12 workflows. Fixes Windows self‑hosted hangs and prevents node_modules lock errors while speeding up rebuilds.

- **Bug Fixes**
  - Set NX_DAEMON=false in all jobs to prevent lingering Nx processes on Windows runners.
  - On Windows releases, stop the Nx daemon before cleanup to avoid node_modules file locks and post-build deadlocks.

- **New Features**
  - Cache .nx/cache via actions/cache on Linux, macOS, Windows, and ARM64 with yarn-nx- keys.
  - Use clean: false on checkout and delete dist/ and node_modules while preserving .nx/cache.

<sup>Written for commit d7b37ef058f9d14b156b47fdf0fadaf243678844. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

