### PR TITLE
Stage

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -409,7 +409,7 @@ jobs:
           AGENT_APP_ID: 'com.ever.gauzyagent'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           AGENT_APP_ID: 'com.ever.gauzyagent'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -409,7 +409,7 @@ jobs:
           AGENT_APP_ID: 'com.ever.gauzyagent'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           AGENT_APP_ID: 'com.ever.gauzyagent'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_APP_ID: 'com.ever.gauzydesktop'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_APP_ID: 'com.ever.gauzydesktop'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_APP_ID: 'com.ever.gauzydesktop'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_APP_ID: 'com.ever.gauzydesktop'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_TIMER_APP_ID: 'com.ever.gauzydesktoptimer'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_TIMER_APP_ID: 'com.ever.gauzydesktoptimer'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_TIMER_APP_ID: 'com.ever.gauzydesktoptimer'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_TIMER_APP_ID: 'com.ever.gauzydesktoptimer'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_API_SERVER_APP_ID: 'com.ever.gauzyapiserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_API_SERVER_APP_ID: 'com.ever.gauzyapiserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_API_SERVER_APP_ID: 'com.ever.gauzyapiserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_API_SERVER_APP_ID: 'com.ever.gauzyapiserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_MCP_SERVER_APP_ID: 'com.ever.gauzymcpserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_MCP_SERVER_APP_ID: 'com.ever.gauzymcpserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_MCP_SERVER_APP_ID: 'com.ever.gauzymcpserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_MCP_SERVER_APP_ID: 'com.ever.gauzymcpserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_SERVER_APP_ID: 'com.ever.gauzyserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_SERVER_APP_ID: 'com.ever.gauzyserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -409,7 +409,7 @@ jobs:
           DESKTOP_SERVER_APP_ID: 'com.ever.gauzyserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source
@@ -573,7 +573,7 @@ jobs:
           DESKTOP_SERVER_APP_ID: 'com.ever.gauzyserver'
 
       - name: Fix Node.js PATH for child processes
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $nodeExe = (Get-Command node -ErrorAction Stop).Source


### PR DESCRIPTION
… blocks

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized Windows CI: added $ErrorActionPreference='SilentlyContinue' to agent-stage cleanup to avoid fresh-runner errors while preserving .nx/cache, and replaced 'pwsh' with 'powershell' across workflows to fix missing PowerShell Core on self-hosted runners.

<sup>Written for commit 69792d764e3d231712434abbbdfbefb842a242c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

