### PR TITLE
Stage

### DIFF
--- a/.scripts/electron-desktop-environment/concrete-environment-content/desktop-api-server-environment-content.ts
+++ b/.scripts/electron-desktop-environment/concrete-environment-content/desktop-api-server-environment-content.ts
@@ -1,5 +1,6 @@
 import { IContentGenerator } from '../interfaces/i-content-generator';
 import { IDesktopEnvironment } from '../interfaces/i-desktop-environment';
+import { escapeForSingleQuote } from '../utils/escape-string';
 
 export class DesktopApiServerEnvironmentContent implements IContentGenerator {
 	/**
@@ -30,8 +31,8 @@ export class DesktopApiServerEnvironmentContent implements IContentGenerator {
 			IS_DESKTOP: ${false},
 			IS_SERVER: ${true},
 			IS_SERVER_API: ${true},
-			JWT_SECRET: '${variable.DESKTOP_JWT_SECRET || ''}',
-			JWT_REFRESH_TOKEN_SECRET: '${variable.DESKTOP_JWT_REFRESH_TOKEN_SECRET || ''}'
+			JWT_SECRET: '${escapeForSingleQuote(variable.DESKTOP_JWT_SECRET || '')}',
+			JWT_REFRESH_TOKEN_SECRET: '${escapeForSingleQuote(variable.DESKTOP_JWT_REFRESH_TOKEN_SECRET || '')}'
 		`;
 	}
 }

--- a/.scripts/electron-desktop-environment/concrete-environment-content/desktop-server-environment-content.ts
+++ b/.scripts/electron-desktop-environment/concrete-environment-content/desktop-server-environment-content.ts
@@ -1,5 +1,6 @@
 import { IContentGenerator } from '../interfaces/i-content-generator';
 import { IDesktopEnvironment } from '../interfaces/i-desktop-environment';
+import { escapeForSingleQuote } from '../utils/escape-string';
 
 export class DesktopServerEnvironmentContent implements IContentGenerator {
 	/**
@@ -30,8 +31,8 @@ export class DesktopServerEnvironmentContent implements IContentGenerator {
 			IS_DESKTOP: ${false},
 			IS_SERVER: ${true},
 			IS_SERVER_API: ${false},
-			JWT_SECRET: '${variable.DESKTOP_JWT_SECRET || ''}',
-			JWT_REFRESH_TOKEN_SECRET: '${variable.DESKTOP_JWT_REFRESH_TOKEN_SECRET || ''}'
+			JWT_SECRET: '${escapeForSingleQuote(variable.DESKTOP_JWT_SECRET || '')}',
+			JWT_REFRESH_TOKEN_SECRET: '${escapeForSingleQuote(variable.DESKTOP_JWT_REFRESH_TOKEN_SECRET || '')}'
 		`;
 	}
 }

--- a/.scripts/electron-desktop-environment/utils/escape-string.ts
+++ b/.scripts/electron-desktop-environment/utils/escape-string.ts
@@ -1,0 +1,13 @@
+/**
+ * Escapes a string so it can be safely embedded inside a single-quoted
+ * JavaScript string literal in generated source code.
+ *
+ * Handles backslashes, single quotes, and newline characters that would
+ * otherwise break or alter the emitted string.
+ *
+ * @param value - The raw string to escape.
+ * @returns The escaped string, safe for single-quote interpolation.
+ */
+export function escapeForSingleQuote(value: string): string {
+	return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+}

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -347,8 +347,12 @@ async function startServer(setupConfig: DesktopSetupConfig, restart = false) {
 		process.env.API_PORT = setupConfig.port ? String(setupConfig.port) : String(environment.API_DEFAULT_PORT);
 		process.env.API_HOST = '0.0.0.0';
 		process.env.API_BASE_URL = `http://127.0.0.1:${setupConfig.port || environment.API_DEFAULT_PORT}`;
-		process.env.JWT_SECRET = setupConfig.secret?.jwt;
-		process.env.JWT_REFRESH_TOKEN_SECRET = setupConfig.secret?.refresh_token;
+
+		if (!setupConfig.secret || !setupConfig.secret.jwt || !setupConfig.secret.refresh_token) {
+			throw new AppError('MAINSTRSERVER', new Error('JWT secrets are required for local server startup'));
+		}
+		process.env.JWT_SECRET = setupConfig.secret.jwt;
+		process.env.JWT_REFRESH_TOKEN_SECRET = setupConfig.secret.refresh_token;
 
 		console.log('Setting additional environment variables...', process.env.API_PORT);
 		console.log('Setting additional environment variables...', process.env.API_HOST);

--- a/packages/desktop-ui-lib/src/lib/offline-sync/concretes/sequence-queue.ts
+++ b/packages/desktop-ui-lib/src/lib/offline-sync/concretes/sequence-queue.ts
@@ -1,5 +1,5 @@
 import { ITimeSlot, TimerSyncStateEnum, TimerActionTypeEnum } from '@gauzy/contracts';
-import { asapScheduler, concatMap, defer, of, repeat, timer as synchronizer } from 'rxjs';
+import { concatMap, defer, of, repeat, timer as synchronizer } from 'rxjs';
 import { BACKGROUND_SYNC_OFFLINE_INTERVAL } from '../../constants/app.constants';
 import { ElectronService } from '../../electron/services';
 import { ErrorHandlerService, Store } from '../../services';
@@ -86,7 +86,8 @@ export class SequenceQueue extends OfflineQueue<ISequence> {
 				this._timeTrackerService,
 				this._timeSlotQueueService,
 				this._electronService,
-				this._store
+				this._store,
+				latest ? latest.id : timer.timelogId
 			);
 
 			// append data to queue;
@@ -119,7 +120,7 @@ export class SequenceQueue extends OfflineQueue<ISequence> {
 						});
 					} else if (currentTimeLog.id && timer.stoppedAt) {
 						latest = await this._timeTrackerService.updateTimeLog(timer.timelogId, {
-							startedAt: timer.startedAt || currentTimeLog.startedAt,
+							startedAt: timer.startedAt,
 							stoppedAt: timer.stoppedAt,
 							description: timer.description,
 							projectId: timer.projectId,
@@ -134,41 +135,62 @@ export class SequenceQueue extends OfflineQueue<ISequence> {
 							}
 						});
 					}
