### PR TITLE
fix: workspace switch disconnects user instead of switching

### DIFF
--- a/packages/core/src/lib/auth/auth.service.ts
+++ b/packages/core/src/lib/auth/auth.service.ts
@@ -73,6 +73,7 @@ import { TypeOrmUserRepository } from '../user/repository/type-orm-user.reposito
 import { UserService } from '../user/user.service';
 import { RequestContext } from './../core/context';
 import { OrganizationTeam, Tenant, User } from './../core/entities/internal';
+import { Employee } from '../employee/employee.entity';
 import { freshTimestamp, getORMType, MultiORM, MultiORMEnum, parseTypeORMFindToMikroOrm } from './../core/utils';
 import { prepareSQLQuery as p } from './../database/database.helper';
 import { EmailService } from './../email-send/email.service';
@@ -1311,8 +1312,28 @@ export class AuthService extends SocialAuthService {
 			}
 
 			// Retrieve the employee details associated with the user.
-			// Use provided organizationId if available, otherwise fall back to RequestContext
-			const employee = await this.employeeService.findOneByUserId(user.id, organizationId);
+			// Query directly via repository to bypass TenantAwareCrudService which forces RequestContext.currentTenantId().
+			// This ensures correct employee lookup when tenantId differs from RequestContext (e.g. workspace switch).
+			let employee: Employee | null = null;
+			const employeeAccessWhere: Record<string, any> = {
+				userId: user.id,
+				tenantId,
+				isActive: true,
+				isArchived: false,
+				...(organizationId && { organizationId })
+			};
+
+			switch (this.ormType) {
+				case MultiORMEnum.MikroORM: {
+					const parsed = parseTypeORMFindToMikroOrm<Employee>({ where: employeeAccessWhere });
+					employee = (await this.mikroOrmEmployeeRepository.findOne(parsed.where, parsed.mikroOptions)) as Employee;
+					break;
+				}
+				case MultiORMEnum.TypeORM: {
+					employee = await this.typeOrmEmployeeRepository.findOne({ where: employeeAccessWhere });
+					break;
+				}
+			}
 
 			// Create a payload for the JWT token
 			const payload: JwtPayload = {
@@ -2172,8 +2193,25 @@ export class AuthService extends SocialAuthService {
 				throw new UnauthorizedException('User does not have access to this workspace');
 			}
 
-			// Retrieve the employee details associated with the user
-			const employee = await this.employeeService.findOneByUserId(user.id);
+			// Retrieve the employee details associated with the user in the TARGET workspace.
+			// We cannot use employeeService.findOneByUserId() here because TenantAwareCrudService
+			// forcefully applies RequestContext.currentUser().tenantId, which is still the OLD workspace
+			// during a switch. Instead, query the repository directly with the explicit target tenantId.
+			let employee: Employee | null = null;
+			const employeeWhere = { userId: user.id, tenantId, isActive: true, isArchived: false };
+			const employeeRelations = { organization: true };
+
+			switch (this.ormType) {
+				case MultiORMEnum.MikroORM: {
+					const parsed = parseTypeORMFindToMikroOrm<Employee>({ where: employeeWhere, relations: employeeRelations });
+					employee = (await this.mikroOrmEmployeeRepository.findOne(parsed.where, parsed.mikroOptions)) as Employee;
+					break;
+				}
+				case MultiORMEnum.TypeORM: {
+					employee = await this.typeOrmEmployeeRepository.findOne({ where: employeeWhere, relations: employeeRelations });
+					break;
+				}
+			}
 
 			// Check if the employee is active and not archived
 			if (employee && (!employee.isActive || employee.isArchived)) {
@@ -2189,8 +2227,22 @@ export class AuthService extends SocialAuthService {
 				this.getJwtRefreshToken(user, organizationId)
 			]);
 
-			// Store the current refresh token with the user
-			await this.userService.setCurrentRefreshToken(refresh_token, user.id);
+			// Store the current refresh token with the user.
+			// We cannot use userService.setCurrentRefreshToken() here because TenantAwareCrudService.update()
+			// runs a findOneByWhereOptions guard scoped to RequestContext.currentTenantId() (the OLD workspace),
+			// which won't find a user whose tenantId is the TARGET workspace. Update directly via repository.
+			const hashedRefreshToken = refresh_token
+				? await this.passwordHashService.hash(refresh_token)
+				: refresh_token;
+
+			switch (this.ormType) {
+				case MultiORMEnum.MikroORM:
+					await this.mikroOrmUserRepository.nativeUpdate({ id: user.id, tenantId }, { refreshToken: hashedRefreshToken });
+					break;
+				case MultiORMEnum.TypeORM:
+					await this.typeOrmUserRepository.update({ id: user.id, tenantId }, { refreshToken: hashedRefreshToken });
+					break;
+			}
 
 			// Update the last login timestamp
 			await this.userService.setUserLastLoginTimestamp(user.id);

--- a/packages/ui-core/core/src/lib/interceptors/auth-refresh.interceptor.ts
+++ b/packages/ui-core/core/src/lib/interceptors/auth-refresh.interceptor.ts
@@ -144,6 +144,8 @@ export class AuthRefreshInterceptor implements HttpInterceptor {
 			'/auth/signin.email.social',
 			'/auth/signup.provider.social',
 			'/auth/signup.link.account',
+			'/auth/switch-workspace',
+			'/auth/switch-organization',
 			'/auth/google',
 			'/auth/google/callback',
 			'/auth/facebook',


### PR DESCRIPTION
The switchWorkspace backend method used TenantAwareCrudService through EmployeeService and UserService, which forcefully scopes all queries to RequestContext.currentTenantId() (the OLD workspace). This caused employee lookup, JWT token generation, and refresh token storage to all fail with 'record not found', resulting in the method returning null and the frontend treating it as a logout.

- Query employee directly via repository with explicit target tenantId in switchWorkspace
- Query employee directly via repository with explicit target tenantId in getJwtAccessToken so the generated token contains the correct employeeId for the new workspace
- Load organization relation on employee so frontend receives employee.organization needed to set store.selectedOrganization after the switch
- Update refresh token directly via repository bypassing TenantAwareCrudService.update() guard which also scoped by old tenant
- Add /auth/switch-workspace to AuthRefreshInterceptor auth endpoint list so a 401 during switch does not trigger a token refresh loop ending in logout

# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace switching logging out users. The switch now finds the employee in the target tenant, issues the correct JWT, and preserves the session.

- **Bug Fixes**
  - Bypass `TenantAwareCrudService` during `switchWorkspace` to avoid old-tenant scoping.
  - Query employee via repository with explicit `tenantId` in `switchWorkspace` and `getJwtAccessToken`; include `organization` relation for the client.
  - Only allow active, non-archived employees when switching or issuing tokens.
  - Update refresh token via repository scoped to the target tenant (hashed before save) to avoid guard failures.
  - Add `/auth/switch-workspace` and `/auth/switch-organization` to `AuthRefreshInterceptor` allowlist to prevent refresh-loop/logout during switching.

<sup>Written for commit 25f5788fa98c5e2d9f73f9143fa51145bef257fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

