### PR TITLE
chore(k8s): scale gauzy-prod-api down to 2 replicas (was 4)

### DIFF
--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -82,7 +82,7 @@ kind: Deployment
 metadata:
     name: gauzy-prod-api
 spec:
-    replicas: 4
+    replicas: 2
     selector:
         matchLabels:
             app: gauzy-prod-api


### PR DESCRIPTION
Live observation shows 4 prod-api replicas are heavily over-provisioned: peak ~58m CPU and ~595Mi MEM per pod under current load, while collectively requesting 1.2 cores and ~3.6 GiB. On the now-1-node k8s-gauzy cluster, CPU requests sit at 85% of allocatable — bringing the 4 replicas down to 2 frees 600m CPU and 1.8 GiB MEM in scheduler reservations, giving meaningful headroom for new workloads. `podAntiAffinity` (preferred, not required) still spreads the 2 remaining replicas across nodes if the cluster scales back up. Easy to bump back to 3+ or add HPA if real traffic shows the need.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale `gauzy-prod-api` Deployment from 4 to 2 replicas to right-size capacity and free CPU/memory headroom on the single-node cluster. Preferred podAntiAffinity remains, so replicas will spread across nodes if the cluster scales up; can scale back to 3+ or add HPA if load grows.

<sup>Written for commit ba2a3f8a5eb035a3dd84e09b1d72fd68e4651978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

