### PR TITLE
chore(deps): migrate TypeORM 0.3 -> 1.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -84,7 +84,7 @@
 		"sound-play": "1.1.0",
 		"squirrelly": "^8.0.8",
 		"twing": "^5.0.2",
-		"typeorm": "^0.3.30",
+		"typeorm": "^1.0.0",
 		"undici": "^6.10.2",
 		"custom-electron-titlebar": "^4.4.1"
 	},

--- a/apps/server-api/package.json
+++ b/apps/server-api/package.json
@@ -82,7 +82,7 @@
 		"rxjs": "^7.8.2",
 		"squirrelly": "^8.0.8",
 		"twing": "^5.0.2",
-		"typeorm": "^0.3.30",
+		"typeorm": "^1.0.0",
 		"undici": "^6.10.2",
 		"custom-electron-titlebar": "^4.4.1"
 	},

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -77,7 +77,7 @@
 		"rxjs": "^7.8.2",
 		"squirrelly": "^8.0.8",
 		"twing": "^5.0.2",
-		"typeorm": "^0.3.30",
+		"typeorm": "^1.0.0",
 		"undici": "^6.10.2",
 		"custom-electron-titlebar": "^4.4.1"
 	},

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -37,7 +37,7 @@
 		"graphql": "^16.11.0",
 		"nest-knexjs": "^0.0.30",
 		"slugify": "^1.6.6",
-		"typeorm": "^0.3.30",
+		"typeorm": "^1.0.0",
 		"tslib": "^2.6.2"
 	},
 	"devDependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -45,7 +45,7 @@
 		"mikro-orm-soft-delete": "^1.0.0-alpha.1",
 		"nest-knexjs": "^0.0.30",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -179,7 +179,7 @@
 		"sql.js": "^1.5.0",
 		"streamifier": "^0.1.1",
 		"swagger-ui-express": "^5.0.0",
-		"typeorm": "^0.3.30",
+		"typeorm": "^1.0.0",
 		"underscore": "^1.13.8",
 		"unleash-client": "^3.16.1",
 		"unzipper": "^0.12.1",

--- a/packages/plugins/changelog/package.json
+++ b/packages/plugins/changelog/package.json
@@ -43,7 +43,7 @@
 		"chalk": "^4.1.0",
 		"class-validator": "^0.14.2",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",

--- a/packages/plugins/integration-activepieces/package.json
+++ b/packages/plugins/integration-activepieces/package.json
@@ -45,7 +45,7 @@
 		"moment": "^2.30.1",
 		"rxjs": "^7.8.2",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/express": "^5.0.1",

--- a/packages/plugins/integration-github/package.json
+++ b/packages/plugins/integration-github/package.json
@@ -59,7 +59,7 @@
 		"rxjs": "^7.8.2",
 		"smee-client": "^1.2.3",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30",
+		"typeorm": "^1.0.0",
 		"underscore": "^1.13.8",
 		"uuid": "^14.0.0"
 	},

--- a/packages/plugins/integration-hubstaff/package.json
+++ b/packages/plugins/integration-hubstaff/package.json
@@ -45,7 +45,7 @@
 		"moment": "^2.30.1",
 		"rxjs": "^7.8.2",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/express": "^5.0.1",

--- a/packages/plugins/integration-make-com/package.json
+++ b/packages/plugins/integration-make-com/package.json
@@ -48,7 +48,7 @@
 		"class-validator": "^0.14.2",
 		"rxjs": "^7.8.2",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",

--- a/packages/plugins/integration-plane/package.json
+++ b/packages/plugins/integration-plane/package.json
@@ -43,7 +43,7 @@
 		"class-validator": "^0.14.2",
 		"rxjs": "^7.8.2",
 		"tslib": "^2.3.0",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",

--- a/packages/plugins/integration-sim/package.json
+++ b/packages/plugins/integration-sim/package.json
@@ -43,7 +43,7 @@
 		"rxjs": "^7.8.2",
 		"simstudio-ts-sdk": "^0.1.2",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/express": "^5.0.1",

--- a/packages/plugins/integration-upwork/package.json
+++ b/packages/plugins/integration-upwork/package.json
@@ -47,7 +47,7 @@
 		"fs-extra": "^10.1.0",
 		"moment": "^2.30.1",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30",
