### PR TITLE
Fix/desktop timer widget issues

### DIFF
--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -313,9 +313,7 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 						await timerService.update(
 							new Timer({
 								id: arg.id,
-								...(arg.startedAt && {
-									startedAt: new Date(arg.startedAt)
-								})
+								startedAt: new Date(arg.startedAt)
 							})
 						);
 					}

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -309,14 +309,16 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 					);
 				} else {
 					console.log('Update Synced Timer Offline');
-					await timerService.update(
-						new Timer({
-							id: arg.id,
-							...(arg.startedAt && {
-								startedAt: new Date(arg.startedAt)
+					if (arg.startedAt) {
+						await timerService.update(
+							new Timer({
+								id: arg.id,
+								...(arg.startedAt && {
+									startedAt: new Date(arg.startedAt)
+								})
 							})
-						})
-					);
+						);
+					}
 				}
 			} else {
 				console.log('No arg.id found');

--- a/packages/desktop-lib/src/lib/tray/auth/authentication-handler.ts
+++ b/packages/desktop-lib/src/lib/tray/auth/authentication-handler.ts
@@ -10,7 +10,7 @@ export class AuthenticationHandler {
 		private configStore: IConfigStore,
 		private windowService: IWindowService,
 		private config: any
-	) {}
+	) { }
 
 	async handleAuthSuccess(arg: any): Promise<void> {
 		console.log('Auth Success');
@@ -56,9 +56,9 @@ export class AuthenticationHandler {
 		});
 	}
 
-	async handleLogout(): Promise<void> {
+	async handleLogout(isRestart?: boolean): Promise<void> {
 		await this.stopTimerIfRunning();
-		this.closeWindows();
+		this.closeWindows(isRestart);
 		await this.clearUserData();
 	}
 
@@ -82,9 +82,11 @@ export class AuthenticationHandler {
 		}
 	}
 
