### PR TITLE
Merge pull request #9682 from ever-co/fix/desktop-timer-screenshot-is…

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -64,7 +64,7 @@
 		"app-root-path": "^3.0.0",
 		"auto-launch": "5.0.5",
 		"consolidate": "^0.16.0",
-		"custom-electron-titlebar": "^4.2.8",
+		"custom-electron-titlebar": "^4.4.1",
 		"electron-log": "^4.4.8",
 		"electron-store": "^8.1.0",
 		"electron-updater": "^6.1.7",

--- a/apps/agent/src/package.json
+++ b/apps/agent/src/package.json
@@ -166,7 +166,7 @@
 		"@sentry/node": "10.36.0",
 		"@sentry/core": "10.36.0",
 		"auto-launch": "5.0.5",
-		"custom-electron-titlebar": "^4.2.8",
+		"custom-electron-titlebar": "^4.4.1",
 		"form-data": "^4.0.1",
 		"call-bind-apply-helpers": "^1.0.2",
 		"cheerio-select": "^2.1.0",

--- a/apps/desktop-timer/package.json
+++ b/apps/desktop-timer/package.json
@@ -61,7 +61,7 @@
 		"app-root-path": "^3.0.0",
 		"auto-launch": "5.0.5",
 		"consolidate": "^0.16.0",
-		"custom-electron-titlebar": "^4.2.8",
+		"custom-electron-titlebar": "^4.4.1",
 		"electron-log": "^4.4.8",
 		"electron-store": "^8.1.0",
 		"electron-updater": "^6.1.7",

--- a/apps/desktop-timer/src/index.ts
+++ b/apps/desktop-timer/src/index.ts
@@ -130,6 +130,8 @@ let alwaysOn: AlwaysOn = null;
 
 setupTitlebar();
 
+ipcMain.removeAllListeners('window-set-minimumSize');
+
 console.log('Time Tracker UI Render Path:', path.join(__dirname, './index.html'));
 
 const pathWindow = {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -86,7 +86,7 @@
 		"twing": "^5.0.2",
 		"typeorm": "^0.3.28",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8"
+		"custom-electron-titlebar": "^4.4.1"
 	},
 	"keywords": [],
 	"optionalDependencies": {

--- a/apps/desktop/src/package.json
+++ b/apps/desktop/src/package.json
@@ -219,7 +219,7 @@
 		"twing": "^5.0.2",
 		"underscore": "^1.13.8",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8",
+		"custom-electron-titlebar": "^4.4.1",
 		"call-bind-apply-helpers": "^1.0.2",
 		"cheerio-select": "^2.1.0",
 		"@as-integrations/express5": "^1.1.2"

--- a/apps/server-api/package.json
+++ b/apps/server-api/package.json
@@ -84,7 +84,7 @@
 		"twing": "^5.0.2",
 		"typeorm": "^0.3.28",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8"
+		"custom-electron-titlebar": "^4.4.1"
 	},
 	"optionalDependencies": {
 		"node-linux": "^0.1.12",

--- a/apps/server-api/src/package.json
+++ b/apps/server-api/src/package.json
@@ -213,7 +213,7 @@
 		"twing": "^5.0.2",
 		"underscore": "^1.13.8",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8",
+		"custom-electron-titlebar": "^4.4.1",
 		"@as-integrations/express5": "^1.1.2",
 		"call-bind-apply-helpers": "^1.0.2",
 		"cheerio-select": "^2.1.0"

--- a/apps/server-mcp/package.json
+++ b/apps/server-mcp/package.json
@@ -48,6 +48,6 @@
 		"electron-updater": "^6.1.7",
 		"electron-util": "^0.18.1",
 		"zod": "^4.3.6",
-		"custom-electron-titlebar": "^4.2.8"
+		"custom-electron-titlebar": "^4.4.1"
 	}
 }

--- a/apps/server-mcp/src/package.json
+++ b/apps/server-mcp/src/package.json
@@ -139,7 +139,7 @@
 		"electron-store": "^8.1.0",
 		"electron-updater": "^6.1.7",
 		"electron-util": "^0.18.1",
