### PR TITLE
Stage

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -623,6 +623,7 @@
 		"rangepicker",
 		"RDCL",
 		"RDCL",
+		"reconnections",
 		"Recu",
 		"Recu",
 		"rediss",

--- a/packages/plugins/integration-zapier/package.json
+++ b/packages/plugins/integration-zapier/package.json
@@ -49,13 +49,13 @@
 		"rxjs": "^7.8.2",
 		"tslib": "^2.6.2",
 		"typeorm": "^0.3.28",
-		"zapier-platform-core": "^18.3.0"
+		"zapier-platform-core": "^18.4.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",
 		"@types/node": "^24.10.0",
 		"typescript": "^5.9.3",
-		"zapier-platform-cli": "^18.3.0"
+		"zapier-platform-cli": "^18.4.0"
 	},
 	"keywords": [
 		"zapier",

--- a/packages/plugins/integration-zapier/src/lib/zapier-authorization.controller.ts
+++ b/packages/plugins/integration-zapier/src/lib/zapier-authorization.controller.ts
@@ -225,6 +225,7 @@ export class ZapierAuthorizationController {
 	/**
 	 * Auth test endpoint — validates a Zapier access token.
 	 * Called by the Zapier CLI app to verify the connection is working.
+	 * Supports both opaque tokens (legacy) and JWT tokens (multi-app OAuth).
 	 */
 	@ApiOperation({ summary: 'Test Zapier authentication' })
 	@ApiResponse({
@@ -244,11 +245,26 @@ export class ZapierAuthorizationController {
 			}
 
 			const token = authHeader.substring(7); // Strip "Bearer "
-			const integration = await this.zapierService.findIntegrationByToken(token);
 
+			// Try opaque token first (backward compat) — resolves via IntegrationTenant
+			try {
+				const integration = await this.zapierService.resolveIntegrationFromBearerToken(token);
+				return {
+					authenticated: true,
+					integrationId: integration.id,
+					name: IntegrationEnum.ZAPIER
+				};
+			} catch {
+				// No IntegrationTenant yet — fall through to JWT-only verification
+			}
+
+			// Verify the JWT is valid (sufficient for auth test — IntegrationTenant
+			// may not exist yet when Zapier first tests the OAuth connection)
+			const decoded = this.zapierService.verifyJwtToken(token);
 			return {
 				authenticated: true,
-				integrationId: integration.id,
+				userId: decoded.id,
+				tenantId: decoded.tenantId,
 				name: IntegrationEnum.ZAPIER
 			};
 		} catch (error) {
@@ -260,6 +276,7 @@ export class ZapierAuthorizationController {
 	/**
 	 * Connection label endpoint — returns integration info for Zapier's UI.
 	 * Called by the Zapier CLI app to display a label for the connected account.
+	 * Supports both opaque tokens (legacy) and JWT tokens (multi-app OAuth).
 	 */
 	@ApiOperation({ summary: 'Get Zapier connection info' })
 	@ApiResponse({
@@ -275,12 +292,26 @@ export class ZapierAuthorizationController {
 			}
 
 			const token = authHeader.substring(7);
-			const integration = await this.zapierService.findIntegrationByToken(token);
 
+			// Try opaque token first (backward compat) — resolves via IntegrationTenant
+			try {
+				const integration = await this.zapierService.resolveIntegrationFromBearerToken(token);
+				return {
+					id: integration.id,
+					name: IntegrationEnum.ZAPIER,
+					email: `zapier-integration@${integration.tenantId || 'gauzy'}`
+				};
+			} catch {
+				// No IntegrationTenant yet — fall through to JWT-only verification
+			}
+
+			// Verify the JWT is valid (sufficient for connection label —
+			// IntegrationTenant may not exist yet when Zapier first tests the connection)
+			const decoded = this.zapierService.verifyJwtToken(token);
 			return {
-				id: integration.id,
+				id: decoded.id,
 				name: IntegrationEnum.ZAPIER,
-				email: `zapier-integration@${integration.tenantId || 'gauzy'}`
+				email: `zapier-integration@${decoded.tenantId || 'gauzy'}`
 			};
 		} catch (error) {
 			this.logger.error('Zapier connection info failed', error);

--- a/packages/plugins/integration-zapier/src/lib/zapier-webhook.controller.ts
+++ b/packages/plugins/integration-zapier/src/lib/zapier-webhook.controller.ts
@@ -71,7 +71,8 @@ export class ZapierWebhookController {
 		const token = authorization.split(' ')[1];
 
 		try {
-			const integration = await this.zapierService.findIntegrationByToken(token);
+			// Resolve integration from opaque token or JWT (multi-app OAuth)
+			const integration = await this.zapierService.resolveIntegrationFromBearerToken(token);
 
 			if (!integration) {
 				throw new ForbiddenException('Invalid token');
@@ -229,7 +230,8 @@ export class ZapierWebhookController {
 		const token = authorization.split(' ')[1];
 
 		try {
-			const integration = await this.zapierService.findIntegrationByToken(token);
+			// Resolve integration from opaque token or JWT (multi-app OAuth)
+			const integration = await this.zapierService.resolveIntegrationFromBearerToken(token);
 
 			if (!integration) {
 				throw new ForbiddenException('Invalid token');

--- a/packages/plugins/integration-zapier/src/lib/zapier.service.ts
+++ b/packages/plugins/integration-zapier/src/lib/zapier.service.ts
@@ -1,10 +1,10 @@
-import { Injectable, BadRequestException, HttpException, HttpStatus, NotFoundException, Logger } from '@nestjs/common';
+import { Injectable, BadRequestException, HttpException, HttpStatus, NotFoundException, Logger, UnauthorizedException } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { CommandBus } from '@nestjs/cqrs';
 import { AxiosError, AxiosResponse } from 'axios';
 import { DeepPartial, Like } from 'typeorm';
 import { catchError, firstValueFrom, map } from 'rxjs';
-import { ConfigService } from '@gauzy/config';
+import { ConfigService, environment } from '@gauzy/config';
 import {
 	IIntegrationTenant,
 	IntegrationEnum,
@@ -31,6 +31,7 @@ import {
 } from './zapier.types';
 import { IZapierCreateZapInput, IZapierZap, IZapierZapTemplate } from '@gauzy/contracts';
 import { randomBytes } from 'node:crypto';
+import { verify } from 'jsonwebtoken';
 
 @Injectable()
 export class ZapierService {
@@ -800,10 +801,14 @@ export class ZapierService {
 	 * @throws NotFoundException if the token is invalid or no Zapier integration is found.
 	 */
 	async findIntegrationByToken(token: string): Promise<IIntegrationTenant> {
-		// 1) Lookup the Gauzy-issued OAuth access token (separate from Zapier API tokens)
-		const setting = await this._integrationSettingService.findOneByWhereOptions({
-			settingsName: 'oauth_access_token',
-			settingsValue: token
+		// 1) Lookup the Gauzy-issued OAuth access token (separate from Zapier API tokens).
+		//    Use the repository directly to bypass tenant-aware scoping, because this
+		//    method is called from @Public() endpoints where no user is in the request context.
+		const setting = await this._integrationSettingService.typeOrmIntegrationSettingRepository.findOne({
+			where: {
+				settingsName: 'oauth_access_token',
+				settingsValue: token
+			}
 		});
 
 		// 2) Ensure we have an integrationId
@@ -827,6 +832,116 @@ export class ZapierService {
 			...integrationTenant,
 			name: IntegrationEnum.ZAPIER
 		};
+	}
+
+	/**
+	 * Find the Zapier IntegrationTenant for a given tenantId and (optionally) organizationId.
+	 * When organizationId is provided the lookup is scoped to that org, preventing
+	 * ambiguous matches in tenants with multiple organizations.
+	 *
+	 * @param tenantId - The tenant ID (from JWT)
+	 * @param organizationId - The organization ID (from JWT, optional)
+	 * @returns The matching IIntegrationTenant
+	 * @throws NotFoundException if no Zapier integration exists for this tenant
+	 */
+	async findIntegrationByTenantId(tenantId: string, organizationId?: string): Promise<IIntegrationTenant> {
+		if (organizationId) {
+			// Scoped lookup — organizationId is known, so the match is unambiguous
+			const integrationTenant = await this._integrationTenantService.findOneByOptions({
+				where: {
+					tenantId,
+					organizationId,
+					name: IntegrationEnum.ZAPIER
+				} as IIntegrationFilter,
+				relations: ['settings']
+			});
+
+			if (!integrationTenant) {
+				throw new NotFoundException('Zapier integration not found for this tenant');
+			}
+
+			return { ...integrationTenant, name: IntegrationEnum.ZAPIER };
+		}
+
+		// No organizationId — fail-closed: only succeed if exactly one Zapier integration exists
+		const { items, total } = await this._integrationTenantService.findAll({
+			where: {
+				tenantId,
+				name: IntegrationEnum.ZAPIER
+			} as IIntegrationFilter,
+			relations: ['settings']
+		});
+
+		if (total === 0) {
+			throw new NotFoundException('Zapier integration not found for this tenant');
+		}
+
+		if (total > 1) {
+			throw new BadRequestException(
+				'Multiple Zapier integrations found for this tenant. Token must include organizationId to resolve the correct one.'
+			);
+		}
+
+		return { ...items[0], name: IntegrationEnum.ZAPIER };
+	}
+
+	/**
+	 * Resolve the Zapier integration from a Bearer token.
+	 * Tries opaque token lookup first (backward compatibility), then
+	 * falls back to JWT verification + tenantId lookup for tokens
+	 * issued by the multi-app OAuth system.
+	 *
+	 * @param token - The Bearer token (opaque or JWT)
+	 * @returns The matching IIntegrationTenant
+	 * @throws NotFoundException if neither lookup succeeds
+	 */
+	async resolveIntegrationFromBearerToken(token: string): Promise<IIntegrationTenant> {
+		// 1) Try opaque token lookup (Zapier-issued tokens)
+		try {
+			return await this.findIntegrationByToken(token);
+		} catch (error) {
+			// Only fall through to JWT if the token was simply not found.
+			// Re-throw infrastructure errors (DB failures, etc.) immediately.
+			if (!(error instanceof NotFoundException)) {
+				throw error;
+			}
+		}
+
+		// 2) Try JWT verification (multi-app OAuth tokens)
+		try {
+			const decoded = this.verifyJwtToken(token);
+			if (!decoded?.tenantId) {
+				throw new UnauthorizedException('JWT missing tenantId');
+			}
+			return await this.findIntegrationByTenantId(decoded.tenantId, decoded.organizationId);
+		} catch (error: any) {
+			// Let known HTTP exceptions (auth, not-found, bad-request) surface with their status code.
+			// Only re-throw unexpected errors (DB failures, etc.) as-is.
+			if (error instanceof HttpException) {
+				this.logger.debug('resolveIntegrationFromBearerToken: no integration found — %s', error?.message);
+				throw error;
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Verify a JWT token issued by the multi-app OAuth system.
+	 *
+	 * @param token - The JWT token to verify
+	 * @returns The decoded payload containing id (userId) and tenantId
+	 * @throws UnauthorizedException if the token is invalid or expired
+	 */
+	verifyJwtToken(token: string): { id: string; tenantId: string; organizationId?: string } {
+		try {
+			const decoded = verify(token, environment.JWT_SECRET!);
+			if (typeof decoded !== 'object' || !decoded || !('tenantId' in decoded)) {
+				throw new Error('Invalid JWT payload structure');
+			}
+			return decoded as { id: string; tenantId: string; organizationId?: string };
+		} catch {
+			throw new UnauthorizedException('Invalid or expired access token');
+		}
 	}
 
 	/**

--- a/packages/plugins/integration-zapier/zapier/package.json
+++ b/packages/plugins/integration-zapier/zapier/package.json
@@ -13,13 +13,13 @@
 		"clean": "rimraf lib dist"
 	},
 	"dependencies": {
-		"zapier-platform-core": "18.3.0"
+		"zapier-platform-core": "18.4.0"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.0",
 		"rimraf": "^3.0.2",
 		"typescript": "^5.9.3",
-		"zapier-platform-cli": "18.3.0"
+		"zapier-platform-cli": "18.4.0"
 	},
 	"private": true
 }

--- a/packages/plugins/integration-zapier/zapier/src/authentication.ts
+++ b/packages/plugins/integration-zapier/zapier/src/authentication.ts
@@ -41,10 +41,14 @@ export const authentication = {
 
 	/** OAuth2 specific configuration */
 	oauth2Config: {
-		/** Configuration for the authorization URL */
+		/**
+		 * Authorization URL — uses the multi-app OAuth provider at
+		 * /api/integration/ever-gauzy/oauth/authorize which redirects to
+		 * the Gauzy consent page where the user logs in and approves access.
+		 */
 		authorizeUrl: {
 			method: 'GET',
-			url: `${process.env.API_BASE_URL}/api/integration/zapier/oauth/authorize`,
+			url: `${process.env.API_BASE_URL}/api/integration/ever-gauzy/oauth/authorize`,
 			params: {
 				client_id: '{{process.env.CLIENT_ID}}',
 				state: '{{bundle.inputData.state}}',
@@ -52,10 +56,13 @@ export const authentication = {
 				response_type: 'code'
 			}
 		},
-		/** Configuration for obtaining access token */
+		/**
+		 * Token exchange — uses the multi-app OAuth token endpoint which
+		 * validates the authorization code and returns a signed JWT.
+		 */
 		getAccessToken: {
 			method: 'POST',
-			url: `${process.env.API_BASE_URL}/api/integration/zapier/oauth/token`,
+			url: `${process.env.API_BASE_URL}/api/integration/ever-gauzy/oauth/token`,
 			body: {
 				code: '{{bundle.inputData.code}}',
 				client_id: '{{process.env.CLIENT_ID}}',
@@ -68,24 +75,13 @@ export const authentication = {
 				Accept: 'application/json'
 			}
 		},
-		/** Configuration for refreshing access token */
-		refreshAccessToken: {
-			method: 'POST',
-			url: `${process.env.API_BASE_URL}/api/integration/zapier/oauth/refresh-token`,
-			body: {
-				refresh_token: '{{bundle.authData.refresh_token}}',
-				client_id: '{{process.env.CLIENT_ID}}',
-				client_secret: '{{process.env.CLIENT_SECRET}}',
-				grant_type: 'refresh_token'
-			},
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-				Accept: 'application/json'
-			}
-		},
 		/** OAuth2 scopes required for the integration */
 		scope: 'zap zap:write authentication',
-		/** Enable automatic token refresh */
-		autoRefresh: true
+		/**
+		 * Disable auto-refresh — the multi-app OAuth system issues long-lived
+		 * JWTs. Configure the Zapier OAuth client's accessTokenTtl for a
+		 * long TTL (e.g. 365 days) to avoid frequent reconnections.
+		 */
+		autoRefresh: false
 	}
 };

--- a/packages/plugins/integration-zapier/zapier/src/index.ts
+++ b/packages/plugins/integration-zapier/zapier/src/index.ts
@@ -24,6 +24,11 @@ export default {
   platformVersion,
   authentication,
 
+  // Global flags for the app
+  flags: {
+    cleanInputData: false,
+  },
+
   // Triggers that users can use to start Zaps
   triggers: {
     [timerStatusKey]: timerStatus,

--- a/packages/plugins/integration-zapier/zapier/tsconfig.json
+++ b/packages/plugins/integration-zapier/zapier/tsconfig.json
@@ -9,7 +9,8 @@
         "strict": true,
         "declaration": true,
         "sourceMap": true,
-        "incremental": true
+        "incremental": true,
+        "skipLibCheck": true
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "**/*.test.ts", "lib"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3595,6 +3595,11 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
+"@babel/runtime@^7.18.3":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@babel/template@^7.27.1", "@babel/template@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
@@ -29500,6 +29505,11 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-metaschema@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/json-metaschema/-/json-metaschema-1.3.0.tgz#c0385355546131bd4e359327fb2a180089a2d2d0"
+  integrity sha512-FMDPEZQzqIVOQZ3OxzWryI28W6IZ9QKLcHObO9bS+SJrwnV3xQD0QtnhtgSpIZd8Xuy0xBqeRA74vfTnpK4eVg==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -29533,6 +29543,14 @@ json-schema-resolver@^3.0.0:
     debug "^4.1.1"
     fast-uri "^3.0.5"
     rfdc "^1.1.4"
+
+json-schema-to-ts@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz#81f3acaf5a34736492f6f5f51870ef9ece1ca853"
+  integrity sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    ts-algebra "^2.0.0"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -41828,6 +41846,11 @@ ts-action@11.0.0:
   resolved "https://registry.yarnpkg.com/ts-action/-/ts-action-11.0.0.tgz#abb7f510b0d2e0b9534900cc22c45b8f7e795a3c"
   integrity sha512-TDxvzZ5UtKsBuw0McRs/L+iASj80m60nV8EXCP680ZdIl+oRHPGnBk85sZJWXLzqQwb6yQ+CcMzPTfBr0dEaAA==
 
+ts-algebra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-2.0.0.tgz#4e3e0953878f26518fce7f6bb115064a65388b7a"
+  integrity sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
+
 ts-api-utils@^2.1.0, ts-api-utils@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.4.0.tgz#2690579f96d2790253bdcf1ca35d569ad78f9ad8"
@@ -44403,10 +44426,10 @@ yoctocolors@^2.1.1:
   resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.2.tgz#d795f54d173494e7d8db93150cec0ed7f678c83a"
   integrity sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==
 
-zapier-platform-cli@^18.3.0:
-  version "18.3.0"
-  resolved "https://registry.yarnpkg.com/zapier-platform-cli/-/zapier-platform-cli-18.3.0.tgz#a99a654ecc5e99f86c0a9466a25992be411568a6"
-  integrity sha512-XKtrhOgfrVuY8MeCYA3mpqKe/tCg996r0mbgi9FV20aT/divPTMvk2IIHspUZSvSYBQJiDF5SSwD5CprBN9/5w==
+zapier-platform-cli@^18.4.0:
+  version "18.4.0"
+  resolved "https://registry.yarnpkg.com/zapier-platform-cli/-/zapier-platform-cli-18.4.0.tgz#6731aef9e63f7a6f2339738bb7060e652b14d79d"
+  integrity sha512-FYPJIcqa7E4mPaxBxyatMyEw59rvozEvcGYgVyqIug2gHkYz2ToFyOQyRgWbO0OMjw7OocPiLPp+CZlBpubSTQ==
   dependencies:
     "@oclif/core" "4.5.2"
     "@oclif/plugin-autocomplete" "3.2.34"
@@ -44446,31 +44469,33 @@ zapier-platform-cli@^18.3.0:
     yeoman-environment "4.4.3"
     yeoman-generator "7.5.1"
 
-zapier-platform-core@^18.3.0:
-  version "18.3.0"
-  resolved "https://registry.yarnpkg.com/zapier-platform-core/-/zapier-platform-core-18.3.0.tgz#e13547af6ffdd0b956f0b37d22efe1736cef8e92"
-  integrity sha512-qhvWPLqGd29o4SnAE4Ve9K6BLeCUjko16pdxqK9KNzjDH5e57RLOqFICuXS+0DATcKirdqUCoodxnMTHahk/XA==
+zapier-platform-core@^18.4.0:
+  version "18.4.0"
+  resolved "https://registry.yarnpkg.com/zapier-platform-core/-/zapier-platform-core-18.4.0.tgz#32b16ed15498d8e0afe45706b4291f8cc58ac322"
+  integrity sha512-A9hs/p5brkLhFDUZljbI76gcwhtJFOTHNGzkeyd/2FsHWaLkalOWMPPRtYWpGxbecOXZrnaIy2R3fOQ2XEf1QA==
   dependencies:
     "@zapier/secret-scrubber" "^1.1.2"
     content-disposition "0.5.4"
     dotenv "17.2.1"
     fernet "^0.3.3"
     form-data "4.0.5"
+    json-schema-to-ts "3.1.1"
     lodash "4.17.23"
     mime-types "3.0.1"
     node-abort-controller "3.1.1"
     node-fetch "2.7.0"
     oauth-sign "0.9.0"
     semver "7.7.2"
-    zapier-platform-schema "18.3.0"
+    zapier-platform-schema "18.4.0"
   optionalDependencies:
     "@types/node" "^20.3.1"
 
-zapier-platform-schema@18.3.0:
-  version "18.3.0"
-  resolved "https://registry.yarnpkg.com/zapier-platform-schema/-/zapier-platform-schema-18.3.0.tgz#384f733535fe2d9cf4b3761452a18db2e8f3e67a"
-  integrity sha512-WigaXQyHGowxerFO6lfF44RvgmdFbTIHRWus7AeVT+3bQdN+rJeadlTM9/gTrkmrgcbK3dQaoi4OuNsoASf3Cg==
+zapier-platform-schema@18.4.0:
+  version "18.4.0"
+  resolved "https://registry.yarnpkg.com/zapier-platform-schema/-/zapier-platform-schema-18.4.0.tgz#c168afcd94dfbc1db14c9017be84c74c41181617"
+  integrity sha512-Y1TkdbREJORfD+Gcd1RMugSRBS+s6ulDIp44RnQxmt1sr6vKct1HuyyUVdBIHidWETG3Zu7lfoGZSkqakYYrRg==
   dependencies:
+    json-metaschema "1.3.0"
     jsonschema "1.5.0"
     lodash "4.17.23"
 


### PR DESCRIPTION
fix: Enhance Zapier CLI app

# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication/token verification paths and changes how public endpoints resolve integrations, so misconfiguration of `JWT_SECRET` or tenant/org resolution could break Zapier connections. Dependency bumps and Zapier app OAuth endpoint changes may also affect existing installs/refresh behavior.
> 
> **Overview**
> Improves the Zapier integration to work with **multi-app OAuth** by accepting either legacy opaque tokens or signed JWT access tokens across Zapier’s `auth/test`, `auth/me`, and webhook subscription endpoints.
> 
> This introduces centralized bearer-token resolution in `ZapierService` (JWT verification via `environment.JWT_SECRET`, tenant/org-based integration lookup with a fail-closed ambiguity check) and adjusts token setting lookups to bypass tenant scoping for `@Public()` endpoints.
> 
> Separately updates the Zapier CLI app to use the `/api/integration/ever-gauzy/oauth/*` authorization/token endpoints, disables auto-refresh, adds a global `cleanInputData` flag, and bumps Zapier platform dependencies to `18.4.0` (plus `skipLibCheck` for the Zapier app TS build).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda198064f3cc60bf9d2cf17ea73a8c5a7ecf15e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add JWT-based auth to the Zapier integration and switch the CLI app to the multi-app OAuth flow, while keeping legacy opaque tokens working. This improves connection reliability and unifies token handling across auth tests and webhooks.

- **New Features**
  - Resolve Bearer tokens by trying opaque tokens first, then JWT verification; used by webhooks, auth test, and connection label.
  - Switch Zapier CLI app to `/api/integration/ever-gauzy/oauth/{authorize,token}` and disable refresh (use long-lived JWTs).
  - Improve public token lookup to bypass tenant scoping and add tenant/organization-aware integration resolution with clear errors.
  - Update `zapier-platform-core` and `zapier-platform-cli` to `18.4.0`; add `skipLibCheck` and set app flag `cleanInputData: false`.

- **Migration**
  - Redeploy the Zapier CLI app with the new OAuth endpoints; existing Zaps keep working via backward-compatible tokens.
  - Ensure `JWT_SECRET` is set for the API so JWTs can be verified.
  - For tenants with multiple Zapier integrations, reconnect using an org-scoped token to avoid ambiguity.

<sup>Written for commit eda198064f3cc60bf9d2cf17ea73a8c5a7ecf15e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

