### PR TITLE
fix: logs window add new export log button

### DIFF
--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -53,6 +53,7 @@ import { TranslateService } from './translation';
 import { ActivityWindow } from '@gauzy/desktop-activity';
 import { DesktopPermissionHandler } from './utilities/desktop-permission-handler';
 import { runTccutil, getAppId, getOSInfo } from './utilities/util';
+import { exportAuditLogs } from './utilities/export-log';
 import { AuditLogHandler } from './audit';
 
 // Lazily initialized — construction is deferred until after app.ready to avoid
@@ -654,7 +655,19 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 			console.error('Failed to update screenshot sync status', error);
 		}
 
-	})
+	});
+
+	ipcMain.handle('EXPORT_AUDIT_LOGS', async() => {
+		try {
+			const result = await exportAuditLogs();
+			return result;
+		} catch (error) {
+			console.error(`Failed export logs to file, ${error.message}`);
+			return {
+				success: false
+			}
+		}
+	});
 
 	pluginListeners();
 }
@@ -1615,7 +1628,8 @@ export function removeAllHandlers() {
 		'GET_AUDIT_LOGS',
 		'GET_HARDWARE_ACCELERATION_STATE',
 		'SET_HARDWARE_ACCELERATION',
-		'UPDATE_SCREENSHOT_SYNC_STATUS'
+		'UPDATE_SCREENSHOT_SYNC_STATUS',
+		'EXPORT_AUDIT_LOGS'
 	];
 	channels.forEach((channel: string) => {
 		ipcMain.removeHandler(channel);

--- a/packages/desktop-lib/src/lib/utilities/export-log.ts
+++ b/packages/desktop-lib/src/lib/utilities/export-log.ts
@@ -38,7 +38,12 @@ export async function exportAuditLogs(): Promise<{ success: boolean; filePath?: 
 	}
 
 	const stream = fs.createWriteStream(filePath);
-	const streamError = new Promise<never>((_, reject) => stream.once('error', reject));
+
+	let streamReject: (err: Error) => void;
+	const streamError = new Promise<never>((_, reject) => {
+		streamReject = reject;
+		stream.once('error', reject);
+	});
 
 	try {
 		const pageSize = 1000;
@@ -59,9 +64,11 @@ export async function exportAuditLogs(): Promise<{ success: boolean; filePath?: 
 			}
 			page += 1;
 		}
-		await closeStream(stream);
+		await Promise.race([closeStream(stream), streamError]);
+		stream.off('error', streamReject!);
 		return { success: true, filePath };
 	} catch (err) {
+		stream.off('error', streamReject!);
 		stream.destroy();
 		throw err;
 	}

--- a/packages/desktop-lib/src/lib/utilities/export-log.ts
+++ b/packages/desktop-lib/src/lib/utilities/export-log.ts
@@ -1,0 +1,69 @@
+import * as fs from 'node:fs';
+import { AuditLogService } from '../offline/services';
+import { dialog, SaveDialogReturnValue } from 'electron';
+
+let auditLogService: AuditLogService | null = null;
+
+function getAuditLogService(): AuditLogService {
+	if (auditLogService) {
+		return auditLogService;
+	}
+	auditLogService = new AuditLogService();
+	return auditLogService;
+}
+
+async function showSaveDialog(): Promise<SaveDialogReturnValue>  {
+	return await dialog.showSaveDialog({
+		title: 'Export Logs',
+		defaultPath: `logs-${Date.now()}.jsonl`,
+		filters: [
+			{
+				name: 'JSON Lines',
+				extensions: ['jsonl']
+			},
+			{
+				name: 'csv',
+				extensions: ['csv']
+			}
+		]
+	});
+}
+
+function closeStream(stream: fs.WriteStream): Promise<void> {
+	return new Promise((resolve, reject) => {
+		stream.end((err: Error | null | undefined) => (err ? reject(err) : resolve()));
+	});
+}
+
+export async function exportAuditLogs(): Promise<{ success: boolean; filePath?: string }> {
+	const { filePath, canceled } = await showSaveDialog();
+	if (canceled || !filePath) {
+		return { success: false };
+	}
+
+	const stream = fs.createWriteStream(filePath);
+
+	try {
+		const pageSize = 1000;
+		let page = 0;
+		while (true) {
+			const logs = await getAuditLogService().findAuditLogs({
+				page,
+				limit: pageSize,
+				sortBy: 'createdAt'
+			});
+			if (!logs?.data?.length) {
+				break;
+			}
+			for (const row of logs.data) {
+				stream.write(JSON.stringify(row) + '\n');
+			}
+			page += 1;
+		}
+		await closeStream(stream);
+		return { success: true, filePath };
+	} catch (err) {
+		stream.destroy();
+		throw err;
+	}
+}

--- a/packages/desktop-lib/src/lib/utilities/export-log.ts
+++ b/packages/desktop-lib/src/lib/utilities/export-log.ts
@@ -12,7 +12,7 @@ function getAuditLogService(): AuditLogService {
 	return auditLogService;
 }
 
-async function showSaveDialog(): Promise<SaveDialogReturnValue>  {
+async function showSaveDialog(): Promise<SaveDialogReturnValue> {
 	return await dialog.showSaveDialog({
 		title: 'Export Logs',
 		defaultPath: `logs-${Date.now()}.jsonl`,
@@ -20,10 +20,6 @@ async function showSaveDialog(): Promise<SaveDialogReturnValue>  {
 			{
 				name: 'JSON Lines',
 				extensions: ['jsonl']
-			},
-			{
-				name: 'csv',
-				extensions: ['csv']
 			}
 		]
 	});
@@ -42,6 +38,7 @@ export async function exportAuditLogs(): Promise<{ success: boolean; filePath?: 
 	}
 
 	const stream = fs.createWriteStream(filePath);
+	const streamError = new Promise<never>((_, reject) => stream.once('error', reject));
 
 	try {
 		const pageSize = 1000;
@@ -56,7 +53,9 @@ export async function exportAuditLogs(): Promise<{ success: boolean; filePath?: 
 				break;
 			}
 			for (const row of logs.data) {
-				stream.write(JSON.stringify(row) + '\n');
+				if (!stream.write(JSON.stringify(row) + '\n')) {
+					await Promise.race([new Promise<void>((resolve) => stream.once('drain', resolve)), streamError]);
+				}
 			}
 			page += 1;
 		}

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.html
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.html
@@ -4,19 +4,27 @@
 			<nb-card-header class="log-header">
 				<span class="title">Application Logs</span>
 				<div class="header-actions">
-					<nb-select [selected]="logLevelFilter()" (selectedChange)="onLevelChange($event)" size="small"
-						placeholder="Log Level">
+					<nb-select
+						[selected]="logLevelFilter()"
+						(selectedChange)="onLevelChange($event)"
+						size="small"
+						placeholder="Log Level"
+					>
 						<nb-option value="all">All Levels</nb-option>
 						<nb-option value="info">Info</nb-option>
 						<nb-option value="warn">Warn</nb-option>
 						<nb-option value="error">Error</nb-option>
 					</nb-select>
 
-					<nb-select [selected]="serviceNameFilter()" (selectedChange)="onServiceChange($event)" size="small"
-						placeholder="Service">
+					<nb-select
+						[selected]="serviceNameFilter()"
+						(selectedChange)="onServiceChange($event)"
+						size="small"
+						placeholder="Service"
+					>
 						<nb-option value="all">All Services</nb-option>
 						@for (svc of serviceNames(); track svc) {
-						<nb-option [value]="svc">{{ svc }}</nb-option>
+							<nb-option [value]="svc">{{ svc }}</nb-option>
 						}
 					</nb-select>
 
@@ -24,45 +32,72 @@
 						<nb-icon icon="refresh-outline"></nb-icon>
 					</button>
 
-					<nb-checkbox [checked]="isFollowing()" (checkedChange)="toggleFollow()" status="success"
-						[nbTooltip]="isFollowing() ? 'Following — auto-scrolling to newest log' : 'Follow — enable to auto-scroll'">
+					<nb-checkbox
+						[checked]="isFollowing()"
+						(checkedChange)="toggleFollow()"
+						status="success"
+						[nbTooltip]="
+							isFollowing()
+								? 'Following — auto-scrolling to newest log'
+								: 'Follow — enable to auto-scroll'
+						"
+					>
 						Follow
 					</nb-checkbox>
+					<button nbButton ghost size="small" nbTooltip="Export" (click)="exportAuditLogs()" type="button"
+						[disabled]="exportLoading()">
+						<nb-icon icon="save-outline"></nb-icon>
+					</button>
 				</div>
 			</nb-card-header>
 
 			<nb-card-body>
-				<div class="log-viewport" #scrollContainer (scroll)="onScroll($event)"
-					role="log" aria-live="polite" aria-label="Application Logs"
-					[attr.aria-busy]="isLoading() || isLoadingMore()">
-
+				<div
+					class="log-viewport"
+					#scrollContainer
+					(scroll)="onScroll($event)"
+					role="log"
+					aria-live="polite"
+					aria-label="Application Logs"
+					[attr.aria-busy]="isLoading() || isLoadingMore()"
+				>
 					@if (filteredLogs().length === 0 && !isLoading()) {
-					<div class="empty-state">
-						<nb-icon icon="file-text-outline" status="basic"></nb-icon>
-						<p>No log entries found.</p>
-					</div>
+						<div class="empty-state">
+							<nb-icon icon="file-text-outline" status="basic"></nb-icon>
+							<p>No log entries found.</p>
+						</div>
 					}
 
 					@for (log of filteredLogs(); track log.id) {
-					<div class="log-entry" [class]="'log-entry--' + log.logLevel">
-						<div class="log-entry__meta">
-							<span class="level-badge" [class]="'level-' + log.logLevel">{{ log.logLevel | uppercase
+						<div class="log-entry" [class]="'log-entry--' + log.logLevel">
+							<div class="log-entry__meta">
+								<span class="level-badge" [class]="'level-' + log.logLevel">{{
+									log.logLevel | uppercase
 								}}</span>
-							<span class="meta-service">{{ log.serviceName }}</span>
-							<span class="meta-sep">·</span>
-							<span class="meta-time">{{ log.createdAt | date : 'yyyy-MM-dd HH:mm:ss' }}</span>
+								<span class="meta-service">{{ log.serviceName }}</span>
+								<span class="meta-sep">·</span>
+								<span class="meta-time">{{ log.createdAt | date: 'yyyy-MM-dd HH:mm:ss' }}</span>
+							</div>
+							<p class="log-entry__message">{{ log.message }}</p>
 						</div>
-						<p class="log-entry__message">{{ log.message }}</p>
-					</div>
 					}
 
 					@if (isLoading()) {
-						<div class="spinner-row" [nbSpinner]="true" nbSpinnerSize="small" nbSpinnerStatus="primary"></div>
+						<div
+							class="spinner-row"
+							[nbSpinner]="true"
+							nbSpinnerSize="small"
+							nbSpinnerStatus="primary"
+						></div>
 					}
 					@if (isLoadingMore()) {
 						<div class="load-more-bar">
-							<div [nbSpinner]="true" nbSpinnerSize="tiny" nbSpinnerStatus="primary"
-								class="load-more-spinner"></div>
+							<div
+								[nbSpinner]="true"
+								nbSpinnerSize="tiny"
+								nbSpinnerStatus="primary"
+								class="load-more-spinner"
+							></div>
 							<span>Loading older entries…</span>
 						</div>
 					}
@@ -71,7 +106,6 @@
 					}
 				</div>
 			</nb-card-body>
-
 		</nb-card>
 	</nb-layout-column>
 </nb-layout>

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
@@ -62,19 +62,18 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 	/** When true, each new IPC log entry auto-scrolls the viewport to the bottom. */
 	readonly isFollowing = signal(true);
 
-	readonly serviceNames = computed(() =>
-		[...new Set(this.allItems().map((i) => i.serviceName))]
-	);
+	readonly serviceNames = computed(() => [...new Set(this.allItems().map((i) => i.serviceName))]);
 
 	readonly filteredLogs = computed(() => {
 		const level = this.logLevelFilter();
 		const service = this.serviceNameFilter();
 		return this.allItems().filter(
 			(item) =>
-				(level === 'all' || item.logLevel === level) &&
-				(service === 'all' || item.serviceName === service)
+				(level === 'all' || item.logLevel === level) && (service === 'all' || item.serviceName === service)
 		);
 	});
+
+	exportLoading = signal<boolean>(false);
 
 	ngOnInit(): void {
 		this.loggerService.logsStream$.pipe(takeUntil(this.destroy$)).subscribe((items) => {
@@ -96,7 +95,6 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 				}
 			});
 		});
-
 
 		this.loadEntries(true);
 	}
@@ -154,7 +152,12 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 
 	onScroll(event: Event): void {
 		const el = event.target as HTMLElement;
-		if (el.scrollTop + el.clientHeight >= el.scrollHeight - 20 && !this.isLoadingMore() && this.hasMore() && !this.isLoading()) {
+		if (
+			el.scrollTop + el.clientHeight >= el.scrollHeight - 20 &&
+			!this.isLoadingMore() &&
+			this.hasMore() &&
+			!this.isLoading()
+		) {
 			this.loadOlderEntries();
 		}
 	}
@@ -172,8 +175,6 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 			);
 
 			this.hasMore.set(result.length >= this.pageSize());
-
-
 		} catch (error) {
 			console.error('Failed to load older log entries', error);
 			// Roll back the page increment so the next attempt requests the correct page.
@@ -190,5 +191,11 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 			error: 'level-error'
 		};
 		return map[level ?? ''] ?? 'level-info';
