### PR TITLE
fix: use /user/me endpoint for own profile to avoid ORG_USERS_VIEW pe…

### DIFF
--- a/packages/ui-core/shared/src/lib/user/edit-profile-form/edit-profile-form.component.ts
+++ b/packages/ui-core/shared/src/lib/user/edit-profile-form/edit-profile-form.component.ts
@@ -136,14 +136,16 @@ export class EditProfileFormComponent implements OnInit, OnDestroy {
 	 */
 	async getUserProfile(): Promise<void> {
 		try {
-			// Get the user ID from the selected user or fallback to the current user
-			const userId = this.selectedUser?.id || this.user?.id;
-			if (!userId) {
-				throw new Error('User ID is missing.');
-			}
+			const relations = ['tags', 'role'];
+			let user: IUser;
 
-			// Fetch user details with specific relations
-			const user = await this._userService.getUserById(userId, ['tags', 'role']);
+			// If a different user is selected (admin editing another user), use getUserById which requires ORG_USERS_VIEW.
+			// Otherwise load the current user's own profile via /user/me which has no permission restriction.
+			if (this.selectedUser?.id && this.selectedUser.id !== this.user?.id) {
+				user = await this._userService.getUserById(this.selectedUser.id, relations);
+			} else {
+				user = await this._userService.getMe(relations);
+			}
 
 			// Patch the form with the retrieved user data
 			this._patchForm({ ...user });


### PR DESCRIPTION
…rmission requirement

GET /user/:id requires ORG_USERS_VIEW permission which employees don't have, causing a 403 when loading their own profile. Use /user/me (no permission guard) for own profile, and keep getUserById only when an admin is editing a different user.

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 403 errors on employee profile pages by loading the signed-in user's data via the /user/me endpoint. Keeps getUserById only when an admin edits another user, with the same relations (tags, role).

<sup>Written for commit b7e457b0523496f03eab8c1de8464e94c280f9dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

