### PR TITLE
[Fix] Help Center Article Description fields patch and retrieve

### DIFF
--- a/packages/plugins/knowledge-base/src/lib/help-center-article/help-center-article.controller.ts
+++ b/packages/plugins/knowledge-base/src/lib/help-center-article/help-center-article.controller.ts
@@ -1,6 +1,6 @@
 import { PermissionsEnum, IHelpCenterArticle, ID, IPagination, IHelpCenterArticleFiltering } from '@gauzy/contracts';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { Controller, HttpStatus, Post, Body, UseGuards, Get, Param, Delete, HttpCode, Put, Res, Query, Req } from '@nestjs/common';
+import { Controller, HttpStatus, Post, Body, UseGuards, Get, Param, Delete, HttpCode, Put, Patch, Res, Query, Req } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CommandBus } from '@nestjs/cqrs';
 import { Response, Request } from 'express';
@@ -97,7 +97,7 @@ export class HelpCenterArticleController extends CrudController<HelpCenterArticl
 	}
 
 	/**
-	 * Returns the binary state as octet-stream.
+	 * Returns the Y.js binary state as application/octet-stream.
 	 * Returns an empty buffer if no binary is stored yet.
 	 */
 	@ApiOperation({ summary: 'Get article binary description' })
@@ -109,7 +109,7 @@ export class HelpCenterArticleController extends CrudController<HelpCenterArticl
 	): Promise<void> {
 		const binary = await this.helpCenterArticleService.getDescriptionBinary(id);
 		res.setHeader('Content-Type', 'application/octet-stream');
-		res.send(binary ?? new Uint8Array(0));
+		res.send(binary ?? Buffer.alloc(0));
 	}
 
 	/**
@@ -126,8 +126,34 @@ export class HelpCenterArticleController extends CrudController<HelpCenterArticl
 	): Promise<void> {
 		const binary = await this.helpCenterArticleService.readBinaryStream(req);
 		await this.commandBus.execute(
-			new HelpCenterUpdateArticleCommand(id, { descriptionBinary: new Uint8Array(binary) })
+			new HelpCenterUpdateArticleCommand(id, { descriptionBinary: binary as any })
 		);
+	}
+
+	/**
+	 * Atomic update of all description fields (binary, HTML, JSON).
+	 *
+	 * Binary content is received as a base64-encoded string and decoded server-side.
+	 * Uses a direct QueryBuilder update to bypass TypeORM's QueryDeepPartialEntity
+	 * typing, which silently drops Buffer values for Uint8Array-typed entity fields.
+	 */
+	@ApiOperation({ summary: 'Atomic update of all description fields (binary + HTML + JSON)' })
+	@ApiResponse({ status: HttpStatus.OK, description: 'Description updated.' })
+	@HttpCode(HttpStatus.OK)
+	@Patch(':id/description')
+	async patchDescription(
+		@Param('id', UUIDValidationPipe) id: string,
+		@Body() body: { descriptionBinary?: string; descriptionHtml?: string; descriptionJson?: any }
+	): Promise<void> {
+		await this.helpCenterArticleService.updateDescriptionFields(id, {
+			descriptionBinary: body.descriptionBinary
+				? Buffer.from(body.descriptionBinary, 'base64')
+				: undefined,
+			descriptionHtml: body.descriptionHtml,
+			descriptionJson: body.descriptionJson !== undefined
+				? (typeof body.descriptionJson === 'string' ? body.descriptionJson : JSON.stringify(body.descriptionJson))
+				: undefined
+		});
 	}
 
 	@ApiOperation({

--- a/packages/plugins/knowledge-base/src/lib/help-center-article/help-center-article.service.ts
+++ b/packages/plugins/knowledge-base/src/lib/help-center-article/help-center-article.service.ts
@@ -270,14 +270,59 @@ export class HelpCenterArticleService extends TenantAwareCrudService<HelpCenterA
 	}
 
 	/**
-	 * Get the raw binary description of an article.
-	 * Returns null if not yet set.
+	 * Get the raw binary description of an article as a Buffer.
+	 *
+	 * Uses QueryBuilder directly to avoid TypeORM DISTINCT subquery issues
+	 * when `select: { descriptionBinary: true }` omits the 'id' column.
+	 *
+	 * @returns Buffer if binary exists, null otherwise
 	 */
-	public async getDescriptionBinary(id: ID): Promise<Uint8Array | null> {
-		const { record: article } = await this.findOneOrFailByIdString(id, {
-			select: { descriptionBinary: true } as any
-		});
-		return article?.descriptionBinary ?? null;
+	public async getDescriptionBinary(id: ID): Promise<Buffer | null> {
+		const article = await this.typeOrmHelpCenterArticleRepository
+			.createQueryBuilder('article')
+			.select(['article.id', 'article.descriptionBinary'])
+			.where('article.id = :id', { id })
+			.getOne();
+		return article?.descriptionBinary ? Buffer.from(article.descriptionBinary) : null;
+	}
+
+	/**
+	 * Atomic update of description fields using QueryBuilder directly.
+	 *
+	 * This bypasses the CrudService.update() → TypeORM Repository.update() chain
+	 * because TypeORM's QueryDeepPartialEntity typing silently drops Buffer values
+	 * for entity fields typed as Uint8Array, preventing binary data from being persisted
+	 * to PostgreSQL bytea columns.
+	 *
+	 * @param id - Article ID
+	 * @param fields - Object with descriptionBinary (Buffer), descriptionHtml, descriptionJson
+	 */
+	public async updateDescriptionFields(
+		id: ID,
+		fields: { descriptionBinary?: Buffer; descriptionHtml?: string; descriptionJson?: string }
+	): Promise<void> {
+		const setClauses: Record<string, any> = {};
+
+		if (fields.descriptionBinary) {
+			setClauses.descriptionBinary = fields.descriptionBinary;
+		}
+		if (fields.descriptionHtml !== undefined) {
+			setClauses.descriptionHtml = fields.descriptionHtml;
+		}
+		if (fields.descriptionJson !== undefined) {
+			setClauses.descriptionJson = fields.descriptionJson;
+		}
+
+		if (Object.keys(setClauses).length === 0) {
+			return;
+		}
+
+		await this.typeOrmHelpCenterArticleRepository
+			.createQueryBuilder()
+			.update()
+			.set(setClauses)
+			.where('id = :id', { id })
+			.execute();
 	}
 
 	/**

--- a/packages/plugins/knowledge-base/src/lib/help-center-article/help-center-article.service.ts
+++ b/packages/plugins/knowledge-base/src/lib/help-center-article/help-center-article.service.ts
@@ -274,15 +274,22 @@ export class HelpCenterArticleService extends TenantAwareCrudService<HelpCenterA
 	 *
 	 * Uses QueryBuilder directly to avoid TypeORM DISTINCT subquery issues
 	 * when `select: { descriptionBinary: true }` omits the 'id' column.
+	 * Scoped to the current tenant to prevent cross-tenant data access.
 	 *
 	 * @returns Buffer if binary exists, null otherwise
 	 */
 	public async getDescriptionBinary(id: ID): Promise<Buffer | null> {
-		const article = await this.typeOrmHelpCenterArticleRepository
+		const tenantId = RequestContext.currentTenantId();
+		const qb = this.typeOrmHelpCenterArticleRepository
 			.createQueryBuilder('article')
 			.select(['article.id', 'article.descriptionBinary'])
-			.where('article.id = :id', { id })
-			.getOne();
+			.where('article.id = :id', { id });
+
+		if (tenantId) {
+			qb.andWhere('article.tenantId = :tenantId', { tenantId });
+		}
+
+		const article = await qb.getOne();
 		return article?.descriptionBinary ? Buffer.from(article.descriptionBinary) : null;
 	}
 
@@ -294,16 +301,18 @@ export class HelpCenterArticleService extends TenantAwareCrudService<HelpCenterA
 	 * for entity fields typed as Uint8Array, preventing binary data from being persisted
 	 * to PostgreSQL bytea columns.
 	 *
+	 * Scoped to the current tenant to prevent cross-tenant data modification.
+	 *
 	 * @param id - Article ID
-	 * @param fields - Object with descriptionBinary (Buffer), descriptionHtml, descriptionJson
+	 * @param fields - Object with descriptionBinary (Buffer | null to clear), descriptionHtml, descriptionJson
 	 */
 	public async updateDescriptionFields(
 		id: ID,
-		fields: { descriptionBinary?: Buffer; descriptionHtml?: string; descriptionJson?: string }
+		fields: { descriptionBinary?: Buffer | null; descriptionHtml?: string; descriptionJson?: string }
 	): Promise<void> {
 		const setClauses: Record<string, any> = {};
 
-		if (fields.descriptionBinary) {
+		if (fields.descriptionBinary !== undefined) {
 			setClauses.descriptionBinary = fields.descriptionBinary;
 		}
 		if (fields.descriptionHtml !== undefined) {
@@ -317,12 +326,18 @@ export class HelpCenterArticleService extends TenantAwareCrudService<HelpCenterA
 			return;
 		}
 
-		await this.typeOrmHelpCenterArticleRepository
+		const tenantId = RequestContext.currentTenantId();
+		const qb = this.typeOrmHelpCenterArticleRepository
 			.createQueryBuilder()
 			.update()
 			.set(setClauses)
-			.where('id = :id', { id })
-			.execute();
+			.where('id = :id', { id });
+
+		if (tenantId) {
+			qb.andWhere('"tenantId" = :tenantId', { tenantId });
+		}
+
+		await qb.execute();
 	}
 
 	/**


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes binary description retrieval and persistence for Help Center articles and adds an atomic PATCH endpoint to update binary, HTML, and JSON fields. Uses Buffer storage and tenant-scoped `TypeORM` QueryBuilder for reliable reads and writes.

- **New Features**
  - Added PATCH `:id/description` to update `descriptionBinary` (base64), `descriptionHtml`, and `descriptionJson` in one call.
  - Server decodes base64 to `Buffer`; `descriptionJson` is stringified when an object.

- **Bug Fixes**
  - GET binary now responds as `application/octet-stream` and returns `Buffer.alloc(0)` when empty.
  - Switched to `Buffer` for read/write to prevent `Uint8Array` issues and silent drops in `TypeORM`.
  - Fetch and update use QueryBuilder with tenant filter to avoid select/distinct issues and cross-tenant access.
  - Stream read path no longer wraps binary into `Uint8Array` before update.

<sup>Written for commit ff36247fc0e7d60f91e8af6cf3fb6cbfa4f4fb9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

