### PR TITLE
fix: use DEMO_PASSWORD_LESS_MAGIC_CODE constant for demo magic login …

### DIFF
--- a/.scripts/env.ts
+++ b/.scripts/env.ts
@@ -224,7 +224,7 @@ export const env: Env = cleanEnv(
 		DEMO_ADMIN_PASSWORD: str({ default: 'admin' }),
 
 		DEMO_EMPLOYEE_EMAIL: str({ default: 'employee@ever.co' }),
-		DEMO_EMPLOYEE_PASSWORD: str({ default: '123456' }),
+		DEMO_EMPLOYEE_PASSWORD: str({ default: '12345678' }),
 
 		CHATWOOT_SDK_TOKEN: str({ default: '' }),
 		CHAT_MESSAGE_GOOGLE_MAP: str({ default: '' }),

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ More information about our Server & Desktop Apps:
 -   Setup Gauzy Server with default choices in Setup Wizard and run it.
 -   You can also setup Gauzy Desktop App (can run independently or connect to Gauzy Server) or Gauzy Desktop Timer App (should be connected to Gauzy Server)
 -   You can login with `admin@ever.co` and password `admin` to check Admin functionality if you installed Gauzy Server or Gauzy Desktop App. Note: such an Admin user is not an employee, so you will not be able to track time.
--   You can login with `employee@ever.co` and password `123456` to check Employee-related functionality in Gauzy UI or to run Desktop Timer from an "Employee" perspective (such a user is an Employee and can track time).
+-   You can login with `employee@ever.co` and password `12345678` to check Employee-related functionality in Gauzy UI or to run Desktop Timer from an "Employee" perspective (such a user is an Employee and can track time).
 -   If you install Gauzy Server, it is possible to connect to it using a browser (by default on <http://localhost:4200>) or using Gauzy Desktop Apps (make sure to configure Desktop apps to connect to Gauzy API on <http://127.0.0.1:3000/api> because it's where Gauzy Server API runs by default).
 -   You can read more information about our Desktop Apps on the [Desktop Apps Wiki Page](https://github.com/ever-co/ever-gauzy/wiki/Gauzy-Desktop-Apps) and our Server at the [Server Wiki Page](https://github.com/ever-co/ever-gauzy/wiki/Gauzy-Server).
 
@@ -200,7 +200,7 @@ Please refer to our official [Platform Documentation](https://docs.gauzy.co) and
 -   Run `docker-compose -f docker-compose.demo.yml up`, if you want to run the platform in basic configuration (e.g. for Demo / explore functionality / quick run) using our prebuilt Docker images. Check `.env.demo.compose` file for different settings (optionally), e.g. DB type. _(Note: Docker Compose will use latest images pre-build automatically from head of `master` branch using GitHub CI/CD.)_
 -   Open <http://localhost:4200> in your browser.
 -   Login with email `admin@ever.co` and password: `admin` for Super Admin user.
--   Login with email `employee@ever.co` and password: `123456` for Employee user.
+-   Login with email `employee@ever.co` and password: `12345678` for Employee user.
 -   Enjoy!
 
 #### Production
@@ -248,7 +248,7 @@ Together with Gauzy, the Docker Compose commands described above for Production 
 -   Run both API and UI with a single command: `yarn start`.
 -   Open Gauzy UI on <http://localhost:4200> in your browser (API runs on <http://localhost:3000/api>).
 -   Login with email `admin@ever.co` and password: `admin` for Super Admin user.
--   Login with email `employee@ever.co` and password: `123456` for Employee user.
+-   Login with email `employee@ever.co` and password: `12345678` for Employee user.
 -   Enjoy!
 
 Notes:

--- a/apps/gauzy-e2e/src/support/Base/pagedata/LoginPageData.ts
+++ b/apps/gauzy-e2e/src/support/Base/pagedata/LoginPageData.ts
@@ -3,5 +3,5 @@ export const LoginPageData = {
 	email: 'admin@ever.co',
 	password: 'admin',
 	empEmail: 'employee@ever.co',
-	empPassword: '123456'
+	empPassword: '12345678'
 };

--- a/packages/config/src/lib/environments/environment.prod.ts
+++ b/packages/config/src/lib/environments/environment.prod.ts
@@ -360,7 +360,7 @@ export const environment: IEnvironment = {
 		adminEmail: process.env.DEMO_ADMIN_EMAIL || `local.admin@ever.co`,
 		adminPassword: process.env.DEMO_ADMIN_PASSWORD || `admin`,
 		employeeEmail: process.env.DEMO_EMPLOYEE_EMAIL || `employee@ever.co`,
-		employeePassword: process.env.DEMO_EMPLOYEE_PASSWORD || `123456`
+		employeePassword: process.env.DEMO_EMPLOYEE_PASSWORD || `12345678`
 	}
 };
 

--- a/packages/config/src/lib/environments/environment.ts
+++ b/packages/config/src/lib/environments/environment.ts
@@ -307,7 +307,7 @@ export const environment: IEnvironment = {
 		adminEmail: process.env.DEMO_ADMIN_EMAIL || `local.admin@ever.co`,
 		adminPassword: process.env.DEMO_ADMIN_PASSWORD || `admin`,
 		employeeEmail: process.env.DEMO_EMPLOYEE_EMAIL || `employee@ever.co`,
-		employeePassword: process.env.DEMO_EMPLOYEE_PASSWORD || `123456`
+		employeePassword: process.env.DEMO_EMPLOYEE_PASSWORD || `12345678`
 	}
 };
 

--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -1577,7 +1577,7 @@ export class AuthService extends SocialAuthService {
 
 				// Check the value of the 'email' variable against certain demo email addresses
 				if (email === demoEmployeeEmail || email === demoAdminEmail) {
-					magicCode = environment.demoCredentialConfig?.employeePassword || DEMO_PASSWORD_LESS_MAGIC_CODE;
+					magicCode = DEMO_PASSWORD_LESS_MAGIC_CODE;
 					isDemoCode = true;
 				}
 			}

--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -1577,7 +1577,7 @@ export class AuthService extends SocialAuthService {
 
 				// Check the value of the 'email' variable against certain demo email addresses
 				if (email === demoEmployeeEmail || email === demoAdminEmail) {
-					magicCode = DEMO_PASSWORD_LESS_MAGIC_CODE;
+					magicCode = DEMO_PASSWORD_LESS_MAGIC_CODE || environment.demoCredentialConfig?.employeePassword;
 					isDemoCode = true;
 				}
 			}

--- a/packages/core/src/lib/candidate/default-candidates.ts
+++ b/packages/core/src/lib/candidate/default-candidates.ts
@@ -3,7 +3,7 @@ import { ComponentLayoutStyleEnum, LanguagesEnum } from '@gauzy/contracts';
 export const DEFAULT_CANDIDATES = [
 	{
 		email: 'john@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'John',
 		lastName: 'S.',
 		imageUrl: 'assets/images/avatars/alish.jpg',
@@ -13,7 +13,7 @@ export const DEFAULT_CANDIDATES = [
 	},
 	{
 		email: 'jaye@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Jaye',
 		lastName: 'J.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -23,7 +23,7 @@ export const DEFAULT_CANDIDATES = [
 	},
 	{
 		email: 'kasey@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Kasey',
 		lastName: 'K.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -33,7 +33,7 @@ export const DEFAULT_CANDIDATES = [
 	},
 	{
 		email: 'norris@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Norris ',
 		lastName: 'N.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -43,7 +43,7 @@ export const DEFAULT_CANDIDATES = [
 	},
 	{
 		email: 'estella@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Estella',
 		lastName: 'E.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -53,7 +53,7 @@ export const DEFAULT_CANDIDATES = [
 	},
 	{
 		email: 'greg@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Greg ',
 		lastName: 'G.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',

--- a/packages/core/src/lib/employee/default-employees.ts
+++ b/packages/core/src/lib/employee/default-employees.ts
@@ -18,7 +18,7 @@ export const DEFAULT_EMPLOYEES: any = [
 export const DEFAULT_EVER_EMPLOYEES: any = [
 	{
 		email: 'ruslan@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Ruslan',
 		lastName: 'K.',
 		imageUrl: 'assets/images/avatars/ruslan.jpg',
@@ -28,7 +28,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'alish@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Alish',
 		lastName: 'M.',
 		imageUrl: 'assets/images/avatars/alish.jpg',
@@ -40,7 +40,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'booster@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Booster',
 		lastName: 'P.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -52,7 +52,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'yoster@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Yoster',
 		lastName: 'F.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -64,7 +64,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'hoster@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Hoster',
 		lastName: 'H.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -76,7 +76,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'aster@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Aster',
 		lastName: 'A.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -88,7 +88,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'roster@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Roster',
 		lastName: 'R.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -100,7 +100,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'dister@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Dister',
 		lastName: 'D.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -112,7 +112,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'postern@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Postern',
 		lastName: 'P.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -124,7 +124,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'kyoster@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Kyoster',
 		lastName: 'K.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -136,7 +136,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'taster@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Taster',
 		lastName: 'T.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -148,7 +148,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'mustero@smooper.xyz',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Mustero',
 		lastName: 'M.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -160,7 +160,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'desterrro@hotmail.com',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Desterrro',
 		lastName: 'D.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',
@@ -172,7 +172,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'ckhandla94@gmail.com',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Chetan',
 		lastName: 'K.',
 		imageUrl: 'assets/images/avatars/chetan.png',
@@ -184,7 +184,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'rahulrathore576@gmail.com',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Rahul',
 		lastName: 'R.',
 		imageUrl: 'assets/images/avatars/rahul.png',
@@ -196,7 +196,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'julia@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Julia',
 		lastName: 'K.',
 		imageUrl: 'assets/images/avatars/julia.png',
@@ -208,7 +208,7 @@ export const DEFAULT_EVER_EMPLOYEES: any = [
 	},
 	{
 		email: 'yostorono@example-ever.co',
-		password: '123456',
+		password: '12345678',
 		firstName: 'Yostorono',
 		lastName: 'Y.',
 		imageUrl: 'assets/images/avatars/avatar-default.svg',

--- a/packages/core/src/lib/user/user.seed.ts
+++ b/packages/core/src/lib/user/user.seed.ts
@@ -382,7 +382,7 @@ const generateRandomUser = async (role: IRole, tenant: ITenant): Promise<IUser> 
 	user.preferredLanguage = getRandomLanguage();
 	user.emailVerifiedAt = new Date();
 	user.lastLoginAt = getRandomDateWithinLast3Months();
-	user.hash = await hashPassword('123456');
+	user.hash = await hashPassword('12345678');
 
 	return user;
 };


### PR DESCRIPTION
…code

The demo magic code was incorrectly using the employee password from env config (123456, 6 chars) instead of the dedicated constant (12345678, 8 chars), causing frontend validation to reject it since the validator enforces exactly ALPHA_NUMERIC_CODE_LENGTH (8) characters.

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix demo magic login by prioritizing `DEMO_PASSWORD_LESS_MAGIC_CODE` (8 chars) and updating the demo employee password to `12345678` across seeds, configs, README, and e2e tests to match `ALPHA_NUMERIC_CODE_LENGTH` and restore sign-in.

<sup>Written for commit 44cd0be6bef2c90eb43e23ddf3b436cc8f7d37b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