-	private closeWindows(): void {
+	private closeWindows(isRestart?: boolean): void {
 		const appWindowManager = AppWindowManager.getInstance();
-		appWindowManager.settingWindow?.close?.();
+		if (!isRestart) {
+			appWindowManager.settingWindow?.close?.();
+		}
 		appWindowManager.alwaysOnWindow?.browserWindow?.close?.();
 	}
 

--- a/packages/desktop-lib/src/lib/tray/handlers/auth-ipc-handler.ts
+++ b/packages/desktop-lib/src/lib/tray/handlers/auth-ipc-handler.ts
@@ -45,11 +45,11 @@ export class AuthIPCHandler {
 	}
 
 	private setupLogoutHandlers(): void {
-		ipcMain.handle('FINAL_LOGOUT', async () => {
+		ipcMain.handle('FINAL_LOGOUT', async (_, arg: { isRestart?: boolean }) => {
 			console.log('Final Logout');
 
 			const timeTrackerWindow = this.windowService.getOne(RegisteredWindow.TIMER);
-			await this.performLogout(timeTrackerWindow);
+			await this.performLogout(timeTrackerWindow, arg?.isRestart);
 		});
 
 		ipcMain.on('logout', () => {
@@ -60,7 +60,7 @@ export class AuthIPCHandler {
 		});
 	}
 
-	private async performLogout(timeTrackerWindow: BrowserWindow): Promise<void> {
+	private async performLogout(timeTrackerWindow: BrowserWindow, isRestart?: boolean): Promise<void> {
 		// Clear timer display
 		this.windowService.webContents(timeTrackerWindow).send('custom_tray_icon', {
 			event: 'updateTimer',
@@ -73,7 +73,7 @@ export class AuthIPCHandler {
 		await this.handleGauzyWindowLogout(timeTrackerWindow);
 		this.closePluginsWindow();
 
-		await this.authHandler.handleLogout();
+		await this.authHandler.handleLogout(isRestart);
 	}
 
 	private updateMenuItems(hasEmployeeId: boolean, timeTrackerEnabled: boolean): void {

--- a/packages/desktop-ui-lib/src/lib/always-on/always-on.component.ts
+++ b/packages/desktop-ui-lib/src/lib/always-on/always-on.component.ts
@@ -41,7 +41,7 @@ export class AlwaysOnComponent implements OnInit, OnDestroy {
 	public isTrackingEnabled: boolean = true;
 	public running = false;
 	public isBillable = true;
-	private readonly COMPACT_MODE_WIDTH = 60;
+	private readonly COMPACT_MODE_WIDTH = 270;
 
 	play = faPlay;
 	pause = faPause;
@@ -132,7 +132,7 @@ export class AlwaysOnComponent implements OnInit, OnDestroy {
 	}
 
 	changeExpandMode(width: number) {
-		if (width > this.COMPACT_MODE_WIDTH) {
+		if (width >= this.COMPACT_MODE_WIDTH) {
 			this.isExpandMode = true;
 		} else {
 			this.isExpandMode = false;

--- a/packages/desktop-ui-lib/src/lib/auth/services/auth-strategy.service.ts
+++ b/packages/desktop-ui-lib/src/lib/auth/services/auth-strategy.service.ts
@@ -157,7 +157,7 @@ export class AuthStrategy extends NbAuthStrategy {
 		);
 	}
 
-	logout(): Observable<NbAuthResult> {
+	logout(isRestart?: boolean): Observable<NbAuthResult> {
 		this.authService
 			.doLogout(this.store.refreshToken)
 			.pipe(
@@ -165,15 +165,15 @@ export class AuthStrategy extends NbAuthStrategy {
 				catchError(() => EMPTY)
 			)
 			.subscribe();
-		return from(this._logout());
+		return from(this._logout(isRestart));
 	}
 
-	private async _logout(): Promise<NbAuthResult> {
+	private async _logout(isRestart?: boolean): Promise<NbAuthResult> {
 		this.store.clear();
 		this.store.serverConnection = 200;
 		if (this.electronService.isElectron) {
 			try {
-				await this.electronService.ipcRenderer.invoke('FINAL_LOGOUT');
+				await this.electronService.ipcRenderer.invoke('FINAL_LOGOUT', { isRestart });
 			} catch (error) {}
 		}
 

--- a/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
@@ -956,6 +956,8 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 	public async restartApp(): Promise<void> {
 		this._isRestart$.next(true);
 		if (!this.isServer && !this.authSetting.isLogout) {
+			// isRestart=true prevents the settings window from being closed during logout,
+			// allowing the restart flow to continue using the same window.
 			await firstValueFrom(this._authStrategy.logout(true));
 			this.currentUser$.next(null);
 			localStorage.clear();

--- a/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
@@ -956,7 +956,7 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 	public async restartApp(): Promise<void> {
 		this._isRestart$.next(true);
 		if (!this.isServer && !this.authSetting.isLogout) {
-			await firstValueFrom(this._authStrategy.logout());
+			await firstValueFrom(this._authStrategy.logout(true));
 			this.currentUser$.next(null);
 			localStorage.clear();
 		}

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -385,6 +385,20 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		}
 	}
 
+	/**
+	 * Cancel the BLOCK_DELAY lock that toggleStart arms after every stop.
+	 * Must be called whenever the lock needs to be force-released before the
+	 * timer fires naturally (e.g. during a restart sequence).
+	 */
+	private _resetProcessingLock(): void {
+		if (this.timerSubscription) {
+			this.timerSubscription.unsubscribe();
+			this.timerSubscription = null;
+		}
+		this.isProcessingEnabled = false;
+		this.loading = false;
+	}
+
 	private countDuration(count, isForcedSync?: boolean): void {
 		if (!this.start || isForcedSync) {
 			this._lastTotalWorkedToday$.next(count.todayDuration);
@@ -2418,14 +2432,9 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			return await lastValueFrom(
 				from(this.toggleStart(false)).pipe(
 					concatMap(async () => {
-						// toggleStart(false) leaves isProcessingEnabled=true and a block timer
-						// running for BLOCK_DELAY (10s). We must clear both before calling
-						// toggleStart(true), otherwise the start will be silently rejected.
-						if (this.timerSubscription) {
-							this.timerSubscription.unsubscribe();
-							this.timerSubscription = null;
-						}
-						this.isProcessingEnabled = false;
+						// toggleStart(false) arms a BLOCK_DELAY lock. Release it via the
+						// shared helper so all lock fields stay in sync in one place.
+						this._resetProcessingLock();
 						return callback ? await callback() : null;
 					}),
 					delay(200), // Brief pause between stop→start for IPC/OS settling

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -391,12 +391,22 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 	 * timer fires naturally (e.g. during a restart sequence).
 	 */
 	private _resetProcessingLock(): void {
+		this._cancelBlockDelayTimer();
+		this.isProcessingEnabled = false;
+		this.loading = false;
+	}
+
+	/**
+	 * Cancel only the pending BLOCK_DELAY auto-unblock timer without touching
+	 * isProcessingEnabled or loading. Use this when the restart path needs to
+	 * prevent the timer from firing mid-callback while still keeping the
+	 * processing guard active until the restart is ready to proceed.
+	 */
+	private _cancelBlockDelayTimer(): void {
 		if (this.timerSubscription) {
 			this.timerSubscription.unsubscribe();
 			this.timerSubscription = null;
 		}
-		this.isProcessingEnabled = false;
-		this.loading = false;
 	}
 
 	private countDuration(count, isForcedSync?: boolean): void {
@@ -2432,15 +2442,18 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			return await lastValueFrom(
 				from(this.toggleStart(false)).pipe(
 					concatMap(async () => {
-						// Keep the processing lock held while the callback runs so no
-						// external toggleStart() call can interleave during this window.
+						// Cancel the BLOCK_DELAY auto-unblock timer immediately so it
+						// cannot fire and clear isProcessingEnabled mid-callback.
+						// isProcessingEnabled intentionally stays true here — it keeps
+						// the guard up while the (potentially long) callback runs.
+						this._cancelBlockDelayTimer();
 						return callback ? await callback() : null;
 					}),
 					delay(200), // Brief pause between stop→start for IPC/OS settling
 					concatMap(async (callbackResult) => {
-						// Release the lock only now, immediately before re-starting, so
-						// toggleStart(true) sees a clean state and isProcessingEnabled
-						// never has a gap where another caller could sneak in.
+						// Full lock release immediately before re-starting: clears
+						// isProcessingEnabled and loading so toggleStart(true) sees a
+						// clean state with no interleaving window.
 						this._resetProcessingLock();
 						await this.toggleStart(true); // Restart process
 						return callbackResult; // Return the callback result

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -51,7 +51,7 @@ import {
 	asyncScheduler,
 	BehaviorSubject,
 	concatMap,
-	debounceTime,
+	delay,
 	exhaustMap,
 	filter,
 	from,
@@ -2415,11 +2415,20 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		this._isLockSyncProcess = true;
 
 		try {
-			// Resolve promise and debounce to avoid rapid calls
 			return await lastValueFrom(
 				from(this.toggleStart(false)).pipe(
-					debounceTime(200),
-					concatMap(() => (callback ? from(callback()) : of(null))), // Safely execute callback
+					concatMap(async () => {
+						// toggleStart(false) leaves isProcessingEnabled=true and a block timer
+						// running for BLOCK_DELAY (10s). We must clear both before calling
+						// toggleStart(true), otherwise the start will be silently rejected.
+						if (this.timerSubscription) {
+							this.timerSubscription.unsubscribe();
+							this.timerSubscription = null;
+						}
+						this.isProcessingEnabled = false;
+						return callback ? await callback() : null;
+					}),
+					delay(200), // Brief pause between stop→start for IPC/OS settling
 					concatMap(async (callbackResult) => {
 						await this.toggleStart(true); // Restart process
 						return callbackResult; // Return the callback result

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2432,13 +2432,16 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			return await lastValueFrom(
 				from(this.toggleStart(false)).pipe(
 					concatMap(async () => {
-						// toggleStart(false) arms a BLOCK_DELAY lock. Release it via the
-						// shared helper so all lock fields stay in sync in one place.
-						this._resetProcessingLock();
+						// Keep the processing lock held while the callback runs so no
+						// external toggleStart() call can interleave during this window.
 						return callback ? await callback() : null;
 					}),
 					delay(200), // Brief pause between stop→start for IPC/OS settling
 					concatMap(async (callbackResult) => {
+						// Release the lock only now, immediately before re-starting, so
+						// toggleStart(true) sees a clean state and isProcessingEnabled
+						// never has a gap where another caller could sneak in.
+						this._resetProcessingLock();
 						await this.toggleStart(true); // Restart process
 						return callbackResult; // Return the callback result
 					}),

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.service.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.service.ts
@@ -135,7 +135,7 @@ export class TimeTrackerService {
 		private readonly _teamsCacheService: TeamsCacheService,
 		private readonly _taskPriorityCacheService: TaskPriorityCacheService,
 		private readonly _taskSizeCacheService: TaskSizeCacheService
-	) { }
+	) {}
 
 	createAuthorizationHeader(headers: Headers) {
 		headers.append('Authorization', 'Basic ' + btoa('username:password'));
@@ -148,8 +148,8 @@ export class TimeTrackerService {
 				tenantId: values.tenantId,
 				...(values.projectId
 					? {
-						projectId: values.projectId
-					}
+							projectId: values.projectId
+						}
 					: {}),
 				...(values.organizationTeamId && {
 					teams: {
@@ -340,8 +340,8 @@ export class TimeTrackerService {
 			tenantId: values.tenantId,
 			...(values.organizationContactId
 				? {
-					organizationContactId: values.organizationContactId
-				}
+						organizationContactId: values.organizationContactId
+					}
 				: {}),
 			...(values.organizationTeamId && {
 				organizationTeamId: values.organizationTeamId
@@ -467,12 +467,10 @@ export class TimeTrackerService {
 	}
 
 	async getTimeLogById(timeLogId: string) {
-		const timeLog$ = this.http
-			.get(`${API_PREFIX}/timesheet/time-log/${timeLogId}`)
-			.pipe(
-				map((response: any) => response),
-				shareReplay(1)
-			);
+		const timeLog$ = this.http.get(`${API_PREFIX}/timesheet/time-log/${timeLogId}`).pipe(
+			map((response: any) => response),
+			shareReplay(1)
+		);
 		return firstValueFrom(timeLog$);
 	}
 
@@ -535,7 +533,9 @@ export class TimeTrackerService {
 			organizationTeamId: values.organizationTeamId
 		};
 		this._loggerService.log.info(`Toggle Start Timer Request: ${moment().format()}`, body);
-		return this._serialized('toggleApiStart', () => firstValueFrom(this.http.post(`${API_PREFIX}/timesheet/timer/start`, { ...body }, options)));
+		return this._serialized('toggleApiStart', () =>
+			firstValueFrom(this.http.post(`${API_PREFIX}/timesheet/timer/start`, { ...body }, options))
+		);
 	}
 
 	toggleApiStop(values) {
@@ -586,7 +586,10 @@ export class TimeTrackerService {
 			try {
 				return firstValueFrom(this.http.post<ITimeLog>(API_URL, body, options));
 			} catch (error) {
-				this._loggerService.error<any>(`Error stopping timer: ${moment().format()}`, { error, requestBody: body });
+				this._loggerService.error<any>(`Error stopping timer: ${moment().format()}`, {
+					error,
+					requestBody: body
+				});
 				throw error;
 			}
 		});
@@ -613,17 +616,19 @@ export class TimeTrackerService {
 			source: TimeLogSourceEnum.DESKTOP,
 			tenantId: this._store.tenantId,
 			organizationId: this._store.organizationId,
-			organizationContactId: payload.organizationContactId,
 			employeeId: this._store.user?.employee?.id,
+			...(payload.organizationContactId ? { organizationContactId: payload.organizationContactId } : {}),
 			...(payload.description ? { description: payload.description } : {}),
 			...(payload.taskId ? { taskId: payload.taskId } : {}),
 			...(payload.projectId ? { projectId: payload.projectId } : {})
-		}
+		};
 		const options = {
 			headers: new HttpHeaders({ timeout: TIMEOUT.toString() })
 		};
 		this._loggerService.log.info(`Update Time Log Request: ${timeLogId} ${moment().format()}`, timeLogPayload);
-		return this._serialized(`updateTimeLog:${timeLogId}`, () => firstValueFrom(this.http.put<ITimeLog>(API_URL, timeLogPayload, options)));
+		return this._serialized(`updateTimeLog:${timeLogId}`, () =>
+			firstValueFrom(this.http.put<ITimeLog>(API_URL, timeLogPayload, options))
+		);
 	}
 
 	addTimeLog(payload: Partial<ITimeLog>) {
@@ -645,19 +650,21 @@ export class TimeTrackerService {
 			logType: TimeLogType.TRACKED,
 			source: TimeLogSourceEnum.DESKTOP,
 			tenantId: this._store.tenantId,
-			organizationContactId: payload.organizationContactId,
 			organizationId: this._store.organizationId,
 			employeeId: this._store.user?.employee?.id,
+			...(payload.organizationContactId ? { organizationContactId: payload.organizationContactId } : {}),
 			...(payload.description ? { description: payload.description } : {}),
 			...(payload.taskId ? { taskId: payload.taskId } : {}),
 			...(payload.projectId ? { projectId: payload.projectId } : {})
-		}
+		};
 
 		const options = {
 			headers: new HttpHeaders({ timeout: TIMEOUT.toString() })
 		};
 		this._loggerService.log.info(`Add Time Log Request: ${moment().format()}`, timeLogPayload);
-		return this._serialized('addTimeLog', () => firstValueFrom(this.http.post<ITimeLog>(API_URL, timeLogPayload, options)));
+		return this._serialized('addTimeLog', () =>
+			firstValueFrom(this.http.post<ITimeLog>(API_URL, timeLogPayload, options))
+		);
 	}
 
 	deleteTimeSlot(values) {

--- a/packages/desktop-window/src/lib/always-on.ts
+++ b/packages/desktop-window/src/lib/always-on.ts
@@ -94,7 +94,7 @@ export class AlwaysOn extends BaseWindow implements IBaseWindow {
 	}
 
 	public isDestroyed(): boolean {
-		if(!this.browserWindow) {
+		if (!this.browserWindow) {
 			return true;
 		}
 		return this.browserWindow.isDestroyed();


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop timer widget’s restart reliability (including midnight auto-restart) and Always On behavior, improving stop→start flows and logout/restart handling.

- **Bug Fixes**
  - Stop→start reliability: cancel the pending BLOCK_DELAY auto-unblock, hold/release the processing lock, and add a brief delay before restart to prevent silent start failures (covers midnight auto-restart).
  - Logout/restart: propagate `isRestart` through `FINAL_LOGOUT`; keep Settings open on restart, close Always On, and stop any running timer first.
  - Always On UI: set compact width to 270 and use an inclusive check for expand mode.
  - Safer updates/API: only update offline timers when `startedAt` exists; omit `organizationContactId` in time-log payloads when missing.

<sup>Written for commit 53d55dcc6e03f461c06d8fb37ca875dba2bb53b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

