### PR TITLE
feat: desktop timer visible session timer list

### DIFF
--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -1535,7 +1535,6 @@ export function ipcTimer(
 			return timerSessions;
 		} catch (error) {
 			log.error('Error on get timer sessions', error);
-			throw new UIError('500', error, 'IPCGETTIMSESS');
 		}
 	});
 

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -1632,7 +1632,9 @@ export function removeTimerHandlers() {
 		'CURRENT_TIMER',
 		'LAST_SYNCED_INTERVAL',
 		'UPDATE_SELECTOR',
-		'UPDATE_SYNC_STATE'
+		'UPDATE_SYNC_STATE',
+		'GET_TIMER_SESSIONS',
+		'GET_TIMER_SESSION'
 	];
 	channels.forEach((channel: string) => {
 		ipcMain.removeHandler(channel);

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -1248,7 +1248,7 @@ export function ipcTimer(
 	ipcMain.handle(
 		'UPDATE_SYNC_STATE',
 		async (
-			event,
+			_,
 			arg: {
 				actionType: TimerActionTypeEnum;
 				data: {
@@ -1261,7 +1261,7 @@ export function ipcTimer(
 		) => {
 			try {
 				await getTimerHandler().updateTimerSyncState(arg.actionType, arg.data);
-				event.sender.send('TIMER_SESSION_UPDATED');
+				timeTrackerWindow.webContents.send('TIMER_SESSION_UPDATED');
 			} catch (error) {
 				console.error(`ERROR_UPDATE_SYNC_STATE: ${error}`);
 			}

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -830,7 +830,7 @@ export function ipcTimer(
 				log.info(`StartInactivityDetection: ${moment().format()}`);
 				powerManagerDetectInactivity.startInactivityDetection();
 			}
-
+			timeTrackerWindow.webContents.send('TIMER_SESSION_UPDATED');
 			return timerResponse;
 		} catch (error) {
 			log.error('Error on start timer', error);
@@ -1076,6 +1076,7 @@ export function ipcTimer(
 			});
 
 			cleanupPowerManagers();
+			timeTrackerWindow.webContents.send('TIMER_SESSION_UPDATED');
 
 			return timerResponse;
 		} catch (error) {
@@ -1247,18 +1248,20 @@ export function ipcTimer(
 	ipcMain.handle(
 		'UPDATE_SYNC_STATE',
 		async (
-			_,
+			event,
 			arg: {
 				actionType: TimerActionTypeEnum;
 				data: {
 					state: TimerSyncStateEnum;
 					duration: number;
 					timerId: number;
+					timelogId?: string;
 				};
 			}
 		) => {
 			try {
 				await getTimerHandler().updateTimerSyncState(arg.actionType, arg.data);
+				event.sender.send('TIMER_SESSION_UPDATED');
 			} catch (error) {
 				console.error(`ERROR_UPDATE_SYNC_STATE: ${error}`);
 			}
@@ -1521,6 +1524,29 @@ export function ipcTimer(
 		);
 		desktopPermissionHandler.showDialogPermissionConfirm();
 	});
+
+	ipcMain.handle('GET_TIMER_SESSIONS', async ( _, args: { start: Date | string; end: Date | string }) => {
+		try {
+			const range = {
+				start: new Date(args.start),
+				end: new Date(args.end),
+			};
+			const timerSessions = await getTimerService().getListByDate(range);
+			return timerSessions;
+		} catch (error) {
+			log.error('Error on get timer sessions', error);
+			throw new UIError('500', error, 'IPCGETTIMSESS');
+		}
+	});
+
+	ipcMain.handle('GET_TIMER_SESSION', async ( _, args: { timerSessionId: number }) => {
+		try {
+			const timerSession = await getTimerService().findById({ id: args.timerSessionId });
+			return timerSession;
+		} catch (error) {
+			return null;
+		}
+	})
 }
 
 export function removeMainListener() {

--- a/packages/desktop-lib/src/lib/desktop-timer.ts
+++ b/packages/desktop-lib/src/lib/desktop-timer.ts
@@ -856,6 +856,7 @@ export default class TimerHandler {
 			state: TimerSyncStateEnum;
 			duration: number;
 			timerId: number;
+			timelogId?: string;
 		}
 	) {
 		const lastTimer = await this._timerService.findById({ id: data.timerId });
@@ -875,7 +876,8 @@ export default class TimerHandler {
 			new Timer({
 				...lastTimer,
 				...(type === 'startTimer' ? { startSyncState: data.state } : { stopSyncState: data.state }),
-				...(data.duration ? { syncDuration: data.duration } : {})
+				...(data.duration ? { syncDuration: data.duration } : {}),
+				...(typeof data.timelogId !== 'undefined' ? { timelogId: data.timelogId } : {})
 			})
 		);
 		await this._auditLogHandler.timerAuditInfo(

--- a/packages/desktop-lib/src/lib/offline/dao/timer.dao.ts
+++ b/packages/desktop-lib/src/lib/offline/dao/timer.dao.ts
@@ -210,4 +210,22 @@ export class TimerDAO implements DAO<TimerTO> {
 			)
 			.andWhere('synced', true);
 	}
+
+	public async findByDate(employeeId: string, date: { start: Date; end: Date }): Promise<TimerTO[]> {
+		const toLocalDateString = (d: Date): string => {
+			const y = d.getFullYear();
+			const m = String(d.getMonth() + 1).padStart(2, '0');
+			const day = String(d.getDate()).padStart(2, '0');
+			return `${y}-${m}-${day}`;
+		};
+		const startDate = toLocalDateString(date.start);
+		const endDate = toLocalDateString(date.end);
+		return await this._provider
+			.connection<TimerTO>(TABLE_NAME_TIMERS)
+			.where('employeeId', employeeId)
+			.whereRaw("date(startedAt/1000, 'unixepoch', 'localtime') >= ?", [startDate])
+			.whereRaw("date(startedAt/1000, 'unixepoch', 'localtime') <= ?", [endDate])
+			.whereNotNull('startedAt')
+			.orderBy('startedAt', 'desc');
+	}
 }

--- a/packages/desktop-lib/src/lib/offline/services/timer.service.ts
+++ b/packages/desktop-lib/src/lib/offline/services/timer.service.ts
@@ -177,4 +177,17 @@ export class TimerService implements ITimerService<TimerTO> {
 			return [];
 		}
 	}
+
+	public async getListByDate(date: { start: Date; end: Date }): Promise<TimerTO[]> {
+		try {
+			const user = await this._userService.retrieve();
+			if (user && user.employeeId) {
+				return await this._timerDAO.findByDate(user.employeeId, date);
+			}
+			return [];
+		} catch (error) {
+			console.error('Failed to get timer list by date', error);
+			return [];
+		}
+	}
 }

--- a/packages/desktop-ui-lib/src/lib/recap/recap-children-routing.module.ts
+++ b/packages/desktop-ui-lib/src/lib/recap/recap-children-routing.module.ts
@@ -27,6 +27,10 @@ export const recapChildRoutes: Routes = [
 		loadComponent: () => import('./features/projects/projects.component').then((m) => m.ProjectsComponent)
 	},
 	{
+		path: 'sessions-list',
+		loadComponent: () => import('../time-tracker/timer-session/timer-session.component').then((m) => m.TimerSessionComponent)
+	},
+	{
 		path: '**',
 		redirectTo: 'hourly'
 	}

--- a/packages/desktop-ui-lib/src/lib/recap/recap-routing.module.ts
+++ b/packages/desktop-ui-lib/src/lib/recap/recap-routing.module.ts
@@ -26,6 +26,11 @@ export const recapRoutes: Routes = [
 		loadChildren: () => import('../time-tracker/task-table/task-table.module').then((m) => m.TaskTableModule)
 	},
 	{
+		path: 'sessions-list',
+		loadComponent: () =>
+			import('../time-tracker/timer-session/timer-session.component').then((m) => m.TimerSessionComponent)
+	},
+	{
 		path: '**',
 		redirectTo: ''
 	}

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2810,6 +2810,11 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			disabled: this._isOffline
 		},
 		{
+			title: this._translateService.instant('MENU.SESSIONS'),
+			route: ['/', 'time-tracker', 'sessions-list'],
+			activeLinkOptions: { exact: false },
+		},
+		{
 			title: this._translateService.instant('TIMER_TRACKER.MENU.DAILY_RECAP'),
 			route: ['/', 'time-tracker', 'daily'],
 			activeLinkOptions: { exact: false },

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2810,7 +2810,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			disabled: this._isOffline
 		},
 		{
-			title: this._translateService.instant('MENU.SESSIONS'),
+			title: this._translateService.instant('TIMER_TRACKER.MENU.SESSIONS'),
 			route: ['/', 'time-tracker', 'sessions-list'],
 			activeLinkOptions: { exact: false },
 		},

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.html
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.html
@@ -1,0 +1,93 @@
+<div class="wrap">
+	<div class="page-head">
+		<div>
+			<div class="page-title">Session list</div>
+			<div class="page-meta">
+				{{ dateLabel() }} · {{ filteredSessions().length }} sessions.
+			</div>
+		</div>
+		<div class="page-actions">
+			<ngx-date-range-picker
+				[isLockDatePicker]="true"
+				[arrows]="true"
+				[isSingleDatePicker]="true"
+				[isDisableFutureDatePicker]="true"
+				class="medium"
+				(rangeChanges)="onRangeChange($event)"
+				[dates]="selectedRange"
+			></ngx-date-range-picker>
+		</div>
+	</div>
+
+	<div class="filter-bar">
+		@for (f of filterOptions; track f.value) {
+			<button class="filter-chip" [class.active]="statusFilter() === f.value" (click)="setFilter(f.value)">
+				{{ f.label }}
+			</button>
+		}
+	</div>
+
+	<div class="session-list">
+		@if (filteredSessions().length > 0) {
+			@for (s of filteredSessions(); track s.id) {
+				<div class="session-row">
+					<div class="session-body">
+						<div class="row-top">
+							<span class="task-name">{{ s.taskName || 'No Task' }}</span>
+
+							<div class="row-top-right">
+								@if (s.statusSync === 'removed') {
+									<button class="retry-btn" (click)="retrySync(s, $event)">
+										<nb-icon icon="refresh-outline"></nb-icon> Retry
+									</button>
+								} @else if (s.statusSync !== 'removed') {
+									<span class="sync-badge" [ngClass]="syncConfig[s.statusSync]?.cssClass">
+										<nb-icon
+											[icon]="syncConfig[s.statusSync]?.icon"
+											[class.spin]="s.statusSync === 'syncing'"
+										></nb-icon>
+										{{ syncConfig[s.statusSync]?.label }}
+									</span>
+								}
+							</div>
+						</div>
+						<div class="row-meta">
+							<div class="meta-item">
+								<nb-icon icon="folder-outline" class="meta-icon"></nb-icon>
+								<span class="badge">
+									{{ s.projectName || 'No project' }}
+								</span>
+							</div>
+
+							<span class="meta-sep">·</span>
+
+							<div class="meta-item">
+								<nb-icon icon="person-outline" class="meta-icon"></nb-icon>
+								<span>{{ s.clientName || 'No Client' }}</span>
+							</div>
+
+							<span class="meta-sep">·</span>
+
+							<div class="meta-item">
+								<nb-icon icon="clock-outline" class="meta-icon"></nb-icon>
+								<span class="meta-dur">{{ formatSeconds(s.syncDuration || s.duration / 1000) }}</span>
+							</div>
+
+							<span class="meta-sep">·</span>
+
+							<div class="meta-item timestamps">
+								<nb-icon icon="play-circle-outline" class="meta-icon"></nb-icon>
+								<span>{{ formatDatetime(s.startedAt) }}</span>
+								<nb-icon icon="arrow-forward-outline" class="meta-icon arrow"></nb-icon>
+								<nb-icon icon="stop-circle-outline" class="meta-icon"></nb-icon>
+								<span>{{ formatDatetime(s.stoppedAt) }}</span>
+							</div>
+						</div>
+					</div>
+				</div>
+			}
+		} @else {
+			<div class="empty-state">No sessions match your filter</div>
+		}
+	</div>
+</div>

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.html
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.html
@@ -1,102 +1,117 @@
-<div class="wrap">
-	<div class="page-head">
-		<div>
-			<div class="page-title">{{'TIMER_TRACKER.SESSION_LIST' | translate}}</div>
-			<div class="page-meta">{{ dateLabel() }} · {{ filteredSessions().length }} {{ 'TIMER_TRACKER.SESSION' | translate }}.</div>
-		</div>
-		<div class="page-actions">
-			<ngx-date-range-picker
-				[isLockDatePicker]="true"
-				[arrows]="true"
-				[isSingleDatePicker]="true"
-				[isDisableFutureDatePicker]="true"
-				class="medium"
-				(rangeChanges)="onRangeChange($event)"
-				[dates]="selectedRange"
-			></ngx-date-range-picker>
-		</div>
-	</div>
-
-	<div class="filter-bar">
-		@for (f of filterOptions; track f.value) {
-			<button class="filter-chip" [class.active]="statusFilter() === f.value" (click)="setFilter(f.value)">
-				{{ f.label }}
-			</button>
-		}
-	</div>
-
-	<div class="session-list">
-		@if (filteredSessions().length > 0) {
-			@for (s of filteredSessions(); track s.id) {
-				<div class="session-row" [class.running]="s.statusSync === 'running'">
-					<div class="color-bar" [ngClass]="getColorBar(s.statusSync)"></div>
-					@if (s.statusSync === 'running') {
-						<div class="live-dot"></div>
-					}
-					<div class="session-body">
-						<div class="row-top">
-							<span class="task-name">{{ s.taskName || 'No Task' }}</span>
-
-							<div class="row-top-right">
-								<span class="dur-local" [class.live]="s.statusSync === 'running'">{{
-									formatSeconds(s.duration / 1000)
-								}}</span>
-							</div>
-						</div>
-						<div class="row-bottom">
-							<div class="row-meta">
-								<div class="meta-item">
-									<nb-icon icon="folder-outline" class="meta-icon"></nb-icon>
-									<span class="badge">
-										{{ s.projectName || 'No project' }}
-									</span>
-								</div>
-
-								<span class="meta-sep">·</span>
-
-								<div class="meta-item">
-									<nb-icon icon="person-outline" class="meta-icon"></nb-icon>
-									<span>{{ s.clientName || 'No Client' }}</span>
-								</div>
-
-								<span class="meta-sep">·</span>
-
-								<div class="meta-item timestamps">
-									<nb-icon icon="play-circle-outline" class="meta-icon"></nb-icon>
-									<span>{{ formatDatetime(s.startedAt) }}</span>
-									<nb-icon icon="arrow-forward-outline" class="meta-icon arrow"></nb-icon>
-									<nb-icon icon="stop-circle-outline" class="meta-icon"></nb-icon>
-									<span>{{ formatDatetime(s.stoppedAt) }}</span>
-								</div>
-							</div>
-
-							<div class="row-bottom-right">
-								@if (s.statusSync === 'synced') {
-									<span class="dur-server cloud-time status-synced">
-										<i class="fa-regular fa-cloud"></i>
-										{{ formatSeconds(s.syncDuration) }}
-									</span>
-								} @else if (s.statusSync === 'removed') {
-									<button
-										class="retry-btn"
-										(click)="retrySync(s, $event)"
-										[disabled]="onRetry()"
-									>
-										<nb-icon icon="refresh-outline" [class.spin]="onRetry()"></nb-icon> Retry
-									</button>
-								} @else {
-									<span class="dur-server cloud-time status-pending">
-										<nb-icon icon="clock-outline"></nb-icon>
-										--
-									</span>
-								}
-							</div>
-						</div>
+<nb-layout>
+	<nb-layout-column>
+		@let sessionList = filteredSessions();
+		<nb-card class="session-card">
+			<nb-card-header class="page-head">
+				<div>
+					<div class="page-title">{{ 'TIMER_TRACKER.SESSION_LIST' | translate }}</div>
+					<div class="page-meta">
+						{{ dateLabel() }} · {{ sessionList.length }} {{ 'TIMER_TRACKER.SESSION' | translate }}.
 					</div>
 				</div>
-			}
-		} @else {
-			<div class="empty-state">No sessions match your filter</div>
-		}
-	</div>
-</div>
+				<div class="page-actions">
+					<ngx-date-range-picker
+						[isLockDatePicker]="true"
+						[arrows]="true"
+						[isSingleDatePicker]="true"
+						[isDisableFutureDatePicker]="true"
+						class="medium"
+						(rangeChanges)="onRangeChange($event)"
+						[dates]="selectedRange"
+					></ngx-date-range-picker>
+				</div>
+			</nb-card-header>
+
+			<nb-card-body>
+				<div class="filter-bar">
+					@for (f of filterOptions; track f.value) {
+						<button
+							type="button"
+							class="filter-chip"
+							[class.active]="statusFilter() === f.value"
+							(click)="setFilter(f.value)"
+						>
+							{{ f.label }}
+						</button>
+					}
+				</div>
+
+				<nb-list class="session-list">
+					@for (s of sessionList; track s.id) {
+						<nb-list-item class="session-row" [class.running]="s.statusSync === 'running'">
+							<div class="color-bar" [ngClass]="getColorBar(s.statusSync)"></div>
+							@if (s.statusSync === 'running') {
+								<div class="live-dot"></div>
+							}
+							<div class="session-body">
+								<div class="row-top">
+									<span class="task-name">{{ s.taskName || 'No Task' }}</span>
+
+									<div class="row-top-right">
+										<span class="dur-local" [class.live]="s.statusSync === 'running'">{{
+											formatSeconds(s.duration / 1000)
+										}}</span>
+									</div>
+								</div>
+								<div class="row-bottom">
+									<div class="row-meta">
+										<div class="meta-item">
+											<nb-icon icon="folder-outline" class="meta-icon"></nb-icon>
+											<span class="badge">
+												{{ s.projectName || 'No project' }}
+											</span>
+										</div>
+
+										<span class="meta-sep">·</span>
+
+										<div class="meta-item">
+											<nb-icon icon="person-outline" class="meta-icon"></nb-icon>
+											<span>{{ s.clientName || 'No Client' }}</span>
+										</div>
+
+										<span class="meta-sep">·</span>
+
+										<div class="meta-item timestamps">
+											<nb-icon icon="play-circle-outline" class="meta-icon"></nb-icon>
+											<span>{{ formatDatetime(s.startedAt) }}</span>
+											<nb-icon icon="arrow-forward-outline" class="meta-icon arrow"></nb-icon>
+											<nb-icon icon="stop-circle-outline" class="meta-icon"></nb-icon>
+											<span>{{ formatDatetime(s.stoppedAt) }}</span>
+										</div>
+									</div>
+
+									<div class="row-bottom-right">
+										@if (s.statusSync === 'synced') {
+											<span class="dur-server cloud-time status-synced">
+												<i class="fa-regular fa-cloud"></i>
+												{{ formatSeconds(s.syncDuration) }}
+											</span>
+										} @else if (s.statusSync === 'removed') {
+											<button
+												type="button"
+												class="retry-btn"
+												(click)="retrySync(s, $event)"
+												[disabled]="onRetry()"
+											>
+												<nb-icon icon="refresh-outline" [class.spin]="onRetry()"></nb-icon>
+												Retry
+											</button>
+										} @else {
+											<span class="dur-server cloud-time status-pending">
+												<nb-icon icon="clock-outline"></nb-icon>
+												--
+											</span>
+										}
+									</div>
+								</div>
+							</div>
+						</nb-list-item>
+					}
+					@if (sessionList.length <= 0) {
+						<nb-list-item class="empty-state">No sessions match your filter</nb-list-item>
+					}
+				</nb-list>
+			</nb-card-body>
+		</nb-card>
+	</nb-layout-column>
+</nb-layout>

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.html
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.html
@@ -1,10 +1,8 @@
 <div class="wrap">
 	<div class="page-head">
 		<div>
-			<div class="page-title">Session list</div>
-			<div class="page-meta">
-				{{ dateLabel() }} · {{ filteredSessions().length }} sessions.
-			</div>
+			<div class="page-title">{{'TIMER_TRACKER.SESSION_LIST' | translate}}</div>
+			<div class="page-meta">{{ dateLabel() }} · {{ filteredSessions().length }} {{ 'TIMER_TRACKER.SESSION' | translate }}.</div>
 		</div>
 		<div class="page-actions">
 			<ngx-date-range-picker
@@ -30,57 +28,68 @@
 	<div class="session-list">
 		@if (filteredSessions().length > 0) {
 			@for (s of filteredSessions(); track s.id) {
-				<div class="session-row">
+				<div class="session-row" [class.running]="s.statusSync === 'running'">
+					<div class="color-bar" [ngClass]="getColorBar(s.statusSync)"></div>
+					@if (s.statusSync === 'running') {
+						<div class="live-dot"></div>
+					}
 					<div class="session-body">
 						<div class="row-top">
 							<span class="task-name">{{ s.taskName || 'No Task' }}</span>
 
 							<div class="row-top-right">
-								@if (s.statusSync === 'removed') {
-									<button class="retry-btn" (click)="retrySync(s, $event)">
-										<nb-icon icon="refresh-outline"></nb-icon> Retry
-									</button>
-								} @else if (s.statusSync !== 'removed') {
-									<span class="sync-badge" [ngClass]="syncConfig[s.statusSync]?.cssClass">
-										<nb-icon
-											[icon]="syncConfig[s.statusSync]?.icon"
-											[class.spin]="s.statusSync === 'syncing'"
-										></nb-icon>
-										{{ syncConfig[s.statusSync]?.label }}
-									</span>
-								}
+								<span class="dur-local" [class.live]="s.statusSync === 'running'">{{
+									formatSeconds(s.duration / 1000)
+								}}</span>
 							</div>
 						</div>
-						<div class="row-meta">
-							<div class="meta-item">
-								<nb-icon icon="folder-outline" class="meta-icon"></nb-icon>
-								<span class="badge">
-									{{ s.projectName || 'No project' }}
-								</span>
+						<div class="row-bottom">
+							<div class="row-meta">
+								<div class="meta-item">
+									<nb-icon icon="folder-outline" class="meta-icon"></nb-icon>
+									<span class="badge">
+										{{ s.projectName || 'No project' }}
+									</span>
+								</div>
+
+								<span class="meta-sep">·</span>
+
+								<div class="meta-item">
+									<nb-icon icon="person-outline" class="meta-icon"></nb-icon>
+									<span>{{ s.clientName || 'No Client' }}</span>
+								</div>
+
+								<span class="meta-sep">·</span>
+
+								<div class="meta-item timestamps">
+									<nb-icon icon="play-circle-outline" class="meta-icon"></nb-icon>
+									<span>{{ formatDatetime(s.startedAt) }}</span>
+									<nb-icon icon="arrow-forward-outline" class="meta-icon arrow"></nb-icon>
+									<nb-icon icon="stop-circle-outline" class="meta-icon"></nb-icon>
+									<span>{{ formatDatetime(s.stoppedAt) }}</span>
+								</div>
 							</div>
 
-							<span class="meta-sep">·</span>
-
-							<div class="meta-item">
-								<nb-icon icon="person-outline" class="meta-icon"></nb-icon>
-								<span>{{ s.clientName || 'No Client' }}</span>
-							</div>
-
-							<span class="meta-sep">·</span>
-
-							<div class="meta-item">
-								<nb-icon icon="clock-outline" class="meta-icon"></nb-icon>
-								<span class="meta-dur">{{ formatSeconds(s.syncDuration || s.duration / 1000) }}</span>
-							</div>
-
-							<span class="meta-sep">·</span>
-
-							<div class="meta-item timestamps">
-								<nb-icon icon="play-circle-outline" class="meta-icon"></nb-icon>
-								<span>{{ formatDatetime(s.startedAt) }}</span>
-								<nb-icon icon="arrow-forward-outline" class="meta-icon arrow"></nb-icon>
-								<nb-icon icon="stop-circle-outline" class="meta-icon"></nb-icon>
-								<span>{{ formatDatetime(s.stoppedAt) }}</span>
+							<div class="row-bottom-right">
+								@if (s.statusSync === 'synced') {
+									<span class="dur-server cloud-time status-synced">
+										<i class="fa-regular fa-cloud"></i>
+										{{ formatSeconds(s.syncDuration) }}
+									</span>
+								} @else if (s.statusSync === 'removed') {
+									<button
+										class="retry-btn"
+										(click)="retrySync(s, $event)"
+										[disabled]="onRetry()"
+									>
+										<nb-icon icon="refresh-outline" [class.spin]="onRetry()"></nb-icon> Retry
+									</button>
+								} @else {
+									<span class="dur-server cloud-time status-pending">
+										<nb-icon icon="clock-outline"></nb-icon>
+										--
+									</span>
+								}
 							</div>
 						</div>
 					</div>

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.scss
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.scss
@@ -1,23 +1,23 @@
 // ── Variables ─────────────────────────────────────────────────
-$bg:          var(--gauzy-card-2);
-$surface:     #1e2340;
-$card:        #252b48;
-$border:      rgba(255, 255, 255, 0.08);
-$divider:     var(--devider-color);
-$text:        var(--gauzy-text-color-1);
-$hint:        #8f9bb3;
-$primary:     #3366ff;
+$bg: var(--gauzy-card-2);
+$surface: var(--gauzy-card-3);
+$card: #252b48;
+$border: rgba(255, 255, 255, 0.08);
+$divider: var(--devider-color);
+$text: var(--gauzy-text-color-1);
+$hint: #8f9bb3;
+$primary: #3366ff;
 $primary-dim: rgba(51, 102, 255, 0.12);
-$success:     #00d68f;
+$success: #00d68f;
 $success-dim: rgba(0, 214, 143, 0.12);
-$warning:     #ffaa00;
+$warning: #ffaa00;
 $warning-dim: rgba(255, 170, 0, 0.12);
-$danger:      #ff3d71;
-$danger-dim:  rgba(255, 61, 113, 0.12);
-$radius:      8px;
-$radius-lg:   12px;
-$info-dim:      rgba(0, 149, 255, 0.12);
-$info:          #0095ff;
+$danger: #ff3d71;
+$danger-dim: rgba(255, 61, 113, 0.12);
+$radius: 8px;
+$radius-lg: 12px;
+$info-dim: rgba(0, 149, 255, 0.12);
+$info: #0095ff;
 
 // ── Host ──────────────────────────────────────────────────────
 :host {
@@ -91,7 +91,9 @@ $info:          #0095ff;
     background: $primary;
     color: #fff;
 
-    &:hover { background: darken($primary, 8%); }
+    &:hover {
+      background: darken($primary, 8%);
+    }
   }
 }
 
@@ -155,7 +157,13 @@ $info:          #0095ff;
   &:hover {
     border-color: rgba(255, 255, 255, 0.14);
 
-    .row-actions { opacity: 1; }
+    .row-actions {
+      opacity: 1;
+    }
+  }
+
+  &.running {
+    border-color: rgba(0, 214, 143, 0.4);
   }
 }
 
@@ -164,6 +172,50 @@ $info:          #0095ff;
   height: 38px;
   border-radius: 0;
   flex-shrink: 0;
+
+  &.status-synced {
+    background: $info;
+  }
+
+  &.status-pending {
+    background: $warning;
+  }
+
+  &.status-syncing {
+    background: $info;
+  }
+
+  &.status-failed {
+    background: $danger;
+  }
+
+  &.status-removed {
+    background: $danger;
+  }
+  &.status-running {
+    background: $success;
+  }
+}
+
+.live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: $success;
+  flex-shrink: 0;
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.3;
+    transform: scale(0.7);
+  }
 }
 
 .session-info {
@@ -200,10 +252,26 @@ $info:          #0095ff;
   font-size: 11px;
   font-weight: 500;
 
-  &-blue   { background: $primary-dim;  color: #7b9fff; border: 1px solid rgba($primary,  0.2); }
-  &-green  { background: $success-dim;  color: $success; border: 1px solid rgba($success, 0.2); }
-  &-amber  { background: $warning-dim;  color: $warning; border: 1px solid rgba($warning, 0.2); }
-  &-red    { background: $danger-dim;   color: #ff7096;  border: 1px solid rgba($danger,  0.2); }
+  &-blue {
+    background: $primary-dim;
+    color: #7b9fff;
+    border: 1px solid rgba($primary, 0.2);
+  }
+  &-green {
+    background: $success-dim;
+    color: $success;
+    border: 1px solid rgba($success, 0.2);
+  }
+  &-amber {
+    background: $warning-dim;
+    color: $warning;
+    border: 1px solid rgba($warning, 0.2);
+  }
+  &-red {
+    background: $danger-dim;
+    color: #ff7096;
+    border: 1px solid rgba($danger, 0.2);
+  }
 }
 
 // ── Duration column ───────────────────────────────────────────
@@ -245,8 +313,12 @@ $info:          #0095ff;
   line-height: 1;
   transition: color 0.15s;
 
-  &:hover { color: $text; }
-  &.danger:hover { color: $danger; }
+  &:hover {
+    color: $text;
+  }
+  &.danger:hover {
+    color: $danger;
+  }
 }
 
 .session-body {
@@ -298,7 +370,9 @@ $info:          #0095ff;
   font-family: inherit;
   transition: background 0.15s;
 
-  nb-icon { font-size: 13px; }
+  nb-icon {
+    font-size: 13px;
+  }
 
   &:hover {
     background: $danger-dim;
@@ -316,7 +390,9 @@ $info:          #0095ff;
   font-weight: 500;
   white-space: nowrap;
 
-  nb-icon { font-size: 13px; }
+  nb-icon {
+    font-size: 13px;
+  }
 
   &.status-synced {
     background: $success-dim;
@@ -339,13 +415,27 @@ $info:          #0095ff;
 
 // Spinning icon for syncing state
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-nb-icon.spin { display: inline-block; animation: spin 1s linear infinite; }
+nb-icon.spin {
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
 
 // ── Row meta ──────────────────────────────────────────────────
+.row-bottom {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .row-meta {
   display: flex;
   align-items: center;
@@ -353,6 +443,13 @@ nb-icon.spin { display: inline-block; animation: spin 1s linear infinite; }
   gap: 6px;
   font-size: 12px;
   color: $hint;
+  flex: 1;
+}
+
+.row-bottom-right {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .meta-item {
@@ -360,14 +457,19 @@ nb-icon.spin { display: inline-block; animation: spin 1s linear infinite; }
   align-items: center;
   gap: 4px;
 
-  &.timestamps { gap: 5px; }
+  &.timestamps {
+    gap: 5px;
+  }
 }
 
 .meta-icon {
   font-size: 13px;
   opacity: 0.65;
 
-  &.arrow { font-size: 11px; opacity: 0.35; }
+  &.arrow {
+    font-size: 11px;
+    opacity: 0.35;
+  }
 }
 
 .meta-sep {
@@ -390,10 +492,41 @@ nb-icon.spin { display: inline-block; animation: spin 1s linear infinite; }
   font-size: 11px;
   font-weight: 500;
 
-  &-blue  { background: $primary-dim; color: #7b9fff;  border: 1px solid rgba(51,102,255,0.2); }
-  &-green { background: $success-dim; color: $success;  border: 1px solid rgba(0,214,143,0.2); }
-  &-amber { background: $warning-dim; color: $warning;  border: 1px solid rgba(255,170,0,0.2); }
-  &-red   { background: $danger-dim;  color: #ff7096;   border: 1px solid rgba(255,61,113,0.2); }
+  &-blue {
+    background: $primary-dim;
+    color: #7b9fff;
+    border: 1px solid rgba(51, 102, 255, 0.2);
+  }
+  &-green {
+    background: $success-dim;
+    color: $success;
+    border: 1px solid rgba(0, 214, 143, 0.2);
+  }
+  &-amber {
+    background: $warning-dim;
+    color: $warning;
+    border: 1px solid rgba(255, 170, 0, 0.2);
+  }
+  &-red {
+    background: $danger-dim;
+    color: #ff7096;
+    border: 1px solid rgba(255, 61, 113, 0.2);
+  }
+}
+
+.cloud-time {
+  &.status-synced {
+    color: $info;
+  }
+  &.status-pending {
+    color: $warning;
+  }
+  &.status-failed {
+    color: $danger;
+  }
+  &.status-running {
+    color: $success;
+  }
 }
 
 // ── Empty state ───────────────────────────────────────────────
@@ -410,16 +543,6 @@ nb-icon.spin { display: inline-block; animation: spin 1s linear infinite; }
   }
 }
 
-// ── Footer ────────────────────────────────────────────────────
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: 16px;
-  padding-top: 12px;
-  border-top: 1px solid $divider;
-}
-
 .footer-total {
   font-size: 13px;
   color: $hint;
@@ -431,84 +554,38 @@ nb-icon.spin { display: inline-block; animation: spin 1s linear infinite; }
   }
 }
 
-// ── Modal ─────────────────────────────────────────────────────
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 100;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.modal {
-  background: $surface;
-  border: 1px solid $border;
-  border-radius: $radius-lg;
-  padding: 24px;
-  width: 100%;
-  max-width: 420px;
-}
-
-.modal-title {
-  font-size: 15px;
-  font-weight: 500;
-  margin-bottom: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-// ── Form ──────────────────────────────────────────────────────
-.form-group { margin-bottom: 14px; }
-
-.form-label {
-  font-size: 12px;
-  color: $hint;
-  margin-bottom: 6px;
-  display: block;
-}
-
-.form-input,
-.form-select {
-  width: 100%;
-  background: $card;
-  border: 1px solid $border;
-  border-radius: $radius;
-  padding: 9px 12px;
-  color: $text;
-  font-family: inherit;
-  font-size: 13px;
-  outline: none;
-  transition: border-color 0.15s;
-
-  &:focus { border-color: rgba($primary, 0.5); }
-  &::placeholder { color: $hint; }
-  option { background: $surface; }
-}
-
-.form-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-}
-
-.form-error {
-  font-size: 12px;
-  color: $danger;
-  margin-top: -6px;
-  margin-bottom: 8px;
-}
-
-.modal-actions {
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
-  margin-top: 20px;
-}
-
 .session-list {
   max-height: 450px;
   overflow-y: auto !important;
+}
+
+.dur-local {
+  font-family: 'DM Mono', monospace;
+  font-size: 14px;
+  font-weight: 500;
+  color: $text;
+
+  &.live {
+    color: $success;
+  }
+}
+
+.dur-server {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  color: $hint;
+
+  nb-icon {
+    font-size: 13px;
+  }
+
+  &.offline {
+    color: rgba(255, 255, 255, 0.2);
+    nb-icon {
+      color: rgba(255, 255, 255, 0.2);
+    }
+  }
 }

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.scss
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.scss
@@ -1,0 +1,514 @@
+// ── Variables ─────────────────────────────────────────────────
+$bg:          var(--gauzy-card-2);
+$surface:     #1e2340;
+$card:        #252b48;
+$border:      rgba(255, 255, 255, 0.08);
+$divider:     var(--devider-color);
+$text:        var(--gauzy-text-color-1);
+$hint:        #8f9bb3;
+$primary:     #3366ff;
+$primary-dim: rgba(51, 102, 255, 0.12);
+$success:     #00d68f;
+$success-dim: rgba(0, 214, 143, 0.12);
+$warning:     #ffaa00;
+$warning-dim: rgba(255, 170, 0, 0.12);
+$danger:      #ff3d71;
+$danger-dim:  rgba(255, 61, 113, 0.12);
+$radius:      8px;
+$radius-lg:   12px;
+$info-dim:      rgba(0, 149, 255, 0.12);
+$info:          #0095ff;
+
+// ── Host ──────────────────────────────────────────────────────
+:host {
+  display: block;
+  background: $bg;
+  min-height: 100vh;
+  font-family: 'DM Sans', sans-serif;
+  color: $text;
+  font-size: 14px;
+}
+
+// ── Wrap ──────────────────────────────────────────────────────
+.wrap {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 28px 20px;
+}
+
+// ── Page header ───────────────────────────────────────────────
+.page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.page-title {
+  font-size: 17px;
+  font-weight: 500;
+  color: $text;
+}
+
+.page-meta {
+  font-size: 12px;
+  color: $hint;
+  margin-top: 3px;
+}
+
+.head-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+// ── Buttons ───────────────────────────────────────────────────
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 14px;
+  border-radius: $radius;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: background 0.15s;
+
+  &-ghost {
+    background: transparent;
+    color: $hint;
+    border: 1px solid $border;
+
+    &:hover {
+      background: $divider;
+      color: $text;
+    }
+  }
+
+  &-primary {
+    background: $primary;
+    color: #fff;
+
+    &:hover { background: darken($primary, 8%); }
+  }
+}
+
+// ── Filter chips ──────────────────────────────────────────────
+.filter-bar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  padding: 5px 12px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid $border;
+  background: transparent;
+  color: $hint;
+  font-family: inherit;
+  transition: all 0.15s;
+
+  &.active {
+    background: $primary-dim;
+    color: #7b9fff;
+    border-color: rgba($primary, 0.3);
+  }
+
+  &:hover:not(.active) {
+    background: $divider;
+    color: $text;
+  }
+}
+
+// ── Group label ───────────────────────────────────────────────
+.group-label {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.07em;
+  color: $hint;
+  text-transform: uppercase;
+  padding: 4px 0 8px;
+  margin-top: 4px;
+}
+
+// ── Session rows ──────────────────────────────────────────────
+.session-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: $radius;
+  padding: 13px 16px;
+  margin-bottom: 6px;
+  cursor: pointer;
+  width: 99%;
+  transition: border-color 0.15s;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.14);
+
+    .row-actions { opacity: 1; }
+  }
+}
+
+.color-bar {
+  width: 3px;
+  height: 38px;
+  border-radius: 0;
+  flex-shrink: 0;
+}
+
+.session-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: $text;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.task-proj {
+  font-size: 12px;
+  color: $hint;
+  margin-top: 2px;
+}
+
+// ── Badges ────────────────────────────────────────────────────
+.badges {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 500;
+
+  &-blue   { background: $primary-dim;  color: #7b9fff; border: 1px solid rgba($primary,  0.2); }
+  &-green  { background: $success-dim;  color: $success; border: 1px solid rgba($success, 0.2); }
+  &-amber  { background: $warning-dim;  color: $warning; border: 1px solid rgba($warning, 0.2); }
+  &-red    { background: $danger-dim;   color: #ff7096;  border: 1px solid rgba($danger,  0.2); }
+}
+
+// ── Duration column ───────────────────────────────────────────
+.dur-col {
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.dur {
+  font-family: 'DM Mono', monospace;
+  font-size: 13px;
+  font-weight: 500;
+  color: $text;
+}
+
+.time-range {
+  font-size: 11px;
+  color: $hint;
+  margin-top: 2px;
+}
+
+// ── Row actions ───────────────────────────────────────────────
+.row-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  color: $hint;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  font-size: 15px;
+  line-height: 1;
+  transition: color 0.15s;
+
+  &:hover { color: $text; }
+  &.danger:hover { color: $danger; }
+}
+
+.session-body {
+  flex: 1;
+  min-width: 0;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+// ── Row top: task name + right slot ───────────────────────────
+.row-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.task-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: $text;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.row-top-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+// ── Retry button (replaces sync badge on failed) ──────────────
+.retry-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid rgba(255, 61, 113, 0.35);
+  color: $danger;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-family: inherit;
+  transition: background 0.15s;
+
+  nb-icon { font-size: 13px; }
+
+  &:hover {
+    background: $danger-dim;
+  }
+}
+
+// ── Sync status badge ─────────────────────────────────────────
+.sync-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+
+  nb-icon { font-size: 13px; }
+
+  &.status-synced {
+    background: $success-dim;
+    color: $success;
+    border: 1px solid rgba(0, 214, 143, 0.25);
+  }
+
+  &.status-pending {
+    background: $warning-dim;
+    color: $warning;
+    border: 1px solid rgba(255, 170, 0, 0.25);
+  }
+
+  &.status-syncing {
+    background: $info-dim;
+    color: $info;
+    border: 1px solid rgba(0, 149, 255, 0.25);
+  }
+}
+
+// Spinning icon for syncing state
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+nb-icon.spin { display: inline-block; animation: spin 1s linear infinite; }
+
+// ── Row meta ──────────────────────────────────────────────────
+.row-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: $hint;
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  &.timestamps { gap: 5px; }
+}
+
+.meta-icon {
+  font-size: 13px;
+  opacity: 0.65;
+
+  &.arrow { font-size: 11px; opacity: 0.35; }
+}
+
+.meta-sep {
+  color: rgba(255, 255, 255, 0.15);
+  font-size: 10px;
+  user-select: none;
+}
+
+.meta-dur {
+  font-family: 'DM Mono', monospace;
+  font-size: 12px;
+  font-weight: 500;
+  color: $text;
+}
+
+// ── Badges ────────────────────────────────────────────────────
+.badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 500;
+
+  &-blue  { background: $primary-dim; color: #7b9fff;  border: 1px solid rgba(51,102,255,0.2); }
+  &-green { background: $success-dim; color: $success;  border: 1px solid rgba(0,214,143,0.2); }
+  &-amber { background: $warning-dim; color: $warning;  border: 1px solid rgba(255,170,0,0.2); }
+  &-red   { background: $danger-dim;  color: #ff7096;   border: 1px solid rgba(255,61,113,0.2); }
+}
+
+// ── Empty state ───────────────────────────────────────────────
+.empty-state {
+  text-align: center;
+  padding: 40px 0;
+  color: $hint;
+  font-size: 13px;
+
+  nb-icon {
+    font-size: 24px;
+    display: block;
+    margin-bottom: 8px;
+  }
+}
+
+// ── Footer ────────────────────────────────────────────────────
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid $divider;
+}
+
+.footer-total {
+  font-size: 13px;
+  color: $hint;
+
+  span {
+    font-family: 'DM Mono', monospace;
+    font-weight: 500;
+    color: $text;
+  }
+}
+
+// ── Modal ─────────────────────────────────────────────────────
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: $radius-lg;
+  padding: 24px;
+  width: 100%;
+  max-width: 420px;
+}
+
+.modal-title {
+  font-size: 15px;
+  font-weight: 500;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+// ── Form ──────────────────────────────────────────────────────
+.form-group { margin-bottom: 14px; }
+
+.form-label {
+  font-size: 12px;
+  color: $hint;
+  margin-bottom: 6px;
+  display: block;
+}
+
+.form-input,
+.form-select {
+  width: 100%;
+  background: $card;
+  border: 1px solid $border;
+  border-radius: $radius;
+  padding: 9px 12px;
+  color: $text;
+  font-family: inherit;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s;
+
+  &:focus { border-color: rgba($primary, 0.5); }
+  &::placeholder { color: $hint; }
+  option { background: $surface; }
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.form-error {
+  font-size: 12px;
+  color: $danger;
+  margin-top: -6px;
+  margin-bottom: 8px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 20px;
+}
+
+.session-list {
+  max-height: 450px;
+  overflow-y: auto !important;
+}

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.scss
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.scss
@@ -1,23 +1,21 @@
 // ── Variables ─────────────────────────────────────────────────
 $bg: var(--gauzy-card-2);
 $surface: var(--gauzy-card-3);
-$card: #252b48;
-$border: rgba(255, 255, 255, 0.08);
+$border: var(--gauzy-border-default-color);
 $divider: var(--divider-color);
 $text: var(--gauzy-text-color-1);
-$hint: #8f9bb3;
-$primary: #3366ff;
-$primary-dim: rgba(51, 102, 255, 0.12);
-$success: #00d68f;
+$hint: var(--gauzy-text-color-2);
+$primary-dim: var(--color-primary-transparent-100);
+$success: var(--color-success-default);
 $success-dim: rgba(0, 214, 143, 0.12);
 $warning: #ffaa00;
 $warning-dim: rgba(255, 170, 0, 0.12);
 $danger: #ff3d71;
 $danger-dim: rgba(255, 61, 113, 0.12);
-$radius: 8px;
-$radius-lg: 12px;
+$radius: var(--border-radius);
+$radius-lg: calc(var(--border-radius) * 1.5);
 $info-dim: rgba(0, 149, 255, 0.12);
-$info: #0095ff;
+$info: var(--color-info-default);
 
 :host {
   display: block;
@@ -26,19 +24,40 @@ $info: #0095ff;
   font-family: 'DM Sans', sans-serif;
   color: $text;
   font-size: 14px;
+
+  nb-layout {
+    min-height: unset;
+    background: $bg;
+  }
+
+  nb-layout-column {
+    padding: 28px 20px;
+  }
 }
 
-.wrap {
+.session-card {
   max-width: 800px;
   margin: 0 auto;
-  padding: 28px 20px;
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: $radius-lg;
+
+  nb-card-header {
+    border-bottom: 1px solid $border;
+    background: transparent;
+    padding: 16px 20px;
+  }
+
+  nb-card-body {
+    padding: 16px 20px;
+    background: transparent;
+  }
 }
 
 .page-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 20px;
 }
 
 .page-title {
@@ -84,11 +103,11 @@ $info: #0095ff;
   }
 
   &-primary {
-    background: $primary;
+    background: var(--color-primary-default);
     color: #fff;
 
     &:hover {
-      background: darken($primary, 8%);
+      background: var(--color-primary-600);
     }
   }
 }
@@ -115,7 +134,7 @@ $info: #0095ff;
   &.active {
     background: $primary-dim;
     color: #7b9fff;
-    border-color: rgba($primary, 0.3);
+    border-color: rgba(51, 102, 255, 0.3);
   }
 
   &:hover:not(.active) {
@@ -134,11 +153,56 @@ $info: #0095ff;
   margin-top: 4px;
 }
 
+// Reset Nebular's nb-list and nb-list-item host defaults so our layout takes over
+:host ::ng-deep {
+  nb-list.session-list {
+    padding: 0;
+    border: none;
+    background: transparent;
+    display: block;
+  }
+
+  nb-list-item.session-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: $bg;
+    border: 1px solid $border;
+    border-radius: $radius;
+    padding: 13px 16px;
+    margin-bottom: 6px;
+    cursor: pointer;
+    width: 99%;
+    transition: border-color 0.15s;
+    box-sizing: border-box;
+
+    &:hover {
+      border-color: rgba(255, 255, 255, 0.14);
+
+      .row-actions {
+        opacity: 1;
+      }
+    }
+
+    &.running {
+      border-color: rgba(0, 214, 143, 0.4);
+    }
+  }
+
+  nb-list-item.empty-state {
+    display: flex;
+    justify-content: center;
+    padding: 40px 0;
+    border: none;
+    background: transparent;
+  }
+}
+
 .session-row {
   display: flex;
   align-items: center;
   gap: 12px;
-  background: $surface;
+  background: $bg;
   border: 1px solid $border;
   border-radius: $radius;
   padding: 13px 16px;
@@ -248,12 +312,12 @@ $info: #0095ff;
   &-blue {
     background: $primary-dim;
     color: #7b9fff;
-    border: 1px solid rgba($primary, 0.2);
+    border: 1px solid rgba(51, 102, 255, 0.2);
   }
   &-green {
     background: $success-dim;
     color: $success;
-    border: 1px solid rgba($success, 0.2);
+    border: 1px solid rgba(0, 214, 143, 0.2);
   }
   &-amber {
     background: $warning-dim;
@@ -550,6 +614,7 @@ nb-icon.spin {
 .session-list {
   max-height: 450px;
   overflow-y: auto !important;
+  border-radius: $radius;
 }
 
 .dur-local {

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.scss
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.scss
@@ -3,7 +3,7 @@ $bg: var(--gauzy-card-2);
 $surface: var(--gauzy-card-3);
 $card: #252b48;
 $border: rgba(255, 255, 255, 0.08);
-$divider: var(--devider-color);
+$divider: var(--divider-color);
 $text: var(--gauzy-text-color-1);
 $hint: #8f9bb3;
 $primary: #3366ff;
@@ -19,7 +19,6 @@ $radius-lg: 12px;
 $info-dim: rgba(0, 149, 255, 0.12);
 $info: #0095ff;
 
-// ── Host ──────────────────────────────────────────────────────
 :host {
   display: block;
   background: $bg;
@@ -29,14 +28,12 @@ $info: #0095ff;
   font-size: 14px;
 }
 
-// ── Wrap ──────────────────────────────────────────────────────
 .wrap {
   max-width: 800px;
   margin: 0 auto;
   padding: 28px 20px;
 }
 
-// ── Page header ───────────────────────────────────────────────
 .page-head {
   display: flex;
   align-items: center;
@@ -62,7 +59,6 @@ $info: #0095ff;
   align-items: center;
 }
 
-// ── Buttons ───────────────────────────────────────────────────
 .btn {
   display: inline-flex;
   align-items: center;
@@ -97,7 +93,6 @@ $info: #0095ff;
   }
 }
 
-// ── Filter chips ──────────────────────────────────────────────
 .filter-bar {
   display: flex;
   gap: 6px;
@@ -129,7 +124,6 @@ $info: #0095ff;
   }
 }
 
-// ── Group label ───────────────────────────────────────────────
 .group-label {
   font-size: 11px;
   font-weight: 500;
@@ -140,7 +134,6 @@ $info: #0095ff;
   margin-top: 4px;
 }
 
-// ── Session rows ──────────────────────────────────────────────
 .session-row {
   display: flex;
   align-items: center;

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.ts
@@ -1,4 +1,4 @@
-import { NgClass, NgIf } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { Component, ChangeDetectionStrategy, signal, computed, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NbCardModule, NbIconModule } from '@nebular/theme';
@@ -10,8 +10,9 @@ import { ElectronService } from '../../electron/services';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { ITimeLog, TimerActionTypeEnum, TimerSyncStateEnum } from '@gauzy/contracts';
+import { TranslatePipe } from '@ngx-translate/core';
 
-export type SyncStatus = 'synced' | 'pending' | 'failed' | 'syncing' | 'removed';
+export type SyncStatus = 'synced' | 'pending' | 'failed' | 'syncing' | 'removed' | 'running';
 
 export interface Session {
 	id: number;
@@ -48,7 +49,8 @@ export const SYNC_CONFIG: Record<SyncStatus, { label: string; cssClass: string; 
 	pending: { label: 'Pending', cssClass: 'status-pending', icon: 'clock-outline' },
 	syncing: { label: 'Syncing', cssClass: 'status-syncing', icon: 'sync-outline' },
 	failed: { label: 'Failed', cssClass: 'status-failed', icon: 'alert-circle-outline' },
-	removed: { label: 'Removed', cssClass: 'status-failed', icon: 'alert-circle-outline' }
+	removed: { label: 'Removed', cssClass: 'status-failed', icon: 'alert-circle-outline' },
+	running: { label: 'Running', cssClass: 'status-running', icon: 'clock-outline' }
 };
 
 @Component({
@@ -56,7 +58,7 @@ export const SYNC_CONFIG: Record<SyncStatus, { label: string; cssClass: string; 
 	templateUrl: './timer-session.component.html',
 	styleUrls: ['./timer-session.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	imports: [FormsModule, NgIf, NgClass, NbCardModule, NbIconModule, DateRangePickerComponent]
+	imports: [FormsModule, NgClass, NbCardModule, NbIconModule, DateRangePickerComponent, TranslatePipe]
 })
 export class TimerSessionComponent {
 	private readonly timerSessionService = inject(TimerSessionService);
@@ -96,10 +98,6 @@ export class TimerSessionComponent {
 			label: 'Pending'
 		},
 		{
-			value: 'syncing',
-			label: 'Syncing'
-		},
-		{
 			value: 'failed',
 			label: 'Failed'
 		},
@@ -111,6 +109,7 @@ export class TimerSessionComponent {
 
 	private readonly destroy$ = new Subject<void>();
 	private timesheets: any[] | null = [];
+	onRetry = signal<boolean>(false);
 
 	readonly filteredSessions = computed(() => {
 		const status = this.statusFilter();
@@ -132,6 +131,10 @@ export class TimerSessionComponent {
 	});
 
 	private statusSyncCheck(session: Session, timeLog?: ITimeLog, offline?: boolean): SyncStatus {
+		if (session.startedAt && !session.stoppedAt) {
+			return 'running';
+		}
+
 		if (!offline) {
 			if (session.timelogId && !timeLog?.id) {
 				return 'removed';
@@ -150,7 +153,7 @@ export class TimerSessionComponent {
 	}
 
 	ngOnInit(): void {
-		this._electronService.ipcRenderer.on('TIMER_SESSION_UPDATED', () => this.sessionUpdateHandler);
+		this._electronService.ipcRenderer.on('TIMER_SESSION_UPDATED', this.sessionUpdateHandler.bind(this));
 		this.selectedRange = {
 			startDate: new Date(),
 			endDate: new Date(),
@@ -165,7 +168,9 @@ export class TimerSessionComponent {
 
 	sessionUpdateHandler(): void {
 		// check current range same as now date if same then update session list else do nothing
+		console.log('session update listener triggered');
 		if (this.currentRange().start.toDateString() === new Date().toDateString()) {
+			console.log('session must be updated');
 			this.loadLocalSessionsForRange();
 		}
 	}
@@ -179,20 +184,6 @@ export class TimerSessionComponent {
 	setFilter(status: SyncStatus): void {
 		this.statusFilter.set(status);
 		this.loadLocalSessionsForRange();
-	}
-
-	exportCsv(): void {
-		const header = 'ID,Started At,Stopped At,Duration (s),Sync State,Description';
-		const rows = this.sessions().map(
-			(s) =>
-				`${s.id},"${new Date(s.startedAt).toISOString()}","${new Date(s.stoppedAt).toISOString()}",${s.duration},"${s.startSyncState}","${s.description ?? ''}"`
-		);
-		const csv = [header, ...rows].join('\n');
-		const blob = new Blob([csv], { type: 'text/csv' });
-		const url = URL.createObjectURL(blob);
-		const a = Object.assign(document.createElement('a'), { href: url, download: 'sessions.csv' });
-		a.click();
-		URL.revokeObjectURL(url);
 	}
 
 	getSyncStatus(session: Session): SyncStatus {
@@ -212,7 +203,8 @@ export class TimerSessionComponent {
 		});
 	}
 
-	formatSeconds(seconds: number): string {
+	formatSeconds(seconds: number = 0): string {
+		seconds = Math.floor(seconds);
 		const h = Math.floor(seconds / 3600);
 		const m = Math.floor((seconds % 3600) / 60);
 		const s = seconds % 60;
@@ -228,31 +220,38 @@ export class TimerSessionComponent {
 	}
 
 	async retrySync(session: Session) {
-		const sessionDetail = await this.timerSessionService.getSession(session.id);
-		await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
-			actionType: TimerActionTypeEnum.STOP_TIMER,
-			data: {
-				timerId: sessionDetail.id,
-				state: TimerSyncStateEnum.SYNCING,
-				timelogId: null
-			}
-		});
-		const timeLog = await this._timeTrackerService.addTimeLog({
-			startedAt: new Date(sessionDetail.startedAt),
-			stoppedAt: new Date(sessionDetail.stoppedAt),
-			description: sessionDetail.description,
-			organizationContactId: sessionDetail.organizationTeamId,
-			taskId: sessionDetail.taskId,
-			projectId: sessionDetail.projectId
-		});
-		await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
-			actionType: TimerActionTypeEnum.STOP_TIMER,
-			data: {
-				timerId: sessionDetail.id,
-				state: TimerSyncStateEnum.SYNCED,
-				timelogId: timeLog.id
-			}
-		});
+		this.onRetry.set(true);
+		try {
+			const sessionDetail = await this.timerSessionService.getSession(session.id);
+			await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
+				actionType: TimerActionTypeEnum.STOP_TIMER,
+				data: {
+					timerId: sessionDetail.id,
+					state: TimerSyncStateEnum.SYNCING
+				}
+			});
+			const timeLog = await this._timeTrackerService.addTimeLog({
+				startedAt: new Date(sessionDetail.startedAt),
+				stoppedAt: new Date(sessionDetail.stoppedAt),
+				description: sessionDetail.description,
+				organizationTeamId: sessionDetail.organizationTeamId,
+				taskId: sessionDetail.taskId,
+				projectId: sessionDetail.projectId
+			});
+			await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
+				actionType: TimerActionTypeEnum.STOP_TIMER,
+				data: {
+					timerId: sessionDetail.id,
+					state: TimerSyncStateEnum.SYNCED,
+					timelogId: timeLog.id,
+					duration: timeLog.duration
+				}
+			});
+		} catch (error) {
+			console.error(`Failed retry synchronize timer ${error.message}`);
+		} finally {
+			this.onRetry.set(false);
+		}
 	}
 
 	onRangeChange(range: { startDate?: string | Date; endDate?: string | Date }): void {
@@ -284,10 +283,12 @@ export class TimerSessionComponent {
 			if (timesheets) {
 				this.timesheets = timesheets;
 			}
-
-			console.log('Timesheets for range:', timesheets);
 		} catch (error) {
 			this.timesheets = null;
 		}
+	}
+
+	getColorBar(status: string): string {
+		return SYNC_CONFIG[status]?.cssClass ?? 'status-pending';
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.ts
@@ -1,7 +1,7 @@
 import { NgClass } from '@angular/common';
 import { Component, ChangeDetectionStrategy, signal, computed, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { NbCardModule, NbIconModule } from '@nebular/theme';
+import { NbCardModule, NbIconModule, NbLayoutModule, NbListModule } from '@nebular/theme';
 import { DateRangePickerComponent } from '../../recap/shared/features/date-range-picker/date-range-picker.component';
 import { IDateRangePicker } from '../../recap/shared/features/date-range-picker/date-picker.interface';
 import { TimerSessionService } from './timer-session.service';
@@ -58,7 +58,16 @@ export const SYNC_CONFIG: Record<SyncStatus, { label: string; cssClass: string; 
 	templateUrl: './timer-session.component.html',
 	styleUrls: ['./timer-session.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	imports: [FormsModule, NgClass, NbCardModule, NbIconModule, DateRangePickerComponent, TranslatePipe]
+	imports: [
+		FormsModule,
+		NgClass,
+		NbCardModule,
+		NbIconModule,
+		DateRangePickerComponent,
+		TranslatePipe,
+		NbLayoutModule,
+		NbListModule
+	]
 })
 export class TimerSessionComponent {
 	private readonly timerSessionService = inject(TimerSessionService);
@@ -108,7 +117,7 @@ export class TimerSessionComponent {
 	];
 
 	private readonly destroy$ = new Subject<void>();
-	private timesheets: any[] | null = [];
+	private timesheets: ITimeLog[] | null = [];
 	onRetry = signal<boolean>(false);
 
 	readonly filteredSessions = computed(() => {
@@ -168,9 +177,7 @@ export class TimerSessionComponent {
 
 	sessionUpdateHandler(): void {
 		// check current range same as now date if same then update session list else do nothing
-		console.log('session update listener triggered');
 		if (this.currentRange().start.toDateString() === new Date().toDateString()) {
-			console.log('session must be updated');
 			this.loadLocalSessionsForRange();
 		}
 	}
@@ -181,9 +188,8 @@ export class TimerSessionComponent {
 		this._electronService.ipcRenderer.removeListener('TIMER_SESSION_UPDATED', this.sessionUpdateHandler);
 	}
 
-	setFilter(status: SyncStatus): void {
+	setFilter(status: SyncStatus | 'all'): void {
 		this.statusFilter.set(status);
-		this.loadLocalSessionsForRange();
 	}
 
 	getSyncStatus(session: Session): SyncStatus {

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.ts
@@ -1,0 +1,293 @@
+import { NgClass, NgIf } from '@angular/common';
+import { Component, ChangeDetectionStrategy, signal, computed, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NbCardModule, NbIconModule } from '@nebular/theme';
+import { DateRangePickerComponent } from '../../recap/shared/features/date-range-picker/date-range-picker.component';
+import { IDateRangePicker } from '../../recap/shared/features/date-range-picker/date-picker.interface';
+import { TimerSessionService } from './timer-session.service';
+import { TimeTrackerService } from '../time-tracker.service';
+import { ElectronService } from '../../electron/services';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { ITimeLog, TimerActionTypeEnum, TimerSyncStateEnum } from '@gauzy/contracts';
+
+export type SyncStatus = 'synced' | 'pending' | 'failed' | 'syncing' | 'removed';
+
+export interface Session {
+	id: number;
+	day: number;
+	duration: number;
+	taskId: string | null;
+	projectId: string | null;
+	employeeId: string;
+	timelogId: string | null;
+	timesheetId: string | null;
+	timeslotId: string | null;
+	createdAt: string;
+	updatedAt: string;
+	startedAt: number;
+	stoppedAt: number;
+	synced: 0 | 1;
+	isStartedOffline: 0 | 1;
+	isStoppedOffline: 0 | 1;
+	version: string;
+	organizationTeamId: string | null;
+	description: string | null;
+	startSyncState: SyncStatus;
+	stopSyncState: SyncStatus;
+	syncDuration: number;
+}
+
+export interface SessionFilter {
+	value: SyncStatus | 'all';
+	label: string;
+}
+
+export const SYNC_CONFIG: Record<SyncStatus, { label: string; cssClass: string; icon: string }> = {
+	synced: { label: 'Synced', cssClass: 'status-synced', icon: 'checkmark-circle-2-outline' },
+	pending: { label: 'Pending', cssClass: 'status-pending', icon: 'clock-outline' },
+	syncing: { label: 'Syncing', cssClass: 'status-syncing', icon: 'sync-outline' },
+	failed: { label: 'Failed', cssClass: 'status-failed', icon: 'alert-circle-outline' },
+	removed: { label: 'Removed', cssClass: 'status-failed', icon: 'alert-circle-outline' }
+};
+
+@Component({
+	selector: 'gauzy-timer-session',
+	templateUrl: './timer-session.component.html',
+	styleUrls: ['./timer-session.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [FormsModule, NgIf, NgClass, NbCardModule, NbIconModule, DateRangePickerComponent]
+})
+export class TimerSessionComponent {
+	private readonly timerSessionService = inject(TimerSessionService);
+	private readonly _electronService = inject(ElectronService);
+	private readonly _timeTrackerService = inject(TimeTrackerService);
+	sessions = signal<Session[]>([]);
+	visibleTotal = '0s';
+
+	searchQuery = '';
+
+	showModal = false;
+	editingSession: Session | null = null;
+	syncConfig = SYNC_CONFIG;
+
+	statusFilter = signal('all');
+
+	currentRange = signal<{ start: Date; end: Date }>({
+		start: new Date(new Date().setHours(0, 0, 0, 0)),
+		end: new Date(new Date().setHours(23, 59, 59, 999))
+	});
+
+	selectedRange: IDateRangePicker;
+
+	dateLabel = signal<string>('');
+
+	filterOptions: SessionFilter[] = [
+		{
+			value: 'all',
+			label: 'All'
+		},
+		{
+			value: 'synced',
+			label: 'Synced'
+		},
+		{
+			value: 'pending',
+			label: 'Pending'
+		},
+		{
+			value: 'syncing',
+			label: 'Syncing'
+		},
+		{
+			value: 'failed',
+			label: 'Failed'
+		},
+		{
+			value: 'removed',
+			label: 'Removed'
+		}
+	];
+
+	private readonly destroy$ = new Subject<void>();
+	private timesheets: any[] | null = [];
+
+	readonly filteredSessions = computed(() => {
+		const status = this.statusFilter();
+		return this.sessions()
+			.map((s) => {
+				const timesheet = this.timesheets?.find((t) => t.id === s.timelogId);
+				return {
+					...s,
+					projectName: timesheet?.project?.name || 'No Project',
+					taskName: timesheet?.task?.title || 'No Task',
+					clientName: timesheet?.organizationContact?.name || 'No Client',
+					statusSync: this.statusSyncCheck(s, timesheet, this.timesheets === null)
+				};
+			})
+			.filter((s) => {
+				if (status === 'all') return true;
+				return s.statusSync === status;
+			});
+	});
+
+	private statusSyncCheck(session: Session, timeLog?: ITimeLog, offline?: boolean): SyncStatus {
+		if (!offline) {
+			if (session.timelogId && !timeLog?.id) {
+				return 'removed';
+			}
+		}
+
+		if (session.startSyncState === 'synced' && session.stopSyncState !== 'synced') {
+			return session.stopSyncState || 'pending';
+		}
+
+		if (session.startSyncState !== 'synced') {
+			return session.startSyncState || 'pending';
+		}
+
+		return session.startSyncState;
+	}
+
+	ngOnInit(): void {
+		this._electronService.ipcRenderer.on('TIMER_SESSION_UPDATED', () => this.sessionUpdateHandler);
+		this.selectedRange = {
+			startDate: new Date(),
+			endDate: new Date(),
+			isCustomDate: false
+		};
+		this.timerSessionService.sessionsStream$.pipe(takeUntil(this.destroy$)).subscribe((items) => {
+			this.sessions.set(items);
+		});
+		this.loadLocalSessionsForRange();
+		this.toDatetimeLocal();
+	}
+
+	sessionUpdateHandler(): void {
+		// check current range same as now date if same then update session list else do nothing
+		if (this.currentRange().start.toDateString() === new Date().toDateString()) {
+			this.loadLocalSessionsForRange();
+		}
+	}
+
+	ngOnDestroy(): void {
+		this.destroy$.next();
+		this.destroy$.complete();
+		this._electronService.ipcRenderer.removeListener('TIMER_SESSION_UPDATED', this.sessionUpdateHandler);
+	}
+
+	setFilter(status: SyncStatus): void {
+		this.statusFilter.set(status);
+		this.loadLocalSessionsForRange();
+	}
+
+	exportCsv(): void {
+		const header = 'ID,Started At,Stopped At,Duration (s),Sync State,Description';
+		const rows = this.sessions().map(
+			(s) =>
+				`${s.id},"${new Date(s.startedAt).toISOString()}","${new Date(s.stoppedAt).toISOString()}",${s.duration},"${s.startSyncState}","${s.description ?? ''}"`
+		);
+		const csv = [header, ...rows].join('\n');
+		const blob = new Blob([csv], { type: 'text/csv' });
+		const url = URL.createObjectURL(blob);
+		const a = Object.assign(document.createElement('a'), { href: url, download: 'sessions.csv' });
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
+	getSyncStatus(session: Session): SyncStatus {
+		if (session.synced) return 'synced';
+		if (session.startSyncState === 'syncing' || session.stopSyncState === 'syncing') return 'syncing';
+		if (session.startSyncState === 'failed' || session.stopSyncState === 'failed') return 'failed';
+		return 'pending';
+	}
+
+	formatDatetime(ms: number): string {
+		if (!ms) return 'now';
+		return new Date(ms).toLocaleString(undefined, {
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	formatSeconds(seconds: number): string {
+		const h = Math.floor(seconds / 3600);
+		const m = Math.floor((seconds % 3600) / 60);
+		const s = seconds % 60;
+		if (h > 0 && m > 0) return `${h}h ${m}m`;
+		if (h > 0) return `${h}h`;
+		if (m > 0 && s > 0) return `${m}m ${s}s`;
+		if (m > 0) return `${m}m`;
+		return `${s}s`;
+	}
+
+	private toDatetimeLocal(): void {
+		this.dateLabel.set(this.currentRange().start.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }));
+	}
+
+	async retrySync(session: Session) {
+		const sessionDetail = await this.timerSessionService.getSession(session.id);
+		await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
+			actionType: TimerActionTypeEnum.STOP_TIMER,
+			data: {
+				timerId: sessionDetail.id,
+				state: TimerSyncStateEnum.SYNCING,
+				timelogId: null
+			}
+		});
+		const timeLog = await this._timeTrackerService.addTimeLog({
+			startedAt: new Date(sessionDetail.startedAt),
+			stoppedAt: new Date(sessionDetail.stoppedAt),
+			description: sessionDetail.description,
+			organizationContactId: sessionDetail.organizationTeamId,
+			taskId: sessionDetail.taskId,
+			projectId: sessionDetail.projectId
+		});
+		await this._electronService.ipcRenderer.invoke('UPDATE_SYNC_STATE', {
+			actionType: TimerActionTypeEnum.STOP_TIMER,
+			data: {
+				timerId: sessionDetail.id,
+				state: TimerSyncStateEnum.SYNCED,
+				timelogId: timeLog.id
+			}
+		});
+	}
+
+	onRangeChange(range: { startDate?: string | Date; endDate?: string | Date }): void {
+		const toLocalDayStart = (d: string | Date): Date => {
+			const local = new Date(d);
+			return new Date(local.getFullYear(), local.getMonth(), local.getDate(), 0, 0, 0, 0);
+		};
+		const toLocalDayEnd = (d: string | Date): Date => {
+			const local = new Date(d);
+			return new Date(local.getFullYear(), local.getMonth(), local.getDate(), 23, 59, 59, 999);
+		};
+
+		this.currentRange.set({
+			start: toLocalDayStart(range.startDate),
+			end: toLocalDayEnd(range.endDate)
+		});
+		this.toDatetimeLocal();
+		this.loadLocalSessionsForRange();
+	}
+
+	async loadLocalSessionsForRange(): Promise<void> {
+		await this.getTimesheetsForRange();
+		await this.timerSessionService.getSessionList(this.currentRange());
+	}
+
+	async getTimesheetsForRange(): Promise<any> {
+		try {
+			const timesheets = await this.timerSessionService.getTimesheets(this.currentRange());
+			if (timesheets) {
+				this.timesheets = timesheets;
+			}
+
+			console.log('Timesheets for range:', timesheets);
+		} catch (error) {
+			this.timesheets = null;
+		}
+	}
+}

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.component.ts
@@ -247,6 +247,7 @@ export class TimerSessionComponent {
 					duration: timeLog.duration
 				}
 			});
+			this._electronService.ipcRenderer.send('refresh-timer');
 		} catch (error) {
 			console.error(`Failed retry synchronize timer ${error.message}`);
 		} finally {

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.service.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, inject } from '@angular/core';
+import { ElectronService } from '../../electron/services';
+import { BehaviorSubject, Observable, map, shareReplay, firstValueFrom } from 'rxjs';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Store } from '../../services';
+import { API_PREFIX } from '../../constants';
+import moment from 'moment';
+import { ITimeLog } from '@gauzy/contracts';
+
+@Injectable({ providedIn: 'root' })
+export class TimerSessionService {
+	private readonly _electronService = inject(ElectronService);
+	private readonly _http = inject(HttpClient);
+	private readonly _store = inject(Store);
+
+	private readonly _sessions$ = new BehaviorSubject<any[]>([]);
+	readonly sessionsStream$: Observable<any[]> = this._sessions$.asObservable();
+
+	async getSessionList(dateRange: { start: Date; end: Date }) {
+		const result = await this._electronService.ipcRenderer.invoke('GET_TIMER_SESSIONS', dateRange);
+		if (result?.length) {
+			this._sessions$.next(result);
+			return;
+		}
+		this._sessions$.next([]);
+	}
+
+	async getSession(sessionId: number) {
+		return await this._electronService.ipcRenderer.invoke('GET_TIMER_SESSION', {
+			timerSessionId: sessionId
+		});
+	}
+
+	async getTimesheets(dateRange: { start: Date; end: Date }): Promise<ITimeLog[]> {
+		const params = new HttpParams({
+			fromObject: {
+				'activityLevel[start]': '0',
+				'activityLevel[end]': '100',
+				'employeeIds[]': [this._store.user?.employee?.id],
+				organizationId: this._store.organizationId || null,
+				tenantId: this._store.tenantId || null,
+				startDate: moment(dateRange.start).utc().format('YYYY-MM-DD HH:mm:ss'),
+				endDate: moment(dateRange.end).utc().format('YYYY-MM-DD HH:mm:ss'),
+				timeZone: 'Asia/Jakarta',
+				'relations[]': ['project', 'task', 'organizationContact'] // arrays are natively supported!
+			}
+		});
+		const timesheets = this._http.get(`${API_PREFIX}/timesheet/time-log`, { params }).pipe(
+			map((res: any) => res)
+		);
+		return firstValueFrom(timesheets) as Promise<any[]>;
+	}
+}

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.service.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.service.ts
@@ -37,7 +37,7 @@ export class TimerSessionService {
 			fromObject: {
 				'activityLevel[start]': '0',
 				'activityLevel[end]': '100',
-				'employeeIds[]': [this._store.user?.employee?.id],
+				'employeeIds[]': [this._store?.user?.employee?.id],
 				organizationId: this._store?.organizationId || null,
 				tenantId: this._store?.tenantId || null,
 				startDate: moment(dateRange.start).utc().format('YYYY-MM-DD HH:mm:ss'),

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.service.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { ElectronService } from '../../electron/services';
 import { BehaviorSubject, Observable, map, shareReplay, firstValueFrom } from 'rxjs';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Store } from '../../services';
+import { Store, TimeZoneManager, TimeTrackerDateManager } from '../../services';
 import { API_PREFIX } from '../../constants';
 import moment from 'moment';
 import { ITimeLog } from '@gauzy/contracts';
@@ -32,6 +32,7 @@ export class TimerSessionService {
 	}
 
 	async getTimesheets(dateRange: { start: Date; end: Date }): Promise<ITimeLog[]> {
+		const timeZone = this._store?.user?.timeZone || moment.tz.guess();
 		const params = new HttpParams({
 			fromObject: {
 				'activityLevel[start]': '0',
@@ -41,13 +42,11 @@ export class TimerSessionService {
 				tenantId: this._store.tenantId || null,
 				startDate: moment(dateRange.start).utc().format('YYYY-MM-DD HH:mm:ss'),
 				endDate: moment(dateRange.end).utc().format('YYYY-MM-DD HH:mm:ss'),
-				timeZone: 'Asia/Jakarta',
+				timeZone,
 				'relations[]': ['project', 'task', 'organizationContact'] // arrays are natively supported!
 			}
 		});
-		const timesheets = this._http.get(`${API_PREFIX}/timesheet/time-log`, { params }).pipe(
-			map((res: any) => res)
-		);
+		const timesheets = this._http.get(`${API_PREFIX}/timesheet/time-log`, { params }).pipe(map((res: any) => res));
 		return firstValueFrom(timesheets) as Promise<any[]>;
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.service.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/timer-session/timer-session.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { ElectronService } from '../../electron/services';
-import { BehaviorSubject, Observable, map, shareReplay, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, Observable, map, firstValueFrom } from 'rxjs';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Store, TimeZoneManager, TimeTrackerDateManager } from '../../services';
+import { Store } from '../../services';
 import { API_PREFIX } from '../../constants';
 import moment from 'moment';
 import { ITimeLog } from '@gauzy/contracts';
@@ -38,8 +38,8 @@ export class TimerSessionService {
 				'activityLevel[start]': '0',
 				'activityLevel[end]': '100',
 				'employeeIds[]': [this._store.user?.employee?.id],
-				organizationId: this._store.organizationId || null,
-				tenantId: this._store.tenantId || null,
+				organizationId: this._store?.organizationId || null,
+				tenantId: this._store?.tenantId || null,
 				startDate: moment(dateRange.start).utc().format('YYYY-MM-DD HH:mm:ss'),
 				endDate: moment(dateRange.end).utc().format('YYYY-MM-DD HH:mm:ss'),
 				timeZone,

--- a/packages/ui-core/i18n/assets/i18n/ar.json
+++ b/packages/ui-core/i18n/assets/i18n/ar.json
@@ -4586,6 +4586,8 @@
 		"DUE": "حق الدفع",
 		"AW_CONNECTED": "متصل بـ ActivityWatch",
 		"AW_DISCONNECTED": "تم فصل ActivityWatch",
+		"SESSION_LIST": "Session List",
+		"SESSION": "session",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "تمت إزالة اللقطة الشاشة الأخيرة والأنشطة بنجاح.",
 			"CANT_RUN_TIMER": "لا يمكنك تشغيل المؤقت في الوقت الحالي.",
@@ -4631,7 +4633,8 @@
 			"WEEKLY_RECAP": "ملخص أسبوعي",
 			"MONTHLY_RECAP": "ملخص شهري",
 			"INSTALL_PLUGIN": "تثبيت الإضافة",
-			"OPEN_LOG_HISTORY": "سجل الأحداث"
+			"OPEN_LOG_HISTORY": "سجل الأحداث",
+			"SESSIONS": "Sessions"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "تتبع الوقت بالساعة",

--- a/packages/ui-core/i18n/assets/i18n/ar.json
+++ b/packages/ui-core/i18n/assets/i18n/ar.json
@@ -4586,8 +4586,8 @@
 		"DUE": "حق الدفع",
 		"AW_CONNECTED": "متصل بـ ActivityWatch",
 		"AW_DISCONNECTED": "تم فصل ActivityWatch",
-		"SESSION_LIST": "Session List",
-		"SESSION": "session",
+		"SESSION_LIST": "قائمة الجلسات",
+		"SESSION": "جلسة",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "تمت إزالة اللقطة الشاشة الأخيرة والأنشطة بنجاح.",
 			"CANT_RUN_TIMER": "لا يمكنك تشغيل المؤقت في الوقت الحالي.",
@@ -4634,7 +4634,7 @@
 			"MONTHLY_RECAP": "ملخص شهري",
 			"INSTALL_PLUGIN": "تثبيت الإضافة",
 			"OPEN_LOG_HISTORY": "سجل الأحداث",
-			"SESSIONS": "Sessions"
+			"SESSIONS": "جلسة"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "تتبع الوقت بالساعة",

--- a/packages/ui-core/i18n/assets/i18n/bg.json
+++ b/packages/ui-core/i18n/assets/i18n/bg.json
@@ -4649,6 +4649,8 @@
 		"DUE": "Дължим",
 		"AW_CONNECTED": "Connected към ActivityWatch",
 		"AW_DISCONNECTED": "Disconnected към ActivityWatch",
+		"SESSION_LIST": "Session List",
+		"SESSION": "session",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Успешно премахнахте последната снимка на екрана и дейностите",
 			"CANT_RUN_TIMER": "В момента не може да стартирате таймера",
@@ -4694,7 +4696,8 @@
 			"WEEKLY_RECAP": "Седмичен обзор",
 			"MONTHLY_RECAP": "Месечен обзор",
 			"INSTALL_PLUGIN": "Инсталиране на плъгин",
-			"OPEN_LOG_HISTORY": "Журнали"
+			"OPEN_LOG_HISTORY": "Журнали",
+			"SESSIONS": "Sessions"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Проследяване на времето по часове",

--- a/packages/ui-core/i18n/assets/i18n/bg.json
+++ b/packages/ui-core/i18n/assets/i18n/bg.json
@@ -4649,8 +4649,8 @@
 		"DUE": "Дължим",
 		"AW_CONNECTED": "Connected към ActivityWatch",
 		"AW_DISCONNECTED": "Disconnected към ActivityWatch",
-		"SESSION_LIST": "Session List",
-		"SESSION": "session",
+		"SESSION_LIST": "Списък със сесии",
+		"SESSION": "Сесии",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Успешно премахнахте последната снимка на екрана и дейностите",
 			"CANT_RUN_TIMER": "В момента не може да стартирате таймера",
@@ -4697,7 +4697,7 @@
 			"MONTHLY_RECAP": "Месечен обзор",
 			"INSTALL_PLUGIN": "Инсталиране на плъгин",
 			"OPEN_LOG_HISTORY": "Журнали",
-			"SESSIONS": "Sessions"
+			"SESSIONS": "Сесии"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Проследяване на времето по часове",

--- a/packages/ui-core/i18n/assets/i18n/de.json
+++ b/packages/ui-core/i18n/assets/i18n/de.json
@@ -4597,6 +4597,8 @@
 		"DUE": "Wegen",
 		"AW_CONNECTED": "ActivityWatch's verbunden.",
 		"AW_DISCONNECTED": "ActivityWatch ist nicht verbunden.",
+		"SESSION_LIST": "Session List",
+		"SESSION": "session",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Erfolgreich den letzten Screenshot und die Aktivitäten entfernen.",
 			"CANT_RUN_TIMER": "Du kannst den Timer im Moment nicht starten.",
@@ -4642,7 +4644,8 @@
 			"WEEKLY_RECAP": "Wöchentliche Zusammenfassung",
 			"MONTHLY_RECAP": "Monatliche Zusammenfassung",
 			"INSTALL_PLUGIN": "Plugin installieren",
-			"OPEN_LOG_HISTORY": "Protokollverlauf"
+			"OPEN_LOG_HISTORY": "Protokollverlauf",
+			"SESSIONS": "Sessions"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Stündliche Zeiterfassung",

--- a/packages/ui-core/i18n/assets/i18n/de.json
+++ b/packages/ui-core/i18n/assets/i18n/de.json
@@ -4597,8 +4597,8 @@
 		"DUE": "Wegen",
 		"AW_CONNECTED": "ActivityWatch's verbunden.",
 		"AW_DISCONNECTED": "ActivityWatch ist nicht verbunden.",
-		"SESSION_LIST": "Session List",
-		"SESSION": "session",
+		"SESSION_LIST": "Sitzungsliste",
+		"SESSION": "Sitzung",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Erfolgreich den letzten Screenshot und die Aktivitäten entfernen.",
 			"CANT_RUN_TIMER": "Du kannst den Timer im Moment nicht starten.",
@@ -4645,7 +4645,7 @@
 			"MONTHLY_RECAP": "Monatliche Zusammenfassung",
 			"INSTALL_PLUGIN": "Plugin installieren",
 			"OPEN_LOG_HISTORY": "Protokollverlauf",
-			"SESSIONS": "Sessions"
+			"SESSIONS": "Sitzung"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Stündliche Zeiterfassung",

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -4759,6 +4759,8 @@
 		"DUE": "Due",
 		"AW_CONNECTED": "ActivityWatch's connected",
 		"AW_DISCONNECTED": "ActivityWatch's disconnected",
+		"SESSION_LIST": "Session List",
+		"SESSION": "session",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Successfully remove last screenshot and activities",
 			"CANT_RUN_TIMER": "Your can't run timer for the moment",
@@ -4804,7 +4806,8 @@
 			"WEEKLY_RECAP": "Weekly Recap",
 			"MONTHLY_RECAP": "Monthly Recap",
 			"INSTALL_PLUGIN": "Install Plugin",
-			"OPEN_LOG_HISTORY": "Logs"
+			"OPEN_LOG_HISTORY": "Logs",
+			"SESSIONS": "Sessions"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Hourly Time Tracking",

--- a/packages/ui-core/i18n/assets/i18n/es.json
+++ b/packages/ui-core/i18n/assets/i18n/es.json
@@ -4603,8 +4603,8 @@
 		"DUE": "Debido",
 		"AW_CONNECTED": "\"Conexión de ActivityWatch\"",
 		"AW_DISCONNECTED": "ActivityWatch está desconectado.",
-		"SESSION_LIST": "Session List",
-		"SESSION": "session",
+		"SESSION_LIST": "Lista de sesiones",
+		"SESSION": "sesión",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Eliminar correctamente la última captura de pantalla y actividades.",
 			"CANT_RUN_TIMER": "No puedes ejecutar el temporizador por el momento.",
@@ -4651,7 +4651,7 @@
 			"MONTHLY_RECAP": "Resumen Mensual",
 			"INSTALL_PLUGIN": "Instalar complemento",
 			"OPEN_LOG_HISTORY": "Historial de registros",
-			"SESSIONS": "Sessions"
+			"SESSIONS": "Sesiones"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Seguimiento del tiempo por hora",

--- a/packages/ui-core/i18n/assets/i18n/es.json
+++ b/packages/ui-core/i18n/assets/i18n/es.json
@@ -4603,6 +4603,8 @@
 		"DUE": "Debido",
 		"AW_CONNECTED": "\"Conexión de ActivityWatch\"",
 		"AW_DISCONNECTED": "ActivityWatch está desconectado.",
+		"SESSION_LIST": "Session List",
+		"SESSION": "session",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Eliminar correctamente la última captura de pantalla y actividades.",
 			"CANT_RUN_TIMER": "No puedes ejecutar el temporizador por el momento.",
@@ -4648,7 +4650,8 @@
 			"WEEKLY_RECAP": "Resumen Semanal",
 			"MONTHLY_RECAP": "Resumen Mensual",
 			"INSTALL_PLUGIN": "Instalar complemento",
-			"OPEN_LOG_HISTORY": "Historial de registros"
+			"OPEN_LOG_HISTORY": "Historial de registros",
+			"SESSIONS": "Sessions"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Seguimiento del tiempo por hora",

--- a/packages/ui-core/i18n/assets/i18n/fr.json
+++ b/packages/ui-core/i18n/assets/i18n/fr.json
@@ -4592,6 +4592,8 @@
 		"DUE": "En raison de",
 		"AW_CONNECTED": "La connexion d'ActivityWatch.",
 		"AW_DISCONNECTED": "ActivityWatch est déconnecté.",
+		"SESSION_LIST": "Liste des sessions",
+		"SESSION": "session",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Supprimer avec succès la dernière capture d'écran et les activités.",
 			"CANT_RUN_TIMER": "Vous ne pouvez pas exécuter le minuteur pour le moment.",
@@ -4637,7 +4639,8 @@
 			"WEEKLY_RECAP": "Récapitulatif Hebdomadaire",
 			"MONTHLY_RECAP": "Récapitulatif Mensuel",
 			"INSTALL_PLUGIN": "Installer plugin",
-			"OPEN_LOG_HISTORY": "Historique des journaux"
+			"OPEN_LOG_HISTORY": "Historique des journaux",
+			"SESSIONS": "Sessions"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Suivi du temps horaire",

--- a/packages/ui-core/i18n/assets/i18n/he.json
+++ b/packages/ui-core/i18n/assets/i18n/he.json
@@ -4613,6 +4613,8 @@
 		"DUE": "מועדו",
 		"AW_CONNECTED": "קיימת חיבור ל־ActivityWatch",
 		"AW_DISCONNECTED": "אין חיבור ל־ActivityWatch",
+		"SESSION_LIST": "רשימת הפגישות",
+		"SESSION": "פגישה",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "הסרת התמונה האחרונה ויומן הפעילות בוצעה בהצלחה",
 			"CANT_RUN_TIMER": "אינך יכול להפעיל את הטיימר כרגע",
@@ -4658,7 +4660,8 @@
 			"WEEKLY_RECAP": "סיכום שבועי",
 			"MONTHLY_RECAP": "סיכום חודשי",
 			"INSTALL_PLUGIN": "התקנת תוסף",
-			"OPEN_LOG_HISTORY": "יומן פעילות"
+			"OPEN_LOG_HISTORY": "יומן פעילות",
+			"SESSIONS": "פגישות"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "מעקב זמן לפי שעות",

--- a/packages/ui-core/i18n/assets/i18n/it.json
+++ b/packages/ui-core/i18n/assets/i18n/it.json
@@ -4601,6 +4601,8 @@
 		"DUE": "Due",
 		"AW_CONNECTED": "Connesso ad ActivityWatch",
 		"AW_DISCONNECTED": "ActivityWatch è disconnesso",
+		"SESSION_LIST": "Elenco sessioni",
+		"SESSION": "sessione",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Rimozione dello screenshot e delle attività precedenti effettuata con successo",
 			"CANT_RUN_TIMER": "Non puoi avviare il timer al momento",
@@ -4646,7 +4648,8 @@
 			"WEEKLY_RECAP": "Riepilogo Settimanale",
 			"MONTHLY_RECAP": "Riepilogo Mensile",
 			"INSTALL_PLUGIN": "Installa plugin",
-			"OPEN_LOG_HISTORY": "Storico dei log"
+			"OPEN_LOG_HISTORY": "Storico dei log",
+			"SESSIONS": "Sessioni"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Tracciamento del tempo orario",

--- a/packages/ui-core/i18n/assets/i18n/nl.json
+++ b/packages/ui-core/i18n/assets/i18n/nl.json
@@ -4601,6 +4601,8 @@
 		"DUE": "Vanwege",
 		"AW_CONNECTED": "Verbonden met ActivityWatch",
 		"AW_DISCONNECTED": "ActivityWatch is losgekoppeld.",
+		"SESSION_LIST": "Sessielijst",
+		"SESSION": "sessie",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Laatste screenshot en activiteiten succesvol verwijderd",
 			"CANT_RUN_TIMER": "Je kunt de timer momenteel niet gebruiken.",
@@ -4646,7 +4648,8 @@
 			"WEEKLY_RECAP": "Wekelijks Overzicht",
 			"MONTHLY_RECAP": "Maandelijks Overzicht",
 			"INSTALL_PLUGIN": "Plugin installeren",
-			"OPEN_LOG_HISTORY": "Logboekgeschiedenis"
+			"OPEN_LOG_HISTORY": "Logboekgeschiedenis",
+			"SESSIONS": "Sessies"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Uurlijkse tijdregistratie",

--- a/packages/ui-core/i18n/assets/i18n/pl.json
+++ b/packages/ui-core/i18n/assets/i18n/pl.json
@@ -4600,6 +4600,8 @@
 		"DUE": "Z powodu / Do zapłaty",
 		"AW_CONNECTED": "Połączony z ActivityWatch",
 		"AW_DISCONNECTED": "ActivityWatch jest odłączony",
+		"SESSION_LIST": "Lista sesji",
+		"SESSION": "sesja",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Pomyślnie usunięto ostatni zrzut ekranu i aktywności",
 			"CANT_RUN_TIMER": "Nie możesz uruchomić timera na razie",
@@ -4645,7 +4647,8 @@
 			"WEEKLY_RECAP": "Cotygodniowe Podsumowanie",
 			"MONTHLY_RECAP": "Miesięczne Podsumowanie",
 			"INSTALL_PLUGIN": "Zainstaluj wtyczkę",
-			"OPEN_LOG_HISTORY": "Historia dzienników"
+			"OPEN_LOG_HISTORY": "Historia dzienników",
+			"SESSIONS": "Sesje"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Śledzenie czasu według godzin",

--- a/packages/ui-core/i18n/assets/i18n/pt.json
+++ b/packages/ui-core/i18n/assets/i18n/pt.json
@@ -4601,6 +4601,8 @@
 		"DUE": "Devido",
 		"AW_CONNECTED": "Atividade do ActivityWatch conectada.",
 		"AW_DISCONNECTED": "ActivityWatch está desconectado.",
+		"SESSION_LIST": "Lista de sessões",
+		"SESSION": "sessão",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Remover com sucesso a última captura de tela e atividades.",
 			"CANT_RUN_TIMER": "Você não pode executar um cronômetro no momento.",
@@ -4646,7 +4648,8 @@
 			"WEEKLY_RECAP": "Recapitulação Semanal",
 			"MONTHLY_RECAP": "Recapitulação Mensal",
 			"INSTALL_PLUGIN": "Instalar plugin",
-			"OPEN_LOG_HISTORY": "Histórico de registros"
+			"OPEN_LOG_HISTORY": "Histórico de registros",
+			"SESSIONS": "Sessões"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Rastreamento de Tempo Horário",

--- a/packages/ui-core/i18n/assets/i18n/ru.json
+++ b/packages/ui-core/i18n/assets/i18n/ru.json
@@ -4619,6 +4619,8 @@
 		"DUE": "Срок",
 		"AW_CONNECTED": "ActivityWatch подключено",
 		"AW_DISCONNECTED": "ActivityWatch отключено",
+		"SESSION_LIST": "Список сессий",
+		"SESSION": "сессия",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "Последний снимок экрана и действия успешно удалены",
 			"CANT_RUN_TIMER": "Вы не можете запустить таймер на данный момент",
@@ -4664,7 +4666,8 @@
 			"WEEKLY_RECAP": "Еженедельный Обзор",
 			"MONTHLY_RECAP": "Ежемесячный Обзор",
 			"INSTALL_PLUGIN": "Установить плагин",
-			"OPEN_LOG_HISTORY": "Журнал событий"
+			"OPEN_LOG_HISTORY": "Журнал событий",
+			"SESSIONS": "Сессии"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "Часовой учет времени",

--- a/packages/ui-core/i18n/assets/i18n/zh.json
+++ b/packages/ui-core/i18n/assets/i18n/zh.json
@@ -4601,6 +4601,8 @@
 		"DUE": "由于",
 		"AW_CONNECTED": "ActivityWatch的连接",
 		"AW_DISCONNECTED": "ActivityWatch的断开连接",
+		"SESSION_LIST": "会话列表",
+		"SESSION": "会话",
 		"TOASTR": {
 			"REMOVE_SCREENSHOT": "成功删除最后一张截图和活动",
 			"CANT_RUN_TIMER": "你暂时无法运行计时器。",
@@ -4646,7 +4648,8 @@
 			"WEEKLY_RECAP": "每周回顾",
 			"MONTHLY_RECAP": "每月回顾",
 			"INSTALL_PLUGIN": "安装插件",
-			"OPEN_LOG_HISTORY": "日志历史"
+			"OPEN_LOG_HISTORY": "日志历史",
+			"SESSIONS": "会话"
 		},
 		"RECAP": {
 			"HOURLY_TIME_TRACKING": "按小时跟踪时间",


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Sessions list in the desktop Time Tracker to browse and filter daily timer sessions with live updates and a one‑click retry for removed/conflict sessions. Includes IPC endpoints and local date‑safe queries to show accurate status with project/task/client context.

- **New Features**
  - UI: New “Sessions” view at `/time-tracker/sessions-list` (added to the menu) with a single‑day date picker, status chips (All/Synced/Pending/Failed/Removed), running indicator, and project/task/client labels.
  - Sync retry: For “Removed” sessions, a Retry button recreates the timelog and updates sync state and duration; `UPDATE_SYNC_STATE` now accepts an optional `timelogId`.
  - Real‑time: Timer start/stop and sync updates emit `TIMER_SESSION_UPDATED` so today’s list refreshes automatically.
  - Data + IPC: `GET_TIMER_SESSIONS`/`GET_TIMER_SESSION` plus offline DAO/service (`findByDate`/`getListByDate`) fetch sessions for the current employee and local day.

- **Bug Fixes**
  - Fixed retry flow for removed/conflict sessions to mark Syncing → Synced, set `duration`/`timelogId`, refresh the list, and trigger `refresh-timer` for the active timer UI.
  - Improved status mapping and local date handling to avoid timezone drift and show running/live states correctly.
  - Added store safety checks in `TimerSessionService` and small UI/translation cleanups.

<sup>Written for commit 0bbfb865cb9a0ff6622da5a061ffd30bd1d1b1ad. Summary will update on new commits. <a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9697?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

