### PR TITLE
Fix/about window detail os

### DIFF
--- a/packages/contracts/src/lib/desktop-timer.model.ts
+++ b/packages/contracts/src/lib/desktop-timer.model.ts
@@ -76,5 +76,11 @@ export interface ILogRequestPage {
 	logLevel?: TLogLevel;
 }
 
+export interface IOSInfo {
+	os: NodeJS.Platform;
+	arch: NodeJS.Architecture;
+	version: string;
+}
+
 // Combine them into a union
 export type AuditLogArgs = ILogRequest;

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -4,7 +4,8 @@ import {
 	TimerActionTypeEnum,
 	TimerSyncStateEnum,
 	ILogRequest,
-	ILogRequestPage
+	ILogRequestPage,
+    IOSInfo
 } from '@gauzy/contracts';
 import { AkitaStorageEngine, WindowManager, logger as log } from '@gauzy/desktop-core';
 import { ScreenCaptureNotification } from '@gauzy/desktop-window';
@@ -51,7 +52,7 @@ import { RemoteTrackingSleep } from './strategies';
 import { TranslateService } from './translation';
 import { ActivityWindow } from '@gauzy/desktop-activity';
 import { DesktopPermissionHandler } from './utilities/desktop-permission-handler';
-import { runTccutil, getAppId } from './utilities/util';
+import { runTccutil, getAppId, getOSInfo } from './utilities/util';
 import { AuditLogHandler } from './audit';
 
 // Lazily initialized — construction is deferred until after app.ready to avoid
@@ -145,8 +146,8 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 		}
 	});
 
