### PR TITLE
fix(plugins): apply AI suggestion by bot agent reviewers

### DIFF
--- a/apps/gauzy/src/app/app.module.ts
+++ b/apps/gauzy/src/app/app.module.ts
@@ -34,7 +34,6 @@ import { IFeatureToggle, LanguagesEnum } from '@gauzy/contracts';
 import { UiCoreModule } from '@gauzy/ui-core';
 import { getPluginUiConfig } from '@gauzy/plugin-ui';
 import { GAUZY_ENV, environment } from '@gauzy/ui-config';
-import { isNotEmpty } from '@gauzy/ui-core/common';
 import {
 	APIInterceptor,
 	AppInitService,
@@ -248,8 +247,11 @@ export class AppModule {
 		const uiConfig = getPluginUiConfig();
 
 		const localeOptions: moment.LocaleSpecification = {};
-		if (isNotEmpty(uiConfig.startWeekOn)) {
-			localeOptions.week = { dow: uiConfig.startWeekOn };
+		const dow = uiConfig.startWeekOn;
+
+		// Validate the day of the week number (0 = Sunday, 1 = Monday, ..., 6 = Saturday)
+		if (typeof dow === 'number' && dow >= 0 && dow <= 6) {
+			localeOptions.week = { dow };
 		}
 
 		/** Update the locale with the default language. */

--- a/apps/gauzy/src/app/pages/pages.routes.spec.ts
+++ b/apps/gauzy/src/app/pages/pages.routes.spec.ts
@@ -22,7 +22,17 @@ describe('pages.routes', () => {
 		const missing = [...reserved].filter((p) => !corePaths.has(p));
 		const extra = [...corePaths].filter((p) => !reserved.has(p));
 
-		expect(missing).toEqual([]);
-		expect(extra).toEqual([]);
+		if (missing.length > 0) {
+			throw new Error(
+				`Missing reserved paths (in RESERVED_PAGE_SECTION_PATHS but not in getPagesRoutes()): ${missing.join(', ')}. ` +
+					`Update getPagesRoutes() or remove from RESERVED_PAGE_SECTION_PATHS.`
+			);
+		}
+		if (extra.length > 0) {
+			throw new Error(
+				`Unexpected core paths (in getPagesRoutes() but not in RESERVED_PAGE_SECTION_PATHS): ${extra.join(', ')}. ` +
+					`Add these to RESERVED_PAGE_SECTION_PATHS to prevent plugin path conflicts.`
+			);
+		}
 	});
 });

--- a/apps/gauzy/src/app/pages/pages.routes.ts
+++ b/apps/gauzy/src/app/pages/pages.routes.ts
@@ -570,7 +570,7 @@ function getReportsRoutes(_pageRouteRegistryService: PageRouteRegistryService): 
 						)
 				},
 				..._pageRouteRegistryService.getPageLocationRoutes('reports-sections'),
-				{ path: '**', component: NotFoundComponent }
+				{ path: '**', component: NotFoundComponent, data: { selectors: false } }
 			]
 		}
 	];

