### PR TITLE
ci: cache node_modules to fix 60-min CircleCI job timeouts; gate desktop off PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,10 @@ jobs:
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
+      - restore_cache:
+          name: Restore node_modules
+          keys:
+            - v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
@@ -110,6 +114,11 @@ jobs:
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
+      - save_cache:
+          name: Save node_modules
+          key: v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
+          paths:
+            - node_modules
       - run:
           name: Install SonarScanner CLI
           command: |
@@ -153,6 +162,10 @@ jobs:
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
+      - restore_cache:
+          name: Restore node_modules
+          keys:
+            - v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
@@ -160,6 +173,11 @@ jobs:
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
+      - save_cache:
+          name: Save node_modules
+          key: v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
+          paths:
+            - node_modules
       - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-monorepo-{{ checksum "yarn.lock" }}
@@ -194,6 +212,10 @@ jobs:
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
+      - restore_cache:
+          name: Restore node_modules
+          keys:
+            - v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
@@ -201,6 +223,11 @@ jobs:
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
+      - save_cache:
+          name: Save node_modules
+          key: v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
+          paths:
+            - node_modules
       - run:
           name: Run Build
           command: nvm use v24 && yarn build:desktop
@@ -244,6 +271,10 @@ jobs:
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
+      - restore_cache:
+          name: Restore node_modules
+          keys:
+            - v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
@@ -251,6 +282,11 @@ jobs:
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
+      - save_cache:
+          name: Save node_modules
+          key: v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
+          paths:
+            - node_modules
       - run:
           name: Run Packages Build
           command: nvm use v24 && yarn build:package:all
@@ -298,6 +334,10 @@ jobs:
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
+      - restore_cache:
+          name: Restore node_modules
+          keys:
+            - v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
@@ -305,6 +345,11 @@ jobs:
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
+      - save_cache:
+          name: Save node_modules
+          key: v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
+          paths:
+            - node_modules
       - run:
           name: Run Packages Build
           command: nvm use v24 && yarn build:package:all
@@ -347,6 +392,10 @@ jobs:
       - run:
           name: Verify Node version
           command: nvm use v24 && node --version
+      - restore_cache:
+          name: Restore node_modules
+          keys:
+            - v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
       - run:
           name: Install Yarn Dependencies
           command: nvm use v24 && yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
@@ -354,6 +403,11 @@ jobs:
       - run:
           name: Run Postinstall Manually
           command: nvm use v24 && yarn postinstall.manual
+      - save_cache:
+          name: Save node_modules
+          key: v1-node-modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "patches/typeorm+1.0.0.patch" }}
+          paths:
+            - node_modules
       - run:
           name: Run API in background
           command: nvm use v24 && yarn start:api:ci
@@ -444,6 +498,13 @@ workflows:
       - build-desktop:
           requires:
             - build-monorepo-root
+          filters:
+            branches:
+              only:
+                - develop
+                - stage
+                - main
+                - master
 
   # ----------------------------------------------------------------------------
   # Test Workflow


### PR DESCRIPTION
## Problem

CircleCI builds were failing on every branch — **`build-web` and `build-desktop` are killed at exactly 60:00**. The CircleCI v1.1 API confirms this is the **hard per-job time limit** (Free plan = 1 hour), not your code:

| Job | Result | Duration |
|---|---|---|
| build-monorepo-root | ✅ | ~48 min (install only, no app build) |
| build-api | ✅ | ~56 min (3.8 min under the wire — lucky) |
| build-web | ❌ | **exactly 60:00** — `build_time_millis` 3,600,404 ms, final step `Build timed out` |
| build-desktop | ❌ | **exactly 60:00** — `build_time_millis` 3,600,206 ms |

`no_output_timeout` is 90m on every step, so this is a **job wall-clock cap**, not a no-output timeout, and there's no OOM (no exit 137) or compile error (completed steps exit 0).

## Root cause

**`yarn install` alone takes 44–48 min** of the 60-min budget. Only `~/.cache/yarn` (the download cache) and `.nx/cache` are cached — **`node_modules` is not** — and `persist_to_workspace` was removed (`f0c1279`), so every parallel job rebuilds `node_modules` from an empty tree (the slow link/native-build phase, not download). `build-monorepo-root` already pays this cost but throws the result away. That leaves ~10 min for the actual build → the cap hits mid-build.

## Fix (no machine-size change)

1. **Cache `node_modules` itself**, keyed on `{{ arch }}` + `yarn.lock` + `patches/typeorm+1.0.0.patch` (saved *after* `postinstall.manual`, so it captures `patch-package` + native builds), restored before install in every install-bearing job. `build-monorepo-root` primes the cache; `build-api`/`build-web` restore it → `yarn install` becomes a near no-op. This reclaims the ~45 min and gets web under 60 min.
2. **Gate the electron `build-desktop` to release branches** (`develop`/`stage`/`main`/`master`), mirroring `test-e2e`, so it stops failing on every PR.

`resource_class: large` (machine executor, **15 GB**) is kept on purpose — a Docker executor at the same class is only **8 GB** and would OOM the 12 GB Node heap (`--max-old-space-size=12288`).

## Validation

This PR's **own CircleCI run is the test**: `build-monorepo-root` will cold-install once (~48 min, under the cap) and prime the `node_modules` cache; `build-api`/`build-web` should then restore it and finish well under 60 min. Subsequent runs restore the cache in every job (cross-run), so even the root job gets fast.

## Follow-ups (not in this PR)
- De-dup `build:package:all` (it runs in both `build-api` and `build-web`).
- `nx affected` on PRs so unaffected apps aren't built (needs a real merge-base on CircleCI's shallow clone).

> Diagnosis details and the adversarial review that steered this toward `node_modules`-caching (the `persist_to_workspace` route had a dev-vs-prod build-config trap) are in the session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CircleCI job timeouts by caching `node_modules` and limiting the desktop build to release branches. Builds now reuse install artifacts and complete under the 60‑minute free plan cap.

- Bug Fixes
  - Cache `node_modules` across jobs (keyed by `{{ arch }}`, `yarn.lock`, and `patches/typeorm+1.0.0.patch`); restore before install, save after `yarn postinstall.manual` to include `patch-package` and native builds.
  - `build-monorepo-root` primes the cache; `build-api` and `build-web` restore it, turning the ~45‑minute install into a near no‑op.
  - Gate `build-desktop` to `develop`, `stage`, `main`, and `master` to avoid failing heavy builds on PRs.

<sup>Written for commit d8197f7ce099921a7296bd8443e1c8a1e0d7e974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