-	ipcMain.handle('GET_PLATFORM', () => {
-		return process.platform;
+	ipcMain.handle('GET_PLATFORM', (): IOSInfo => {
+		return getOSInfo();
 	});
 
 	ipcMain.on('return_time_sheet', async (event, arg) => {

--- a/packages/desktop-lib/src/lib/utilities/util.ts
+++ b/packages/desktop-lib/src/lib/utilities/util.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { IOSInfo } from '@gauzy/contracts';
 export function isJSON<T>(input: T): boolean {
 	try {
 		JSON.parse(input as string);
@@ -24,4 +25,12 @@ export function runTccutil(service: string, bundleId: string, timeoutMs = 8000):
 
 export function getAppId() {
 	return process.env.APP_ID || 'com.ever.gauzydesktoptimer';
+}
+
+export function getOSInfo(): IOSInfo {
+	return {
+		os: process.platform,
+		version: process.getSystemVersion(),
+		arch: process.arch
+	}
 }

--- a/packages/desktop-ui-lib/src/lib/dialogs/about/about.component.html
+++ b/packages/desktop-ui-lib/src/lib/dialogs/about/about.component.html
@@ -16,7 +16,7 @@
 							<span>{{ 'TIMER_TRACKER.VERSION' | translate : { version: application?.version } }}</span>
 						</div>
 						<div class="col-12 version-text mb-2">
-							<span>{{ 'TIMER_TRACKER.ARCHITECTURE' | translate : { arch: application?.arch } }}</span>
+							<span>{{ 'TIMER_TRACKER.OS' | translate : { os, arch, systemVersion} }}</span>
 						</div>
 						<div class="col-12 copyright-text text-center mt-0">
 							<span>

--- a/packages/desktop-ui-lib/src/lib/dialogs/about/about.component.ts
+++ b/packages/desktop-ui-lib/src/lib/dialogs/about/about.component.ts
@@ -6,6 +6,7 @@ import { ElectronService } from '../../electron/services';
 import { LanguageElectronService } from '../../language/language-electron.service';
 import { NbLayoutModule, NbCardModule } from '@nebular/theme';
 import { TranslatePipe } from '@ngx-translate/core';
+import { IOSInfo } from '@gauzy/contracts';
 @UntilDestroy({ checkProperties: true })
 @Component({
     selector: 'gauzy-about',
@@ -21,6 +22,7 @@ export class AboutComponent implements OnInit {
 		companyName: 'Ever Co. LTD.',
 		arch: ''
 	};
+	private platformInfo: Partial<IOSInfo> = {}
 	constructor(
 		private readonly _electronService: ElectronService,
 		private readonly _languageElectronService: LanguageElectronService,
@@ -35,13 +37,8 @@ export class AboutComponent implements OnInit {
 		this.getArch();
 	}
 
-	getArch() {
-		this._electronService.ipcRenderer.once('get-arch', (_, arg) => {
-			this._ngZone.run(() => {
-				this._application.arch = arg
-			});
-		});
-		this._electronService.ipcRenderer.send('get-arch');
+	async getArch() {
+		this.platformInfo = await this._electronService.ipcRenderer.invoke('GET_PLATFORM');
 	}
 
 	public async openLink(link: string) {
@@ -73,5 +70,17 @@ export class AboutComponent implements OnInit {
 			companyName: this._environment.COMPANY_NAME
 		};
 		return this._application;
+	}
+
+	public get os(): NodeJS.Platform {
+		return this.platformInfo.os;
+	}
+
+	public get arch(): NodeJS.Architecture {
+		return this.platformInfo.arch;
+	}
+
+	public get systemVersion(): string {
+		return this.platformInfo.version;
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.html
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.html
@@ -36,12 +36,6 @@
 					role="log" aria-live="polite" aria-label="Application Logs"
 					[attr.aria-busy]="isLoading() || isLoadingMore()">
 
-					@if (!hasMore() && filteredLogs().length > 0) {
-					<div class="log-boundary">— Beginning of log history —</div>
-					}
-
-
-
 					@if (filteredLogs().length === 0 && !isLoading()) {
 					<div class="empty-state">
 						<nb-icon icon="file-text-outline" status="basic"></nb-icon>
@@ -71,6 +65,9 @@
 								class="load-more-spinner"></div>
 							<span>Loading older entries…</span>
 						</div>
+					}
+					@if (!hasMore() && filteredLogs().length > 0) {
+						<div class="log-boundary">— Beginning of log history —</div>
 					}
 				</div>
 			</nb-card-body>

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.html
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.html
@@ -36,21 +36,11 @@
 					role="log" aria-live="polite" aria-label="Application Logs"
 					[attr.aria-busy]="isLoading() || isLoadingMore()">
 
-					@if (isLoadingMore()) {
-					<div class="load-more-bar">
-						<div [nbSpinner]="true" nbSpinnerSize="tiny" nbSpinnerStatus="primary"
-							class="load-more-spinner"></div>
-						<span>Loading older entries…</span>
-					</div>
-					}
-
 					@if (!hasMore() && filteredLogs().length > 0) {
 					<div class="log-boundary">— Beginning of log history —</div>
 					}
 
-					@if (isLoading()) {
-					<div class="spinner-row" [nbSpinner]="true" nbSpinnerSize="small" nbSpinnerStatus="primary"></div>
-					}
+
 
 					@if (filteredLogs().length === 0 && !isLoading()) {
 					<div class="empty-state">
@@ -70,6 +60,17 @@
 						</div>
 						<p class="log-entry__message">{{ log.message }}</p>
 					</div>
+					}
+
+					@if (isLoading()) {
+						<div class="spinner-row" [nbSpinner]="true" nbSpinnerSize="small" nbSpinnerStatus="primary"></div>
+					}
+					@if (isLoadingMore()) {
+						<div class="load-more-bar">
+							<div [nbSpinner]="true" nbSpinnerSize="tiny" nbSpinnerStatus="primary"
+								class="load-more-spinner"></div>
+							<span>Loading older entries…</span>
+						</div>
 					}
 				</div>
 			</nb-card-body>

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.html
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.html
@@ -67,7 +67,7 @@
 						</div>
 					}
 					@if (!hasMore() && filteredLogs().length > 0) {
-						<div class="log-boundary">— Beginning of log history —</div>
+						<div class="log-boundary">&mdash; Beginning of log history &mdash;</div>
 					}
 				</div>
 			</nb-card-body>

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
@@ -160,9 +160,6 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 	}
 
 	async loadOlderEntries(): Promise<void> {
-		const el = this.scrollContainer()?.nativeElement;
-		const prevScrollHeight = el?.scrollHeight ?? 0;
-
 		this.isLoadingMore.set(true);
 		this.currentPage.update((p) => p + 1);
 
@@ -175,6 +172,8 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 			);
 
 			this.hasMore.set(result.length >= this.pageSize());
+
+
 		} catch (error) {
 			console.error('Failed to load older log entries', error);
 			// Roll back the page increment so the next attempt requests the correct page.

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
@@ -177,7 +177,7 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 			this.hasMore.set(result.length >= this.pageSize());
 
 			requestAnimationFrame(() => {
-				if (el) el.scrollTop = prevScrollHeight;
+				if (el) el.scrollTop = Math.max(prevScrollHeight - el.clientHeight, 0);
 			});
 		} catch (error) {
 			console.error('Failed to load older log entries', error);

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
@@ -81,7 +81,7 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 			if (!items) return;
 
 			const el = this.scrollContainer()?.nativeElement;
-			const prevScrollHeight = el?.scrollTop ?? 0;
+			const prevScrollHeight = el?.scrollHeight ?? 0;
 
 			this.allItems.set(items);
 
@@ -92,7 +92,7 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 					el.scrollTo({ top: 0, behavior: 'smooth' });
 				} else if (this.isLoadingMore()) {
 					// Loading older entries: keep the viewport anchored so content doesn't jump
-					el.scrollTop = prevScrollHeight;
+					el.scrollTop += el.scrollHeight - prevScrollHeight;
 				}
 			});
 		});

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
@@ -81,7 +81,7 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 			if (!items) return;
 
 			const el = this.scrollContainer()?.nativeElement;
-			const prevScrollHeight = el?.scrollHeight ?? 0;
+			const prevScrollHeight = el?.scrollTop ?? 0;
 
 			this.allItems.set(items);
 
@@ -89,10 +89,10 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 				if (!el) return;
 				if (this.isFollowing() && !this.isLoadingMore()) {
 					// Follow mode: always pin to the newest entry
-					el.scrollTop = el.scrollHeight;
+					el.scrollTo({ top: 0, behavior: 'smooth' });
 				} else if (this.isLoadingMore()) {
 					// Loading older entries: keep the viewport anchored so content doesn't jump
-					el.scrollTop = el.scrollHeight - prevScrollHeight;
+					el.scrollTop = prevScrollHeight;
 				}
 			});
 		});