-				} else if (latest && latest.id && latest.isRunning) {
-					latest = await this._timeTrackerService.toggleApiStop({
-						...timer,
-						...params
-					});
-					await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
-						actionType: TimerActionTypeEnum.STOP_TIMER,
-						data: {
-							state: TimerSyncStateEnum.SYNCED,
-							duration: latest.duration || null,
-							timerId: timer.id
-						}
-					});
+				} else if (latest && latest.id) {
+					if (latest.isRunning) {
+						latest = await this._timeTrackerService.toggleApiStop({
+							...timer,
+							...params
+						});
+						await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
+							actionType: TimerActionTypeEnum.STOP_TIMER,
+							data: {
+								state: TimerSyncStateEnum.SYNCED,
+								duration: latest.duration || null,
+								timerId: timer.id
+							}
+						});
+					} else if (timer.stoppedAt && !latest.isRunning) {
+						latest = await this._timeTrackerService.updateTimeLog(latest.id, {
+							startedAt: timer.startedAt,
+							stoppedAt: timer.stoppedAt,
+							description: timer.description,
+							projectId: timer.projectId,
+							taskId: timer.taskId
+						});
+						await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
+							actionType: TimerActionTypeEnum.STOP_TIMER,
+							data: {
+								state: TimerSyncStateEnum.SYNCED,
+								duration: latest.duration || null,
+								timerId: timer.id
+							}
+						});
+					}
 				}
 			}
 
 			const status = await this._timeTrackerStatusService.status();
 
