### PR TITLE
fix: mcp dockers

### DIFF
--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -115,11 +115,18 @@ RUN apk add --no-cache python3 python3-dev py3-pip py3-setuptools build-base gcc
     && npm install yarn -g --force \
     && npm install --quiet ts-node@10.9.2 -g
 
+# Create working directory with correct ownership so node user can create symlinks
+RUN mkdir -p /srv/gauzy-mcp-auth && chown node:node /srv/gauzy-mcp-auth
+
 USER node:node
 
 WORKDIR /srv/gauzy-mcp-auth
 
 COPY --chown=node:node --from=build /srv/gauzy-mcp-auth/dist .
+
+# Create dist -> . symlink so ../../../dist/ paths in package.json resolve correctly in Docker
+RUN ln -s . dist
+
 COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -160,11 +160,18 @@ RUN apk add --no-cache python3 python3-dev py3-pip py3-setuptools build-base gcc
     && npm install yarn -g --force \
     && npm install --quiet ts-node@10.9.2 -g
 
+# Create working directory with correct ownership so node user can create symlinks
+RUN mkdir -p /srv/gauzy-mcp && chown node:node /srv/gauzy-mcp
+
 USER node:node
 
 WORKDIR /srv/gauzy-mcp
 
 COPY --chown=node:node --from=build /srv/gauzy-mcp/dist .
+
+# Create dist -> . symlink so ../../../dist/ paths in package.json resolve correctly in Docker
+RUN ln -s . dist
+
 COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP and MCP Auth Docker images to prevent permission and path errors. Working dirs are owned by the node user and a dist symlink ensures package.json paths resolve.

- **Bug Fixes**
  - Create /srv/gauzy-mcp and /srv/gauzy-mcp-auth with node:node ownership.
  - Add dist -> . symlink in both images to satisfy ../../../dist paths.

<sup>Written for commit 7f14b414b48c6f4c0db3dcfa2901b3e3212d792c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

