### PR TITLE
chore: k8s pods for now to run without issues

### DIFF
--- a/.deploy/k8s/k8s-manifest.civo.demo.yaml
+++ b/.deploy/k8s/k8s-manifest.civo.demo.yaml
@@ -48,8 +48,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ["ALL"]
                   image: ghcr.io/ever-co/gauzy-api-demo:latest
                   env:
                       - name: API_HOST
@@ -121,8 +119,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ["ALL"]
                   image: ghcr.io/ever-co/gauzy-webapp-demo:latest
                   env:
                       - name: DEMO

--- a/.deploy/k8s/k8s-manifest.civo.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.civo.prod.yaml
@@ -48,8 +48,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ["ALL"]
                   image: ghcr.io/ever-co/gauzy-api:latest
                   env:
                       - name: API_HOST
@@ -292,8 +290,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ["ALL"]
                   image: ghcr.io/ever-co/gauzy-webapp:latest
                   env:
                       - name: DEMO

--- a/.deploy/k8s/k8s-manifest.civo.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.civo.stage.yaml
@@ -48,8 +48,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ["ALL"]
                   image: ghcr.io/ever-co/gauzy-api-stage:latest
                   env:
                       - name: API_HOST
@@ -294,8 +292,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ["ALL"]
                   image: ghcr.io/ever-co/gauzy-webapp-stage:latest
                   env:
                       - name: DEMO

--- a/.deploy/k8s/k8s-manifest.cw.demo.yaml
+++ b/.deploy/k8s/k8s-manifest.cw.demo.yaml
@@ -63,8 +63,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: ever-registry.tenant-acb888-ever.ord1.ingress.coreweave.cloud/ever-co/gauzy-api-demo:latest
                   env:
                       - name: API_HOST
@@ -155,8 +153,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: ever-registry.tenant-acb888-ever.ord1.ingress.coreweave.cloud/ever-co/gauzy-webapp-demo:latest
                   env:
                       - name: DEMO

--- a/.deploy/k8s/k8s-manifest.cw.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.cw.prod.yaml
@@ -74,8 +74,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: ever-registry.tenant-acb888-ever.ord1.ingress.coreweave.cloud/ever-co/gauzy-api:latest
                   env:
                       - name: API_HOST
@@ -348,8 +346,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: ever-registry.tenant-acb888-ever.ord1.ingress.coreweave.cloud/ever-co/gauzy-webapp:latest
                   env:
                       - name: DEMO

--- a/.deploy/k8s/k8s-manifest.cw.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.cw.stage.yaml
@@ -74,8 +74,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: ever-registry.tenant-acb888-ever.ord1.ingress.coreweave.cloud/ever-co/gauzy-api-stage:latest
                   env:
                       - name: API_HOST
@@ -348,8 +346,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: ever-registry.tenant-acb888-ever.ord1.ingress.coreweave.cloud/ever-co/gauzy-webapp-stage:latest
                   env:
                       - name: DEMO

--- a/.deploy/k8s/k8s-manifest.demo.yaml
+++ b/.deploy/k8s/k8s-manifest.demo.yaml
@@ -100,8 +100,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-api-demo:latest
                   env:
                       - name: API_HOST
@@ -176,8 +174,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-webapp-demo:latest
                   env:
                       - name: DEMO

--- a/.deploy/k8s/k8s-manifest.mcp-auth.demo.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp-auth.demo.yaml
@@ -37,8 +37,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-mcp-auth-demo:latest
                   env:
                       - name: DB_URI

--- a/.deploy/k8s/k8s-manifest.mcp-auth.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp-auth.prod.yaml
@@ -37,8 +37,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-mcp-auth:latest
                   env:
                       - name: DB_URI

--- a/.deploy/k8s/k8s-manifest.mcp-auth.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp-auth.stage.yaml
@@ -37,8 +37,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-mcp-auth-stage:latest
                   env:
                       - name: DB_URI

--- a/.deploy/k8s/k8s-manifest.mcp.demo.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.demo.yaml
@@ -41,8 +41,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-mcp-demo:latest
                   env:
                       - name: NODE_ENV

--- a/.deploy/k8s/k8s-manifest.mcp.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.prod.yaml
@@ -41,8 +41,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-mcp:latest
                   env:
                       - name: NODE_ENV

--- a/.deploy/k8s/k8s-manifest.mcp.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.stage.yaml
@@ -41,8 +41,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-mcp-stage:latest
                   env:
                       - name: NODE_ENV

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -100,8 +100,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-api:latest
                   resources:
                       requests:
@@ -352,8 +350,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-webapp:latest
                   env:
                       - name: DEMO

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -100,8 +100,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-api-stage:latest
                   env:
                       - name: API_HOST
@@ -346,8 +344,6 @@ spec:
                       allowPrivilegeEscalation: false
                       readOnlyRootFilesystem: false
                       runAsNonRoot: false
-                      capabilities:
-                          drop: ['ALL']
                   image: registry.digitalocean.com/ever/gauzy-webapp-stage:latest
                   env:
                       - name: DEMO


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed capabilities.drop: ["ALL"] from Kubernetes manifests for API, Webapp, MCP, and MCP-Auth to fix pod startup failures. Pods now run across Civo, CoreWeave, and DigitalOcean clusters; other security settings remain unchanged.

<sup>Written for commit 801f727a125133611b6d07c7f107c68d2847c645. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

