### PR TITLE
ci: restore build caching via CircleCI Nx cache (fix timeout regression)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
@@ -124,7 +124,7 @@ jobs:
             ./sonar-scanner/bin/sonar-scanner \
               -Dsonar.host.url=${SONAR_SERVER:-https://sonarcloud.io} \
               -Dsonar.token=${SONAR_TOKEN}
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-sonarqube-{{ checksum "yarn.lock" }}
@@ -156,7 +156,7 @@ jobs:
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
@@ -185,25 +185,36 @@ jobs:
           keys:
             - yarn-packages-desktop-{{ checksum "yarn.lock" }}
             - yarn-packages-desktop-
+      - restore_cache:
+          name: Restore Nx Cache
+          keys:
+            - nx-cache-{{ arch }}-{{ .Branch }}-
+            - nx-cache-{{ arch }}-develop-
+            - nx-cache-{{ arch }}-
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
       - run:
           name: Run Build
           command: nvm use v24 && yarn build:desktop
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-desktop-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+      - save_cache:
+          name: Save Nx Cache
+          key: nx-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
+          paths:
+            - .nx/cache
 
   # ----------------------------------------------------------------------------
   # Build API Application
@@ -224,29 +235,40 @@ jobs:
           keys:
             - yarn-packages-api-{{ checksum "yarn.lock" }}
             - yarn-packages-api-
+      - restore_cache:
+          name: Restore Nx Cache
+          keys:
+            - nx-cache-{{ arch }}-{{ .Branch }}-
+            - nx-cache-{{ arch }}-develop-
+            - nx-cache-{{ arch }}-
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
       - run:
           name: Run Packages Build
           command: nvm use v24 && yarn build:package:all
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - run:
           name: Run Build
           command: nvm use v24 && yarn build:api:prod:ci
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-api-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+      - save_cache:
+          name: Save Nx Cache
+          key: nx-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
+          paths:
+            - .nx/cache
 
   # ----------------------------------------------------------------------------
   # Build Web Application (Gauzy Frontend)
@@ -267,29 +289,40 @@ jobs:
           keys:
             - yarn-packages-web-{{ checksum "yarn.lock" }}
             - yarn-packages-web-
+      - restore_cache:
+          name: Restore Nx Cache
+          keys:
+            - nx-cache-{{ arch }}-{{ .Branch }}-
+            - nx-cache-{{ arch }}-develop-
+            - nx-cache-{{ arch }}-
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
       - run:
           name: Run Packages Build
           command: nvm use v24 && yarn build:package:all
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - run:
           name: Run Build
           command: nvm use v24 && yarn build:gauzy:prod:ci
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-web-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+      - save_cache:
+          name: Save Nx Cache
+          key: nx-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}-{{ epoch }}
+          paths:
+            - .nx/cache
 
   # ----------------------------------------------------------------------------
   # End-to-End Tests
@@ -317,7 +350,7 @@ jobs:
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
@@ -380,7 +413,7 @@ jobs:
           command: |
             nvm use v24
             yarn install --ignore-scripts && yarn postinstall.manual
-          no_output_timeout: 60m
+          no_output_timeout: 90m
       - pulumi/update:
           stack: dev
       - save_cache:


### PR DESCRIPTION
﻿Fixes the CircleCI build-timeout regression. **Root cause:** when the Nx Cloud org was disabled we set `NX_NO_CLOUD=true` to stop the hard failure, but that removed remote build caching — so each of build-api/build-web/build-desktop did full **cold rebuilds of ~60 libs** every run, blowing past timeouts (build:package:all ran 3x cold per workflow). **Fix:** persist Nx's local `.nx/cache` across runs via CircleCI `restore_cache`/`save_cache` (build is cacheable; `cacheDirectory=.nx/cache`); the 3 build jobs cross-share the lib cache. Also bumps `no_output_timeout` 60m->90m for the cold first run + Angular's quiet optimization phases. First run populates the cache (cold); subsequent runs are incremental/fast.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Nx build caching in CircleCI to fix build timeouts by persisting the local cache and increasing `no_output_timeout` for cold runs.

- **Bug Fixes**
  - Persist `.nx/cache` using CircleCI `restore_cache`/`save_cache`, shared across `build-api`, `build-web`, and `build-desktop`.
  - Add cache keys with `arch` and branch, with a `develop` fallback, so subsequent builds reuse compiled libs even with `NX_NO_CLOUD=true`.
  - Raise `no_output_timeout` from 60m to 90m for install and build steps to cover the first cold run and quiet optimization phases.

<sup>Written for commit 4c443a88aef707e16f2c3a4de1f763439ee6112d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

