### PR TITLE
fix(core): CORS origin validation callback and Helmet cross-origin resource policy

### DIFF
--- a/packages/core/src/lib/bootstrap/index.ts
+++ b/packages/core/src/lib/bootstrap/index.ts
@@ -171,7 +171,12 @@ export async function bootstrap(pluginConfig?: Partial<ApplicationPluginConfig>)
 			contentSecurityPolicy: isProduction
 				? undefined // use Helmet's strict default CSP in production
 				: false, // disable CSP in dev/stage so Swagger/Scalar inline scripts work
-			crossOriginResourcePolicy: { policy: 'cross-origin' } // Allow cross-origin loading of resources (e.g. screenshots, images)
+			crossOriginResourcePolicy: isProduction
+        		? { policy: 'same-origin' }  // Strict in prod — resources come from S3 or other storage anyway
+        		: { policy: 'cross-origin' }, // Relaxed in dev/stage — resources served from API
+    		crossOriginEmbedderPolicy: isProduction
+        		? true   // keep strict default in production
+        		: false  // Relaxed in dev/stage for Electron/desktop loading resources from API server
 		})
 	);
 


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-request CORS origin validation via a callback that checks an allowlist, allows no-origin requests, and suppresses CORS headers (no 500) for disallowed origins; fallback to '*' when no allowlist and only enable credentials when one is set. Update `helmet` to keep CSP strict in prod and disabled in dev/stage, set cross-origin resource policy to 'same-origin' in prod and 'cross-origin' in dev/stage, and enable cross-origin embedder policy in prod (disabled in dev/stage); plus a `cspell` typo fix.

<sup>Written for commit 0d8b09b4aebd3cdaa4c6d14bbe3a9ac4e42f3793. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



