### PR TITLE
Fix/desktop timer offline mode

### DIFF
--- a/apps/agent/src/main/init/ipcMain.ts
+++ b/apps/agent/src/main/init/ipcMain.ts
@@ -5,7 +5,7 @@ import {
 	app
 } from 'electron';
 import * as remoteMain from '@electron/remote/main';
-import { logger as log, store } from '@gauzy/desktop-core';
+import { IConfig, logger as log, store } from '@gauzy/desktop-core';
 import {
 	LocalStore,
 	TranslateService,
@@ -14,6 +14,7 @@ import {
 	UserService,
 	pluginListeners,
 	ProviderFactory,
+	DesktopOfflineModeHandler,
 } from '@gauzy/desktop-lib';
 import { getApiBaseUrl, delaySync, getAuthConfig, getAppSetting, updateProject } from '../util';
 import { startServer } from './app';
@@ -331,6 +332,15 @@ export default function AppIpcMain() {
 			projectId: data.projectId ?? null
 		});
 		return true;
+	});
+
+	ipcMain.handle('IS_OFFLINE', async () => {
+		const configs: IConfig = LocalStore.getStore('configs');
+		if (configs?.serverConfigConnected) {
+			const offlineMode = DesktopOfflineModeHandler.instance;
+			return offlineMode.enabled;
+		}
+		return false;
 	});
 
 	ipcMain.on('get-arch', (event) => {

--- a/apps/desktop-timer/src/app/app.component.ts
+++ b/apps/desktop-timer/src/app/app.component.ts
@@ -65,12 +65,20 @@ export class AppComponent implements OnInit, AfterViewInit {
 			.pipe(
 				switchMap((arg) =>
 					interval(1000).pipe(
-						exhaustMap(() =>
-							from(this.appService.pingServer(arg)).pipe(
-								map(() => 200),
-								catchError((err) => of(err?.status ?? 0))
+						exhaustMap(() => {
+							console.log('Pinging server...');
+							return from(this.electronService.ipcRenderer.invoke('IS_OFFLINE')).pipe(
+								switchMap((isOfflineMode) => {
+									if (isOfflineMode) {
+										return of(200);
+									}
+									return from(this.appService.pingServer(arg)).pipe(
+										map(() => 200),
+										catchError((err) => of(err?.status ?? 0))
+									);
+								})
 							)
-						),
+						}),
 						tap((status) => {
 							this.store.serverConnection = status;
 						}),

--- a/apps/desktop-timer/src/app/app.component.ts
+++ b/apps/desktop-timer/src/app/app.component.ts
@@ -66,7 +66,6 @@ export class AppComponent implements OnInit, AfterViewInit {
 				switchMap((arg) =>
 					interval(1000).pipe(
 						exhaustMap(() => {
-							console.log('Pinging server...');
 							return from(this.electronService.ipcRenderer.invoke('IS_OFFLINE')).pipe(
 								switchMap((isOfflineMode) => {
 									if (isOfflineMode) {

--- a/apps/desktop-timer/src/index.ts
+++ b/apps/desktop-timer/src/index.ts
@@ -472,7 +472,7 @@ async function restartApp(arg?: IConfig) {
 	app.exit(0);
 }
 
-async function checkOfllineMode(configs: IConfig) {
+async function checkOfflineMode(configs: IConfig) {
 	try {
 		if (configs?.serverUrl && configs?.serverConfigConnected) {
 			const offlineModeHandler = DesktopOfflineModeHandler.instance;
@@ -519,7 +519,7 @@ app.on('ready', async () => {
 	await setupDatabase();
 	initialAppMenu();
 	try {
-		await checkOfllineMode(configs);
+		await checkOfflineMode(configs);
 		timeTrackerWindow = await createTimeTrackerWindow(
 			timeTrackerWindow,
 			pathWindow.timeTrackerUi,

--- a/apps/desktop-timer/src/index.ts
+++ b/apps/desktop-timer/src/index.ts
@@ -899,6 +899,15 @@ ipcMain.handle('set-tray-icon', () => {
 	};
 });
 
+ipcMain.handle('IS_OFFLINE', async () => {
+	const configs: IConfig = LocalStore.getStore('configs');
+	if (configs?.serverConfigConnected) {
+		const offlineMode = DesktopOfflineModeHandler.instance;
+		return offlineMode.enabled;
+	}
+	return false;
+});
+
 ipcMain.on('get-arch', (event) => {
 	event.sender.send('get-arch', process.arch);
 });

--- a/apps/desktop-timer/src/index.ts
+++ b/apps/desktop-timer/src/index.ts
@@ -53,7 +53,8 @@ import {
 	TranslateService,
 	TrayIconFactory,
 	UIError,
-	handleDesktopStartup
+	handleDesktopStartup,
+	DesktopOfflineModeHandler
 } from '@gauzy/desktop-lib';
 import {
 	AlwaysOn,
@@ -471,6 +472,17 @@ async function restartApp(arg?: IConfig) {
 	app.exit(0);
 }
 
+async function checkOfllineMode(configs: IConfig) {
+	try {
+		if (configs?.serverUrl && configs?.serverConfigConnected) {
+			const offlineModeHandler = DesktopOfflineModeHandler.instance;
+			await offlineModeHandler.connectivity();
+		}
+	} catch (error) {
+		console.error('Error checking offline mode:', error);
+	}
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
@@ -507,6 +519,7 @@ app.on('ready', async () => {
 	await setupDatabase();
 	initialAppMenu();
 	try {
+		await checkOfllineMode(configs);
 		timeTrackerWindow = await createTimeTrackerWindow(
 			timeTrackerWindow,
 			pathWindow.timeTrackerUi,
@@ -658,14 +671,16 @@ ipcMain.on('minimize_on_startup', (event, arg) => {
 });
 
 app.on('activate', () => {
+	const configs = LocalStore.getStore('configs');
 	if (gauzyWindow) {
-		if (LocalStore.getStore('configs').gauzyWindow) {
+		if (configs?.gauzyWindow) {
 			gauzyWindow.show();
 		}
 	} else if (
 		!onWaitingServer &&
-		LocalStore.getStore('configs') &&
-		LocalStore.getStore('configs').isSetup &&
+		configs &&
+		configs.isSetup &&
+		configs.serverConfigConnected &&
 		timeTrackerWindow
 	) {
 		// On macOS, it's common to re-create a window in the app when the
@@ -675,7 +690,9 @@ app.on('activate', () => {
 	} else {
 		if (setupWindow) {
 			setupWindow.show();
-			splashScreen.close();
+			if (!splashScreen?.isDestroyed()) {
+				splashScreen?.close();
+			}
 		}
 	}
 });

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -46,7 +46,8 @@ import {
 	removeMainListener,
 	removeTimerListener,
 	setupAkitaStorageHandler,
-	handleDesktopStartup
+	handleDesktopStartup,
+    DesktopOfflineModeHandler
 } from '@gauzy/desktop-lib';
 import {
 	AlwaysOn,
@@ -63,6 +64,7 @@ import * as Sentry from '@sentry/electron/main';
 import { fork } from 'child_process';
 import { autoUpdater } from 'electron-updater';
 import { initSentry } from './sentry';
+import { IConfig } from '@gauzy/desktop-core';
 
 /**
  * Describes the configuration for building the Gauzy API base URL.
@@ -969,6 +971,15 @@ ipcMain.handle('get-app-path', () => app.getAppPath());
 ipcMain.handle('app_setting', () => LocalStore.getApplicationConfig());
 ipcMain.on('get-arch', (event) => {
 	event.sender.send('get-arch', process.arch);
+});
+
+ipcMain.handle('IS_OFFLINE', async () => {
+	const configs: IConfig = LocalStore.getStore('configs');
+	if (configs?.serverConfigConnected) {
+		const offlineMode = DesktopOfflineModeHandler.instance;
+		return offlineMode.enabled;
+	}
+	return false;
 });
 
 /**

--- a/packages/desktop-core/src/lib/store/types.ts
+++ b/packages/desktop-core/src/lib/store/types.ts
@@ -70,6 +70,7 @@ export interface IConfig {
 			cert: string;
 		};
 	};
+	serverConfigConnected?: boolean
 }
 
 export interface IAuth {

--- a/packages/desktop-core/src/lib/store/types.ts
+++ b/packages/desktop-core/src/lib/store/types.ts
@@ -70,7 +70,7 @@ export interface IConfig {
 			cert: string;
 		};
 	};
-	serverConfigConnected?: boolean
+	serverConfigConnected?: boolean;
 }
 
 export interface IAuth {

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -383,6 +383,14 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 		};
 	});
 
+	ipcMain.handle('SET_OFFLINE_MODE', async () => {
+		offlineMode.forceOffline();
+	})
+
+	ipcMain.handle('IS_OFFLINE', async () => {
+		return offlineMode.enabled;
+	});
+
 	pluginListeners();
 }
 
@@ -1062,11 +1070,13 @@ export function ipcTimer(
 
 			timeTrackerWindow.webContents.send('timer_tracker_show', {
 				...LocalStore.beforeRequestParams(),
+				isOffline: offlineMode.enabled,
 				timeSlotId: lastTime ? lastTime.timeslotId : null
 			});
 		} catch (error) {
 			log.error('Error on refresh timer', error);
 			timeTrackerWindow.webContents.send('timer_tracker_show', {
+				isOffline: offlineMode.enabled,
 				...LocalStore.beforeRequestParams(),
 				timeSlotId: null
 			});

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -384,12 +384,9 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 	});
 
 	ipcMain.handle('SET_OFFLINE_MODE', async () => {
+		const offlineMode = DesktopOfflineModeHandler.instance;
 		offlineMode.forceOffline();
 	})
-
-	ipcMain.handle('IS_OFFLINE', async () => {
-		return offlineMode.enabled;
-	});
 
 	pluginListeners();
 }
@@ -1282,8 +1279,7 @@ export function removeAllHandlers() {
 		'COLLECT_ACTIVITIES',
 		'START_SERVER',
 		'GET_LAST_CAPTURE',
-		'SET_OFFLINE_MODE',
-		'IS_OFFLINE',
+		'SET_OFFLINE_MODE'
 	];
 	channels.forEach((channel: string) => {
 		ipcMain.removeHandler(channel);

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -1281,7 +1281,9 @@ export function removeAllHandlers() {
 		'FINISH_SYNCED_TIMER',
 		'COLLECT_ACTIVITIES',
 		'START_SERVER',
-		'GET_LAST_CAPTURE'
+		'GET_LAST_CAPTURE',
+		'SET_OFFLINE_MODE',
+		'IS_OFFLINE',
 	];
 	channels.forEach((channel: string) => {
 		ipcMain.removeHandler(channel);

--- a/packages/desktop-lib/src/lib/interfaces/i-offline-mode.ts
+++ b/packages/desktop-lib/src/lib/interfaces/i-offline-mode.ts
@@ -35,5 +35,9 @@ export interface IOfflineMode {
 	 */
 	connectivity(): Promise<void>;
 
+	/**
+     * Immediately enables offline mode without waiting for connectivity check.
+	 * Used when a hard network error is detected.
+	 */
 	forceOffline(): void;
 }

--- a/packages/desktop-lib/src/lib/interfaces/i-offline-mode.ts
+++ b/packages/desktop-lib/src/lib/interfaces/i-offline-mode.ts
@@ -34,4 +34,6 @@ export interface IOfflineMode {
 	 * Check api connectivity
 	 */
 	connectivity(): Promise<void>;
+
+	forceOffline(): void;
 }

--- a/packages/desktop-lib/src/lib/offline/desktop-offline-mode-handler.ts
+++ b/packages/desktop-lib/src/lib/offline/desktop-offline-mode-handler.ts
@@ -30,7 +30,7 @@ export class DesktopOfflineModeHandler extends EventEmitter implements IOfflineM
 		this._pingTimer = null;
 
 		// Default ping timer interval set to 40 seconds
-		this._PING_INTERVAL = 40 * 1000;
+		this._PING_INTERVAL = 10 * 1000;
 
 		this.on('connection-restored', () => {
 			console.log('[OfflineModeHandler]: Connection restored');
@@ -162,5 +162,14 @@ export class DesktopOfflineModeHandler extends EventEmitter implements IOfflineM
 	public get isTracking(): boolean {
 		const setting = LocalStore.getStore('appSetting');
 		return setting && setting.timerStarted;
+	}
+
+	public forceOffline(): void {
+		if (!this._isEnabled) {
+			console.log('[OfflineModeHandler]: Hard network error detected. Forcing offline instantly.');
+			this._startedAt = new Date();
+			this._isEnabled = true;
+			this.emit('offline');
+		}
 	}
 }

--- a/packages/desktop-lib/src/lib/offline/desktop-offline-mode-handler.ts
+++ b/packages/desktop-lib/src/lib/offline/desktop-offline-mode-handler.ts
@@ -29,7 +29,7 @@ export class DesktopOfflineModeHandler extends EventEmitter implements IOfflineM
 		// Initial server ping timer
 		this._pingTimer = null;
 
-		// Default ping timer interval set to 40 seconds
+		// Default ping timer interval set to 10 seconds
 		this._PING_INTERVAL = 10 * 1000;
 
 		this.on('connection-restored', () => {

--- a/packages/desktop-ui-lib/src/lib/language/language.service.ts
+++ b/packages/desktop-ui-lib/src/lib/language/language.service.ts
@@ -5,17 +5,27 @@ import { toParams } from '@gauzy/ui-core/common';
 import { firstValueFrom, map, shareReplay } from 'rxjs';
 import { API_PREFIX } from '../constants/app.constants';
 import { LanguageCacheService } from '../services';
+import { Store } from '../services';
 
 @Injectable({
 	providedIn: 'root'
 })
 export class LanguageService {
-	constructor(private _http: HttpClient, private _languageCacheService: LanguageCacheService) {}
+	constructor(
+		private _http: HttpClient,
+		private _languageCacheService: LanguageCacheService,
+		private _store: Store
+	) {}
 
 	public all(): Promise<{ items: ILanguage[] }> {
 		const KEY = 'all';
 		let languages$ = this._languageCacheService.getValue(KEY);
 		if (!languages$) {
+			// If offline and cache is cold, return empty payload instead of throwing
+			if (this._store.isOffline) {
+				console.warn('[LanguageService.all]: Offline, returning empty language list.');
+				return Promise.resolve({ items: [] });
+			}
 			languages$ = this._http.get<{ items: ILanguage[] }>(`${API_PREFIX}/languages`).pipe(
 				map((response: { items: ILanguage[] }) => response),
 				shareReplay(1)
@@ -29,6 +39,11 @@ export class LanguageService {
 		const params = toParams({ is_system: 1 });
 		let languages$ = this._languageCacheService.getValue(params);
 		if (!languages$) {
+			// If offline and cache is cold, return empty payload instead of throwing
+			if (this._store.isOffline) {
+				console.warn('[LanguageService.system]: Offline, returning empty system language list.');
+				return Promise.resolve({ items: [] });
+			}
 			languages$ = this._http
 				.get<{ items: ILanguage[] }>(`${API_PREFIX}/languages`, {
 					params

--- a/packages/desktop-ui-lib/src/lib/language/language.service.ts
+++ b/packages/desktop-ui-lib/src/lib/language/language.service.ts
@@ -4,8 +4,7 @@ import { ILanguage } from '@gauzy/contracts';
 import { toParams } from '@gauzy/ui-core/common';
 import { firstValueFrom, map, shareReplay } from 'rxjs';
 import { API_PREFIX } from '../constants/app.constants';
-import { LanguageCacheService } from '../services';
-import { Store } from '../services';
+import { LanguageCacheService, Store } from '../services';
 
 @Injectable({
 	providedIn: 'root'

--- a/packages/desktop-ui-lib/src/lib/server-down/server-down.page.ts
+++ b/packages/desktop-ui-lib/src/lib/server-down/server-down.page.ts
@@ -6,7 +6,6 @@ import { catchError, distinctUntilChanged, filter, switchMap, takeUntil, tap } f
 import { GAUZY_ENV } from '../constants';
 import { LanguageElectronService } from '../language/language-electron.service';
 import { ServerConnectionService, Store } from '../services';
-import { ElectronService } from '../electron/services';
 import { NbLayoutModule } from '@nebular/theme';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -22,7 +21,6 @@ export class ServerDownPage implements OnInit, OnDestroy {
 	private redirectUrl: string | null = null;
 
 	constructor(
-		private readonly electronService: ElectronService,
 		private readonly store: Store,
 		private readonly serverConnectionService: ServerConnectionService,
 		private readonly router: Router,

--- a/packages/desktop-ui-lib/src/lib/server-down/server-down.page.ts
+++ b/packages/desktop-ui-lib/src/lib/server-down/server-down.page.ts
@@ -6,6 +6,7 @@ import { catchError, distinctUntilChanged, filter, switchMap, takeUntil, tap } f
 import { GAUZY_ENV } from '../constants';
 import { LanguageElectronService } from '../language/language-electron.service';
 import { ServerConnectionService, Store } from '../services';
+import { ElectronService } from '../electron/services';
 import { NbLayoutModule } from '@nebular/theme';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -21,6 +22,7 @@ export class ServerDownPage implements OnInit, OnDestroy {
 	private redirectUrl: string | null = null;
 
 	constructor(
+		private readonly electronService: ElectronService,
 		private readonly store: Store,
 		private readonly serverConnectionService: ServerConnectionService,
 		private readonly router: Router,
@@ -43,20 +45,34 @@ export class ServerDownPage implements OnInit, OnDestroy {
 		interval(checkIntervalMs)
 			.pipe(
 				tap(() => console.log('Checking server connection to URL:', url)),
-				switchMap(() =>
-					from(this.serverConnectionService.checkServerConnection(url)).pipe(
+				switchMap(() => {
+					// Determine target URL based on authentication status (token presence)
+					const getTargetUrl = () => {
+						return this.redirectUrl || '/';
+					};
+
+					if (this.store.isOffline && this.store.token) {
+						return from(Promise.resolve(200)).pipe(
+							tap(() => {
+								const targetUrl = getTargetUrl();
+								console.log('Offline mode active, bypassing server down page, navigating to:', targetUrl);
+								this.router.navigateByUrl(targetUrl);
+							})
+						);
+					}
+
+					return from(this.serverConnectionService.checkServerConnection(url)).pipe(
 						distinctUntilChanged(),
 						tap(() => console.log('Server connection status:', this.store.serverConnection)),
 						filter(() => Number(this.store.serverConnection) === 200 || !!this.store.userId),
 						tap(() => {
-							// Navigate to the original URL if available, otherwise go to root
-							const targetUrl = this.redirectUrl || '/';
+							const targetUrl = getTargetUrl();
 							console.log('Connection restored, navigating to:', targetUrl);
 							this.router.navigateByUrl(targetUrl);
 						}),
 						catchError(() => EMPTY) // Silently handle errors to keep the stream alive
-					)
-				),
+					);
+				}),
 				takeUntil(this.destroy$)
 			)
 			.subscribe({

--- a/packages/desktop-ui-lib/src/lib/services/server-connection.service.ts
+++ b/packages/desktop-ui-lib/src/lib/services/server-connection.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { Store } from './store.service';
+import { ElectronService } from '../electron/services';
 
 interface IConnectionStatus {
 	status: number;
@@ -14,7 +15,11 @@ export class ServerConnectionService {
 	private readonly CONNECTION_ENDPOINT = '/api';
 	private readonly LOCALHOST_URL = 'http://localhost:3000';
 
-	constructor(private readonly httpClient: HttpClient, private readonly store: Store) {}
+	constructor(
+		private readonly httpClient: HttpClient,
+		private readonly store: Store,
+		private readonly _electronService: ElectronService
+	) {}
 
 	/**
 	 * Checks the server connection status
@@ -31,6 +36,10 @@ export class ServerConnectionService {
 		this.logConnectionAttempt(url);
 
 		try {
+			const isOfflineMode = await this._electronService.ipcRenderer.invoke('IS_OFFLINE');
+			if (isOfflineMode) {
+				return this.handleSuccessfulConnection({ status: 200 }, url);
+			}
 			const response = await this.attemptServerConnection(url);
 			return this.handleSuccessfulConnection(response, url);
 		} catch (error) {

--- a/packages/desktop-ui-lib/src/lib/services/server-connection.service.ts
+++ b/packages/desktop-ui-lib/src/lib/services/server-connection.service.ts
@@ -35,11 +35,21 @@ export class ServerConnectionService {
 		const url = this.buildConnectionUrl(endPoint);
 		this.logConnectionAttempt(url);
 
+		// Probe offline state separately — if the IPC call fails for any reason
+		// (handler not yet registered, bridge not ready, etc.), fall through to
+		// the real HTTP check rather than short-circuiting with a false error.
+		let isOfflineMode = false;
 		try {
-			const isOfflineMode = await this._electronService.ipcRenderer.invoke('IS_OFFLINE');
-			if (isOfflineMode) {
-				return this.handleSuccessfulConnection({ status: 200 }, url);
-			}
+			isOfflineMode = await this._electronService.ipcRenderer.invoke('IS_OFFLINE');
+		} catch (ipcError) {
+			console.warn('IS_OFFLINE IPC probe failed, falling back to HTTP check:', ipcError);
+		}
+
+		if (isOfflineMode) {
+			return this.handleSuccessfulConnection({ status: 200 }, url);
+		}
+
+		try {
 			const response = await this.attemptServerConnection(url);
 			return this.handleSuccessfulConnection(response, url);
 		} catch (error) {

--- a/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
@@ -1053,12 +1053,12 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 					this.currentUser$.next(null);
 					return;
 				}
-				if (!this._store.isOffline) {
+				if (this._store.isOffline) {
+					const usr = this._store.user;
+					this.currentUser$.next(usr);
+				} else {
 					const user = await this.timeTrackerService.getUserDetail();
 					this.currentUser$.next(user);
-				} else {
-					const usr = this._store.user;
-					this.currentUser$.next(usr)
 				}
 
 			} catch (error) {

--- a/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
@@ -44,7 +44,7 @@ import { SpinnerButtonDirective } from '../directives/spinner-button.directive';
 import { ElectronService } from '../electron/services';
 import { LanguageElectronService } from '../language/language-electron.service';
 import { LanguageSelectorComponent } from '../language/language-selector.component';
-import { TimeZoneManager, ToastrNotificationService, ZoneEnum } from '../services';
+import { TimeZoneManager, ToastrNotificationService, ZoneEnum, Store } from '../services';
 import { SetupService } from '../setup/setup.service';
 import { SwitchThemeComponent } from '../theme-selector/switch-theme/switch-theme.component';
 import { ReplacePipe } from '../time-tracker/pipes/replace.pipe';
@@ -518,7 +518,8 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 		@Inject(GAUZY_ENV)
 		private readonly _environment: any,
 		private readonly _domSanitizer: DomSanitizer,
-		private readonly _languageElectronService: LanguageElectronService
+		private readonly _languageElectronService: LanguageElectronService,
+		private readonly _store: Store
 	) {
 		this._loading$ = new BehaviorSubject(false);
 		this._automaticUpdate$ = new BehaviorSubject(false);
@@ -640,12 +641,12 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 			this.menus = this.isServer
 				? ['TIMER_TRACKER.SETTINGS.UPDATE', 'TIMER_TRACKER.SETTINGS.ADVANCED_SETTINGS', 'MENU.ABOUT']
 				: [
-						...(allowScreenshotCapture ? ['TIMER_TRACKER.SETTINGS.SCREEN_CAPTURE'] : []),
-						'TIMER_TRACKER.TIMER',
-						'TIMER_TRACKER.SETTINGS.UPDATE',
-						'TIMER_TRACKER.SETTINGS.ADVANCED_SETTINGS',
-						'MENU.ABOUT'
-				  ];
+					...(allowScreenshotCapture ? ['TIMER_TRACKER.SETTINGS.SCREEN_CAPTURE'] : []),
+					'TIMER_TRACKER.TIMER',
+					'TIMER_TRACKER.SETTINGS.UPDATE',
+					'TIMER_TRACKER.SETTINGS.ADVANCED_SETTINGS',
+					'MENU.ABOUT'
+				];
 			const lastMenu =
 				this._selectedMenu && this.menus.includes(this._selectedMenu) ? this._selectedMenu : this.menus[0];
 			this._selectedMenu$.next(lastMenu);
@@ -1052,8 +1053,14 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 					this.currentUser$.next(null);
 					return;
 				}
-				const user = await this.timeTrackerService.getUserDetail();
-				this.currentUser$.next(user);
+				if (!this._store.isOffline) {
+					const user = await this.timeTrackerService.getUserDetail();
+					this.currentUser$.next(user);
+				} else {
+					const usr = this._store.user;
+					this.currentUser$.next(usr)
+				}
+
 			} catch (error) {
 				console.log('User Detail error', error);
 			}

--- a/packages/desktop-ui-lib/src/lib/shared/features/client-selector/+state/client-selector.service.ts
+++ b/packages/desktop-ui-lib/src/lib/shared/features/client-selector/+state/client-selector.service.ts
@@ -58,6 +58,11 @@ export class ClientSelectorService extends SelectorService<IOrganizationContact>
 	public async load(options?: { searchTerm?: string }): Promise<void> {
 		try {
 			this.selectorStore.setLoading(true);
+
+			if (this.store.isOffline) {
+				console.warn('Offline mode: Unable to fetch clients from the server.');
+				return;
+			}
 			const { searchTerm: name } = options || {};
 			const {
 				organizationId,

--- a/packages/desktop-ui-lib/src/lib/shared/features/client-selector/+state/client-selector.service.ts
+++ b/packages/desktop-ui-lib/src/lib/shared/features/client-selector/+state/client-selector.service.ts
@@ -60,6 +60,7 @@ export class ClientSelectorService extends SelectorService<IOrganizationContact>
 			this.selectorStore.setLoading(true);
 
 			if (this.store.isOffline) {
+				this.selectorStore.setLoading(false);
 				console.warn('Offline mode: Unable to fetch clients from the server.');
 				return;
 			}

--- a/packages/desktop-ui-lib/src/lib/shared/features/project-selector/+state/project-selector.service.ts
+++ b/packages/desktop-ui-lib/src/lib/shared/features/project-selector/+state/project-selector.service.ts
@@ -74,6 +74,7 @@ export class ProjectSelectorService extends SelectorService<IOrganizationProject
 
 			if (this.store.isOffline) {
 				console.log('[ProjectSelector]: Skipped fetching projects because app is offline.');
+				this.projectSelectorStore.setLoading(false);
 				return;
 			}
 

--- a/packages/desktop-ui-lib/src/lib/shared/features/project-selector/+state/project-selector.service.ts
+++ b/packages/desktop-ui-lib/src/lib/shared/features/project-selector/+state/project-selector.service.ts
@@ -71,6 +71,12 @@ export class ProjectSelectorService extends SelectorService<IOrganizationProject
 	}): Promise<void> {
 		try {
 			this.projectSelectorStore.setLoading(true);
+
+			if (this.store.isOffline) {
+				console.log('[ProjectSelector]: Skipped fetching projects because app is offline.');
+				return;
+			}
+
 			const { searchTerm: name } = options || {};
 			const {
 				organizationId,

--- a/packages/desktop-ui-lib/src/lib/shared/features/task-selector/+state/task-selector.service.ts
+++ b/packages/desktop-ui-lib/src/lib/shared/features/task-selector/+state/task-selector.service.ts
@@ -72,6 +72,11 @@ export class TaskSelectorService extends SelectorService<ITask> {
 	public async load(options?: { searchTerm?: string; projectId?: string }): Promise<void> {
 		try {
 			this.taskSelectorStore.setLoading(true);
+			if (this.store.isOffline) {
+				console.warn('Offline mode: Unable to fetch tasks from the server.');
+				return;
+			}
+
 			const { searchTerm } = options || {};
 			const {
 				organizationId,

--- a/packages/desktop-ui-lib/src/lib/shared/features/task-selector/+state/task-selector.service.ts
+++ b/packages/desktop-ui-lib/src/lib/shared/features/task-selector/+state/task-selector.service.ts
@@ -73,6 +73,7 @@ export class TaskSelectorService extends SelectorService<ITask> {
 		try {
 			this.taskSelectorStore.setLoading(true);
 			if (this.store.isOffline) {
+				this.taskSelectorStore.setLoading(false);
 				console.warn('Offline mode: Unable to fetch tasks from the server.');
 				return;
 			}

--- a/packages/desktop-ui-lib/src/lib/shared/features/team-selector/+state/team-selector.service.ts
+++ b/packages/desktop-ui-lib/src/lib/shared/features/team-selector/+state/team-selector.service.ts
@@ -29,6 +29,10 @@ export class TeamSelectorService extends SelectorService<IOrganizationTeam> {
 	public async load(options?: { searchTerm?: string; projectId?: string }): Promise<void> {
 		try {
 			this.teamSelectorStore.setLoading(true);
+			if (this.store.isOffline) {
+				console.warn('Cannot load teams while offline.');
+				return;
+			}
 			const { searchTerm: name } = options || {};
 			const {
 				organizationId,

--- a/packages/desktop-ui-lib/src/lib/shared/features/team-selector/+state/team-selector.service.ts
+++ b/packages/desktop-ui-lib/src/lib/shared/features/team-selector/+state/team-selector.service.ts
@@ -31,6 +31,7 @@ export class TeamSelectorService extends SelectorService<IOrganizationTeam> {
 			this.teamSelectorStore.setLoading(true);
 			if (this.store.isOffline) {
 				console.warn('Cannot load teams while offline.');
+				this.teamSelectorStore.setLoading(false);
 				return;
 			}
 			const { searchTerm: name } = options || {};

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -949,7 +949,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		this.electronService.ipcRenderer.on('timer_tracker_show', (event, arg) =>
 			this._ngZone.run(async () => {
 				if (!this._store.user?.employee) return;
-				this._isOffline$.next(typeof arg.isOffline !== 'undefined' ? arg.isOffline : this._isOffline);
+				this._isOffline$.next(arg.isOffline !== 'undefined' ? arg.isOffline : this._isOffline);
 				this._store.host = arg.apiHost;
 				this.apiHost = arg.apiHost;
 				this.argFromMain = arg;

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -949,7 +949,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		this.electronService.ipcRenderer.on('timer_tracker_show', (event, arg) =>
 			this._ngZone.run(async () => {
 				if (!this._store.user?.employee) return;
-				this._isOffline$.next(arg.isOffline ? arg.isOffline : this._isOffline);
+				this._isOffline$.next(typeof arg.isOffline !== 'undefined' ? arg.isOffline : this._isOffline);
 				this._store.host = arg.apiHost;
 				this.apiHost = arg.apiHost;
 				this.argFromMain = arg;
@@ -1977,8 +1977,25 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 
 	public async setTimerDetails(): Promise<void> {
 		try {
-			const res: any = await this.timeTrackerService.getUserDetail();
-			if (res.employee && res.employee.organization) {
+			let res: any;
+			console.log('Fetching user details with offline mode:', this._isOffline);
+			console.log('Store user details before fetching:', this._store.user);
+			if (!this._isOffline) {
+				try {
+					res = await this.timeTrackerService.getUserDetail();
+					console.log('Fetched user details:', res);
+					if (!this._store.user?.employee?.organization && res?.employee?.organization) {
+						this._store.user = res;
+					}
+				} catch (apiError) {
+					console.log('WARN: setTimerDetails API Error:', apiError, 'Falling back to local store...');
+					res = this._store.user;
+				}
+			} else {
+				res = this._store.user;
+			}
+
+			if (res && res.employee && res.employee.organization) {
 				this.userData = res;
 				if (res.role && res.role.rolePermissions) {
 					this._store.userRolePermissions = res.role.rolePermissions;

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -949,7 +949,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		this.electronService.ipcRenderer.on('timer_tracker_show', (event, arg) =>
 			this._ngZone.run(async () => {
 				if (!this._store.user?.employee) return;
-				this._isOffline$.next(arg.isOffline !== 'undefined' ? arg.isOffline : this._isOffline);
+				this._isOffline$.next(typeof arg.isOffline !== 'undefined' ? arg.isOffline : this._isOffline);
 				this._store.host = arg.apiHost;
 				this.apiHost = arg.apiHost;
 				this.argFromMain = arg;

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -1978,12 +1978,9 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 	public async setTimerDetails(): Promise<void> {
 		try {
 			let res: any;
-			console.log('Fetching user details with offline mode:', this._isOffline);
-			console.log('Store user details before fetching:', this._store.user);
 			if (!this._isOffline) {
 				try {
 					res = await this.timeTrackerService.getUserDetail();
-					console.log('Fetched user details:', res);
 					if (!this._store.user?.employee?.organization && res?.employee?.organization) {
 						this._store.user = res;
 					}


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes offline mode in the desktop timer so the app can start, navigate, and track time without a live server. Adds startup and IPC checks to detect and propagate offline state across the app.

- **New Features**
  - IPC: `IS_OFFLINE` moved to app index for early startup access; added `SET_OFFLINE_MODE`; `timer_tracker_show` now includes `isOffline`.
  - `DesktopOfflineModeHandler`: added `forceOffline()`; ping interval reduced to 10s; connectivity check on startup when `serverConfigConnected`.

- **Bug Fixes**
  - Short-circuit pings and server checks via `IS_OFFLINE` (desktop, timer, agent) and return 200 when offline; fall back to HTTP if IPC fails.
  - Bypass the Server Down page when offline and authenticated; navigate to the intended route.
  - Offline-safe UI: Timer/Settings use local user/org; clients/projects/tasks/teams skip loading; Language service returns empty lists.
  - Safer startup/activation: probe connectivity before creating the timer window; respect `serverConfigConnected` in `IConfig`; guard splash screen close.

<sup>Written for commit 55ae4f10ae1a4136bb4e1356d46aaf48cef0a82b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

