### PR TITLE
[Fix] Direct local installation

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -879,7 +879,8 @@
 		"sidemenu",
 		"ptdu",
 		"ptau",
-		"Centralises"
+		"Centralises",
+		"Dispatchable"
 	],
 	"useGitignore": true,
 	"ignorePaths": [

--- a/packages/desktop-lib/src/lib/plugin-system/data-access/plugin-manager.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/data-access/plugin-manager.ts
@@ -6,7 +6,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { PluginMetadataService } from '../database/plugin-metadata.service';
 import { PluginEventManager } from '../events/plugin-event.manager';
-import { IPlugin, IPluginManager, IPluginMetadata, IPluginMetadataFindOne, PluginDownloadContextType } from '../shared';
+import { IPlugin, IPluginManager, IPluginMetadata, IPluginMetadataFindOne, IPluginMetadataUpdate, PluginDownloadContextType } from '../shared';
 import { lazyLoader } from '../shared/lazy-loader';
 import { DownloadContextFactory } from './download-context.factory';
 
@@ -39,10 +39,10 @@ export class PluginManager implements IPluginManager {
 		} else {
 			/* Install plugin */
 			await this.installPlugin(
-				{ 
-					...metadata, 
-					marketplaceId: config.marketplaceId || null, 
-					versionId: config.versionId || null 
+				{
+					...metadata,
+					marketplaceId: config.marketplaceId || null,
+					versionId: config.versionId || null
 				},
 				pathDirname
 			);
@@ -86,13 +86,15 @@ export class PluginManager implements IPluginManager {
 		}
 	}
 
-	// Update plugin marketplace metadata
-	// For local installations, marketplaceId may be null
+	// Update plugin marketplace metadata (marketplaceId is the record identifier for buildQuery)
 	public async completeInstallation(marketplaceId: string | null, installationId: string): Promise<void> {
-		const updateData: any = { installationId };
-		if (marketplaceId) {
-			updateData.marketplaceId = marketplaceId;
+		if (!marketplaceId) {
+			logger.warn(
+				`completeInstallation: marketplaceId is required to identify the record; skipping update for installationId: ${installationId}`
+			);
+			return;
 		}
+		const updateData: IPluginMetadataUpdate = { marketplaceId, installationId };
 		await this.pluginMetadataService.update(updateData);
 	}
 

--- a/packages/desktop-lib/src/lib/plugin-system/data-access/plugin-manager.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/data-access/plugin-manager.ts
@@ -26,7 +26,7 @@ export class PluginManager implements IPluginManager {
 		return this.instance;
 	}
 
-	public async downloadPlugin<U extends { contextType: PluginDownloadContextType; marketplaceId: ID; versionId: ID }>(
+	public async downloadPlugin<U extends { contextType: PluginDownloadContextType; marketplaceId?: ID; versionId?: ID }>(
 		config: U
 	): Promise<IPluginMetadata> {
 		logger.info(`Downloading plugin...`);
@@ -39,7 +39,11 @@ export class PluginManager implements IPluginManager {
 		} else {
 			/* Install plugin */
 			await this.installPlugin(
-				{ ...metadata, marketplaceId: config.marketplaceId, versionId: config.versionId },
+				{ 
+					...metadata, 
+					marketplaceId: config.marketplaceId || null, 
+					versionId: config.versionId || null 
+				},
 				pathDirname
 			);
 		}
@@ -83,11 +87,13 @@ export class PluginManager implements IPluginManager {
 	}
 
 	// Update plugin marketplace metadata
-	public async completeInstallation(marketplaceId: string, installationId: string): Promise<void> {
-		await this.pluginMetadataService.update({
-			marketplaceId,
-			installationId
-		});
+	// For local installations, marketplaceId may be null
+	public async completeInstallation(marketplaceId: string | null, installationId: string): Promise<void> {
+		const updateData: any = { installationId };
+		if (marketplaceId) {
+			updateData.marketplaceId = marketplaceId;
+		}
+		await this.pluginMetadataService.update(updateData);
 	}
 
 	public async installPlugin(pluginMetadata: IPluginMetadata, pluginDir: string): Promise<void> {

--- a/packages/desktop-lib/src/lib/plugin-system/data-access/plugin-manager.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/data-access/plugin-manager.ts
@@ -86,15 +86,20 @@ export class PluginManager implements IPluginManager {
 		}
 	}
 
-	// Update plugin marketplace metadata (marketplaceId is the record identifier for buildQuery)
-	public async completeInstallation(marketplaceId: string | null, installationId: string): Promise<void> {
-		if (!marketplaceId) {
+	// Update plugin marketplace metadata; falls back to plugin name for locally installed plugins
+	public async completeInstallation(marketplaceId: string | null, installationId: string, name?: string): Promise<void> {
+		if (!marketplaceId && !name) {
 			logger.warn(
-				`completeInstallation: marketplaceId is required to identify the record; skipping update for installationId: ${installationId}`
+				`completeInstallation: either marketplaceId or name is required to identify the record; skipping update for installationId: ${installationId}`
 			);
 			return;
 		}
-		const updateData: IPluginMetadataUpdate = { marketplaceId, installationId };
+		const updateData: IPluginMetadataUpdate = { installationId };
+		if (marketplaceId) {
+			updateData.marketplaceId = marketplaceId;
+		} else {
+			updateData.name = name;
+		}
 		await this.pluginMetadataService.update(updateData);
 	}
 

--- a/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
@@ -13,10 +13,49 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 	/**
 	 * Resolve an archive entry path against a base extraction directory and ensure
 	 * it does not escape the base (Zip Slip protection).
+	 *
+	 * This method rejects:
+	 * - empty/whitespace-only paths
+	 * - absolute or UNC paths
+	 * - paths that contain any ".." segments
+	 * - paths that, after resolution, are outside the base directory
 	 */
 	private static safeExtractPath(baseDir: string, entryPath: string): string | null {
+		// Basic sanity checks.
+		if (!entryPath || !entryPath.trim()) {
+			return null;
+		}
+
+		// Archive entries typically use POSIX-style separators, so normalize on "/"
+		// when looking for traversal segments, regardless of host OS.
+		const normalizedEntryPath = entryPath.replace(/\\/g, '/');
+
+		// Reject any absolute/UNC-like paths outright.
+		if (path.isAbsolute(normalizedEntryPath)) {
+			return null;
+		}
+		if (process.platform === 'win32') {
+			// UNC paths such as \\server\share or //server/share
+			if (
+				normalizedEntryPath.startsWith('\\\\') ||
+				normalizedEntryPath.startsWith('//')
+			) {
+				return null;
+			}
+			// Patterns like "c:/" or "c:\" (drive-absolute) should also be rejected.
+			if (/^[a-zA-Z]:[\\/]/.test(normalizedEntryPath)) {
+				return null;
+			}
+		}
+
+		// Reject any path that contains a ".." segment after normalization.
+		const segments = normalizedEntryPath.split('/');
+		if (segments.some((segment) => segment === '..')) {
+			return null;
+		}
+
 		// Resolve the candidate path against the base directory.
-		const resolved = path.resolve(baseDir, entryPath);
+		const resolved = path.resolve(baseDir, normalizedEntryPath);
 
 		// Normalize base directory and ensure it ends with a path separator so
 		// that "/tmp/base2" does not match "/tmp/base".

--- a/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
@@ -9,6 +9,37 @@ import { LoadPluginDialog } from '../dialog/load-plugin.dialog';
 
 export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 	private static readonly MAX_RETRIES = 3;
+
+	/**
+	 * Resolve an archive entry path against a base extraction directory and ensure
+	 * it does not escape the base (Zip Slip protection).
+	 */
+	private static safeExtractPath(baseDir: string, entryPath: string): string | null {
+		// Resolve the candidate path against the base directory.
+		const resolved = path.resolve(baseDir, entryPath);
+
+		// Normalize base directory and ensure it ends with a path separator so
+		// that "/tmp/base2" does not match "/tmp/base".
+		const normalizedBase = path.resolve(baseDir);
+		const baseWithSep =
+			normalizedBase.endsWith(path.sep) ? normalizedBase : normalizedBase + path.sep;
+
+		// On Windows, comparisons are case-insensitive for paths.
+		if (process.platform === 'win32') {
+			const resolvedLower = resolved.toLowerCase();
+			const baseLower = baseWithSep.toLowerCase();
+			if (resolvedLower === normalizedBase.toLowerCase() || resolvedLower.startsWith(baseLower)) {
+				return resolved;
+			}
+		} else {
+			if (resolved === normalizedBase || resolved.startsWith(baseWithSep)) {
+				return resolved;
+			}
+		}
+
+		// Path would escape the base directory; treat as unsafe.
+		return null;
+	}
 	private static readonly RETRY_DELAY_MS = 1000;
 	private static readonly MAX_FILE_SIZE = 500 * 1024 * 1024; // 500MB per file
 	private static readonly MAX_TOTAL_SIZE = 1024 * 1024 * 1024; // 1GB total extraction limit
@@ -120,18 +151,17 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 						const { path: entryPath, type } = entry;
 
 						// Security: Zip Slip prevention
-						if (!this.isSafePath(extractDir, entryPath)) {
+						const safePath = LocalDownloadStrategy.safeExtractPath(extractDir, entryPath);
+						if (!safePath) {
 							logger.warn(`Unsafe archive entry skipped: ${entryPath}`);
 							return entry.autodrain();
 						}
-
-						const resolvedPath = path.resolve(extractDir, entryPath);
 
 						if (type === 'Directory') {
 							// Autodrain synchronously first to avoid backpressure,
 							// then push only the mkdir promise.
 							entry.autodrain();
-							pendingWrites.push(fs.mkdir(resolvedPath, { recursive: true }).then(() => void 0));
+							pendingWrites.push(fs.mkdir(safePath, { recursive: true }).then(() => void 0));
 							return;
 						}
 
@@ -144,8 +174,8 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 								let bytesWritten = 0;
 								let limitReached = false;
 								try {
-									await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
-									writeStream = createWriteStream(resolvedPath);
+									await fs.mkdir(path.dirname(safePath), { recursive: true });
+									writeStream = createWriteStream(safePath);
 
 									// Attach counter before piping so every chunk is measured.
 									entry.on('data', (chunk: Buffer) => {
@@ -189,7 +219,7 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 										if (writeStream) entry.unpipe(writeStream);
 										if (writeStream && !writeStream.writableEnded) writeStream.destroy(err);
 										try {
-											await fs.unlink(resolvedPath);
+											await fs.unlink(safePath);
 										} catch {}
 									}
 									throw err;

--- a/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
@@ -117,7 +117,7 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 				createReadStream(filePath)
 					.pipe(unzipper.Parse())
 					.on('entry', (entry: any) => {
-						const { path: entryPath, type, size } = entry;
+						const { path: entryPath, type } = entry;
 
 						// Security: Zip Slip prevention
 						if (!this.isSafePath(extractDir, entryPath)) {
@@ -125,46 +125,73 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 							return entry.autodrain();
 						}
 
-						// Security: per-file size limit
-						if (size > LocalDownloadStrategy.MAX_FILE_SIZE) {
-							logger.warn(`Archive entry too large (${size} bytes): ${entryPath}`);
-							return entry.autodrain();
-						}
-
-						// Security: total extraction size limit
-						totalSize += size;
-						if (totalSize > LocalDownloadStrategy.MAX_TOTAL_SIZE) {
-							return reject(
-								new Error(
-									`Total extraction size exceeded (${LocalDownloadStrategy.MAX_TOTAL_SIZE} bytes)`
-								)
-							);
-						}
-
 						const resolvedPath = path.resolve(extractDir, entryPath);
 
 						if (type === 'Directory') {
-							pendingWrites.push(
-								fs.mkdir(resolvedPath, { recursive: true }).then(() => entry.autodrain())
-							);
+							// Issue 4: autodrain synchronously first to avoid backpressure,
+							// then push only the mkdir promise.
+							entry.autodrain();
+							pendingWrites.push(fs.mkdir(resolvedPath, { recursive: true }).then(() => void 0));
 							return;
 						}
 
-						// File extraction with cleanup on failure
+						// Issue 2: File extraction with actual byte-count enforcement.
+						// `entry.size` from ZIP metadata may be 0 or the compressed size,
+						// so we count bytes via data events instead.
 						pendingWrites.push(
 							(async () => {
 								let writeStream: ReturnType<typeof createWriteStream> | null = null;
+								let bytesWritten = 0;
+								let limitReached = false;
 								try {
 									await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
 									writeStream = createWriteStream(resolvedPath);
+
+									// Attach counter before piping so every chunk is measured.
+									entry.on('data', (chunk: Buffer) => {
+										if (limitReached) return;
+										bytesWritten += chunk.length;
+										totalSize += chunk.length;
+
+										if (bytesWritten > LocalDownloadStrategy.MAX_FILE_SIZE) {
+											limitReached = true;
+											logger.warn(`File size limit exceeded (actual bytes): ${entryPath}`);
+											entry.unpipe(writeStream);
+											if (writeStream && !writeStream.writableEnded) writeStream.destroy();
+											reject(
+												new Error(
+													`File too large: ${entryPath} exceeds ${LocalDownloadStrategy.MAX_FILE_SIZE} bytes`
+												)
+											);
+											return;
+										}
+
+										if (totalSize > LocalDownloadStrategy.MAX_TOTAL_SIZE) {
+											limitReached = true;
+											logger.warn(`Total extraction size exceeded at: ${entryPath}`);
+											entry.unpipe(writeStream);
+											if (writeStream && !writeStream.writableEnded) writeStream.destroy();
+											reject(
+												new Error(
+													`Total extraction size exceeded (${LocalDownloadStrategy.MAX_TOTAL_SIZE} bytes)`
+												)
+											);
+											return;
+										}
+									});
+
 									entry.pipe(writeStream);
 									await finished(writeStream);
 								} catch (err) {
-									if (!entry.destroyed) entry.destroy();
-									if (writeStream && !writeStream.destroyed) writeStream.destroy();
-									try {
-										await fs.unlink(resolvedPath);
-									} catch {}
+									if (!limitReached) {
+										// Issue 3: unpipe entry from writeStream and destroy writeStream
+										// properly so the error propagates and the pipe is cleaned up.
+										if (writeStream) entry.unpipe(writeStream);
+										if (writeStream && !writeStream.writableEnded) writeStream.destroy(err);
+										try {
+											await fs.unlink(resolvedPath);
+										} catch {}
+									}
 									throw err;
 								}
 							})()

--- a/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
@@ -128,14 +128,14 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 						const resolvedPath = path.resolve(extractDir, entryPath);
 
 						if (type === 'Directory') {
-							// Issue 4: autodrain synchronously first to avoid backpressure,
+							// Autodrain synchronously first to avoid backpressure,
 							// then push only the mkdir promise.
 							entry.autodrain();
 							pendingWrites.push(fs.mkdir(resolvedPath, { recursive: true }).then(() => void 0));
 							return;
 						}
 
-						// Issue 2: File extraction with actual byte-count enforcement.
+						// File extraction with actual byte-count enforcement.
 						// `entry.size` from ZIP metadata may be 0 or the compressed size,
 						// so we count bytes via data events instead.
 						pendingWrites.push(
@@ -184,7 +184,7 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 									await finished(writeStream);
 								} catch (err) {
 									if (!limitReached) {
-										// Issue 3: unpipe entry from writeStream and destroy writeStream
+										// Unpipe entry from writeStream and destroy writeStream
 										// properly so the error propagates and the pipe is cleaned up.
 										if (writeStream) entry.unpipe(writeStream);
 										if (writeStream && !writeStream.writableEnded) writeStream.destroy(err);

--- a/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/data-access/strategies/local-download.strategy.ts
@@ -1,6 +1,7 @@
 import { logger } from '@gauzy/desktop-core';
-import { createReadStream } from 'fs';
+import { createReadStream, createWriteStream } from 'fs';
 import * as fs from 'fs/promises';
+import { finished } from 'node:stream/promises';
 import * as path from 'path';
 import * as unzipper from 'unzipper';
 import { ILocalDownloadConfig, IPluginDownloadResponse, IPluginDownloadStrategy } from '../../shared';
@@ -9,6 +10,9 @@ import { LoadPluginDialog } from '../dialog/load-plugin.dialog';
 export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 	private static readonly MAX_RETRIES = 3;
 	private static readonly RETRY_DELAY_MS = 1000;
+	private static readonly MAX_FILE_SIZE = 500 * 1024 * 1024; // 500MB per file
+	private static readonly MAX_TOTAL_SIZE = 1024 * 1024 * 1024; // 1GB total extraction limit
+	private static readonly MANIFEST_FILENAME = 'manifest.json';
 
 	/**
 	 * Downloads and installs a plugin from a local zip file
@@ -19,26 +23,37 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 	async execute<T>(config: T): Promise<IPluginDownloadResponse> {
 		const { pluginPath } = config as ILocalDownloadConfig;
 		let zipFilePath: string | null = null;
+		const tempExtractPath = path.join(pluginPath, `.temp-extract-${Date.now()}`);
 
 		try {
 			zipFilePath = await this.getZipFilePathFromUser();
 			await this.validateZipFile(zipFilePath);
 
-			const fileName = path.basename(zipFilePath);
-			const tempDirPath = await this.unzip(zipFilePath, pluginPath);
-			const pluginDir = path.join(tempDirPath, fileName.replace(/\.zip$/i, ''));
+			await this.unzip(zipFilePath, tempExtractPath);
+
+			const pluginDir = await this.findPluginDirectory(tempExtractPath, path.basename(zipFilePath));
+			if (!pluginDir) {
+				throw new Error('Could not find plugin directory in the selected zip');
+			}
 
 			const metadata = await this.readAndValidateManifest(pluginDir);
 			const pathDirname = await this.createUniquePluginDirectory(pluginPath, pluginDir, metadata.name);
 
 			await this.cleanupZipFile(zipFilePath);
 
+			// Clean up temp extraction directory (plugin was already moved out)
+			try {
+				await fs.rm(tempExtractPath, { recursive: true, force: true });
+			} catch (cleanupError) {
+				logger.warn(`Failed to cleanup temp extraction directory: ${tempExtractPath}`);
+			}
+
 			return { pathDirname, metadata };
 		} catch (error) {
 			logger.error(`Plugin installation failed: ${error.message}`);
 
 			// Cleanup any partially created files
-			await this.cleanupOnError(zipFilePath);
+			await this.cleanupOnError(zipFilePath, tempExtractPath);
 			throw error;
 		}
 	}
@@ -66,26 +81,167 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 		}
 	}
 
-	private async unzip(filePath: string, extractDir: string): Promise<string> {
+	/**
+	 * Validates that a file path is safe and doesn't attempt path traversal (Zip Slip prevention)
+	 */
+	private isSafePath(rootDir: string, entryPath: string): boolean {
+		if (!entryPath) return false;
+
+		const normalizedEntry = entryPath.replaceAll('\\', '/');
+
+		// Reject Unix-style absolute paths
+		if (normalizedEntry === '/' || normalizedEntry.startsWith('/')) return false;
+
+		// Reject Windows absolute paths and drive letters
+		if (path.isAbsolute(entryPath)) return false;
+		if (/^[a-zA-Z]:/.test(normalizedEntry)) return false;
+
+		// Resolve and verify the target stays within rootDir
+		const resolvedRoot = path.resolve(rootDir);
+		const resolvedTarget = path.resolve(rootDir, entryPath);
+
+		if (resolvedTarget === resolvedRoot) return false;
+		if (!resolvedTarget.startsWith(resolvedRoot + path.sep)) return false;
+
+		return true;
+	}
+
+	private async unzip(filePath: string, extractDir: string): Promise<void> {
 		try {
 			await fs.mkdir(extractDir, { recursive: true });
+			let totalSize = 0;
 
 			await new Promise<void>((resolve, reject) => {
+				const pendingWrites: Promise<void>[] = [];
+
 				createReadStream(filePath)
-					.pipe(unzipper.Extract({ path: extractDir }))
-					.on('close', resolve)
+					.pipe(unzipper.Parse())
+					.on('entry', (entry: any) => {
+						const { path: entryPath, type, size } = entry;
+
+						// Security: Zip Slip prevention
+						if (!this.isSafePath(extractDir, entryPath)) {
+							logger.warn(`Unsafe archive entry skipped: ${entryPath}`);
+							return entry.autodrain();
+						}
+
+						// Security: per-file size limit
+						if (size > LocalDownloadStrategy.MAX_FILE_SIZE) {
+							logger.warn(`Archive entry too large (${size} bytes): ${entryPath}`);
+							return entry.autodrain();
+						}
+
+						// Security: total extraction size limit
+						totalSize += size;
+						if (totalSize > LocalDownloadStrategy.MAX_TOTAL_SIZE) {
+							return reject(
+								new Error(
+									`Total extraction size exceeded (${LocalDownloadStrategy.MAX_TOTAL_SIZE} bytes)`
+								)
+							);
+						}
+
+						const resolvedPath = path.resolve(extractDir, entryPath);
+
+						if (type === 'Directory') {
+							pendingWrites.push(
+								fs.mkdir(resolvedPath, { recursive: true }).then(() => entry.autodrain())
+							);
+							return;
+						}
+
+						// File extraction with cleanup on failure
+						pendingWrites.push(
+							(async () => {
+								let writeStream: ReturnType<typeof createWriteStream> | null = null;
+								try {
+									await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+									writeStream = createWriteStream(resolvedPath);
+									entry.pipe(writeStream);
+									await finished(writeStream);
+								} catch (err) {
+									if (!entry.destroyed) entry.destroy();
+									if (writeStream && !writeStream.destroyed) writeStream.destroy();
+									try {
+										await fs.unlink(resolvedPath);
+									} catch {}
+									throw err;
+								}
+							})()
+						);
+					})
+					.on('close', async () => {
+						try {
+							await Promise.all(pendingWrites);
+							resolve();
+						} catch (err) {
+							reject(err);
+						}
+					})
 					.on('error', reject);
 			});
 
-			logger.info('File unzipped successfully');
-			return extractDir;
+			logger.info(`File unzipped successfully (total size: ${(totalSize / 1024 / 1024).toFixed(2)} MB)`);
 		} catch (error) {
 			throw new Error(`Failed to unzip file: ${error.message}`);
 		}
 	}
 
+	private async findPluginDirectory(basePath: string, zipFileName: string): Promise<string | null> {
+		try {
+			// Try the expected directory name first (zip filename without extension)
+			const expectedDir = path.join(basePath, zipFileName.replace(/\.zip$/i, ''));
+			try {
+				await fs.access(expectedDir);
+				return expectedDir;
+			} catch {
+				// Fall back to searching for manifest.json
+				return await this.searchForManifest(basePath);
+			}
+		} catch (error) {
+			logger.error(`Error finding plugin directory: ${error.message}`);
+			return null;
+		}
+	}
+
+	private async searchForManifest(startPath: string): Promise<string | null> {
+		const results: string[] = [];
+
+		const search = async (currentDir: string, depth: number): Promise<boolean> => {
+			if (depth > 3) return false;
+
+			try {
+				const files = await fs.readdir(currentDir);
+
+				for (const file of files) {
+					const fullPath = path.join(currentDir, file);
+					const stat = await fs.stat(fullPath);
+
+					if (stat.isDirectory()) {
+						const found = await search(fullPath, depth + 1);
+						if (found) return true;
+					} else if (file === LocalDownloadStrategy.MANIFEST_FILENAME) {
+						results.push(fullPath);
+						return true;
+					}
+				}
+			} catch (error) {
+				logger.warn(`Error searching directory ${currentDir}: ${error.message}`);
+			}
+			return false;
+		};
+
+		await search(startPath, 0);
+
+		if (results.length === 0) {
+			throw new Error(`No ${LocalDownloadStrategy.MANIFEST_FILENAME} found in the zip file`);
+		}
+
+		return path.dirname(results[0]);
+	}
+
 	private async readAndValidateManifest(pluginDir: string): Promise<any> {
-		const manifestPath = path.join(pluginDir, 'manifest.json');
+		const manifestPath = path.join(pluginDir, LocalDownloadStrategy.MANIFEST_FILENAME);
 
 		try {
 			const manifestContent = await fs.readFile(manifestPath, { encoding: 'utf8' });
@@ -133,10 +289,17 @@ export class LocalDownloadStrategy implements IPluginDownloadStrategy {
 		}
 	}
 
-	private async cleanupOnError(zipFilePath: string | null): Promise<void> {
+	private async cleanupOnError(zipFilePath: string | null, tempExtractPath?: string): Promise<void> {
 		try {
 			if (zipFilePath) {
 				await this.cleanupZipFile(zipFilePath);
+			}
+			if (tempExtractPath) {
+				try {
+					await fs.rm(tempExtractPath, { recursive: true, force: true });
+				} catch (error) {
+					logger.warn(`Failed to cleanup temp extraction directory: ${tempExtractPath}`);
+				}
 			}
 		} catch (cleanupError) {
 			logger.warn(`Cleanup failed: ${cleanupError.message}`);

--- a/packages/desktop-lib/src/lib/plugin-system/events/plugin.event.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/events/plugin.event.ts
@@ -178,13 +178,13 @@ class ElectronPluginListener {
 
 	private async syncMarketplaceInstallationId(
 		event: IpcMainEvent,
-		{ marketplaceId, installationId }: { marketplaceId: string; installationId: string }
+		{ marketplaceId, installationId, name }: { marketplaceId: string | null; installationId: string; name?: string }
 	): Promise<void> {
 		event.reply(PluginChannel.STATUS, {
 			status: 'inProgress',
 			message: 'Updating Plugin Marketplace Installation ID...'
 		});
-		await this.pluginManager.completeInstallation(marketplaceId, installationId);
+		await this.pluginManager.completeInstallation(marketplaceId, installationId, name);
 		event.reply(PluginChannel.STATUS, { status: 'success', message: 'Installation completed' });
 	}
 

--- a/packages/desktop-lib/src/lib/plugin-system/shared/interfaces/plugin-manager.interface.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/shared/interfaces/plugin-manager.interface.ts
@@ -9,7 +9,7 @@ export interface IPluginManager {
 	downloadPlugin(config: any): Promise<IPluginMetadata>;
 	activatePlugin(name: string): Promise<void>;
 	deactivatePlugin(name: string): Promise<void>;
-	completeInstallation(marketplaceId: ID | null, installationId: string): Promise<void>;
+	completeInstallation(marketplaceId: ID | null, installationId: string, name?: string): Promise<void>;
 	uninstallPlugin(input: IPluginMetadataFindOne): Promise<ID>;
 	getAllPlugins(): Promise<IPluginMetadata[]>;
 	getOnePlugin(name: string): Promise<IPluginMetadata>;

--- a/packages/desktop-lib/src/lib/plugin-system/shared/interfaces/plugin-manager.interface.ts
+++ b/packages/desktop-lib/src/lib/plugin-system/shared/interfaces/plugin-manager.interface.ts
@@ -9,7 +9,7 @@ export interface IPluginManager {
 	downloadPlugin(config: any): Promise<IPluginMetadata>;
 	activatePlugin(name: string): Promise<void>;
 	deactivatePlugin(name: string): Promise<void>;
-	completeInstallation(marketplaceId: ID, installationId: string): Promise<void>;
+	completeInstallation(marketplaceId: ID | null, installationId: string): Promise<void>;
 	uninstallPlugin(input: IPluginMetadataFindOne): Promise<ID>;
 	getAllPlugins(): Promise<IPluginMetadata[]>;
 	getOnePlugin(name: string): Promise<IPluginMetadata>;

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/+state/plugin.effect.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/+state/plugin.effect.ts
@@ -77,6 +77,21 @@ export class PluginEffects {
 			ofType(PluginActions.activate),
 			tap(() => this.pluginStore.update({ activating: true })),
 			switchMap(({ plugin }) => {
+				// Local plugin — no marketplace, no access check, no server call
+				if (!plugin.marketplaceId) {
+					this.pluginElectronService.activate(plugin);
+					return this.pluginElectronService
+						.progress((message) => this.toastrService.info(message))
+						.pipe(
+							tap((res) => this.handleProgress(res)),
+							finalize(() => this.pluginStore.update({ activating: false })),
+							catchError((error) => {
+								this.toastrService.error(error);
+								return EMPTY;
+							})
+						);
+				}
+
 				// Gate: verify user has access before activation
 				return this.accessService.checkAccess(plugin.marketplaceId).pipe(
 					switchMap((access) => {
@@ -127,6 +142,21 @@ export class PluginEffects {
 			ofType(PluginActions.deactivate),
 			tap(() => this.pluginStore.update({ deactivating: true })),
 			switchMap(({ plugin }) => {
+				// Local plugin — no marketplace, no server call needed
+				if (!plugin.marketplaceId) {
+					this.pluginElectronService.deactivate(plugin);
+					return this.pluginElectronService
+						.progress((message) => this.toastrService.info(message))
+						.pipe(
+							tap((res) => this.handleProgress(res)),
+							finalize(() => this.pluginStore.update({ deactivating: false })),
+							catchError((error) => {
+								this.toastrService.error(error);
+								return EMPTY;
+							})
+						);
+				}
+
 				// First check with server-side to validate plugin can be deactivated
 				return this.pluginService.deactivate(plugin.marketplaceId, plugin.installationId).pipe(
 					switchMap(() => {

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/+state/plugin.effect.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/+state/plugin.effect.ts
@@ -78,8 +78,8 @@ export class PluginEffects {
 			ofType(PluginActions.activate),
 			tap(() => this.pluginStore.update({ activating: true })),
 			switchMap(({ plugin }) => {
-				// Local plugin — no marketplace, no access check, no server call
-				if (!plugin.marketplaceId) {
+				// Local plugin — no marketplace, no access check, no server call.
+				if (!plugin.marketplaceId && !plugin.installationId) {
 					return this.handleLocalPluginFlow(plugin, 'activate');
 				}
 
@@ -133,8 +133,9 @@ export class PluginEffects {
 			ofType(PluginActions.deactivate),
 			tap(() => this.pluginStore.update({ deactivating: true })),
 			switchMap(({ plugin }) => {
-				// Local plugin — no marketplace, no server call needed
-				if (!plugin.marketplaceId) {
+				// Local plugin — no marketplace, no server call needed.
+				// Both fields must be absent (see activate$ comment).
+				if (!plugin.marketplaceId && !plugin.installationId) {
 					return this.handleLocalPluginFlow(plugin, 'deactivate');
 				}
 

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/+state/plugin.effect.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/+state/plugin.effect.ts
@@ -5,6 +5,7 @@ import { catchError, EMPTY, filter, finalize, from, map, switchMap, tap } from '
 import { ToastrNotificationService } from '../../../../services';
 import { PluginAccessSyncService } from '../../services/plugin-access-sync.service';
 import { PluginElectronService } from '../../services/plugin-electron.service';
+import type { IPlugin } from '../../services/plugin-loader.service';
 import { PluginSubscriptionAccessService } from '../../services/plugin-subscription-access.service';
 import { PluginService } from '../../services/plugin.service';
 import { PluginActions } from './plugin.action';
@@ -79,17 +80,7 @@ export class PluginEffects {
 			switchMap(({ plugin }) => {
 				// Local plugin — no marketplace, no access check, no server call
 				if (!plugin.marketplaceId) {
-					this.pluginElectronService.activate(plugin);
-					return this.pluginElectronService
-						.progress((message) => this.toastrService.info(message))
-						.pipe(
-							tap((res) => this.handleProgress(res)),
-							finalize(() => this.pluginStore.update({ activating: false })),
-							catchError((error) => {
-								this.toastrService.error(error);
-								return EMPTY;
-							})
-						);
+					return this.handleLocalPluginFlow(plugin, 'activate');
 				}
 
 				// Gate: verify user has access before activation
@@ -144,17 +135,7 @@ export class PluginEffects {
 			switchMap(({ plugin }) => {
 				// Local plugin — no marketplace, no server call needed
 				if (!plugin.marketplaceId) {
-					this.pluginElectronService.deactivate(plugin);
-					return this.pluginElectronService
-						.progress((message) => this.toastrService.info(message))
-						.pipe(
-							tap((res) => this.handleProgress(res)),
-							finalize(() => this.pluginStore.update({ deactivating: false })),
-							catchError((error) => {
-								this.toastrService.error(error);
-								return EMPTY;
-							})
-						);
+					return this.handleLocalPluginFlow(plugin, 'deactivate');
 				}
 
 				// First check with server-side to validate plugin can be deactivated
@@ -230,6 +211,29 @@ export class PluginEffects {
 			)
 		)
 	);
+
+	/**
+	 * Shared handler for local (non-marketplace) plugin activate/deactivate flows.
+	 * Centralises progress wiring, store flag reset, and error handling to avoid duplication.
+	 */
+	private handleLocalPluginFlow(plugin: IPlugin, action: 'activate' | 'deactivate') {
+		if (action === 'activate') {
+			this.pluginElectronService.activate(plugin);
+		} else {
+			this.pluginElectronService.deactivate(plugin);
+		}
+		const storeFlag = action === 'activate' ? { activating: false } : { deactivating: false };
+		return this.pluginElectronService
+			.progress((message) => this.toastrService.info(message))
+			.pipe(
+				tap((res) => this.handleProgress(res)),
+				finalize(() => this.pluginStore.update(storeFlag)),
+				catchError((error) => {
+					this.toastrService.error(error);
+					return EMPTY;
+				})
+			);
+	}
 
 	private handleProgress(arg: { message?: string }): void {
 		this.toastrService.success(arg?.message);

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/actions/plugin-installation.action.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/actions/plugin-installation.action.ts
@@ -14,7 +14,7 @@ export class PluginInstallationActions {
 	public static startDownload = createAction('[Plugin Installation] Start Download', <T>(config: T) => ({ config }));
 	public static downloadCompleted = createAction(
 		'[Plugin Installation] Download Completed',
-		(plugin: IPlugin, message?: string) => ({ plugin, message })
+		(plugin: IPlugin, contextType?: string, message?: string) => ({ plugin, contextType, message })
 	);
 	public static downloadFailed = createAction('[Plugin Installation] Download Failed', (error: string, pluginId?: string) => ({
 		error,
@@ -52,7 +52,7 @@ export class PluginInstallationActions {
 	// Step 4: Activation
 	public static startActivation = createAction(
 		'[Plugin Installation] Start Activation',
-		(installationId: string, marketplaceId: string) => ({ installationId, marketplaceId })
+		(installationId: string | null, marketplaceId: string | null, name?: string) => ({ installationId, marketplaceId, name })
 	);
 	public static activationCompleted = createAction(
 		'[Plugin Installation] Activation Completed',

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/actions/plugin-installation.action.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/actions/plugin-installation.action.ts
@@ -14,7 +14,12 @@ export class PluginInstallationActions {
 	public static startDownload = createAction('[Plugin Installation] Start Download', <T>(config: T) => ({ config }));
 	public static downloadCompleted = createAction(
 		'[Plugin Installation] Download Completed',
-		(plugin: IPlugin, contextType?: string, message?: string) => ({ plugin, contextType, message })
+		(plugin: IPlugin, message?: string, contextType?: string, localInstallId?: string) => ({
+			plugin,
+			message,
+			contextType,
+			localInstallId
+		})
 	);
 	public static downloadFailed = createAction('[Plugin Installation] Download Failed', (error: string, pluginId?: string) => ({
 		error,
@@ -52,16 +57,21 @@ export class PluginInstallationActions {
 	// Step 4: Activation
 	public static startActivation = createAction(
 		'[Plugin Installation] Start Activation',
-		(installationId: string | null, marketplaceId: string | null, name?: string) => ({ installationId, marketplaceId, name })
+		(installationId: string | null, marketplaceId: string | null, name?: string, localInstallId?: string) => ({
+			installationId,
+			marketplaceId,
+			name,
+			localInstallId
+		})
 	);
 	public static activationCompleted = createAction(
 		'[Plugin Installation] Activation Completed',
-		(plugin: IPlugin, message?: string) => ({ plugin, message })
+		(plugin: IPlugin, message?: string, localInstallId?: string) => ({ plugin, message, localInstallId })
 	);
-	public static activationFailed = createAction('[Plugin Installation] Activation Failed', (error: string, pluginId?: string) => ({
-		error,
-		pluginId
-	}));
+	public static activationFailed = createAction(
+		'[Plugin Installation] Activation Failed',
+		(error: string, pluginId?: string, localInstallId?: string) => ({ error, pluginId, localInstallId })
+	);
 
 	// Cleanup
 	public static clearError = createAction('[Plugin Installation] Clear Error', (pluginId?: string) => ({ pluginId }));

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/effects/plugin-installation.effect.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/effects/plugin-installation.effect.ts
@@ -207,8 +207,11 @@ export class PluginInstallationEffects {
 						this.pluginInstallationStore.setInstalling(pluginId, true);
 						this.pluginInstallationStore.setErrorMessage(pluginId, null);
 					} else {
-						// Track loading state for local/direct installs using a placeholder key
-						this.pluginInstallationStore.setInstalling('local', true);
+						// Generate a unique ID per local install to avoid key collisions
+						// for concurrent local installations.
+						const localInstallId = crypto.randomUUID();
+						(config as Record<string, unknown>)['_localInstallId'] = localInstallId;
+						this.pluginInstallationStore.setInstalling(localInstallId, true);
 					}
 					// Dispatch download start action to trigger download effect
 					return PluginInstallationActions.startDownload(config);
@@ -241,7 +244,12 @@ export class PluginInstallationEffects {
 							);
 						}),
 						map(({ plugin, message }) =>
-							PluginInstallationActions.downloadCompleted(plugin, config?.['contextType'], message)
+							PluginInstallationActions.downloadCompleted(
+								plugin,
+								message,
+								config?.['contextType'],
+								config?.['_localInstallId'] as string | undefined
+							)
 						),
 						finalize(() => {
 							const pluginId = config?.['marketplaceId'];
@@ -251,6 +259,12 @@ export class PluginInstallationEffects {
 						}),
 						catchError((error) => {
 							const pluginId = config?.['marketplaceId'];
+							// For local installs, clear the unique loading key directly here
+							// so the placeholder is not stuck in the store on failure.
+							const localInstallId = config?.['_localInstallId'] as string | undefined;
+							if (localInstallId) {
+								this.pluginInstallationStore.setInstalling(localInstallId, false);
+							}
 							return of(
 								PluginInstallationActions.downloadFailed(error?.message || 'Download failed', pluginId)
 							);
@@ -272,7 +286,7 @@ export class PluginInstallationEffects {
 		() =>
 			this.action$.pipe(
 				ofType(PluginInstallationActions.downloadCompleted),
-				map(({ plugin, contextType }) => {
+				map(({ plugin, contextType, localInstallId }) => {
 					const { marketplaceId: pluginId, versionId } = plugin || {};
 					// For marketplace plugins, proceed with server installation
 					if (pluginId && versionId) {
@@ -283,7 +297,12 @@ export class PluginInstallationEffects {
 					// All three conditions together prevent marketplace plugins from bypassing
 					// access checks through the local installation path.
 					if (contextType === 'local' && !pluginId && plugin?.name) {
-						return PluginInstallationActions.startActivation(plugin.installationId || null, null, plugin.name);
+						return PluginInstallationActions.startActivation(
+							plugin.installationId || null,
+							null,
+							plugin.name,
+							localInstallId
+						);
 					}
 					return PluginInstallationActions.downloadFailed(
 						this.translateService.instant('PLUGIN.TOASTR.ERROR.INVALID_PLUGIN_DATA')
@@ -434,14 +453,16 @@ export class PluginInstallationEffects {
 						this.pluginInstallationStore.setActivating(marketplaceId, true);
 					}
 				}),
-				switchMap(({ installationId, marketplaceId, name }) => {
+				switchMap(({ installationId, marketplaceId, name, localInstallId }) => {
 					return this.activateCommand.execute({ marketplaceId, installationId, name }).pipe(
 						tap(({ message }) => {
 							this.toastrService.success(
 								message || this.translateService.instant('PLUGIN.TOASTR.SUCCESS.ACTIVATION_COMPLETED')
 							);
 						}),
-						map(({ plugin, message }) => PluginInstallationActions.activationCompleted(plugin, message)),
+						map(({ plugin, message }) =>
+							PluginInstallationActions.activationCompleted(plugin, message, localInstallId)
+						),
 						finalize(() => {
 							if (marketplaceId) {
 								this.pluginInstallationStore.setActivating(marketplaceId, false);
@@ -452,7 +473,8 @@ export class PluginInstallationEffects {
 							of(
 								PluginInstallationActions.activationFailed(
 									error?.message || 'Activation failed',
-									marketplaceId
+									marketplaceId,
+									localInstallId
 								)
 							)
 						)
@@ -472,18 +494,22 @@ export class PluginInstallationEffects {
 		() =>
 			this.action$.pipe(
 				ofType(PluginInstallationActions.activationCompleted),
-				concatMap(({ plugin: { marketplaceId } }) => {
+				concatMap(({ plugin: { marketplaceId }, localInstallId }) => {
 					this.handleSuccess('Installation done', marketplaceId);
-					const actions: any[] = [
+					type DispatchableAction =
+						| ReturnType<typeof PluginActions.selectPlugin>
+						| ReturnType<typeof PluginActions.refresh>
+						| ReturnType<typeof PluginToggleActions.toggle>;
+					const actions: DispatchableAction[] = [
 						PluginActions.selectPlugin(null),
 						PluginActions.refresh()
 					];
 					// Only toggle for marketplace plugins
 					if (marketplaceId) {
 						actions.unshift(PluginToggleActions.toggle({ pluginId: marketplaceId, enabled: true }));
-					} else {
-						// Clear local install loading state on successful completion
-						this.pluginInstallationStore.setInstalling('local', false);
+					} else if (localInstallId) {
+						// Clear the unique local install loading key generated at install start
+						this.pluginInstallationStore.setInstalling(localInstallId, false);
 					}
 					return actions;
 				})
@@ -505,10 +531,9 @@ export class PluginInstallationEffects {
 						this.pluginInstallationStore.setInstalling(pluginId, false);
 						this.pluginInstallationStore.setDownloading(pluginId, false);
 						this.pluginInstallationStore.setErrorMessage(pluginId, error);
-					} else {
-						// Clear local install loading state on failure
-						this.pluginInstallationStore.setInstalling('local', false);
 					}
+					// For local installs the unique loading key is cleared directly in the
+					// downloadPlugin$ catchError, so no additional cleanup is needed here.
 					this.toastrService.error(
 						error || this.translateService.instant('PLUGIN.TOASTR.ERROR.DOWNLOAD_FAILED')
 					);
@@ -594,14 +619,14 @@ export class PluginInstallationEffects {
 		() =>
 			this.action$.pipe(
 				ofType(PluginInstallationActions.activationFailed),
-				concatMap(({ error, pluginId }) => {
+				concatMap(({ error, pluginId, localInstallId }) => {
 					if (pluginId) {
 						this.pluginInstallationStore.setInstalling(pluginId, false);
 						this.pluginInstallationStore.setActivating(pluginId, false);
 						this.pluginInstallationStore.setErrorMessage(pluginId, error);
-					} else {
-						// Clear local install loading state on activation failure
-						this.pluginInstallationStore.setInstalling('local', false);
+					} else if (localInstallId) {
+						// Clear the unique local install loading key on activation failure
+						this.pluginInstallationStore.setInstalling(localInstallId, false);
 					}
 					this.toastrService.error(
 						error || this.translateService.instant('PLUGIN.TOASTR.ERROR.ACTIVATION_FAILED')

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/effects/plugin-installation.effect.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/effects/plugin-installation.effect.ts
@@ -304,6 +304,10 @@ export class PluginInstallationEffects {
 							localInstallId
 						);
 					}
+					// Clear the local install loading key before dispatching failure
+					if (localInstallId) {
+						this.pluginInstallationStore.setInstalling(localInstallId, false);
+					}
 					return PluginInstallationActions.downloadFailed(
 						this.translateService.instant('PLUGIN.TOASTR.ERROR.INVALID_PLUGIN_DATA')
 					);

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/effects/plugin-installation.effect.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/effects/plugin-installation.effect.ts
@@ -256,15 +256,14 @@ export class PluginInstallationEffects {
 							if (pluginId) {
 								this.pluginInstallationStore.setDownloading(pluginId, false);
 							}
-						}),
-						catchError((error) => {
-							const pluginId = config?.['marketplaceId'];
-							// For local installs, clear the unique loading key directly here
-							// so the placeholder is not stuck in the store on failure.
+							// Clear localInstallId here so that switchMap cancellation
 							const localInstallId = config?.['_localInstallId'] as string | undefined;
 							if (localInstallId) {
 								this.pluginInstallationStore.setInstalling(localInstallId, false);
 							}
+						}),
+						catchError((error) => {
+							const pluginId = config?.['marketplaceId'];
 							return of(
 								PluginInstallationActions.downloadFailed(error?.message || 'Download failed', pluginId)
 							);

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/effects/plugin-installation.effect.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/component/plugin-marketplace/+state/effects/plugin-installation.effect.ts
@@ -206,6 +206,9 @@ export class PluginInstallationEffects {
 					if (pluginId) {
 						this.pluginInstallationStore.setInstalling(pluginId, true);
 						this.pluginInstallationStore.setErrorMessage(pluginId, null);
+					} else {
+						// Track loading state for local/direct installs using a placeholder key
+						this.pluginInstallationStore.setInstalling('local', true);
 					}
 					// Dispatch download start action to trigger download effect
 					return PluginInstallationActions.startDownload(config);
@@ -237,7 +240,9 @@ export class PluginInstallationEffects {
 								message || this.translateService.instant('PLUGIN.TOASTR.INFO.DOWNLOAD_COMPLETED')
 							);
 						}),
-						map(({ plugin, message }) => PluginInstallationActions.downloadCompleted(plugin, message)),
+						map(({ plugin, message }) =>
+							PluginInstallationActions.downloadCompleted(plugin, config?.['contextType'], message)
+						),
 						finalize(() => {
 							const pluginId = config?.['marketplaceId'];
 							if (pluginId) {
@@ -261,20 +266,28 @@ export class PluginInstallationEffects {
 	/**
 	 * Step 2: Server Installation Effect
 	 * Single Responsibility: Only handles server-side installation
+	 * For local installations (without marketplace metadata), skip server installation
 	 */
 	serverInstallPlugin$ = createEffect(
 		() =>
 			this.action$.pipe(
 				ofType(PluginInstallationActions.downloadCompleted),
-				map(({ plugin }) => {
+				map(({ plugin, contextType }) => {
 					const { marketplaceId: pluginId, versionId } = plugin || {};
+					// For marketplace plugins, proceed with server installation
 					if (pluginId && versionId) {
 						return PluginInstallationActions.startServerInstallation(pluginId, versionId);
-					} else {
-						return PluginInstallationActions.downloadFailed(
-							this.translateService.instant('PLUGIN.TOASTR.ERROR.INVALID_PLUGIN_DATA')
-						);
 					}
+					// For local/direct installations: the contextType must be explicitly 'local',
+					// the DB record must have no marketplaceId, and a plugin name must be present.
+					// All three conditions together prevent marketplace plugins from bypassing
+					// access checks through the local installation path.
+					if (contextType === 'local' && !pluginId && plugin?.name) {
+						return PluginInstallationActions.startActivation(plugin.installationId || null, null, plugin.name);
+					}
+					return PluginInstallationActions.downloadFailed(
+						this.translateService.instant('PLUGIN.TOASTR.ERROR.INVALID_PLUGIN_DATA')
+					);
 				})
 			),
 		{
@@ -410,14 +423,19 @@ export class PluginInstallationEffects {
 
 	/**
 	 * Execute plugin activation
+	 * Handles both marketplace and local installations
 	 */
 	executeActivation$ = createEffect(
 		() =>
 			this.action$.pipe(
 				ofType(PluginInstallationActions.startActivation),
-				tap(({ marketplaceId }) => this.pluginInstallationStore.setActivating(marketplaceId, true)),
-				switchMap(({ installationId, marketplaceId }) => {
-					return this.activateCommand.execute({ marketplaceId, installationId }).pipe(
+				tap(({ marketplaceId }) => {
+					if (marketplaceId) {
+						this.pluginInstallationStore.setActivating(marketplaceId, true);
+					}
+				}),
+				switchMap(({ installationId, marketplaceId, name }) => {
+					return this.activateCommand.execute({ marketplaceId, installationId, name }).pipe(
 						tap(({ message }) => {
 							this.toastrService.success(
 								message || this.translateService.instant('PLUGIN.TOASTR.SUCCESS.ACTIVATION_COMPLETED')
@@ -425,8 +443,10 @@ export class PluginInstallationEffects {
 						}),
 						map(({ plugin, message }) => PluginInstallationActions.activationCompleted(plugin, message)),
 						finalize(() => {
-							this.pluginInstallationStore.setActivating(marketplaceId, false);
-							this.pluginInstallationStore.setInstalling(marketplaceId, false);
+							if (marketplaceId) {
+								this.pluginInstallationStore.setActivating(marketplaceId, false);
+								this.pluginInstallationStore.setInstalling(marketplaceId, false);
+							}
 						}),
 						catchError((error) =>
 							of(
@@ -446,6 +466,7 @@ export class PluginInstallationEffects {
 
 	/**
 	 * Finalize installation after successful activation
+	 * For local installations without marketplaceId, skip marketplace-specific actions
 	 */
 	finalizeInstallation$ = createEffect(
 		() =>
@@ -453,11 +474,18 @@ export class PluginInstallationEffects {
 				ofType(PluginInstallationActions.activationCompleted),
 				concatMap(({ plugin: { marketplaceId } }) => {
 					this.handleSuccess('Installation done', marketplaceId);
-					return [
-						PluginToggleActions.toggle({ pluginId: marketplaceId, enabled: true }),
+					const actions: any[] = [
 						PluginActions.selectPlugin(null),
 						PluginActions.refresh()
 					];
+					// Only toggle for marketplace plugins
+					if (marketplaceId) {
+						actions.unshift(PluginToggleActions.toggle({ pluginId: marketplaceId, enabled: true }));
+					} else {
+						// Clear local install loading state on successful completion
+						this.pluginInstallationStore.setInstalling('local', false);
+					}
+					return actions;
 				})
 			),
 		{
@@ -477,6 +505,9 @@ export class PluginInstallationEffects {
 						this.pluginInstallationStore.setInstalling(pluginId, false);
 						this.pluginInstallationStore.setDownloading(pluginId, false);
 						this.pluginInstallationStore.setErrorMessage(pluginId, error);
+					} else {
+						// Clear local install loading state on failure
+						this.pluginInstallationStore.setInstalling('local', false);
 					}
 					this.toastrService.error(
 						error || this.translateService.instant('PLUGIN.TOASTR.ERROR.DOWNLOAD_FAILED')
@@ -568,6 +599,9 @@ export class PluginInstallationEffects {
 						this.pluginInstallationStore.setInstalling(pluginId, false);
 						this.pluginInstallationStore.setActivating(pluginId, false);
 						this.pluginInstallationStore.setErrorMessage(pluginId, error);
+					} else {
+						// Clear local install loading state on activation failure
+						this.pluginInstallationStore.setInstalling('local', false);
 					}
 					this.toastrService.error(
 						error || this.translateService.instant('PLUGIN.TOASTR.ERROR.ACTIVATION_FAILED')

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/domain/commands/activate-plugin.command.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/domain/commands/activate-plugin.command.ts
@@ -52,22 +52,19 @@ export class ActivatePluginCommand
 
 		// For local installations, skip marketplace-specific checks
 		if (!marketplaceId) {
-			// Ensure at least one identifier is available before constructing the lookup.
-			if (!name && !installationId) {
+			// name is the only reliable look-up key for local plugins.
+			// installationId is a backend DB record ID, not a marketplaceId, so it
+			// cannot be passed to checkInstallation (which expects a marketplaceId).
+			if (!name) {
 				return throwError(
 					() =>
 						new Error(
-							'Cannot activate plugin: either plugin name or installationId must be provided.'
+							'Cannot activate plugin: plugin name must be provided for local installations.'
 						)
 				);
 			}
 			// Direct local activation without server validation.
-			// Look up by name (reliable unique key for local plugins) when available;
-			// fall back to checkInstallation only for marketplace plugins with a known installationId.
-			const pluginLookup = name
-				? from(this.pluginElectronService.plugin(name))
-				: from(this.pluginElectronService.checkInstallation(installationId));
-			return pluginLookup.pipe(
+			return from(this.pluginElectronService.plugin(name)).pipe(
 				switchMap((plugin) => {
 					// Guard against null/undefined plugin before proceeding.
 					if (!plugin) {

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/domain/commands/activate-plugin.command.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/domain/commands/activate-plugin.command.ts
@@ -52,6 +52,15 @@ export class ActivatePluginCommand
 
 		// For local installations, skip marketplace-specific checks
 		if (!marketplaceId) {
+			// Issue 10: Ensure at least one identifier is available before constructing the lookup.
+			if (!name && !installationId) {
+				return throwError(
+					() =>
+						new Error(
+							'Cannot activate plugin: either plugin name or installationId must be provided.'
+						)
+				);
+			}
 			// Direct local activation without server validation.
 			// Look up by name (reliable unique key for local plugins) when available;
 			// fall back to checkInstallation only for marketplace plugins with a known installationId.
@@ -60,6 +69,10 @@ export class ActivatePluginCommand
 				: from(this.pluginElectronService.checkInstallation(installationId));
 			return pluginLookup.pipe(
 				switchMap((plugin) => {
+					// Issue 9: Guard against null/undefined plugin before proceeding.
+					if (!plugin) {
+						return throwError(() => new Error('Plugin not found'));
+					}
 					// SECURITY GUARD: Even though the caller did not supply a marketplaceId,
 					if (plugin?.marketplaceId) {
 						return throwError(

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/domain/commands/activate-plugin.command.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/domain/commands/activate-plugin.command.ts
@@ -8,10 +8,13 @@ import { IInstallationCommand } from '../interfaces';
 
 /**
  * Parameters for activate plugin command
+ * marketplaceId can be null for local/direct installations
  */
 export interface IActivatePluginCommandParams {
-	marketplaceId: string;
+	marketplaceId: string | null;
 	installationId?: string;
+	/** Plugin name, used to look up locally installed plugins when marketplaceId is absent */
+	name?: string;
 }
 
 /**
@@ -42,11 +45,45 @@ export class ActivatePluginCommand
 
 	/**
 	 * Executes the activate plugin command
+	 * For local installations (marketplaceId is null), skip server validation and access checks
 	 */
 	public execute(params: IActivatePluginCommandParams): Observable<IActivatePluginCommandResult> {
-		const { marketplaceId, installationId } = params;
+		const { marketplaceId, installationId, name } = params;
 
-		// Gate: verify user has access before proceeding with activation
+		// For local installations, skip marketplace-specific checks
+		if (!marketplaceId) {
+			// Direct local activation without server validation.
+			// Look up by name (reliable unique key for local plugins) when available;
+			// fall back to checkInstallation only for marketplace plugins with a known installationId.
+			const pluginLookup = name
+				? from(this.pluginElectronService.plugin(name))
+				: from(this.pluginElectronService.checkInstallation(installationId));
+			return pluginLookup.pipe(
+				switchMap((plugin) => {
+					// SECURITY GUARD: Even though the caller did not supply a marketplaceId,
+					if (plugin?.marketplaceId) {
+						return throwError(
+							() =>
+								new Error(
+									'This plugin is registered in the marketplace and must be activated through the marketplace.'
+								)
+						);
+					}
+
+					this.pluginElectronService.activate(plugin);
+
+					return this.pluginElectronService.progress<void, IPlugin>().pipe(
+						map(({ data, message }) => ({
+							success: true,
+							plugin: data || plugin,
+							message
+						}))
+					);
+				})
+			);
+		}
+
+		// For marketplace installations, verify access and validate with server
 		return this.accessService.checkAccess(marketplaceId).pipe(
 			switchMap((access) => {
 				if (!access.hasAccess) {

--- a/packages/desktop-ui-lib/src/lib/settings/plugins/domain/commands/activate-plugin.command.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/plugins/domain/commands/activate-plugin.command.ts
@@ -52,7 +52,7 @@ export class ActivatePluginCommand
 
 		// For local installations, skip marketplace-specific checks
 		if (!marketplaceId) {
-			// Issue 10: Ensure at least one identifier is available before constructing the lookup.
+			// Ensure at least one identifier is available before constructing the lookup.
 			if (!name && !installationId) {
 				return throwError(
 					() =>
@@ -69,7 +69,7 @@ export class ActivatePluginCommand
 				: from(this.pluginElectronService.checkInstallation(installationId));
 			return pluginLookup.pipe(
 				switchMap((plugin) => {
-					// Issue 9: Guard against null/undefined plugin before proceeding.
+					// Guard against null/undefined plugin before proceeding.
 					if (!plugin) {
 						return throwError(() => new Error('Plugin not found'));
 					}


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds secure direct local plugin installation from ZIP files with path traversal protections and size limits, plus offline activate/deactivate with reliable UI state. Updates metadata handling to support nullable IDs and name-based updates for local installs (GP-784).

- **New Features**
  - Local ZIP install: safe path resolver (rejects absolute/UNC/drive-letter/..), stream-extracts to temp dir, enforces 500MB/file and 1GB total, cleans partials and temp dir.
  - Manifest discovery up to 3 levels; move into a unique plugin directory.
  - Local flows: shared UI handler for activate/deactivate; per-install `localInstallId` for concurrent installs; `downloadPlugin` accepts optional IDs (stored as null); `completeInstallation` updates by `name` when `marketplaceId` is null; activation supports null `marketplaceId` and requires `name`.

- **Bug Fixes**
  - Zip Slip hardening across OSes; count streamed bytes; delete partial files on limit exceed.
  - Prevent marketplace bypass: skip server install only when `contextType === 'local'`, no `marketplaceId`, and `name` present; local activation refuses plugins that have a `marketplaceId`.
  - Accurate local detection: treat a plugin as local only when both `marketplaceId` and `installationId` are absent.
  - UI resilience: fix stuck loading for local installs by clearing the unique `localInstallId` only after a successful download (and on activation failure); avoid premature cleanup during download errors.

<sup>Written for commit 262b718d018071f989532d8cf702ae0207da62c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