+	}
+
+	async exportAuditLogs() {
+		this.exportLoading.set(true);
+		await this.loggerService.exportAuditLogs();
+		this.exportLoading.set(false);
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.component.ts
@@ -73,7 +73,7 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 		);
 	});
 
-	exportLoading = signal<boolean>(false);
+	readonly exportLoading = signal<boolean>(false);
 
 	ngOnInit(): void {
 		this.loggerService.logsStream$.pipe(takeUntil(this.destroy$)).subscribe((items) => {
@@ -194,8 +194,13 @@ export class AuditTrailLoggerComponent implements OnInit, OnDestroy {
 	}
 
 	async exportAuditLogs() {
-		this.exportLoading.set(true);
-		await this.loggerService.exportAuditLogs();
-		this.exportLoading.set(false);
+		try {
+			this.exportLoading.set(true);
+			await this.loggerService.exportAuditLogs();
+		} catch (error) {
+			console.error('Failed export audit logs', error);
+		} finally {
+			this.exportLoading.set(false);
+		}
 	}
 }

--- a/packages/desktop-ui-lib/src/lib/logger/logger.service.ts
+++ b/packages/desktop-ui-lib/src/lib/logger/logger.service.ts
@@ -39,4 +39,8 @@ export class LoggerService {
 		this.logs$.next(logsResult);
 		return logsResult;
 	}
+
+	public async exportAuditLogs() {
+		await this._electronService.ipcRenderer.invoke('EXPORT_AUDIT_LOGS');
+	}
 }

--- a/packages/desktop-window/src/lib/desktop-window-timer.ts
+++ b/packages/desktop-window/src/lib/desktop-window-timer.ts
@@ -215,7 +215,7 @@ export function childWindowOpen(window: BrowserWindow, preloadPath?: string) {
 				action: 'allow',
 				overrideBrowserWindowOptions: {
 					title: 'Log History',
-					width: 460,
+					width: 480,
 					height: 800,
 					titleBarStyle: 'hidden',
 					titleBarOverlay: true,


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Export Logs button to the Logs window to save audit logs to a JSON Lines file via a new IPC channel. Uses streaming with backpressure and safe stream closure, plus a save dialog, a loading state, and a slightly wider window.

- New Features
  - Export button in the logger UI; disabled while exporting; logs window width set to 480.
  - IPC handler `EXPORT_AUDIT_LOGS` in `desktop-ipc` calls the export utility, returns `{ success, filePath }` (or `{ success: false }`), logs errors, and is cleaned up in `removeAllHandlers`.
  - `utilities/export-log` opens a save dialog (default `logs-<timestamp>.jsonl`), pages `AuditLogService` results, and streams NDJSON to disk with backpressure handling; invoked via `ipcRenderer.invoke('EXPORT_AUDIT_LOGS')`.

- Bug Fixes
  - Properly closes the write stream and detaches error handlers to prevent hanging exports.

<sup>Written for commit 2f1d144001ab79903d99d386b27f0fd40b87045f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

