### PR TITLE
chore: create migrations file for the new integrations files

### DIFF
--- a/packages/core/src/lib/database/migrations/1774291434025-SeedNewIntegrationsAndIntegrationTypes.ts
+++ b/packages/core/src/lib/database/migrations/1774291434025-SeedNewIntegrationsAndIntegrationTypes.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 import * as chalk from 'chalk';
 import { IntegrationTypeEnum } from "@gauzy/contracts";
-import { DEFAULT_INTEGRATIONS, DEFAULT_SYSTEM_INTEGRATIONS, DEFAULT_AI_INTEGRATIONS } from "../../integration/default-integration";
+import { DEFAULT_INTEGRATIONS } from "../../integration/default-integration";
 import { IntegrationsUtils } from "../../integration/utils";
 import { DatabaseTypeEnum } from "@gauzy/config";
 
@@ -43,11 +43,7 @@ export class SeedNewIntegrationsAndIntegrationTypes1774291434025 implements Migr
     * @param queryRunner
     */
     public async sqlitePostgresUpsert(queryRunner: QueryRunner): Promise<any> {
-        console.log(chalk.yellow(this.name + ' start running!'));
-
         await IntegrationsUtils.upsertIntegrationTypes(queryRunner, [IntegrationTypeEnum.AUTOMATION_TOOLS, IntegrationTypeEnum.AI_AGENTS]);
-        await IntegrationsUtils.upsertIntegrationsAndIntegrationTypes(queryRunner, DEFAULT_SYSTEM_INTEGRATIONS);
-        await IntegrationsUtils.upsertIntegrationsAndIntegrationTypes(queryRunner, DEFAULT_AI_INTEGRATIONS);
         await IntegrationsUtils.upsertIntegrationsAndIntegrationTypes(queryRunner, DEFAULT_INTEGRATIONS);
     }
 

--- a/packages/core/src/lib/database/migrations/1774291434025-SeedNewIntegrationsAndIntegrationTypes.ts
+++ b/packages/core/src/lib/database/migrations/1774291434025-SeedNewIntegrationsAndIntegrationTypes.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import * as chalk from 'chalk';
+import { IntegrationTypeEnum } from "@gauzy/contracts";
+import { DEFAULT_INTEGRATIONS, DEFAULT_SYSTEM_INTEGRATIONS, DEFAULT_AI_INTEGRATIONS } from "../../integration/default-integration";
+import { IntegrationsUtils } from "../../integration/utils";
+import { DatabaseTypeEnum } from "@gauzy/config";
+
+export class SeedNewIntegrationsAndIntegrationTypes1774291434025 implements MigrationInterface {
+
+    name = 'SeedNewIntegrationsAndIntegrationTypes1774291434025';
+
+    /**
+     * Up Migration
+     *
+     * @param queryRunner
+     */
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        console.log(chalk.yellow(this.name + ' start running!'));
+
+        switch (queryRunner.connection.options.type) {
+            case DatabaseTypeEnum.sqlite:
+            case DatabaseTypeEnum.betterSqlite3:
+            case DatabaseTypeEnum.postgres:
+                await this.sqlitePostgresUpsert(queryRunner);
+                break;
+            case DatabaseTypeEnum.mysql:
+                await this.mysqlUpsert(queryRunner);
+                break;
+            default:
+                throw Error(`Unsupported database: ${queryRunner.connection.options.type}`);
+        }
+    }
+    /**
+     * Down Migration
+     *
+     * @param queryRunner
+     */
+    public async down(queryRunner: QueryRunner): Promise<void> { }
+
+    /**
+    * Sqlite | better-sqlite3 | Postgres Up Migration
+    *
+    * @param queryRunner
+    */
+    public async sqlitePostgresUpsert(queryRunner: QueryRunner): Promise<any> {
+        console.log(chalk.yellow(this.name + ' start running!'));
+
+        await IntegrationsUtils.upsertIntegrationTypes(queryRunner, [IntegrationTypeEnum.AUTOMATION_TOOLS, IntegrationTypeEnum.AI_AGENTS]);
+        await IntegrationsUtils.upsertIntegrationsAndIntegrationTypes(queryRunner, DEFAULT_SYSTEM_INTEGRATIONS);
+        await IntegrationsUtils.upsertIntegrationsAndIntegrationTypes(queryRunner, DEFAULT_AI_INTEGRATIONS);
+        await IntegrationsUtils.upsertIntegrationsAndIntegrationTypes(queryRunner, DEFAULT_INTEGRATIONS);
+    }
+
+    /**
+    * MySQL Up Migration
+    *
+    * @param queryRunner
+    */
+    public async mysqlUpsert(queryRunner: QueryRunner): Promise<any> { }
+}


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DB migration to seed new integration types (AUTOMATION_TOOLS, AI_AGENTS) and default integrations so they’re available by default.

- **Migration**
  - Upserts `AUTOMATION_TOOLS` and `AI_AGENTS` types and seeds `DEFAULT_INTEGRATIONS`.
  - Supports `sqlite`, `better-sqlite3`, and `postgres`; MySQL path is a no-op.
  - Throws on unsupported DB types; no down migration.

<sup>Written for commit 9be16599c7a44b4163c3eaca0656376515f96f14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