--- a/packages/plugin-ui/src/lib/plugin-ui.interface.ts
+++ b/packages/plugin-ui/src/lib/plugin-ui.interface.ts
@@ -66,19 +66,7 @@ export interface IOnPluginConfigChange {
  *
  * Use this when you want a single interface that expresses both lifecycle hooks.
  */
-export interface IPluginUiLifecycleMethods {
-	/**
-	 * Called when the plugin module is being initialized.
-	 * @returns A void or a Promise representing the completion of the operation.
-	 */
-	ngOnPluginBootstrap(): void | Promise<void>;
-
-	/**
-	 * Called when the plugin module is being destroyed.
-	 * @returns A void or a Promise representing the completion of the operation.
-	 */
-	ngOnPluginDestroy(): void | Promise<void>;
-}
+export interface IPluginUiLifecycleMethods extends IOnPluginUiBootstrap, IOnPluginUiDestroy {}
 
 /**
  * Extended lifecycle methods (optional hooks).

--- a/packages/plugins/job-employee-ui/src/lib/components/job-search-status-editor/job-search-status-editor.component.ts
+++ b/packages/plugins/job-employee-ui/src/lib/components/job-search-status-editor/job-search-status-editor.component.ts
@@ -5,7 +5,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { IEmployee, IOrganization } from '@gauzy/contracts';
 import { distinctUntilChange } from '@gauzy/ui-core/common';
 import { Store } from '@gauzy/ui-core/core';
-import { ToggleSwitcherComponent } from '@gauzy/ui-core/shared';
+import { TableComponentsModule, ToggleSwitcherComponent } from '@gauzy/ui-core/shared';
 import { JobSearchStoreService } from '../../providers/job-search-store.service';
 
 @UntilDestroy()
@@ -14,17 +14,18 @@ import { JobSearchStoreService } from '../../providers/job-search-store.service'
 		<ngx-toggle-switcher
 			[label]="false"
 			(onSwitched)="updateJobSearchAvailability($event)"
-			[value]="employee?.isJobSearchActive || false"
+			[value]="employee?.isJobSearchActive ?? false"
 		></ngx-toggle-switcher>
 	`,
-	standalone: false
+	standalone: true,
+	imports: [TableComponentsModule]
 })
 export class JobSearchStatusEditorComponent extends DefaultEditor implements AfterViewInit, OnInit {
 	public organization!: IOrganization;
 	public employee!: IEmployee;
 
-	@Input() cell!: Cell;
-	@ViewChild(ToggleSwitcherComponent) switcher!: ToggleSwitcherComponent;
+	@Input() readonly cell!: Cell;
+	@ViewChild(ToggleSwitcherComponent) readonly switcher!: ToggleSwitcherComponent;
 
 	private readonly _cdr = inject(ChangeDetectorRef);
 	private readonly _store = inject(Store);

--- a/packages/plugins/job-employee-ui/src/lib/job-employee.module.ts
+++ b/packages/plugins/job-employee-ui/src/lib/job-employee.module.ts
@@ -20,7 +20,7 @@ import { JobSearchStatusEditorComponent } from './components/job-search-status-e
 import { JobSearchStoreService } from './providers/job-search-store.service';
 
 @NgModule({
-	declarations: [JobEmployeeComponent, JobSearchStatusEditorComponent],
+	declarations: [JobEmployeeComponent],
 	providers: [JobSearchStoreService],
 	imports: [
 		RouterModule.forChild([]),
@@ -29,7 +29,8 @@ import { JobSearchStoreService } from './providers/job-search-store.service';
 		SharedModule,
 		SmartDataViewLayoutModule,
 		DynamicTabsModule,
-		TableComponentsModule
+		TableComponentsModule,
+		JobSearchStatusEditorComponent
 	]
 })
 export class JobEmployeeModule implements IOnPluginUiBootstrap, IOnPluginUiDestroy {

--- a/packages/plugins/jobs-ui/src/lib/components/job-layout/job-layout.component.spec.ts
+++ b/packages/plugins/jobs-ui/src/lib/components/job-layout/job-layout.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { provideRouter } from '@angular/router';
 
 import { JobLayoutComponent } from './job-layout.component';
 
@@ -9,7 +9,7 @@ describe('JobLayoutComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			imports: [RouterModule.forRoot([])],
+			providers: [provideRouter([])],
 			declarations: [JobLayoutComponent],
 			teardown: { destroyAfterEach: false }
 		}).compileComponents();

--- a/packages/plugins/jobs-ui/src/lib/job.routes.ts
+++ b/packages/plugins/jobs-ui/src/lib/job.routes.ts
@@ -21,17 +21,17 @@ export const JOBS_PAGE_ROUTE: PageRouteRegistryConfig = {
 /**
  * Builds the child routes for the jobs section: layout + redirect + plugin-contributed tabs.
  *
- * @param registry Page route registry to fetch routes from JOBS_SECTIONS_LOCATION
+ * @param _pageRouteRegistryService Page route registry to fetch routes from JOBS_SECTIONS_LOCATION
  * @returns Route array for the ROUTES provider in JobsModule
  */
-export function getJobsChildRoutes(registry: PageRouteRegistryService): Route[] {
+export function getJobsRoutes(_pageRouteRegistryService: PageRouteRegistryService): Route[] {
 	return [
 		{
 			path: '',
 			component: JobLayoutComponent,
 			children: [
 				{ path: '', redirectTo: DEFAULT_JOBS_TAB, pathMatch: 'full' },
-				...registry.getPageLocationRoutes(JOBS_SECTIONS_LOCATION)
+				..._pageRouteRegistryService.getPageLocationRoutes(JOBS_SECTIONS_LOCATION)
 			]
 		}
 	];

--- a/packages/plugins/jobs-ui/src/lib/jobs.module.ts
+++ b/packages/plugins/jobs-ui/src/lib/jobs.module.ts
@@ -9,7 +9,7 @@ import {
 import { LoggerService, NavMenuBuilderService, PageRouteRegistryService } from '@gauzy/ui-core/core';
 import { SharedModule } from '@gauzy/ui-core/shared';
 import { JobLayoutComponent } from './components/job-layout/job-layout.component';
-import { getJobsChildRoutes } from './job.routes';
+import { getJobsRoutes } from './job.routes';
 
 @NgModule({
 	declarations: [JobLayoutComponent],
@@ -19,7 +19,7 @@ import { getJobsChildRoutes } from './job.routes';
 		{
 			provide: ROUTES,
 			useFactory: (_pageRouteRegistryService: PageRouteRegistryService) =>
-				getJobsChildRoutes(_pageRouteRegistryService),
+				getJobsRoutes(_pageRouteRegistryService),
 			deps: [PageRouteRegistryService],
 			multi: true
 		}


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves plugin UI lifecycle management and safety, tightens routing/tests, and makes the Job Search status editor standalone. Validates the week-start config to prevent invalid moment locale updates.

- **Refactors**
  - Centralized plugin tracking to { instance, definition }; register before bootstrap and always deregister on destroy.
  - Ordered plugins by dependencies; safer activation predicate handling with error guards and better logs.
  - Tightened helper typings (added PluginUiDefinitionWithModuleOrLoader) and docs for definePluginGroup/init.
  - JobSearchStatusEditor is now standalone and imported by the module.
  - Renamed getJobsChildRoutes to getJobsRoutes and updated the provider.

- **Bug Fixes**
  - Validate startWeekOn (0–6) before applying locale week settings.
  - Added data: { selectors: false } to reports 404 route to avoid selector overlays.
  - Clearer route spec failures with explicit error messages; tests use provideRouter.
  - Safer toggle default (isJobSearchActive ?? false) to avoid undefined states.

<sup>Written for commit 357b623b6da6374768b36fea598025d8a8b1dd7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