+		"typeorm": "^1.0.0",
 		"underscore": "^1.13.8",
 		"upwork-api": "^1.3.8",
 		"uuid": "^14.0.0"

--- a/packages/plugins/integration-wakatime/package.json
+++ b/packages/plugins/integration-wakatime/package.json
@@ -38,7 +38,7 @@
 		"@nestjs/typeorm": "^11.0.1",
 		"moment": "^2.30.1",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@nestjs/testing": "^11.1.26",

--- a/packages/plugins/integration-zapier/package.json
+++ b/packages/plugins/integration-zapier/package.json
@@ -48,7 +48,7 @@
 		"class-validator": "^0.14.2",
 		"rxjs": "^7.8.2",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30",
+		"typeorm": "^1.0.0",
 		"zapier-platform-core": "^18.4.0"
 	},
 	"devDependencies": {

--- a/packages/plugins/jitsu-analytics/package.json
+++ b/packages/plugins/jitsu-analytics/package.json
@@ -38,7 +38,7 @@
 		"chalk": "^4.1.0",
 		"node-fetch": "^2.6.7",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",

--- a/packages/plugins/job-proposal/package.json
+++ b/packages/plugins/job-proposal/package.json
@@ -47,7 +47,7 @@
 		"class-validator": "^0.14.2",
 		"moment": "^2.30.1",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@nestjs/testing": "^11.1.26",

--- a/packages/plugins/job-search/package.json
+++ b/packages/plugins/job-search/package.json
@@ -47,7 +47,7 @@
 		"class-validator": "^0.14.2",
 		"html-to-text": "^9.0.5",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",

--- a/packages/plugins/knowledge-base/package.json
+++ b/packages/plugins/knowledge-base/package.json
@@ -36,7 +36,7 @@
 		"chalk": "^4.1.0",
 		"class-validator": "^0.14.2",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",

--- a/packages/plugins/product-reviews/package.json
+++ b/packages/plugins/product-reviews/package.json
@@ -40,7 +40,7 @@
 		"class-validator": "^0.14.2",
 		"graphql-tag": "^2.12.6",
 		"tslib": "^2.6.2",
-		"typeorm": "^0.3.30"
+		"typeorm": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17170,7 +17170,7 @@ app-builder-lib@26.0.3:
     temp-file "^3.4.0"
     tiny-async-pool "1.3.0"
 
-app-root-path@^3.0.0, app-root-path@^3.1.0:
+app-root-path@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-3.1.0.tgz#5971a2fc12ba170369a7a1ef018c71e6e47c2e86"
   integrity sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==
@@ -22848,7 +22848,7 @@ dotenv@17.4.1:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz#d8e2179fe287365ef3aecb9459668454168eda88"
   integrity sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==
 
-dotenv@^16.4.5, dotenv@^16.6.1:
+dotenv@^16.4.5:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
@@ -25847,7 +25847,7 @@ glob@7.2.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0, glo
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.0.0, glob@^10.2.2, glob@^10.3.10, glob@^10.3.12, glob@^10.4.2, glob@^10.4.5, glob@^10.5.0:
+glob@^10.0.0, glob@^10.2.2, glob@^10.3.10, glob@^10.3.12, glob@^10.4.2, glob@^10.4.5:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
@@ -36042,6 +36042,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
 pidtree@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
@@ -41762,6 +41767,14 @@ tinyglobby@0.2.15, tinyglobby@^0.2.12, tinyglobby@^0.2.14, tinyglobby@^0.2.15:
     fdir "^6.5.0"
     picomatch "^4.0.3"
 
+tinyglobby@^0.2.16:
+  version "0.2.17"
+  resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
 tinygradient@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/tinygradient/-/tinygradient-1.1.5.tgz#0fb855ceb18d96b21ba780b51a8012033b2530ef"
@@ -42548,26 +42561,21 @@ typeface-exo@^0.0.61:
   resolved "https://registry.yarnpkg.com/typeface-exo/-/typeface-exo-0.0.61.tgz#10c6113292da354cb9f26ee9d0b0c996f1a7a3bd"
   integrity sha512-AH3bMVYnVpg2G+CJbgtogTuJpWGS0zspHJzzVR8cCgTtkbUI0pj8WBB+RFo14CHbF5MmZgYe7TVoWz+j4Yo6Jg==
 
-typeorm@^0.3.30:
-  version "0.3.30"
-  resolved "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz#79721a6de089b187b93b2dcd5c542847f07ac8b2"
-  integrity sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==
+typeorm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/typeorm/-/typeorm-1.0.0.tgz#d7a1602f46d2eab253f1973d8f9e42a66d423c5d"
+  integrity sha512-2mSKNqucP8vo+xQLP59xlHUcqLvG6qajxA7q7tnhJgeZjTrA6lK/Ar7LRyiAxdXhyXmGbIPsArPmcUB9Xg+M7w==
   dependencies:
     "@sqltools/formatter" "^1.2.5"
     ansis "^4.2.0"
-    app-root-path "^3.1.0"
-    buffer "^6.0.3"
     dayjs "^1.11.20"
     debug "^4.4.3"
     dedent "^1.7.2"
-    dotenv "^16.6.1"
-    glob "^10.5.0"
     reflect-metadata "^0.2.2"
-    sha.js "^2.4.12"
     sql-highlight "^6.1.0"
+    tinyglobby "^0.2.16"
     tslib "^2.8.1"
-    uuid "^11.1.1"
-    yargs "^17.7.2"
+    yargs "^18.0.0"
 
 typescript@5.9.3, "typescript@>=3 < 6", typescript@^5.0.4, typescript@^5.4.3, typescript@^5.9.3, typescript@~5.9.2:
   version "5.9.3"
@@ -43215,11 +43223,6 @@ uuid@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
-
-uuid@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
-  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 uuid@^14.0.0:
   version "14.0.0"


### PR DESCRIPTION
Migrates **TypeORM `0.3.30` → `1.0.0`** across all declaring `package.json` files + `yarn.lock`.

### Why this is low-risk for this codebase
A usage scan found **0 occurrences** of every removed/renamed 0.3→1.0 API:
`Connection`/`createConnection`/`getConnection`/`getManager`, `findOneById`, `findByIds`, `.exist(`,
`@EntityRepository`, `getCustomRepository`, `AbstractRepository`, `@RelationCount`, `.onConflict`,
`.printSql`. The codebase already uses modern 0.3 patterns (`@nestjs/typeorm` injection, `DataSource`).

- `@nestjs/typeorm@11.0.1` (from #9714) peer-accepts `typeorm@^1.0.0` — required, since 10/11.0.0 crash on the removed `Connection` class.
- SQLite already on `better-sqlite3` ✓. Node ≥24 / ES2023 ✓.
- `yarn install` resolves cleanly to `typeorm@1.0.0` (no peer errors).

### Watch items (runtime, not compile)
- **Null/undefined in `where`** now throws by default in 1.0. If runtime regressions appear, set `invalidWhereValuesBehavior: { null: 'ignore', undefined: 'ignore' }` on the DataSource options in `packages/config`. (Not added preemptively to avoid masking real issues; e2e is currently dormant so won't surface it — flagging for the post-merge smoke check.)
- 193 `relations: [ ... ]` array find-options remain; 1.0 is expected to still accept them — if the build flags them, `npx @typeorm/codemod v1` converts to object form.

### Stacking
Based on #9714 (the consolidated in-major bump). GitHub will auto-retarget this to `develop` when #9714 merges.

Part of the backend "migrate to latest" effort (TypeORM 1.0 → OpenTelemetry → MikroORM 7).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `typeorm` from 0.3.30 to 1.0.0 across the monorepo and refreshes `yarn.lock`. Low risk: no removed 1.0 APIs are used; we already use `DataSource` with `@nestjs/typeorm@11`.

- **Dependencies**
  - Set `typeorm` to `^1.0.0` in 21 `package.json` files and updated `yarn.lock` (transitive updates like `tinyglobby`/`picomatch`; no peer conflicts).
  - Confirmed compatibility with `@nestjs/typeorm@11.0.1`.

- **Migration**
  - If null/undefined in `where` throws, set `invalidWhereValuesBehavior: { null: 'ignore', undefined: 'ignore' }` in DataSource options.
  - If `relations: [ ... ]` arrays are flagged, run `npx @typeorm/codemod v1` to convert to object form.

<sup>Written for commit ff3eaecd27f50216bd74e8f24411f90d4449b864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

