### PR TITLE
[Fix] Added Tenant ID in the Request Context for tenant Api Key guard

### DIFF
--- a/packages/core/src/lib/shared/guards/api-key-auth.guard.ts
+++ b/packages/core/src/lib/shared/guards/api-key-auth.guard.ts
@@ -27,15 +27,22 @@ export class ApiKeyAuthGuard implements CanActivate {
 		}
 
 		// Proceed with API Key authentication if both are present
-		const isValidKey = await this._tenantApiKeyService.validateApiKeyAndSecret(apiKey, apiSecret);
+		const tenantApiKey = await this._tenantApiKeyService.validateApiKeyAndSecret(apiKey, apiSecret);
 
-		if (!isValidKey) {
+		if (!tenantApiKey) {
 			throw new UnauthorizedException(
 				'Access Denied: The provided X-APP-ID or X-API-KEY is invalid or does not have the required permissions.'
 			);
 		}
 
-		return isValidKey;
+		// Set the tenant ID in the request context (via user object)
+		// This ensures that TenantAwareCrudService methods correctly filter queries by tenant
+		request['user'] = {
+			...request['user'],
+			tenantId: tenantApiKey.tenantId
+		} as any;
+
+		return true;
 	}
 
 	/**

--- a/packages/core/src/lib/tenant-api-key/tenant-api-key.service.ts
+++ b/packages/core/src/lib/tenant-api-key/tenant-api-key.service.ts
@@ -120,23 +120,23 @@ export class TenantApiKeyService extends TenantAwareCrudService<TenantApiKey> {
 	 *
 	 * @param apiKey - The API Key to validate.
 	 * @param apiSecret - The API Secret to validate.
-	 * @returns A promise resolving to `true` if valid, otherwise `false`.
+	 * @returns A promise resolving to the `TenantApiKey` entity if valid, otherwise `null`.
 	 */
-	async validateApiKeyAndSecret(apiKey: string, apiSecret: string): Promise<boolean> {
+	async validateApiKeyAndSecret(apiKey: string, apiSecret: string): Promise<TenantApiKey | null> {
 		try {
 			// Retrieve the corresponding tenant_api_key record based on the apiKey
 			const tenantApiKey = await this.getApiKey(apiKey);
 
-			// If the API Key is not found or validation fails, return false
+			// If the API Key is not found or validation fails, return null
 			if (!tenantApiKey || !this.validateApiKey(apiSecret, tenantApiKey.apiSecret)) {
 				console.warn(`Unauthorized: Invalid API Key (X-APP-ID) or Secret (X-API-KEY) for API Key`);
-				return false;
+				return null;
 			}
 
-			return true; // Return true if API Key and Secret are valid
+			return tenantApiKey; // Return the tenant API key entity if valid
 		} catch (error) {
 			console.error(`Database Error: Failed to retrieve tenant API key. Reason: ${error.message}`);
-			return false;
+			return null;
 		}
 	}
 


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tenant ID to the request context after API key auth so tenant-scoped queries work correctly with tenant API keys. Also updates the validation flow to return the tenant API key entity, enabling the guard to set the tenant.

- **Bug Fixes**
  - In `ApiKeyAuthGuard`, set `request.user.tenantId` after successful API key validation to ensure `TenantAwareCrudService` filters by tenant.
  - In `TenantApiKeyService`, change `validateApiKeyAndSecret` to return the `TenantApiKey` entity or `null` (was boolean), and update the guard to use it.

<sup>Written for commit cf29d4377354f1a5fe1bc22977d22ecd3cd3551f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