@@ -107,7 +107,7 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 		// If the user re-enables following, jump to bottom immediately
 		if (next) {
 			const el = this.scrollContainer()?.nativeElement;
-			if (el) el.scrollTop = el.scrollHeight;
+			if (el) el.scrollTo({ top: 0, behavior: 'smooth' });
 		}
 	}
 
@@ -154,7 +154,7 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 
 	onScroll(event: Event): void {
 		const el = event.target as HTMLElement;
-		if (el.scrollTop <= 20 && !this.isLoadingMore() && this.hasMore() && !this.isLoading()) {
+		if (el.scrollTop + el.clientHeight >= el.scrollHeight - 20 && !this.isLoadingMore() && this.hasMore() && !this.isLoading()) {
 			this.loadOlderEntries();
 		}
 	}
@@ -177,7 +177,7 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 			this.hasMore.set(result.length >= this.pageSize());
 
 			requestAnimationFrame(() => {
-				if (el) el.scrollTop = el.scrollHeight - prevScrollHeight;
+				if (el) el.scrollTop = prevScrollHeight;
 			});
 		} catch (error) {
 			console.error('Failed to load older log entries', error);

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
@@ -175,10 +175,6 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 			);
 
 			this.hasMore.set(result.length >= this.pageSize());
-
-			requestAnimationFrame(() => {
-				if (el) el.scrollTop = Math.max(prevScrollHeight - el.clientHeight, 0);
-			});
 		} catch (error) {
 			console.error('Failed to load older log entries', error);
 			// Roll back the page increment so the next attempt requests the correct page.

--- a/packages/desktop-ui-lib/src/lib/logger/logger.service.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.service.ts
@@ -11,7 +11,7 @@ export class LoggerService {
 		private readonly _auditLogService: AuditLogService
 	) {
 		this._electronService.ipcRenderer.on('AUDIT_LOG_ENTRY', (_, logEntry: ILogItems) => {
-			this.logs$.next([...this.logs$.getValue(), logEntry]);
+			this.logs$.next([logEntry, ...this.logs$.getValue()]);
 		});
 	}
 
@@ -22,7 +22,7 @@ export class LoggerService {
 
 	private async getLogs(level: string, service: string, page: number, limit: number): Promise<ILogItems[]> {
 		const logsResult = await this._auditLogService.getAuditLogs(level, service, page, limit);
-		const logsSorted = logsResult.data.sort((a: ILogItems, b: ILogItems) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+		const logsSorted = logsResult.data.sort((a: ILogItems, b: ILogItems) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 		return logsSorted;
 	}
 
@@ -30,7 +30,7 @@ export class LoggerService {
 		const logsResult = await this.getLogs(level, service, page, limit);
 		// Older entries (higher page numbers) must be prepended so the list stays
 		// chronological: oldest at the top, newest at the bottom.
-		this.logs$.next([...logsResult, ...this.logs$.getValue()]);
+		this.logs$.next([...this.logs$.getValue(), ...logsResult]);
 		return logsResult;
 	}
 

--- a/packages/desktop-ui-lib/src/lib/logger/logger.service.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.service.ts
@@ -29,7 +29,7 @@ export class LoggerService {
 	public async nextPage(level: string, service: string, page: number, limit: number): Promise<ILogItems[]> {
 		const logsResult = await this.getLogs(level, service, page, limit);
 		// Older entries (higher page numbers) must be prepended so the list stays
-		// chronological: oldest at the top, newest at the bottom.
+		// chronological: newest at the top, oldest at the bottom.
 		this.logs$.next([...this.logs$.getValue(), ...logsResult]);
 		return logsResult;
 	}

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
@@ -79,8 +79,8 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 	async platformSet() {
 		const platform = await this.permissionService.getPlatform();
 		const hardwareAccelerationDisabled = await this.permissionService.getHardwareAccelerationState();
-		this.isMac.set(platform === 'darwin');
-		this.isWindows.set(platform === 'win32');
+		this.isMac.set(platform.os === 'darwin');
+		this.isWindows.set(platform.os === 'win32');
 		this.hardwareAccelerationDisabled.set(hardwareAccelerationDisabled);
 	}
 

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
@@ -79,8 +79,8 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 	async platformSet() {
 		const platform = await this.permissionService.getPlatform();
 		const hardwareAccelerationDisabled = await this.permissionService.getHardwareAccelerationState();
-		this.isMac.set(platform.os === 'darwin');
-		this.isWindows.set(platform.os === 'win32');
+		this.isMac.set(platform?.os === 'darwin');
+		this.isWindows.set(platform?.os === 'win32');
 		this.hardwareAccelerationDisabled.set(hardwareAccelerationDisabled);
 	}
 

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.service.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.service.ts
@@ -100,7 +100,7 @@ export class PermissionManagerService {
 		this.electronService.ipcRenderer.invoke('RELAUNCH_APP');
 	}
 
-	/** Returns the current OS platform (e.g. 'darwin', 'win32', 'linux'). */
+	/** Returns the current OS platform information including os, architecture, and system version. */
 	getPlatform(): Promise<IOSInfo> {
 		return this.electronService.ipcRenderer.invoke('GET_PLATFORM');
 	}

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.service.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.service.ts
@@ -13,6 +13,7 @@ import {
 	tap
 } from 'rxjs';
 import { ElectronService } from '../electron/services';
+import { IOSInfo } from '@gauzy/contracts';
 
 type PermissionStatus = 'granted' | 'denied' | 'not-determined' | 'restricted' | 'unknown';
 
@@ -100,7 +101,7 @@ export class PermissionManagerService {
 	}
 
 	/** Returns the current OS platform (e.g. 'darwin', 'win32', 'linux'). */
-	getPlatform(): Promise<'darwin' | 'win32' | 'linux'> {
+	getPlatform(): Promise<IOSInfo> {
 		return this.electronService.ipcRenderer.invoke('GET_PLATFORM');
 	}
 

--- a/packages/desktop-ui-lib/src/lib/settings/settings.component.html
+++ b/packages/desktop-ui-lib/src/lib/settings/settings.component.html
@@ -1111,9 +1111,11 @@
 							<img [src]="gauzyIcon" class="margin-icon" />
 						</div>
 						<div class="col-12 version-text">
-							<span>{{ 'TIMER_TRACKER.VERSION' | translate: { version } }}</span>
 							<div>
-								<span>{{ 'TIMER_TRACKER.ARCHITECTURE' | translate: { arch } }}</span>
+								<span>{{ 'TIMER_TRACKER.VERSION' | translate: { version } }}</span>
+							</div>
+							<div>
+								<span>{{ 'TIMER_TRACKER.OS' | translate: { os, arch, systemVersion } }}</span>
 							</div>
 						</div>
 						<div class="col-12 copyright-text text-center">

--- a/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
@@ -1406,14 +1406,14 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 	}
 
 	public get os(): NodeJS.Platform {
-		return this.platformInfo.os;
+		return this.platformInfo?.os;
 	}
 
 	public get arch(): string {
-		return this.platformInfo.arch;
+		return this.platformInfo?.arch;
 	}
 
 	public get systemVersion() {
-		return this.platformInfo.version;
+		return this.platformInfo?.version;
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
+++ b/packages/desktop-ui-lib/src/lib/settings/settings.component.ts
@@ -13,7 +13,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { DEFAULT_SCREENSHOT_FREQUENCY_OPTIONS } from '@gauzy/constants';
-import { LanguagesEnum } from '@gauzy/contracts';
+import { IOSInfo, LanguagesEnum } from '@gauzy/contracts';
 import {
 	NbAccordionModule,
 	NbButtonModule,
@@ -448,7 +448,6 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 		autoStart: true
 	};
 	version = '0.0.0';
-	arch = '';
 	message = {
 		text: 'TIMER_TRACKER.SETTINGS.MESSAGES.APP_UPDATE',
 		status: 'basic'
@@ -505,7 +504,7 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 	private _isHidden$: BehaviorSubject<boolean>;
 	private _simpleScreenshotNotification$: BehaviorSubject<boolean>;
 	private _timeZoneManager = TimeZoneManager;
-	private platformOS: string;
+	private platformInfo: Partial<IOSInfo> = {};
 
 	constructor(
 		private electronService: ElectronService,
@@ -562,7 +561,7 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 		// this.electronService.ipcRenderer.send('request_permission');
 		this.electronService.ipcRenderer.once('get-arch', (_, arg) => {
 			this._ngZone.run(() => {
-				this.arch = arg;
+				this.platformInfo.arch = arg;
 			});
 		});
 		this.setPlatform();
@@ -593,8 +592,8 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 	}
 
 	async setPlatform() {
-		const platform = await this.electronService.ipcRenderer.invoke('GET_PLATFORM');
-		this.platformOS = platform;
+		const platform: IOSInfo = await this.electronService.ipcRenderer.invoke('GET_PLATFORM');
+		this.platformInfo = platform;
 	}
 
 	ngOnDestroy(): void {
@@ -1404,5 +1403,17 @@ export class SettingsComponent implements OnInit, AfterViewInit, OnDestroy {
 				'Update ' + type.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase() + ' setting successfully'
 			);
 		}
+	}
+
+	public get os(): NodeJS.Platform {
+		return this.platformInfo.os;
+	}
+
+	public get arch(): string {
+		return this.platformInfo.arch;
+	}
+
+	public get systemVersion() {
+		return this.platformInfo.version;
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -1694,7 +1694,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		this._auditLogService.timerAuditLogInfo(`User attempted to ${val ? 'start' : 'stop'} the timer${onClick ? ' by clicking the button' : ''}${passed ? ' with pre-granted permissions' : ''}.`);
 		try {
 			const platform = await this.electronService.ipcRenderer.invoke('GET_PLATFORM');
-			if (val && onClick && !passed && platform === 'darwin') {
+			if (val && onClick && !passed && platform?.os === 'darwin') {
 				const allow = await this.checkPermission();
 				if (!allow) {
 					return;

--- a/packages/ui-core/i18n/assets/i18n/ar.json
+++ b/packages/ui-core/i18n/assets/i18n/ar.json
@@ -4359,6 +4359,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "للحصول على تتبع وقت ونشاط أكثر مرونة، يُرجى <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">تنزيل</a> واستخدام <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">تطبيق مؤقت سطح المكتب غاوزي</a>.",
 		"STATUS": "يعمل متتبع الوقت بالفعل في {{ source }}",
 		"VERSION": "الإصدار v{{ version }}",
+		"OS": "نظام التشغيل: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "البنية: {{ arch }}",
 		"WAIT_FOR": "في انتظار {{ name }} للبدء...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/bg.json
+++ b/packages/ui-core/i18n/assets/i18n/bg.json
@@ -4423,6 +4423,7 @@
 		"STATUS": "Проследяването на времето вече работи в {{ source }}",
 		"VERSION": "Версия v{{ version }}",
 		"ARCHITECTURE": "Архитектура: {{ arch }}",
+		"OS": "ОС: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"WAIT_FOR": "Изчаква се {{ name }} да започне...",
 		"SETUP": {
 			"WELCOME": "Добре дошли",

--- a/packages/ui-core/i18n/assets/i18n/de.json
+++ b/packages/ui-core/i18n/assets/i18n/de.json
@@ -4370,6 +4370,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "Für eine flexiblere Zeit- und Aktivitätsverfolgung laden Sie bitte die <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">Gauzy Desktop Timer App</a> herunter und verwenden Sie diese.",
 		"STATUS": "Der Zeitverfolger läuft bereits in der {{ source }}.",
 		"VERSION": "Version v{{ version }}",
+		"OS": "OS: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Architektur: {{ arch }}",
 		"WAIT_FOR": "Warten auf den Beginn von {{ name }}...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -4521,6 +4521,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "For more flexible time and activity tracking, please <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">Download</a> and use the <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">Gauzy Desktop Timer App</a>.",
 		"STATUS": "The time tracker is already running in the {{ source }}",
 		"VERSION": "Version v{{ version }}",
+		"OS": "OS: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Architecture: {{ arch }}",
 		"WAIT_FOR": "Waiting for {{ name }} to start...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/es.json
+++ b/packages/ui-core/i18n/assets/i18n/es.json
@@ -4376,6 +4376,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "Para un seguimiento más flexible del tiempo y las actividades, por favor <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">descargue</a> y utilice la <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">Aplicación de temporizador de escritorio Gauzy</a>.",
 		"STATUS": "El rastreador de tiempo ya está en funcionamiento en {{ source }}.",
 		"VERSION": "Versión v{{ version }}",
+		"OS": "OS: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Arquitectura: {{ arch }}",
 		"WAIT_FOR": "Esperando a {{name}} para empezar...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/fr.json
+++ b/packages/ui-core/i18n/assets/i18n/fr.json
@@ -4365,6 +4365,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "Pour un suivi du temps et des activités plus flexible, veuillez <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">télécharger</a> et utiliser l'application de chronomètre Gauzy pour ordinateur.",
 		"STATUS": "Le suivi du temps est déjà en cours dans {{ source }}.",
 		"VERSION": "Version v{{ version }}",
+		"OS": "OS: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Architecture: {{ arch }}",
 		"WAIT_FOR": "En attendant que {{ name }} commence...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/he.json
+++ b/packages/ui-core/i18n/assets/i18n/he.json
@@ -4386,6 +4386,7 @@
 		"TODAY": "היום",
 		"STATUS": "גשש הזמן כבר פועל ב- {{ source }}",
 		"VERSION": "גרסה v{{ version }}",
+		"OS": "מערכת הפעלה: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "ארכיטקטורה: {{ arch }}",
 		"WAIT_FOR": "ממתין ש-{{ name }} יתחיל...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/it.json
+++ b/packages/ui-core/i18n/assets/i18n/it.json
@@ -4374,6 +4374,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "Per una registrazione del tempo e delle attività più flessibile, ti preghiamo di <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">scaricare</a> e utilizzare l'applicazione Gauzy Timer per Desktop",
 		"STATUS": "Il tracker di tempo è già in funzione nel {{ source }}",
 		"VERSION": "Versione v{{ version }}",
+		"OS": "OS: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Architettura: {{ arch }}",
 		"WAIT_FOR": "In attesa che {{ name }} inizi..",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/nl.json
+++ b/packages/ui-core/i18n/assets/i18n/nl.json
@@ -4374,6 +4374,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "Voor meer flexibele tijd- en activiteitenregistratie, gelieve <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">te downloaden</a> en gebruik te maken van de <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">Gauzy Desktop Timer App</a>.",
 		"STATUS": "De tijdsregistratie is al actief in de {{ source }}",
 		"VERSION": "Versie v{{ version }}",
+		"OS": "OS: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Architectuur: {{ arch }}",
 		"WAIT_FOR": "Wachten op {{ name }} om te beginnen...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/pl.json
+++ b/packages/ui-core/i18n/assets/i18n/pl.json
@@ -4373,6 +4373,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "Aby uzyskać bardziej elastyczne śledzenie czasu i aktywności, proszę <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">pobrać</a> i używać <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">aplikacji Gauzy Desktop Timer</a>",
 		"STATUS": "Śledzenie czasu jest już uruchomione w {{ source }}",
 		"VERSION": "Wersja v{{ version }}",
+		"OS": "OS: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Architektura: {{ arch }}",
 		"WAIT_FOR": "Oczekiwanie na rozpoczęcie przez {{ name }}..",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/pt.json
+++ b/packages/ui-core/i18n/assets/i18n/pt.json
@@ -4374,6 +4374,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "Para um acompanhamento de tempo e atividades mais flexível, por favor, faça o <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">Download</a> e utilize o <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">Aplicativo Gauzy Desktop Timer</a>.",
 		"STATUS": "O rastreador de tempo já está em execução em {{ source }}.",
 		"VERSION": "Versão v{{ version }}",
+		"OS": "OS: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Arquitetura: {{ arch }}",
 		"WAIT_FOR": "Aguardando {{name}} começar...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/ru.json
+++ b/packages/ui-core/i18n/assets/i18n/ru.json
@@ -4392,6 +4392,7 @@
 		"TODAY": "Сегодня",
 		"STATUS": "Тайм-трекер уже работает в {{ source }}",
 		"VERSION": "Версия v{{ version }}",
+		"OS": "ОС: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "Архитектура: {{ arch }}",
 		"WAIT_FOR": "Ожидание запуска {{ name }}...",
 		"SETUP": {

--- a/packages/ui-core/i18n/assets/i18n/zh.json
+++ b/packages/ui-core/i18n/assets/i18n/zh.json
@@ -4374,6 +4374,7 @@
 		"ALERT_DESKTOP_DOWNLOAD": "为了更灵活地跟踪时间和活动，请<a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">下载并使用</a> <a href={{downloadURL}} rel=\"noopener\" target=\"_blank\">Gauzy桌面计时器应用</a>。",
 		"STATUS": "时间跟踪器已经在{{source}}中运行。",
 		"VERSION": "版本 v{{ version }}",
+		"OS": "操作系统: {{ os }} {{ systemVersion }} ({{ arch }})",
 		"ARCHITECTURE": "架构: {{ arch }}",
 		"WAIT_FOR": "等待{{ name }}开始...",
 		"SETUP": {


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show full OS details in About and Settings, and update the audit log to show newest-first with smoother follow and bottom-triggered infinite scroll.

- **New Features**
  - `GET_PLATFORM` now returns `IOSInfo` `{ os, arch, version }` via `getOSInfo()` in `@gauzy/desktop-lib` and `@gauzy/contracts`.
  - About and Settings display “OS: {{ os }} {{ systemVersion }} ({{ arch }})” using `TIMER_TRACKER.OS`; Permission Manager, Time Tracker, and Settings consume `IOSInfo`.

- **Bug Fixes**
  - Logs sorted newest-first; live entries are prepended, and pagination appends older pages.
  - Follow mode keeps view at the top; infinite scroll loads older entries when you reach the bottom with stable anchoring.
  - Spinners and boundary markers moved below the list to reduce layout jumps.

<sup>Written for commit 54f99c4fa7c3bc5be4681ae981372a909bbe3105. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