-		"custom-electron-titlebar": "^4.2.8"
+		"custom-electron-titlebar": "^4.4.1"
 	},
 	"resolutions": {
 		"@gauzy/mcp-server": "file:../../../dist/packages/mcp-server",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -79,7 +79,7 @@
 		"twing": "^5.0.2",
 		"typeorm": "^0.3.28",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8"
+		"custom-electron-titlebar": "^4.4.1"
 	},
 	"optionalDependencies": {
 		"node-linux": "^0.1.12",

--- a/apps/server/src/package.json
+++ b/apps/server/src/package.json
@@ -218,7 +218,7 @@
 		"twing": "^5.0.2",
 		"underscore": "^1.13.8",
 		"undici": "^6.10.2",
-		"custom-electron-titlebar": "^4.2.8",
+		"custom-electron-titlebar": "^4.4.1",
 		"@as-integrations/express5": "^1.1.2",
 		"call-bind-apply-helpers": "^1.0.2",
 		"cheerio-select": "^2.1.0"

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -341,6 +341,7 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 	});
 
 	ipcMain.on('auth_failed', (event, arg) => {
+
 		event.sender.send('show_toast_message', {
 			type: 'error',
 			message: arg.message
@@ -636,14 +637,22 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 	});
 
 	ipcMain.handle('UPDATE_SCREENSHOT_SYNC_STATUS', async (_, arg: { id: number; remove: boolean; failedReason: string; synced: boolean; retries: number }) => {
-		await getScreenshotService().update(new Screenshot({
-			id: arg.id,
-			synced: arg.synced,
-			lastAttemptAt: new Date(),
-			message: arg.failedReason,
-			retries: arg.remove ? 0 : 1,
-			...(arg.remove ? { imagePath: '' } : {})
-		}));
+		try {
+			if (arg.remove) {
+				await getScreenshotService().remove({ id: arg.id });
+			} else {
+				await getScreenshotService().update(new Screenshot({
+					id: arg.id,
+					synced: arg.synced,
+					lastAttemptAt: new Date(),
+					message: arg.failedReason,
+					retries: 1
+				}));
+			}
+		} catch (error) {
+			console.error('Failed to update screenshot sync status', error);
+		}
+
 	})
 
 	pluginListeners();

--- a/packages/desktop-lib/src/lib/desktop-screenshot.ts
+++ b/packages/desktop-lib/src/lib/desktop-screenshot.ts
@@ -524,5 +524,5 @@ export async function notifyScreenshot(notificationWindow, thumb, windowPath, so
 
 function allowScreenshotCapture(): boolean {
 	const auth = LocalStore.getStore('auth');
-	return auth && auth.allowScreenshotCapture;
+	return Boolean((auth?.allowScreenshotCapture ?? false) || (auth?.user?.employee?.allowScreenshotCapture ?? false));
 }

--- a/packages/desktop-lib/src/lib/offline/dao/screenshot.dao.ts
+++ b/packages/desktop-lib/src/lib/offline/dao/screenshot.dao.ts
@@ -39,11 +39,14 @@ export class ScreenshotDAO implements DAO<ScreenshotTO> {
 		if (!value || value.id === undefined) {
 			throw new Error('Cannot delete screenshot data: Missing or invalid id');
 		}
-		await this._provider
+
+		const query = this._provider
 			.connection<ScreenshotTO>(TABLE_NAME_SCREENSHOT)
-			.where('id', '=', value.id)
-			.orWhere('imagePath', '=', value.imagePath)
-			.del();
+			.where('id', '=', value.id);
+		if (value.imagePath) {
+			query.orWhere('imagePath', '=', value.imagePath);
+		}
+		await query.del();
 	}
 
 	public async findUnSyncedScreenshot(limit?: number): Promise<ScreenshotTO[]> {

--- a/packages/desktop-ui-lib/src/lib/offline-sync/concretes/screenshot.queue.ts
+++ b/packages/desktop-ui-lib/src/lib/offline-sync/concretes/screenshot.queue.ts
@@ -28,6 +28,9 @@ export class ScreenshotQueue extends OfflineQueue<IScreenshotQueue> {
 		if (!item.timeslotId || !item.base64Image) {
 			return;
 		}
+		if (this._store.isOffline) {
+			return;
+		}
 		try {
 			item.retries = item.retries || 0;
 			if (item.retries >= 3) {

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -586,7 +586,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 							actionType: TimerActionTypeEnum.START_TIMER,
 							data: {
 								timerId: lastTimer.id,
-								state: TimerSyncStateEnum.SYNCED
+								state: timelog?.id ? TimerSyncStateEnum.SYNCED : TimerSyncStateEnum.FAILED,
 							}
 						});
 					} catch (error) {
@@ -650,7 +650,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 					} catch (error) {
 						// Handle any error during the process
 						lastTimer.isStoppedOffline = true;
-						await this._auditLogService.timerAuditLogError(`Error stop timer to API with ID: ${lastTimer.id}`);
+						await this._auditLogService.timerAuditLogError(`Error stop timer to API with ID: ${lastTimer.id}, ${error.message}`);
 						await this.electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
 							actionType: TimerActionTypeEnum.STOP_TIMER,
 							data: {
@@ -988,18 +988,19 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		return (a && !b) || (!a && b);
 	}
 
-	async prepareWindow() {
+	prepareWindow() {
 		/* initiate screenshot to prevent window sizing */
-		try {
-			const thumbSize = {
-				width: 320,
-				height: 240
-			};
-			await this.electronService.desktopCapturer.getSources({ types: ['screen'], thumbnailSize: thumbSize });
-		} catch (error) {
-			console.error('Error preparing window:', error);
-		}
-
+		setTimeout(async () => {
+			try {
+				const thumbSize = {
+					width: 320,
+					height: 240
+				};
+				await this.electronService.desktopCapturer.getSources({ types: ['screen'], thumbnailSize: thumbSize });
+			} catch (error) {
+				console.error('Error preparing window:', error);
+			}
+		}, 500);
 	}
 
 	ngAfterViewInit(): void {

--- a/packages/desktop-window/src/lib/desktop-window-image-viewer.ts
+++ b/packages/desktop-window/src/lib/desktop-window-image-viewer.ts
@@ -57,7 +57,10 @@ export async function createImageViewerWindow(
 
 	// Attach a custom title bar if a preload script is provided
 	if (preloadPath) {
-		attachTitlebarToWindow(imageViewWindow);
+		attachTitlebarToWindow(imageViewWindow, {
+			minWidth: mainWindowSettings.width,
+			minHeight: mainWindowSettings.height,
+		});
 	}
 
 	// Return the configured Image Viewer window instance

--- a/packages/desktop-window/src/lib/desktop-window-server.ts
+++ b/packages/desktop-window/src/lib/desktop-window-server.ts
@@ -50,7 +50,10 @@ export async function createServerWindow(
 
 	// Attach a custom title bar if a preload script is provided
 	if (preloadPath) {
-		attachTitlebarToWindow(serverWindow);
+		attachTitlebarToWindow(serverWindow, {
+			minWidth: mainWindowSettings.width,
+			minHeight: mainWindowSettings.height,
+		});
 	}
 
 	manager.overrideSystemContextMenu(serverWindow);

--- a/packages/desktop-window/src/lib/desktop-window-setting.ts
+++ b/packages/desktop-window/src/lib/desktop-window-setting.ts
@@ -53,7 +53,10 @@ export async function createSettingsWindow(
 
 	// Optionally attach a custom title bar if a preload script is provided
 	if (preloadPath) {
-		attachTitlebarToWindow(settingsWindow);
+		attachTitlebarToWindow(settingsWindow, {
+			minWidth: mainWindowSettings.width,
+			minHeight: mainWindowSettings.height,
+		});
 	}
 
 	// Register the settings window with the WindowManager

--- a/packages/desktop-window/src/lib/desktop-window-setup.ts
+++ b/packages/desktop-window/src/lib/desktop-window-setup.ts
@@ -61,7 +61,10 @@ export async function createSetupWindow(
 	handleCloseEvent(setupWindow);
 
 	if (preloadPath) {
-		attachTitlebarToWindow(setupWindow);
+		attachTitlebarToWindow(setupWindow, {
+			minWidth: mainWindowSettings.width,
+			minHeight: mainWindowSettings.height,
+		});
 	}
 
 	// Register the Setup window with the WindowManager

--- a/packages/desktop-window/src/lib/desktop-window-timer.ts
+++ b/packages/desktop-window/src/lib/desktop-window-timer.ts
@@ -44,12 +44,12 @@ export async function createTimeTrackerWindow(
 
 	// Attach the custom title bar if a preload script is provided
 	if (preloadPath) {
-		attachTitlebarToWindow(timeTrackerWindow);
+		const { width, height } = getScreenSize();
+		attachTitlebarToWindow(timeTrackerWindow, {
+			minWidth: width,
+			minHeight: height,
+		});
 	}
-
-	// Set the minimum size for the window
-	const { width, height } = getScreenSize();
-	timeTrackerWindow.setMinimumSize(width, height);
 
 	manager.overrideSystemContextMenu(timeTrackerWindow);
 

--- a/packages/desktop-window/src/lib/desktop-window-updater.ts
+++ b/packages/desktop-window/src/lib/desktop-window-updater.ts
@@ -52,7 +52,10 @@ export async function createUpdaterWindow(
 
 	// If a preload path is provided, attach a custom title bar to the window
 	if (preloadPath) {
-		attachTitlebarToWindow(updaterWindow);
+		attachTitlebarToWindow(updaterWindow, {
+			minWidth: mainWindowSettings.width,
+			minHeight: mainWindowSettings.height,
+		});
 	}
 
 	// Return the configured window instance

--- a/packages/desktop-window/src/lib/desktop-window.ts
+++ b/packages/desktop-window/src/lib/desktop-window.ts
@@ -69,7 +69,10 @@ export async function createGauzyWindow(
 
 	// Additional configuration for preloadPath
 	if (preloadPath) {
-		attachTitlebarToWindow(gauzyWindow);
+		attachTitlebarToWindow(gauzyWindow, {
+			minWidth: mainWindowSettings.width,
+			minHeight: mainWindowSettings.height,
+		});
 		gauzyWindow.webContents.send('adjust_view');
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21463,10 +21463,10 @@ currency.js@^2.0.3:
   resolved "https://registry.yarnpkg.com/currency.js/-/currency.js-2.0.4.tgz#a8a4d69be3b2e509bf67a560c78220bc04809cf1"
   integrity sha512-6/OplJYgJ0RUlli74d93HJ/OsKVBi8lB1+Z6eJYS1YZzBuIp4qKKHpJ7ad+GvTlWmLR/hLJOWTykN5Nm8NJ7+w==
 
-custom-electron-titlebar@^4.2.8:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/custom-electron-titlebar/-/custom-electron-titlebar-4.2.8.tgz#8b0d024cf372b10c9758cc512ca55498b69616da"
-  integrity sha512-JEFiOKJdSZtMh90FO90FeEqCc463ZZhuh78JxILvO9Nc0H8I9MfKekgCf6jZH6xccd3/tm1OcYOoUJi3JbXR/w==
+custom-electron-titlebar@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/custom-electron-titlebar/-/custom-electron-titlebar-4.4.1.tgz#aea64f009697c9771cb2a67d2eb5ac8059696906"
+  integrity sha512-I+sOGBdslrGpuCWlhda8P0vtRAZK+W2NzjHLsxTiE2bNmhAIs9YLDe6iRBExwU1xVZt+J1hSXzUT67BlAuMWLA==
 
 custom-event@~1.0.0:
   version "1.0.1"


### PR DESCRIPTION
…sues

Fix/desktop timer screenshot issues

# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreliable screenshot capture in the Desktop Timer by stabilizing window sizing and tightening sync/cleanup logic. Updates `custom-electron-titlebar` to reduce titlebar/min-size conflicts.

- **Bug Fixes**
  - Stabilized window sizing: pass minWidth/minHeight to `attachTitlebarToWindow`, remove legacy min-size IPC, and delay initial desktop capture to avoid resize flicker.
  - Respected screenshot permissions from `auth.allowScreenshotCapture` or `auth.user.employee.allowScreenshotCapture`.
  - Safer screenshot sync: delete record when `remove=true`, wrap updates in try/catch, make DAO delete tolerate missing `imagePath`, and skip upload while offline.
  - Timer sync status: mark start as FAILED when no `timelog.id`; include `error.message` on stop failures.
  - Removed stray `window-set-minimumSize` listeners to prevent conflicts.

- **Dependencies**
  - Bumped `custom-electron-titlebar` to `^4.4.1`.

<sup>Written for commit e6c69ac9b4938dafa04de82d814bbf1156760249. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

