### PR TITLE
fix(integration-plane): bind Plane proxy tenant to the session JWT

### DIFF
--- a/packages/plugins/integration-plane/src/lib/plane-proxy.service.ts
+++ b/packages/plugins/integration-plane/src/lib/plane-proxy.service.ts
@@ -71,20 +71,21 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 					// sees a clean URL regardless of which tenant signal wins below.
 					const pathTenantId = this.extractTenantIdFromPath(req);
 
-					// 1. Explicit header / cookie (Gauzy-originated calls) — JWT-validated.
-					const headerTenantId = this.extractTenantIdFromHeaders(req);
+					// 1. Explicit X-TENANT-ID header (Gauzy-internal calls) — JWT-validated.
+					const headerTenantId = this.extractTenantIdFromHeader(req);
 					if (headerTenantId) {
 						this.validateTenantFromToken(req, headerTenantId);
 						(req as any)[REQ_TENANT_ID] = headerTenantId;
 						return headerTenantId;
 					}
 
-					// 2. The authenticated session cookie is the SOURCE OF TRUTH for the
-					//    tenant. When a valid session is present it OVERRIDES the path
-					//    UUID, so a request can never be served with another tenant's
-					//    resolved config (apiKey / apiSecret / CORS origins) while it
-					//    carries a different tenant's session. Closes the confused-deputy
-					//    where an attacker swaps in someone else's tenant UUID.
+					// 2. The authenticated Plane session is the SOURCE OF TRUTH for the
+					//    tenant. It is resolved BEFORE the ambient `tenant-id` cookie so a
+					//    Plane UI request (session cookie, no Bearer) is never short-
+					//    circuited into the "missing Bearer" path by a stray tenant-id
+					//    cookie. A valid session also OVERRIDES the path UUID, so a request
+					//    can never be served with another tenant's resolved config while it
+					//    carries a different tenant's session (confused-deputy defense).
 					const sessionTenantId = this.extractSessionTenantId(req);
 					if (sessionTenantId) {
 						if (pathTenantId && pathTenantId !== sessionTenantId) {
@@ -98,7 +99,18 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 						return sessionTenantId;
 					}
 
-					// 3. No session yet — public bootstrap (auth/email-check, login,
+					// 3. `tenant-id` cookie from a Gauzy browser session — only honored
+					//    when a Bearer is also present, so it can be cross-checked against
+					//    the token (and so it never throws for a Plane bootstrap request
+					//    that merely carries an ambient tenant-id cookie).
+					const cookieTenantId = this.extractTenantIdFromCookie(req);
+					if (cookieTenantId && this.hasBearerToken(req)) {
+						this.validateTenantFromToken(req, cookieTenantId);
+						(req as any)[REQ_TENANT_ID] = cookieTenantId;
+						return cookieTenantId;
+					}
+
+					// 4. No tenant yet — public bootstrap (auth/email-check, login,
 					//    api/instances). Fall back to the path tenant so CORS and the
 					//    email-check API key resolve for the right tenant.
 					if (pathTenantId) {
@@ -208,14 +220,21 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 	}
 
 	/**
-	 * Extract tenant ID from X-TENANT-ID header or tenant-id cookie.
+	 * Extract the tenant ID from the explicit X-TENANT-ID header.
 	 */
-	private extractTenantIdFromHeaders(req: http.IncomingMessage): string | undefined {
+	private extractTenantIdFromHeader(req: http.IncomingMessage): string | undefined {
 		const tenantIdHeader = req.headers['x-tenant-id'];
 		if (tenantIdHeader) {
 			return Array.isArray(tenantIdHeader) ? tenantIdHeader[0] : tenantIdHeader;
 		}
+		return undefined;
+	}
 
+	/**
+	 * Extract the tenant ID from the ambient `tenant-id` cookie (set by Gauzy
+	 * browser sessions). Lower priority than the authenticated Plane session.
+	 */
+	private extractTenantIdFromCookie(req: http.IncomingMessage): string | undefined {
 		const cookieHeader = req.headers['cookie'];
 		if (cookieHeader) {
 			const match = cookieHeader.match(/(?:^|;\s*)tenant-id=([^;]+)/);
@@ -223,8 +242,15 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 				return decodeURIComponent(match[1]);
 			}
 		}
-
 		return undefined;
+	}
+
+	/**
+	 * Whether the request carries an `Authorization: Bearer` token.
+	 */
+	private hasBearerToken(req: http.IncomingMessage): boolean {
+		const auth = req.headers['authorization'];
+		return typeof auth === 'string' && auth.startsWith('Bearer ');
 	}
 
 	// ── Session-based tenant resolution ──────────────────

--- a/packages/plugins/integration-plane/src/lib/plane-proxy.service.ts
+++ b/packages/plugins/integration-plane/src/lib/plane-proxy.service.ts
@@ -47,6 +47,17 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 		try {
 			const httpServer = this.httpAdapterHost.httpAdapter.getHttpServer();
 
+			// Path<->session binding (extractSessionTenantId) needs JWT_SECRET to verify the
+			// session cookie. Without it every request silently falls back to trusting the
+			// URL tenant, re-opening the confused-deputy. Fail loudly instead of silently.
+			if (!environment.JWT_SECRET) {
+				this.logger.error(
+					'JWT_SECRET is not configured — the Plane proxy cannot bind the path tenant to ' +
+						'the authenticated session and will fall back to trusting the URL tenant. Set ' +
+						'JWT_SECRET so session-based tenant resolution is enforced.'
+				);
+			}
+
 			this.proxyResult = mountPlaneProxy(httpServer, {
 				prefix: PROXY_PREFIX,
 
@@ -56,7 +67,11 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 				 * that authentication is never skipped.
 				 */
 				extractTenantId: (req) => {
-					// 1. Explicit header / cookie (Gauzy-originated calls)
+					// Always strip a UUID path segment first so the downstream proxy app
+					// sees a clean URL regardless of which tenant signal wins below.
+					const pathTenantId = this.extractTenantIdFromPath(req);
+
+					// 1. Explicit header / cookie (Gauzy-originated calls) — JWT-validated.
 					const headerTenantId = this.extractTenantIdFromHeaders(req);
 					if (headerTenantId) {
 						this.validateTenantFromToken(req, headerTenantId);
@@ -64,13 +79,7 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 						return headerTenantId;
 					}
 
-					// 2. UUID baked into the URL path by the Plane UI
-					//    (VITE_API_BASE_URL=.../api/plane/{tenantId}). Always strip it so
-					//    the downstream proxy app sees a clean URL; keep it only as a
-					//    fallback tenant signal for unauthenticated bootstrap requests.
-					const pathTenantId = this.extractTenantIdFromPath(req);
-
-					// 3. The authenticated session cookie is the SOURCE OF TRUTH for the
+					// 2. The authenticated session cookie is the SOURCE OF TRUTH for the
 					//    tenant. When a valid session is present it OVERRIDES the path
 					//    UUID, so a request can never be served with another tenant's
 					//    resolved config (apiKey / apiSecret / CORS origins) while it
@@ -89,7 +98,7 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 						return sessionTenantId;
 					}
 
-					// 4. No session yet — public bootstrap (auth/email-check, login,
+					// 3. No session yet — public bootstrap (auth/email-check, login,
 					//    api/instances). Fall back to the path tenant so CORS and the
 					//    email-check API key resolve for the right tenant.
 					if (pathTenantId) {

--- a/packages/plugins/integration-plane/src/lib/plane-proxy.service.ts
+++ b/packages/plugins/integration-plane/src/lib/plane-proxy.service.ts
@@ -64,8 +64,34 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 						return headerTenantId;
 					}
 
-					// 2. UUID in URL path (Plane UI calls)
+					// 2. UUID baked into the URL path by the Plane UI
+					//    (VITE_API_BASE_URL=.../api/plane/{tenantId}). Always strip it so
+					//    the downstream proxy app sees a clean URL; keep it only as a
+					//    fallback tenant signal for unauthenticated bootstrap requests.
 					const pathTenantId = this.extractTenantIdFromPath(req);
+
+					// 3. The authenticated session cookie is the SOURCE OF TRUTH for the
+					//    tenant. When a valid session is present it OVERRIDES the path
+					//    UUID, so a request can never be served with another tenant's
+					//    resolved config (apiKey / apiSecret / CORS origins) while it
+					//    carries a different tenant's session. Closes the confused-deputy
+					//    where an attacker swaps in someone else's tenant UUID.
+					const sessionTenantId = this.extractSessionTenantId(req);
+					if (sessionTenantId) {
+						if (pathTenantId && pathTenantId !== sessionTenantId) {
+							this.logger.warn(
+								`Plane proxy: path tenant ${pathTenantId} does not match the ` +
+									`authenticated session tenant ${sessionTenantId}; serving the ` +
+									`session tenant.`
+							);
+						}
+						(req as any)[REQ_TENANT_ID] = sessionTenantId;
+						return sessionTenantId;
+					}
+
+					// 4. No session yet — public bootstrap (auth/email-check, login,
+					//    api/instances). Fall back to the path tenant so CORS and the
+					//    email-check API key resolve for the right tenant.
 					if (pathTenantId) {
 						(req as any)[REQ_TENANT_ID] = pathTenantId;
 						return pathTenantId;
@@ -190,6 +216,74 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 		}
 
 		return undefined;
+	}
+
+	// ── Session-based tenant resolution ──────────────────
+
+	/**
+	 * Read and verify the Gauzy JWT carried by the chunked
+	 * `auth-proxy-plane-token-*` cookies and return its `tenantId` claim.
+	 *
+	 * Returns `undefined` when no session cookie is present (unauthenticated
+	 * bootstrap) or when JWT_SECRET is not configured (e.g. a standalone proxy
+	 * that does not share Gauzy's signing secret). A present-but-invalid or
+	 * expired cookie is also treated as no session: the forwarded Bearer is the
+	 * same token and Gauzy rejects it with 401, letting the Plane UI
+	 * re-authenticate gracefully instead of the proxy hard-failing the request.
+	 */
+	private extractSessionTenantId(req: http.IncomingMessage): string | undefined {
+		const token = this.readSessionToken(req);
+		if (!token) {
+			return undefined;
+		}
+
+		const jwtSecret = environment.JWT_SECRET;
+		if (!jwtSecret) {
+			return undefined;
+		}
+
+		try {
+			const payload = verify(token, jwtSecret) as { tenantId?: string };
+			return payload.tenantId || undefined;
+		} catch (error) {
+			this.logger.debug(
+				`Ignoring invalid/expired Plane proxy session cookie: ${
+					error instanceof Error ? error.message : String(error)
+				}`
+			);
+			return undefined;
+		}
+	}
+
+	/**
+	 * Reassemble the chunked `auth-proxy-plane-token-{0,1,...}` cookie into the
+	 * raw JWT string from the raw `Cookie` header (cookies are not parsed yet at
+	 * the HTTP-server interception layer).
+	 */
+	private readSessionToken(req: http.IncomingMessage): string | undefined {
+		const cookieHeader = req.headers['cookie'];
+		if (!cookieHeader) {
+			return undefined;
+		}
+
+		const jar: Record<string, string> = {};
+		for (const part of cookieHeader.split(';')) {
+			const eq = part.indexOf('=');
+			if (eq === -1) {
+				continue;
+			}
+			const key = part.slice(0, eq).trim();
+			if (key) {
+				jar[key] = part.slice(eq + 1).trim();
+			}
+		}
+
+		const chunks: string[] = [];
+		for (let index = 0; jar[`auth-proxy-plane-token-${index}`] !== undefined; index++) {
+			chunks.push(jar[`auth-proxy-plane-token-${index}`]);
+		}
+
+		return chunks.length > 0 ? chunks.join('') : undefined;
 	}
 
 	// ── JWT validation ────────────────────────────────────────────────


### PR DESCRIPTION
## What

Closes a **confused-deputy** in the Plane↔Gauzy proxy's tenant resolution.

`PlaneProxyService.extractTenantId` resolved a tenant's per-tenant Plane config
(`apiKey` / `apiSecret` / CORS origins) from the **UUID baked into the request path**
(`/api/plane/{tenantId}/…`) **without binding it to the authenticated session**. An
authenticated tenant-A user could therefore drive a request through tenant-B's resolved
config by swapping the path UUID.

**No tenant data leaked** pre-fix — Gauzy re-scopes every query to the signed JWT's tenant
(`jwt.strategy.ts` → `RequestContext.currentTenantId()` → `TenantAwareCrudService`) — but the
binding was missing as defense-in-depth and was a latent foot-gun for any future code that
trusts the request-scoped config.

## Changes (`packages/plugins/integration-plane/src/lib/plane-proxy.service.ts`)

- `extractTenantId` now verifies the `auth-proxy-plane-token-*` cookie JWT and, when a valid
  session is present, uses **its `tenantId` as the source of truth**, overriding the path UUID.
  The path UUID remains a fallback only for unauthenticated bootstrap (email-check, login,
  instances).
- The path UUID is now **stripped unconditionally** so `req.url` is always rewritten.
- `onModuleInit` logs a **loud error if `JWT_SECRET` is unset** (otherwise the binding silently
  degrades to trusting the URL tenant).

## Trade-off (intentional)

A multi-tenant user who opens a Plane build baked for tenant A while their session is tenant B
now fails **safe** (CORS-blocked) rather than silently being served B's data in A's build.

## Verification

Adversarially reviewed (4-agent red-team for cross-tenant exfiltration + independent
verification pass) → **SHIP**. Not built in CI locally (Nx monorepo); change is isolated to one
file and type-consistent with surrounding code.

Companion PR (proxy-side `AuthGuard` hardening): ever-co/ever-gauzy-plugins-plane#252

🤖 Generated with [Claude Code](https://claude.com/claude-code)
