### PR TITLE
fix(ci): guard npx call in cleanup step for fresh self-hosted runners

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }


### PR DESCRIPTION
## Summary
- Guard the `npx nx daemon --stop` call in the selective cleanup step with `Get-Command npx` check across all 12 workflow files
- Prevents workflow failure on fresh self-hosted Windows runners where Node.js is not yet installed (cleanup runs before `setup-node`)

## Context
Follow-up to #9465. The selective cleanup step runs before `setup-node`, so `npx` may not be available on a brand-new self-hosted runner. While existing runners will have Node from prior runs, the unguarded `npx` call would abort the workflow on first use of a new runner.

## Changes
```powershell
# Before (fails if npx not in PATH):
npx nx daemon --stop 2>$null

# After (silently skipped on fresh runners):
if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2>$null }
```

Applied to all 12 workflow files: agent, desktop-app, desktop-timer-app, server, server-api, server-mcp (prod + stage).

## Test plan
- [ ] Verify existing self-hosted Windows runner builds still stop the NX daemon correctly
- [ ] Verify workflow doesn't fail if a fresh runner has no Node.js preinstalled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded the npx nx daemon --stop call in the selective cleanup step across all Windows self-hosted workflows. Prevents first-run failures on fresh runners where Node isn’t installed yet.

- **Bug Fixes**
  - Wrapped the daemon stop with a PowerShell Get-Command npx check in 12 workflows (agent, desktop-app, desktop-timer-app, server, server-api, server-mcp; prod + stage).
  - Keeps stopping the NX daemon when npx exists; otherwise skips without failing.
  - Runs safely before setup-node to avoid first-run aborts.

<sup>Written for commit e1b5afdb32f2c20d392a15719c76cfe992da5980. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

