### PR TITLE
fix(deps): resolution version knex to 3.1.0 to fix sqlite migration t…

### DIFF
--- a/apps/agent/src/package.json
+++ b/apps/agent/src/package.json
@@ -154,6 +154,7 @@
 		"@gauzy/desktop-lib": "file:../../../dist/packages/desktop-lib",
 		"@gauzy/desktop-window": "file:../../../dist/packages/desktop-window",
 		"@gauzy/ui-config": "file:../../../dist/packages/ui-config",
-		"@gauzy/constants": "file:../../../dist/packages/constants"
+		"@gauzy/constants": "file:../../../dist/packages/constants",
+		"knex": "3.1.0"
 	}
 }

--- a/apps/desktop-timer/src/package.json
+++ b/apps/desktop-timer/src/package.json
@@ -181,7 +181,7 @@
     "@gauzy/desktop-lib": "file:../../../dist/packages/desktop-lib",
     "@gauzy/desktop-window": "file:../../../dist/packages/desktop-window",
     "@gauzy/ui-config": "file:../../../dist/packages/ui-config",
-	"knex": "3.1.0"
+    "knex": "3.1.0"
   }
 }
 

--- a/apps/desktop-timer/src/package.json
+++ b/apps/desktop-timer/src/package.json
@@ -180,7 +180,8 @@
     "@gauzy/desktop-activity": "file:../../../dist/packages/desktop-activity",
     "@gauzy/desktop-lib": "file:../../../dist/packages/desktop-lib",
     "@gauzy/desktop-window": "file:../../../dist/packages/desktop-window",
-    "@gauzy/ui-config": "file:../../../dist/packages/ui-config"
+    "@gauzy/ui-config": "file:../../../dist/packages/ui-config",
+	"knex": "3.1.0"
   }
 }
 

--- a/apps/desktop/src/package.json
+++ b/apps/desktop/src/package.json
@@ -235,7 +235,7 @@
     "@gauzy/scheduler": "file:../../../dist/packages/scheduler",
     "@gauzy/ui-config": "file:../../../dist/packages/ui-config",
     "@gauzy/utils": "file:../../../dist/packages/utils",
-	"knex": "3.1.0"
+    "knex": "3.1.0"
   },
   "optionalDependencies": {
     "node-linux": "^0.1.12",

--- a/apps/desktop/src/package.json
+++ b/apps/desktop/src/package.json
@@ -234,7 +234,8 @@
     "@gauzy/plugin-integration-activepieces": "file:../../../dist/packages/plugins/integration-activepieces",
     "@gauzy/scheduler": "file:../../../dist/packages/scheduler",
     "@gauzy/ui-config": "file:../../../dist/packages/ui-config",
-    "@gauzy/utils": "file:../../../dist/packages/utils"
+    "@gauzy/utils": "file:../../../dist/packages/utils",
+	"knex": "3.1.0"
   },
   "optionalDependencies": {
     "node-linux": "^0.1.12",

--- a/apps/server-api/src/package.json
+++ b/apps/server-api/src/package.json
@@ -228,7 +228,8 @@
         "@gauzy/plugin-integration-activepieces": "file:../../../dist/packages/plugins/integration-activepieces",
         "@gauzy/scheduler": "file:../../../dist/packages/scheduler",
         "@gauzy/ui-config": "file:../../../dist/packages/ui-config",
-        "@gauzy/utils": "file:../../../dist/packages/utils"
+        "@gauzy/utils": "file:../../../dist/packages/utils",
+		"knex": "3.1.0"
     },
     "optionalDependencies": {
         "node-linux": "^0.1.12",

--- a/apps/server-api/src/package.json
+++ b/apps/server-api/src/package.json
@@ -229,7 +229,7 @@
         "@gauzy/scheduler": "file:../../../dist/packages/scheduler",
         "@gauzy/ui-config": "file:../../../dist/packages/ui-config",
         "@gauzy/utils": "file:../../../dist/packages/utils",
-		"knex": "3.1.0"
+        "knex": "3.1.0"
     },
     "optionalDependencies": {
         "node-linux": "^0.1.12",

--- a/apps/server-mcp/src/package.json
+++ b/apps/server-mcp/src/package.json
@@ -148,7 +148,8 @@
 		"@gauzy/contracts": "file:../../../dist/packages/contracts",
 		"@gauzy/utils": "file:../../../dist/packages/utils",
 		"@gauzy/common": "file:../../../dist/packages/common",
-		"@gauzy/constants": "file:../../../dist/packages/constants"
+		"@gauzy/constants": "file:../../../dist/packages/constants",
+		"knex": "3.1.0"
 	},
 	"pkg": {
 		"assets": [],

--- a/apps/server/src/package.json
+++ b/apps/server/src/package.json
@@ -234,7 +234,7 @@
         "@gauzy/scheduler": "file:../../../dist/packages/scheduler",
         "@gauzy/ui-config": "file:../../../dist/packages/ui-config",
         "@gauzy/utils": "file:../../../dist/packages/utils",
-		"knex": "3.1.0"
+        "knex": "3.1.0"
     },
     "optionalDependencies": {
         "node-linux": "^0.1.12",

--- a/apps/server/src/package.json
+++ b/apps/server/src/package.json
@@ -233,7 +233,8 @@
         "@gauzy/plugin-integration-activepieces": "file:../../../dist/packages/plugins/integration-activepieces",
         "@gauzy/scheduler": "file:../../../dist/packages/scheduler",
         "@gauzy/ui-config": "file:../../../dist/packages/ui-config",
-        "@gauzy/utils": "file:../../../dist/packages/utils"
+        "@gauzy/utils": "file:../../../dist/packages/utils",
+		"knex": "3.1.0"
     },
     "optionalDependencies": {
         "node-linux": "^0.1.12",


### PR DESCRIPTION
…ransaction error

# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `knex` to 3.1.0 across agent, desktop, timer, and server apps to stop SQLite migration transaction failures on startup. This restores reliable migrations in all affected builds.

- **Dependencies**
  - Set `knex` to `3.1.0` in `apps/agent`, `apps/desktop`, `apps/desktop-timer`, `apps/server`, `apps/server-api`, `apps/server-mcp`.

<sup>Written for commit 8817a903068b80f90bf0257075b6145aedf2916e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

