### PR TITLE
fix(typeorm-v1): convert legacy string[] relations/select at runtime (P0 — app unusable after login)

### DIFF
--- a/patches/typeorm+1.0.0.patch
+++ b/patches/typeorm+1.0.0.patch
@@ -1,24 +1,72 @@
-diff --git a/node_modules/typeorm/find-options/FindOneOptions.d.ts b/node_modules/typeorm/find-options/FindOneOptions.d.ts
-index 2e19a6a..54007cb 100644
---- a/node_modules/typeorm/find-options/FindOneOptions.d.ts
-+++ b/node_modules/typeorm/find-options/FindOneOptions.d.ts
-@@ -15,7 +15,7 @@ export interface FindOneOptions<Entity = any> {
+diff --git a/node_modules/typeorm/find-options/FindOptionsUtils.js b/node_modules/typeorm/find-options/FindOptionsUtils.js
+index d5c79d8..6966629 100644
+--- a/node_modules/typeorm/find-options/FindOptionsUtils.js
++++ b/node_modules/typeorm/find-options/FindOptionsUtils.js
+@@ -37,9 +37,29 @@ class FindOptionsUtils {
+             typeof options === "object" &&
+             "select" in options &&
+             Array.isArray(options.select)) {
+-            throw new error_2.TypeORMError(`String-array "select" syntax has been removed. ` +
+-                `Use object syntax instead, e.g. select: { id: true, name: true }. ` +
+-                `See the v1 migration guide for details.`);
++            // Ever Gauzy compat shim: convert the legacy string-array `select` syntax (removed in
++            // v1.0) to the object form v0.3 accepted, instead of rejecting. e.g.
++            // ["id","name","role.name"] => { id: true, name: true, role: { name: true } }
++            const obj = {};
++            for (const col of options.select) {
++                if (typeof col !== "string" || col.length === 0)
++                    continue;
++                let cur = obj;
++                const parts = col.split(".");
++                for (let i = 0; i < parts.length; i++) {
++                    const p = parts[i];
++                    if (i === parts.length - 1) {
++                        if (cur[p] === undefined)
++                            cur[p] = true;
++                    }
++                    else {
++                        if (cur[p] === true || cur[p] === undefined)
++                            cur[p] = {};
++                        cur = cur[p];
++                    }
++                }
++            }
++            options.select = obj;
+         }
+     }
      /**
-      * Specifies what columns should be retrieved.
-      */
--    select?: FindOptionsSelect<Entity>;
-+    select?: FindOptionsSelect<Entity> | string[];
+@@ -53,9 +73,31 @@ class FindOptionsUtils {
+             typeof options === "object" &&
+             "relations" in options &&
+             Array.isArray(options.relations)) {
+-            throw new error_2.TypeORMError(`String-array "relations" syntax has been removed. ` +
+-                `Use object syntax instead, e.g. relations: { profile: true, posts: true }. ` +
+-                `See the v1 migration guide for details.`);
++            // Ever Gauzy compat shim: instead of rejecting the legacy string-array `relations`
++            // syntax (removed in typeorm v1.0), convert it to the object form that v0.3 accepted.
++            // The codebase passes dynamic `string[]` relations in many places; converting here
++            // keeps them working at runtime. e.g. ["role","tenant.featureOrganizations"] =>
++            // { role: true, tenant: { featureOrganizations: true } }
++            const obj = {};
++            for (const rel of options.relations) {
++                if (typeof rel !== "string" || rel.length === 0)
++                    continue;
++                let cur = obj;
++                const parts = rel.split(".");
++                for (let i = 0; i < parts.length; i++) {
++                    const p = parts[i];
++                    if (i === parts.length - 1) {
++                        if (cur[p] === undefined)
++                            cur[p] = true;
++                    }
++                    else {
++                        if (cur[p] === true || cur[p] === undefined)
++                            cur[p] = {};
++                        cur = cur[p];
++                    }
++                }
++            }
++            options.relations = obj;
+         }
+     }
      /**
-      * Simple condition that should be applied to match entities.
-      */
-@@ -23,7 +23,9 @@ export interface FindOneOptions<Entity = any> {
-     /**
-      * Indicates what relations of entity should be loaded (simplified left join form).
-      */
--    relations?: FindOptionsRelations<Entity>;
-+    relations?: FindOptionsRelations<Entity> | string[];
-+    /** @deprecated removed from typeorm 1.0 types but still honored at runtime */
-+    join?: any;
-     /**
-      * Specifies how relations must be loaded - using "joins" or separate queries.
-      * If you are loading too much data with nested joins it's better to load relations


### PR DESCRIPTION
## Problem (P0 regression from the TypeORM 1.0 upgrade #9716)

The TypeORM 1.0 upgrade patched only the **types** to allow `string[]` relations/select, but TypeORM 1.0 **also hard-rejects them at runtime** (`FindOptionsUtils.rejectStringArrayRelations` / `rejectStringArraySelect` throw `TypeORMError`).

The codebase passes **dynamic `string[]` relations** in many places, e.g. `UserService.findMe`:
```ts
const userId = RequestContext.currentUserId();
return await this.findOneByIdString(userId, { relations }); // relations: string[]
```
At runtime this throws → caught → returns `undefined` → `findMeUser` does `user.id` → `Cannot read properties of undefined (reading 'id')`.

**Net effect:** `GET /api/user/me` (getMe) returns an error → the Angular app-init sees no `user.tenantId` → every authenticated user is redirected to `/onboarding/tenant` ("create your first organization"). **The app is unusable after login** (including demo.gauzy.co, deployed from develop).

## Fix
Patch `FindOptionsUtils` to **convert** `string[]` → nested object form (exactly what v0.3 did internally) for both `relations` and `select`, instead of throwing. e.g. `['role','tenant.featureOrganizations'] → { role: true, tenant: { featureOrganizations: true } }`.

- Behavior-preserving for object-form callers (only the array branch changes).
- Applied via `patch-package` (`postinstall.manual` / CI bootstrap).
- Verified locally: `getMe` returns the user with `tenantId`; login → dashboard works.

## Follow-up (separate)
The removed `join` find-option (`rejectJoinOption`) still throws for a few services (payment, employee-statistics, user.service, job-preset). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert legacy string[] relations/select to object syntax at runtime in `typeorm` v1.0 to prevent hard errors and restore login/app init (fixes `/api/user/me`).

- **Bug Fixes**
  - Patched `FindOptionsUtils` to transform string-array `relations` and `select` into nested object form (e.g., ['role', 'tenant.featureOrganizations'] → { role: true, tenant: { featureOrganizations: true } }).
  - Applied via `patch-package`; object-form callers remain unchanged.
  - Verified `getMe` returns a user with `tenantId`; login flow and dashboard now load.

<sup>Written for commit eeb30dda3e105fb1bee50c8684edfdd25d5d1863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

