### PR TITLE
chore: fix windows builds

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Agent
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Agent
         shell: cmd
         run: yarn build:agent:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Agent
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Agent
         shell: cmd
         run: yarn build:agent:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Desktop App
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Desktop App
         shell: cmd
         run: yarn build:desktop:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Desktop App
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Desktop App
         shell: cmd
         run: yarn build:desktop:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Desktop Timer App
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Desktop Timer App
         shell: cmd
         run: yarn build:desktop-timer:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Desktop Timer App
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Desktop Timer App
         shell: cmd
         run: yarn build:desktop-timer:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server API
         shell: cmd
         run: yarn build:gauzy-api-server:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server API
         shell: cmd
         run: yarn build:gauzy-api-server:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server MCP
         shell: cmd
         run: yarn build:gauzy-mcp-server:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server MCP
         shell: cmd
         run: yarn build:gauzy-mcp-server:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server
         shell: cmd
         run: yarn build:gauzy-server:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -338,22 +338,6 @@ jobs:
         with:
           node-version: 24.13.0
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        shell: bash
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            .nx/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-yarn-nx-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-yarn-nx-
-            ${{ runner.os }}-${{ runner.arch }}-yarn-
-
       - name: Install Visual Studio 2022 Build Tools (VCTools)
         shell: powershell
         run: |
@@ -442,6 +426,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server
         shell: powershell
         run: |
@@ -468,7 +460,7 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false
 
   release-windows-arm64:
@@ -606,6 +598,14 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      - name: Increase file handle limits
+        shell: powershell
+        run: |
+          # Increase Node.js UV threadpool for parallel I/O (default is 4)
+          "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Patch graceful-fs to retry EMFILE errors with backoff
+          node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
       - name: Build Server
         shell: cmd
         run: yarn build:gauzy-server:windows:release:gh:arm64
@@ -623,5 +623,5 @@ jobs:
           DO_KEY_ID: ${{ secrets.DO_KEY_ID }}
           DO_SECRET_KEY: ${{ secrets.DO_SECRET_KEY }}
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-          NX_NO_CLOUD: false
+          NX_NO_CLOUD: true
           NX_DAEMON: false


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows CI builds by increasing Node file handling capacity, patching fs for EMFILE retries, and disabling Nx Cloud. Applied across agent, desktop apps, and server workflows for x64 and arm64.

- **Bug Fixes**
  - Set UV_THREADPOOL_SIZE=32 and patched graceful-fs to reduce EMFILE errors on Windows.
  - Disabled Nx Cloud in Windows jobs (NX_NO_CLOUD=true) for more predictable builds.
  - Removed yarn/Nx cache steps from Windows workflows to avoid cache-related failures.
  - Updated all Windows build pipelines: agent, desktop app, desktop timer app, server, server-api, and server-mcp (prod and stage).

<sup>Written for commit 409025c50a22d4577670d78220dde3e1b42964c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

