### PR TITLE
Stage

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -325,8 +325,8 @@ jobs:
       - name: Selective cleanup (preserve .nx/cache)
         shell: powershell
         run: |
-          # Stop NX daemon first to release file locks before cleanup
-          npx nx daemon --stop 2>$null
+          # Stop NX daemon first to release file locks before cleanup (guard for fresh runners without Node)
+          if (Get-Command npx -ErrorAction SilentlyContinue) { npx nx daemon --stop 2> }$null
           # Remove build artifacts but keep NX cache for faster rebuilds
           if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
           if (Test-Path "node_modules") { Remove-Item -Recurse -Force "node_modules" }


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented CI failures on fresh self-hosted runners by guarding the Nx daemon stop step in cleanup. Workflows now skip the npx call when Node isn’t installed, allowing cleanup to continue and preserving the .nx cache.

- **Bug Fixes**
  - Wrapped “npx nx daemon --stop” with a PowerShell Get-Command check across all prod and stage workflows (agent, desktop app, desktop timer, server, server-api, server-mcp).

<sup>Written for commit 1f12f1dd250396ea39cf70b051f0f8691e13a69a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

