### PR TITLE
[Fix:] Injected MikroOrm in Time Slot Module avoiding app crash

### DIFF
--- a/packages/core/src/lib/time-tracking/time-slot/time-slot.module.ts
+++ b/packages/core/src/lib/time-tracking/time-slot/time-slot.module.ts
@@ -11,6 +11,7 @@ import { TimeLogModule } from './../time-log/time-log.module';
 import { EmployeeModule } from './../../employee/employee.module';
 import { ActivityModule } from './../activity/activity.module';
 import { TypeOrmTimeSlotRepository } from './repository/type-orm-time-slot.repository';
+import { MikroOrmTimeSlotRepository } from './repository/mikro-orm-time-slot.repository';
 import { TimeSlotMinute } from './time-slot-minute/time-slot-minute.entity';
 import { TypeOrmTimeSlotMinuteRepository } from './time-slot-minute/repositories/type-orm-time-slot-minute.repository';
 
@@ -25,7 +26,7 @@ import { TypeOrmTimeSlotMinuteRepository } from './time-slot-minute/repositories
 		forwardRef(() => ActivityModule),
 		CqrsModule
 	],
-	providers: [TimeSlotService, TypeOrmTimeSlotRepository, TypeOrmTimeSlotMinuteRepository, ...CommandHandlers],
-	exports: [TimeSlotService, TypeOrmTimeSlotRepository, TypeOrmTimeSlotMinuteRepository]
+	providers: [TimeSlotService, TypeOrmTimeSlotRepository, MikroOrmTimeSlotRepository, TypeOrmTimeSlotMinuteRepository, ...CommandHandlers],
+	exports: [TimeSlotService, TypeOrmTimeSlotRepository, MikroOrmTimeSlotRepository, TypeOrmTimeSlotMinuteRepository]
 })
 export class TimeSlotModule {}


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injected MikroOrmTimeSlotRepository into TimeSlotModule to fix a startup crash caused by a missing provider. Also exported it so dependent modules can use it.

- **Bug Fixes**
  - Added MikroOrmTimeSlotRepository to providers and exports in time-slot.module.ts to resolve DI errors when using MikroORM.

<sup>Written for commit f5c0fcf377170b3a59278cfa11d623a993db16c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