-			asapScheduler.schedule(async () => {
-				try {
-					await this._electronService.ipcRenderer.invoke('UPDATE_SYNCED_TIMER', {
-						lastTimer: latest
-							? latest
-							: {
-									...timer,
-									id: status?.lastLog?.id
-							  },
-						...timer
-					});
-					console.log('⏱ - local database updated');
-				} catch (error) {
-					console.error('🚨 - Error updating local database', error);
-					this._errorHandlerService.handleError(error);
-				}
-			});
+			/* Await directly instead of using asapScheduler (fire-and-forget).
+			  The asapScheduler deferral allowed the next queue item to start processing
+			  before this item's local DB update completed, causing out-of-order writes
+			  that corrupted syncDuration and timeslotId for concurrent offline sessions.
+			*/
+			try {
+				await this._electronService.ipcRenderer.invoke('UPDATE_SYNCED_TIMER', {
+					lastTimer: latest
+						? latest
+						: {
+							...timer,
+							id: status?.lastLog?.id
+						},
+					...timer
+				});
+				console.log('⏱ - local database updated');
+			} catch (error) {
+				console.error('🚨 - Error updating local database', error);
+				this._errorHandlerService.handleError(error);
+			}
 		} catch (error) {
 			console.error('🚨 - Error processing time slot queue', error);
 			this._timeSlotQueueService.viewQueueStateUpdater = {

--- a/packages/desktop-ui-lib/src/lib/offline-sync/concretes/time-slot-queue.ts
+++ b/packages/desktop-ui-lib/src/lib/offline-sync/concretes/time-slot-queue.ts
@@ -13,7 +13,8 @@ export class TimeSlotQueue extends OfflineQueue<ITimeSlot> {
 		private _timeTrackerService: TimeTrackerService,
 		private _timeSlotQueueService: TimeSlotQueueService,
 		private _electronService: ElectronService,
-		private _store: Store
+		private _store: Store,
+		private _timeLogId?: string
 	) {
 		super();
 		this.state = new BlockedTimeSlotState(this);
@@ -26,6 +27,7 @@ export class TimeSlotQueue extends OfflineQueue<ITimeSlot> {
 			recordedAt: interval.startedAt,
 			organizationId: this._store.organizationId,
 			tenantId: this._store.tenantId,
+			...(this._timeLogId ? { timeLogId: this._timeLogId } : {})
 		});
 		console.log('backup', activities);
 		const timeSlotId = activities.id;

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.service.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.service.ts
@@ -53,6 +53,72 @@ export class TimeTrackerService {
 	userId = '';
 	employeeId = '';
 
+	/**
+	 * Promise-chain mutex that serializes timer state mutations.
+	 * toggleApiStart / toggleApiStop / updateTimeLog / addTimeLog all funnel
+	 * through _timerMutex so no two of them can run concurrently.  Without this
+	 * guard, an offline-sync stop and an online session start can reach the server
+	 * simultaneously, causing stopPreviousRunningTimers to override stoppedAt and
+	 * trigger cascade deletion of adjacent timelogs.
+	 */
+	private _timerMutex: Promise<unknown> = Promise.resolve();
+
+	/**
+	 * Failsafe timeout for a single enqueued operation.
+	 * Set to 2× the HTTP layer timeout so legitimate slow requests are never
+	 * killed early, while a genuinely hung call still releases the chain.
+	 */
+	private static readonly _OP_TIMEOUT_MS = 120_000;
+
+	/**
+	 * Enqueue a timer API operation onto the serialization chain.
+	 *
+	 * Guarantees:
+	 *  - Operations execute one at a time, in call order.
+	 *  - A per-operation timeout (_OP_TIMEOUT_MS) releases the chain if the
+	 *    underlying HTTP call never settles, preventing a permanent deadlock.
+	 *  - Errors thrown by `fn` propagate to the caller unchanged; the mutex
+	 *    chain itself never gets stuck regardless of failures.
+	 *
+	 * @param label  Short human-readable name logged at start / end / error.
+	 * @param fn     Factory that returns the Promise to await.
+	 */
+	private _serialized<T>(label: string, fn: () => Promise<T>): Promise<T> {
+		const result: Promise<T> = this._timerMutex.then(async () => {
+			this._loggerService.info(`[TimerMutex] ▶ ${label}`);
+
+			let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+			const timeoutRace = new Promise<never>((_, reject) => {
+				timeoutId = setTimeout(
+					() =>
+						reject(
+							new Error(
+								`[TimerMutex] "${label}" timed out after ${TimeTrackerService._OP_TIMEOUT_MS}ms — mutex released`
+							)
+						),
+					TimeTrackerService._OP_TIMEOUT_MS
+				);
+			});
+
+			try {
+				return await Promise.race([fn(), timeoutRace]);
+			} catch (error) {
+				this._loggerService.error(`[TimerMutex] ✖ ${label}`, error);
+				throw error;
+			} finally {
+				clearTimeout(timeoutId);
+				this._loggerService.info(`[TimerMutex] ■ ${label} done`);
+			}
+		});
+
+		// Absorb rejection on the mutex chain so the next queued operation is
+		// never blocked by the failure of a previous one.  The caller receives
+		// the real rejection via `result`.
+		this._timerMutex = result.catch(() => {});
+		return result;
+	}
+
 	constructor(
 		private readonly http: HttpClient,
 		private readonly _clientCacheService: ClientCacheService,
@@ -469,7 +535,7 @@ export class TimeTrackerService {
 			organizationTeamId: values.organizationTeamId
 		};
 		this._loggerService.log.info(`Toggle Start Timer Request: ${moment().format()}`, body);
-		return firstValueFrom(this.http.post(`${API_PREFIX}/timesheet/timer/start`, { ...body }, options));
+		return this._serialized('toggleApiStart', () => firstValueFrom(this.http.post(`${API_PREFIX}/timesheet/timer/start`, { ...body }, options)));
 	}
 
 	toggleApiStop(values) {
@@ -516,26 +582,38 @@ export class TimeTrackerService {
 		// Log request details
 		this._loggerService.info<any>(`Toggle Stop Timer Request: ${moment().format()}`, body);
 
-		// Perform the API call
-		try {
-			return firstValueFrom(this.http.post<ITimeLog>(API_URL, body, options));
-		} catch (error) {
-			this._loggerService.error<any>(`Error stopping timer: ${moment().format()}`, { error, requestBody: body });
-			throw error;
-		}
+		return this._serialized('toggleApiStop', () => {
+			try {
+				return firstValueFrom(this.http.post<ITimeLog>(API_URL, body, options));
+			} catch (error) {
+				this._loggerService.error<any>(`Error stopping timer: ${moment().format()}`, { error, requestBody: body });
+				throw error;
+			}
+		});
 	}
 
 	updateTimeLog(timeLogId: string, payload: Partial<ITimeLog>) {
 		const TIMEOUT = 15000;
 		const API_URL = `${API_PREFIX}/timesheet/time-log/${timeLogId}`;
+
+		// Guard: a null organizationId causes the server to silently move the timelog to a
+		// null-org timesheet, making it invisible in the dashboard without any error or deletion.
+		if (!this._store.organizationId || !this._store.tenantId) {
+			const msg = `updateTimeLog aborted for ${timeLogId}: organizationId or tenantId is null in store`;
+			this._loggerService.log.warn(msg);
+			throw new Error(msg);
+		}
+
 		const timeLogPayload: Partial<ITimeLog> = {
-			startedAt: moment(payload.startedAt).utc().toDate(),
+			...(payload.startedAt ? { startedAt: moment(payload.startedAt).utc().toDate() } : {}),
 			stoppedAt: moment(payload.stoppedAt).utc().toDate(),
+			...(payload.isRunning !== undefined ? { isRunning: payload.isRunning } : {}),
 			isBillable: true,
 			logType: TimeLogType.TRACKED,
 			source: TimeLogSourceEnum.DESKTOP,
 			tenantId: this._store.tenantId,
 			organizationId: this._store.organizationId,
+			organizationContactId: payload.organizationContactId,
 			employeeId: this._store.user?.employee?.id,
 			...(payload.description ? { description: payload.description } : {}),
 			...(payload.taskId ? { taskId: payload.taskId } : {}),
@@ -545,12 +623,21 @@ export class TimeTrackerService {
 			headers: new HttpHeaders({ timeout: TIMEOUT.toString() })
 		};
 		this._loggerService.log.info(`Update Time Log Request: ${timeLogId} ${moment().format()}`, timeLogPayload);
-		return firstValueFrom(this.http.put<ITimeLog>(API_URL, timeLogPayload, options));
+		return this._serialized(`updateTimeLog:${timeLogId}`, () => firstValueFrom(this.http.put<ITimeLog>(API_URL, timeLogPayload, options)));
 	}
 
 	addTimeLog(payload: Partial<ITimeLog>) {
 		const TIMEOUT = 15000;
 		const API_URL = `${API_PREFIX}/timesheet/time-log`;
+
+		// Guard: a null organizationId causes the server to silently move the timelog to a
+		// null-org timesheet, making it invisible in the dashboard without any error or deletion.
+		if (!this._store.organizationId || !this._store.tenantId) {
+			const msg = `addTimeLog aborted: organizationId or tenantId is null in store`;
+			this._loggerService.log.warn(msg);
+			throw new Error(msg);
+		}
+
 		const timeLogPayload: Partial<ITimeLog> = {
 			startedAt: moment(payload.startedAt).utc().toDate(),
 			stoppedAt: moment(payload.stoppedAt).utc().toDate(),
@@ -558,6 +645,7 @@ export class TimeTrackerService {
 			logType: TimeLogType.TRACKED,
 			source: TimeLogSourceEnum.DESKTOP,
 			tenantId: this._store.tenantId,
+			organizationContactId: payload.organizationContactId,
 			organizationId: this._store.organizationId,
 			employeeId: this._store.user?.employee?.id,
 			...(payload.description ? { description: payload.description } : {}),
@@ -569,7 +657,7 @@ export class TimeTrackerService {
 			headers: new HttpHeaders({ timeout: TIMEOUT.toString() })
 		};
 		this._loggerService.log.info(`Add Time Log Request: ${moment().format()}`, timeLogPayload);
-		return firstValueFrom(this.http.post<ITimeLog>(API_URL, timeLogPayload, options));
+		return this._serialized('addTimeLog', () => firstValueFrom(this.http.post<ITimeLog>(API_URL, timeLogPayload, options)));
 	}
 
 	deleteTimeSlot(values) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18923,9 +18923,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001699, caniuse-lite@^1.0.30001759, caniuse-lite@^1.0.30001766:
-  version "1.0.30001777"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz#028f21e4b2718d138b55e692583e6810ccf60691"
-  integrity sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==
+  version "1.0.30001778"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz#79a8a124e3473a20b70616497b987c30d06570a0"
+  integrity sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==
 
 canonicalize@^1.0.1:
   version "1.0.8"
@@ -30678,9 +30678,9 @@ lockfile@1.0.4:
     signal-exit "^3.0.2"
 
 locutus@^2.0.11, locutus@^3.0.0:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/locutus/-/locutus-3.0.10.tgz#725fa08fb8498bfc17d059fbbd267887368a9931"
-  integrity sha512-F/C16ccWteU0TDnxZ+eqsBh0DoL86EGamIoK8QXr6oHiEpp3UdX1epQaAykb9bBJ1sFOGkBVoDSDSJp8BlVtNA==
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/locutus/-/locutus-3.0.14.tgz#f7acd279aba68f9d7c9b087c403ebbfadc4307a3"
+  integrity sha512-3R3vCGG8DetSYJCkpleF9nYZlThmxfkXsl1R+a7En3pWwY/zRqwsyEa3618nr7N0Esx9F3N625moWVU4OboynA==
 
 lodash-es@^4.17.15, lodash-es@^4.17.21:
   version "4.17.23"
@@ -33063,9 +33063,9 @@ no-case@^2.2.0:
     lower-case "^1.1.1"
 
 node-abi@^3.3.0, node-abi@^3.45.0, node-abi@^3.73.0, node-abi@^3.78.0:
-  version "3.87.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.87.0.tgz#423e28fea5c2f195fddd98acded9938c001ae6dd"
-  integrity sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==
+  version "3.88.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.88.0.tgz#656ce29cbcf7c0bd7d0a9fdff6d6432b0744ce55"
+  integrity sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==
   dependencies:
     semver "^7.3.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18923,9 +18923,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001699, caniuse-lite@^1.0.30001759, caniuse-lite@^1.0.30001766:
-  version "1.0.30001777"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz#028f21e4b2718d138b55e692583e6810ccf60691"
-  integrity sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==
+  version "1.0.30001778"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz#79a8a124e3473a20b70616497b987c30d06570a0"
+  integrity sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==
 
 canonicalize@^1.0.1:
   version "1.0.8"
@@ -33063,9 +33063,9 @@ no-case@^2.2.0:
     lower-case "^1.1.1"
 
 node-abi@^3.3.0, node-abi@^3.45.0, node-abi@^3.73.0, node-abi@^3.78.0:
-  version "3.87.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.87.0.tgz#423e28fea5c2f195fddd98acded9938c001ae6dd"
-  integrity sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==
+  version "3.88.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.88.0.tgz#656ce29cbcf7c0bd7d0a9fdff6d6432b0744ce55"
+  integrity sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==
   dependencies:
     semver "^7.3.5"
 
@@ -42246,9 +42246,9 @@ undici@7.18.2:
   integrity sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==
 
 undici@^6.10.2, undici@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.23.0.tgz#7953087744d9095a96f115de3140ca3828aff3a4"
-  integrity sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==
+  version "6.24.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.24.0.tgz#ad36b879b4882d14addc13dd641da7ed7ac7623a"
+  integrity sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==
 
 undici@^7.0.0, undici@^7.12.0:
   version "7.22.0"


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop timer offline sync issues by serializing timer API calls and enforcing ordered local updates, preventing race conditions and corrupted time logs. Also hardens local server startup and escapes JWT secrets in generated env files.

- **Bug Fixes**
  - Serialize `toggleApiStart`, `toggleApiStop`, `updateTimeLog`, and `addTimeLog` via a mutex with a per-op timeout to prevent overlapping requests and cascade deletions during offline/online transitions.
  - Replace deferred `asapScheduler` update with awaited IPC update in sequence queue to preserve write order; pass `timeLogId` to `TimeSlotQueue` so timeslots link to the correct log.
  - Add guards to `updateTimeLog`/`addTimeLog` when `organizationId`/`tenantId` are missing; support optional fields and include `organizationContactId`.
  - Require JWT secrets for local server start and throw an error if missing.
  - Escape JWT secrets in generated desktop env content using `escapeForSingleQuote` to handle backslashes, quotes, and newlines.

- **Dependencies**
  - Bump `undici` to 6.24.0 and `locutus` to 3.0.14; update `caniuse-lite` and `node-abi` in `yarn.lock`.

<sup>Written for commit 1c6889b6b51a89e2d550fa9166815a36395c5315. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

