### PR TITLE
Fix/last screen capture

### DIFF
--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -161,12 +161,6 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 
 		try {
 			const lastTime = await timerService.findLastOne();
-			if (lastTime && !lastTime.timeslotId) {
-				const lastCapture = await timerService.findLastCapture();
-				if (lastCapture?.timeslotId && lastCapture?.timelogId === lastTime.timelogId) {
-					lastTime.timeslotId = lastCapture.timeslotId;
-				}
-			}
 
 			log.info('Last Capture Time (Desktop IPC):', lastTime);
 
@@ -1255,7 +1249,8 @@ export function removeAllHandlers() {
 		'DESKTOP_CAPTURER_GET_SOURCES',
 		'FINISH_SYNCED_TIMER',
 		'COLLECT_ACTIVITIES',
-		'START_SERVER'
+		'START_SERVER',
+		'GET_LAST_CAPTURE'
 	];
 	channels.forEach((channel: string) => {
 		ipcMain.removeHandler(channel);

--- a/packages/desktop-ui-lib/src/lib/image-viewer/image-viewer.component.ts
+++ b/packages/desktop-ui-lib/src/lib/image-viewer/image-viewer.component.ts
@@ -36,6 +36,7 @@ export class ImageViewerComponent implements OnInit, OnDestroy {
 	items = [];
 
 	item: any = {};
+	private readonly _showImageHandler = this.showImageEventHandler.bind(this);
 	constructor(
 		// private dialogRef: NbDialogRef<any>
 		private readonly _electronService: ElectronService,
@@ -76,13 +77,13 @@ export class ImageViewerComponent implements OnInit, OnDestroy {
 	}
 
 	ngOnInit(): void {
-		this._electronService.ipcRenderer.on('show_image', this.showImageEventHandler.bind(this));
+		this._electronService.ipcRenderer.on('show_image', this._showImageHandler);
 		this._electronService.ipcRenderer.send('image_view_ready');
 		this.active_index = 0;
 	}
 
 	ngOnDestroy(): void {
-		this._electronService.ipcRenderer.removeListener('show_image', this.showImageEventHandler.bind(this));
+		this._electronService.ipcRenderer.removeListener('show_image', this._showImageHandler);
 	}
 
 	close() {
@@ -144,9 +145,14 @@ export class ImageViewerComponent implements OnInit, OnDestroy {
 	}
 
 	private async getLastScreenshot(timeSlotId: string) {
-		const lastTimeSlot = await this._imageViewerService.getTimeSlot({
-			timeSlotId
-		});
-		return lastTimeSlot.screenshots;
+		try {
+			const lastTimeSlot = await this._imageViewerService.getTimeSlot({
+				timeSlotId
+			});
+			return lastTimeSlot?.screenshots || [];
+		} catch(err) {
+			console.error('[ImageViewer] showImageEventHandler error:', err);
+			return [];
+		}
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/image-viewer/image-viewer.service.ts
+++ b/packages/desktop-ui-lib/src/lib/image-viewer/image-viewer.service.ts
@@ -74,7 +74,7 @@ export class ImageViewerService {
 		}
 	}
 
-	async getTimeSlot(values: { timeSlotId: string }): Promise<ITimeSlot> {
+	async getTimeSlot(values: { timeSlotId: string }): Promise<ITimeSlot | null> {
 		const { timeSlotId } = values;
 		if (!timeSlotId) {
 			return null;

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2010,7 +2010,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		}
 
 		this.electronService.ipcRenderer.send('show_image', {
-			screenshot: this.screenshots,
+			screenshots: this.screenshots,
 			timeSlotId: !this._isOffline ? this.lastTimeSlot?.id : null
 		});
 	}

--- a/packages/desktop-window/src/lib/desktop-window-timer.ts
+++ b/packages/desktop-window/src/lib/desktop-window-timer.ts
@@ -48,13 +48,6 @@ export async function createTimeTrackerWindow(
 	const { width, height } = getScreenSize();
 	timeTrackerWindow.setMinimumSize(width, height);
 
-	timeTrackerWindow.on('resize', () => {
-		const [width, height] = timeTrackerWindow.getSize();
-		if (height !== mainWindowSettings.height) {
-			timeTrackerWindow.setSize(width, mainWindowSettings.height);
-		}
-	});
-
 	manager.overrideSystemContextMenu(timeTrackerWindow);
 
 	// Remove the menu from the window


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing last screen capture on startup and prevents the timer window from auto-growing. The image viewer, IPC, and time tracker now coordinate to reliably fetch and show the latest timeslot screenshot.

- **Bug Fixes**
  - Map the last capture’s timeslot to the last timer entry when missing so startup shows the right image.
  - Added IPC GET_LAST_CAPTURE and wired the time tracker to use it on startup.
  - Image viewer handles show_image with either timeSlotId or screenshots and fetches slot images via a cached request.
  - Locked timer window height on resize to stop automatic growth after starting the timer.

<sup>Written for commit 9bf98c1353542008b1e7c4b12d8ae529f1324960. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

