### PR TITLE
fix(security): require a server-minted state nonce for GitHub App installs (GHSA-4rwq-65wh-45h4)

### DIFF
--- a/packages/plugins/integration-github-ui/src/lib/components/installation/installation.component.ts
+++ b/packages/plugins/integration-github-ui/src/lib/components/installation/installation.component.ts
@@ -28,8 +28,11 @@ export class GithubInstallationComponent implements AfterViewInit, OnInit {
 	ngOnInit(): void {
 		this._route.queryParams
 			.pipe(
-				// Filter and keep only valid queryParams with 'installation_id' and 'setup_action'
-				filter(({ installation_id, setup_action }) => !!installation_id && !!setup_action),
+				// Filter and keep only valid queryParams with 'installation_id', 'setup_action' and the
+				// single-use 'state' nonce (required to bind the installation to the initiating tenant).
+				filter(
+					({ installation_id, setup_action, state }) => !!installation_id && !!setup_action && !!state
+				),
 				tap(() => (this.organization = this._store.selectedOrganization)),
 				// Use 'tap' operator to perform an asynchronous action
 				tap(
@@ -61,19 +64,18 @@ export class GithubInstallationComponent implements AfterViewInit, OnInit {
 		if (!this.organization) {
 			return;
 		}
-		// Split the 'state' parameter to extract 'organizationId' and 'tenantId'
-		const { id: organizationId, tenantId } = this.organization;
-		const { installation_id, setup_action } = input;
+		const { installation_id, setup_action, state } = input;
 
-		// Check if all required parameters are provided
-		if (installation_id && setup_action) {
+		// The installation is bound server-side to the tenant/organization recorded against the
+		// single-use `state` nonce minted at initiation, so we forward only GitHub's identifiers plus
+		// the nonce — never a client-supplied tenant/organization (cross-tenant IDOR, GHSA-4rwq-65wh-45h4).
+		if (installation_id && setup_action && state) {
 			try {
 				// Call a service method (likely from _githubService) to add the installation app
 				const integration = await this._githubService.addInstallationApp({
 					installation_id,
 					setup_action,
-					organizationId,
-					tenantId
+					state
 				});
 
 				// Simulate a success scenario, possibly updating the UI or performing other actions

--- a/packages/plugins/integration-github-ui/src/lib/components/installation/installation.component.ts
+++ b/packages/plugins/integration-github-ui/src/lib/components/installation/installation.component.ts
@@ -61,9 +61,8 @@ export class GithubInstallationComponent implements AfterViewInit, OnInit {
 	 * @param input - An object containing input parameters, including 'installation_id', 'setup_action', and 'state'.
 	 */
 	private async verifyGitHubAppAuthorization(input: IGithubAppInstallInput) {
-		if (!this.organization) {
-			return;
-		}
+		// Do NOT gate on a hydrated organization: the server binds the installation to the tenant/org
+		// recorded against the nonce, so a not-yet-hydrated store must not drop a valid GitHub callback.
 		const { installation_id, setup_action, state } = input;
 
 		// The installation is bound server-side to the tenant/organization recorded against the

--- a/packages/plugins/integration-github-ui/src/lib/components/wizard/wizard.component.ts
+++ b/packages/plugins/integration-github-ui/src/lib/components/wizard/wizard.component.ts
@@ -5,7 +5,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { environment } from '@gauzy/ui-config';
 import { IOrganization } from '@gauzy/contracts';
 import { distinctUntilChange, toParams } from '@gauzy/ui-core/common';
-import { Store } from '@gauzy/ui-core/core';
+import { GithubService, Store } from '@gauzy/ui-core/core';
 import { GITHUB_AUTHORIZATION_URL } from '../../github.config';
 
 @UntilDestroy({ checkProperties: true })
@@ -51,7 +51,8 @@ export class GithubWizardComponent implements AfterViewInit, OnInit, OnDestroy {
 	constructor(
 		private readonly _activatedRoute: ActivatedRoute,
 		private readonly _router: Router,
-		private readonly _store: Store
+		private readonly _store: Store,
+		private readonly _githubService: GithubService
 	) {}
 
 	/**
@@ -195,16 +196,34 @@ export class GithubWizardComponent implements AfterViewInit, OnInit, OnDestroy {
 			window.frames[windowName].focus();
 		} else {
 			// Destructure environment variables for better readability
-			const { GAUZY_GITHUB_APP_NAME, GAUZY_GITHUB_REDIRECT_URL, GAUZY_GITHUB_POST_INSTALL_URL } = environment;
-			// Get the redirect URI, Post Install URL from the environment
+			const { GAUZY_GITHUB_APP_NAME, GAUZY_GITHUB_REDIRECT_URL } = environment;
+			// Get the redirect URI from the environment
 			const redirect_uri = GAUZY_GITHUB_REDIRECT_URL;
-			// const client_id = environment.GAUZY_GITHUB_CLIENT_ID;
-			const postInstallURL = GAUZY_GITHUB_POST_INSTALL_URL;
+
+			// Request a single-use, tenant-bound state nonce from the API BEFORE starting the GitHub
+			// App installation. The nonce is echoed back on the post-install callback so the resulting
+			// installation is bound to THIS tenant/organization, preventing cross-tenant installation
+			// hijacking (GHSA-4rwq-65wh-45h4).
+			let state: string;
+			try {
+				const response = await this._githubService.createInstallState({
+					organizationId: this.organization.id,
+					tenantId: this.organization.tenantId
+				});
+				state = response?.state;
+			} catch (error) {
+				console.log('Error while creating GitHub install state: %s', error?.message);
+				return;
+			}
+			if (!state) {
+				console.log('Missing GitHub install state; aborting installation popup.');
+				return;
+			}
 
 			// Define the query parameters for the authorization request
 			const queryParams = toParams({
 				redirect_uri: `${redirect_uri}`,
-				state: `${postInstallURL}`
+				state: `${state}`
 			});
 
 			// Construct the external URL for GitHub authorization with the query parameters

--- a/packages/plugins/integration-github-ui/src/lib/components/wizard/wizard.component.ts
+++ b/packages/plugins/integration-github-ui/src/lib/components/wizard/wizard.component.ts
@@ -148,8 +148,10 @@ export class GithubWizardComponent implements AfterViewInit, OnInit, OnDestroy {
 
 		try {
 			if (!this.window || this.window.closed) {
-				// If no window is open or the existing window is closed, open a new one
-				this.openGitHubAppPopup();
+				// If no window is open or the existing window is closed, open a new one. Awaited so the
+				// async state-nonce request completes (and `this.window` is set) BEFORE we start polling —
+				// otherwise the poller would see a null window and navigate away mid-flow.
+				await this.openGitHubAppPopup();
 			} else {
 				// If a window is already open, you can handle it here (e.g., focus or bring it to the front)
 				this.focusGitHubAppPopup();

--- a/packages/plugins/integration-github/src/lib/github/dto/github-app-install.dto.ts
+++ b/packages/plugins/integration-github/src/lib/github/dto/github-app-install.dto.ts
@@ -22,6 +22,12 @@ export class GithubOAuthDTO extends TenantOrganizationBaseDTO implements IGithub
 }
 
 /**
+ * Payload for minting a single-use, tenant-bound state nonce that starts a GitHub App
+ * installation flow (see GithubOAuthStateService / GHSA-4rwq-65wh-45h4).
+ */
+export class GithubInstallStateDTO extends TenantOrganizationBaseDTO {}
+
+/**
  *
  */
 export class GithubAppInstallDTO implements IGithubAppInstallInput {
@@ -34,4 +40,14 @@ export class GithubAppInstallDTO implements IGithubAppInstallInput {
 	@IsNotEmpty()
 	@IsEnum(GithubSetupActionEnum)
 	readonly setup_action: GithubSetupActionEnum;
+
+	/**
+	 * Single-use state nonce minted by `POST /integration/github/install/state` when the flow was
+	 * initiated. Required: it binds the installation to the initiating tenant/organization and
+	 * prevents cross-tenant installation hijacking (GHSA-4rwq-65wh-45h4).
+	 */
+	@ApiProperty({ type: () => String })
+	@IsNotEmpty()
+	@IsString()
+	readonly state: string;
 }

--- a/packages/plugins/integration-github/src/lib/github/dto/github-app-install.dto.ts
+++ b/packages/plugins/integration-github/src/lib/github/dto/github-app-install.dto.ts
@@ -1,6 +1,6 @@
 import { IGithubAppInstallInput } from '@gauzy/contracts';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsString, Matches } from 'class-validator';
 import { TenantOrganizationBaseDTO } from '@gauzy/core';
 
 /**
@@ -44,10 +44,12 @@ export class GithubAppInstallDTO implements IGithubAppInstallInput {
 	/**
 	 * Single-use state nonce minted by `POST /integration/github/install/state` when the flow was
 	 * initiated. Required: it binds the installation to the initiating tenant/organization and
-	 * prevents cross-tenant installation hijacking (GHSA-4rwq-65wh-45h4).
+	 * prevents cross-tenant installation hijacking (GHSA-4rwq-65wh-45h4). Format: 64-char lowercase
+	 * hex (32 random bytes).
 	 */
 	@ApiProperty({ type: () => String })
 	@IsNotEmpty()
 	@IsString()
+	@Matches(/^[a-f0-9]{64}$/, { message: 'state must be a valid GitHub installation nonce' })
 	readonly state: string;
 }

--- a/packages/plugins/integration-github/src/lib/github/github-authorization.controller.ts
+++ b/packages/plugins/integration-github/src/lib/github/github-authorization.controller.ts
@@ -3,12 +3,17 @@ import { Response } from 'express';
 import { IGithubIntegrationConfig, Public } from '@gauzy/common';
 import { ConfigService } from '@gauzy/config';
 import { IGithubAppInstallInput } from '@gauzy/contracts';
+import { GithubOAuthStateService } from './github-oauth-state.service';
 
 @Controller('/integration/github')
 export class GitHubAuthorizationController {
-	constructor(private readonly _config: ConfigService) {}
+	constructor(
+		private readonly _config: ConfigService,
+		private readonly _githubOAuthStateService: GithubOAuthStateService
+	) {}
 
 	/**
+	 * Public post-install callback hit by GitHub after a user installs the GitHub App.
 	 *
 	 * @param query
 	 * @param response
@@ -22,21 +27,34 @@ export class GitHubAuthorizationController {
 				throw new HttpException('Invalid github callback query data', HttpStatus.BAD_REQUEST);
 			}
 
+			// Validate the state nonce minted when the install flow was initiated. We only PEEK here
+			// (the nonce is consumed when the installation is finalized), but rejecting an unknown
+			// nonce blocks forged callbacks. It also lets us ALWAYS redirect to the server-side
+			// post-install URL rather than to a client-supplied value (closes the open redirect).
+			const stateData = await this._githubOAuthStateService.peek(query.state);
+			if (!stateData) {
+				throw new HttpException('Invalid or expired GitHub installation state.', HttpStatus.BAD_REQUEST);
+			}
+
 			/** Github Config Options */
 			const { postInstallUrl } = this._config.get('github') as IGithubIntegrationConfig;
 
-			/** Construct the redirect URL with query parameters */
+			/** Construct the redirect URL with query parameters. */
 			const urlParams = new URLSearchParams();
 			urlParams.append('installation_id', query.installation_id);
 			urlParams.append('setup_action', query.setup_action);
+			urlParams.append('state', query.state);
 
-			/** Redirect to the URL */
-			if (query.state.startsWith('http')) {
-				return response.redirect(`${query.state}?${urlParams.toString()}`);
-			} else {
-				return response.redirect(`${postInstallUrl}?${urlParams.toString()}`);
-			}
+			/**
+			 * Always redirect to the server-side configured post-install URL — never to a
+			 * client-supplied `state` value (anti open-redirect, GHSA-4rwq-65wh-45h4).
+			 */
+			return response.redirect(`${postInstallUrl}?${urlParams.toString()}`);
 		} catch (error) {
+			// Preserve intentional HTTP exceptions instead of masking them as a generic 500.
+			if (error instanceof HttpException) {
+				throw error;
+			}
 			// Handle errors and return an appropriate error response
 			throw new HttpException(
 				`Failed to add GitHub installation: ${error.message}`,

--- a/packages/plugins/integration-github/src/lib/github/github-oauth-state.service.ts
+++ b/packages/plugins/integration-github/src/lib/github/github-oauth-state.service.ts
@@ -38,6 +38,8 @@ export class GithubOAuthStateService {
 	private static readonly TTL_MS = 10 * 60 * 1000; // 10 minutes
 	/** Minted nonces are 32 random bytes rendered as lowercase hex (64 chars). */
 	private static readonly NONCE_PATTERN = /^[a-f0-9]{64}$/;
+	/** In-process guard for the non-Redis fallback so concurrent consumes can't both resolve a nonce. */
+	private static readonly inFlightConsume = new Set<string>();
 
 	constructor(
 		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
@@ -104,18 +106,26 @@ export class GithubOAuthStateService {
 			return null;
 		}
 		const cacheKey = this.key(nonce);
-		let value: string | null;
 		if (this.redisClient) {
 			// Atomic single-use: GETDEL guarantees exactly one caller resolves a given nonce, even
 			// across replicas, so a replay cannot reuse it (matches AuthService single-use OAuth codes).
-			value = await this.redisClient.getDel(cacheKey);
-		} else {
-			value = (await this.cacheManager.get<string>(cacheKey)) ?? null;
+			return this.deserialize(await this.redisClient.getDel(cacheKey));
+		}
+		// Non-Redis fallback (single-node dev): the get+del is not atomic, so guard it with an
+		// in-process lock — a second concurrent consume of the same nonce returns null (single-use).
+		if (GithubOAuthStateService.inFlightConsume.has(cacheKey)) {
+			return null;
+		}
+		GithubOAuthStateService.inFlightConsume.add(cacheKey);
+		try {
+			const value = (await this.cacheManager.get<string>(cacheKey)) ?? null;
 			if (value) {
 				await this.cacheManager.del(cacheKey);
 			}
+			return this.deserialize(value);
+		} finally {
+			GithubOAuthStateService.inFlightConsume.delete(cacheKey);
 		}
-		return this.deserialize(value);
 	}
 
 	/** Safely parse a cached state value, returning `null` for anything malformed. */

--- a/packages/plugins/integration-github/src/lib/github/github-oauth-state.service.ts
+++ b/packages/plugins/integration-github/src/lib/github/github-oauth-state.service.ts
@@ -1,8 +1,9 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 import { randomBytes } from 'crypto';
 import { ID } from '@gauzy/contracts';
+import { EVER_REDIS_CLIENT } from '@gauzy/core';
 
 /**
  * Server-side state recorded when a GitHub App installation flow is initiated by an authenticated
@@ -17,6 +18,16 @@ export interface IGithubOAuthState {
 	userId?: ID;
 }
 
+/**
+ * Minimal slice of the (node-redis) client we use for ATOMIC single-use nonce operations. The raw
+ * client is provided globally as EVER_REDIS_CLIENT (null when REDIS_ENABLED!='true').
+ */
+interface IRedisAtomicClient {
+	get(key: string): Promise<string | null>;
+	getDel(key: string): Promise<string | null>;
+	set(key: string, value: string, options: { PX: number }): Promise<unknown>;
+}
+
 @Injectable()
 export class GithubOAuthStateService {
 	private readonly logger = new Logger(GithubOAuthStateService.name);
@@ -25,12 +36,24 @@ export class GithubOAuthStateService {
 	private static readonly CACHE_PREFIX = 'github_oauth_state:';
 	/** Single-use nonce lifetime: long enough to complete the GitHub install, short enough to limit replay. */
 	private static readonly TTL_MS = 10 * 60 * 1000; // 10 minutes
+	/** Minted nonces are 32 random bytes rendered as lowercase hex (64 chars). */
+	private static readonly NONCE_PATTERN = /^[a-f0-9]{64}$/;
 
-	constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
+	constructor(
+		@Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+		// Optional raw Redis client for atomic GETDEL (single-use), mirroring AuthService. Null when
+		// Redis is disabled — then we fall back to the (global, possibly multi-layer) cache manager.
+		@Optional() @Inject(EVER_REDIS_CLIENT) private readonly redisClient: IRedisAtomicClient | null
+	) {}
 
 	/** Build the namespaced cache key for a nonce. */
 	private key(nonce: string): string {
 		return `${GithubOAuthStateService.CACHE_PREFIX}${nonce}`;
+	}
+
+	/** Reject anything that is not a well-formed minted nonce (cache-key / log hygiene). */
+	private isValidNonce(nonce?: string): nonce is string {
+		return !!nonce && GithubOAuthStateService.NONCE_PATTERN.test(nonce);
 	}
 
 	/**
@@ -42,7 +65,14 @@ export class GithubOAuthStateService {
 	 */
 	async create(state: IGithubOAuthState): Promise<string> {
 		const nonce = randomBytes(32).toString('hex');
-		await this.cacheManager.set(this.key(nonce), JSON.stringify(state), GithubOAuthStateService.TTL_MS);
+		const value = JSON.stringify(state);
+		const cacheKey = this.key(nonce);
+		if (this.redisClient) {
+			// Authoritative, cross-replica store with TTL (matches the AuthService OAuth pattern).
+			await this.redisClient.set(cacheKey, value, { PX: GithubOAuthStateService.TTL_MS });
+		} else {
+			await this.cacheManager.set(cacheKey, value, GithubOAuthStateService.TTL_MS);
+		}
 		return nonce;
 	}
 
@@ -54,30 +84,38 @@ export class GithubOAuthStateService {
 	 * @returns The bound state, or `null` for an unknown, malformed or expired nonce.
 	 */
 	async peek(nonce?: string): Promise<IGithubOAuthState | null> {
-		if (!nonce) {
+		if (!this.isValidNonce(nonce)) {
 			return null;
 		}
-		const value = await this.cacheManager.get<string>(this.key(nonce));
+		const cacheKey = this.key(nonce);
+		const value = this.redisClient
+			? await this.redisClient.get(cacheKey)
+			: (await this.cacheManager.get<string>(cacheKey)) ?? null;
 		return this.deserialize(value);
 	}
 
 	/**
-	 * Resolve and invalidate a nonce so it can bind at most one installation (single-use).
+	 * Atomically resolve and invalidate a nonce so it binds at most one installation (single-use).
 	 *
 	 * @returns The bound state, or `null` for an unknown, malformed or expired nonce.
 	 */
 	async consume(nonce?: string): Promise<IGithubOAuthState | null> {
-		if (!nonce) {
+		if (!this.isValidNonce(nonce)) {
 			return null;
 		}
 		const cacheKey = this.key(nonce);
-		const value = await this.cacheManager.get<string>(cacheKey);
-		const parsed = this.deserialize(value);
-		if (parsed) {
-			// Best-effort single-use: remove the nonce so a replay cannot reuse it.
-			await this.cacheManager.del(cacheKey);
+		let value: string | null;
+		if (this.redisClient) {
+			// Atomic single-use: GETDEL guarantees exactly one caller resolves a given nonce, even
+			// across replicas, so a replay cannot reuse it (matches AuthService single-use OAuth codes).
+			value = await this.redisClient.getDel(cacheKey);
+		} else {
+			value = (await this.cacheManager.get<string>(cacheKey)) ?? null;
+			if (value) {
+				await this.cacheManager.del(cacheKey);
+			}
 		}
-		return parsed;
+		return this.deserialize(value);
 	}
 
 	/** Safely parse a cached state value, returning `null` for anything malformed. */

--- a/packages/plugins/integration-github/src/lib/github/github-oauth-state.service.ts
+++ b/packages/plugins/integration-github/src/lib/github/github-oauth-state.service.ts
@@ -1,0 +1,96 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Cache } from 'cache-manager';
+import { randomBytes } from 'crypto';
+import { ID } from '@gauzy/contracts';
+
+/**
+ * Server-side state recorded when a GitHub App installation flow is initiated by an authenticated
+ * tenant. The opaque `state` nonce is handed to GitHub and echoed back on the post-install
+ * callback, letting us bind the resulting installation to the tenant/organization that actually
+ * started the flow — instead of trusting client-supplied identifiers (cross-tenant installation
+ * hijack, GHSA-4rwq-65wh-45h4).
+ */
+export interface IGithubOAuthState {
+	tenantId: ID;
+	organizationId: ID;
+	userId?: ID;
+}
+
+@Injectable()
+export class GithubOAuthStateService {
+	private readonly logger = new Logger(GithubOAuthStateService.name);
+
+	/** Cache key prefix for pending GitHub install state nonces. */
+	private static readonly CACHE_PREFIX = 'github_oauth_state:';
+	/** Single-use nonce lifetime: long enough to complete the GitHub install, short enough to limit replay. */
+	private static readonly TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+	constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
+
+	/** Build the namespaced cache key for a nonce. */
+	private key(nonce: string): string {
+		return `${GithubOAuthStateService.CACHE_PREFIX}${nonce}`;
+	}
+
+	/**
+	 * Mint a cryptographically-random, single-use state nonce and persist the initiating
+	 * tenant/organization (and user) against it.
+	 *
+	 * @param state The tenant/organization (and optional user) that initiated the install flow.
+	 * @returns The opaque nonce to pass to GitHub as the `state` query parameter.
+	 */
+	async create(state: IGithubOAuthState): Promise<string> {
+		const nonce = randomBytes(32).toString('hex');
+		await this.cacheManager.set(this.key(nonce), JSON.stringify(state), GithubOAuthStateService.TTL_MS);
+		return nonce;
+	}
+
+	/**
+	 * Resolve the tenant/organization bound to a nonce WITHOUT invalidating it. Used by the public
+	 * post-install callback to reject forged callbacks (and to avoid using `state` as a redirect
+	 * target) while leaving the nonce to be consumed when the installation is finalized.
+	 *
+	 * @returns The bound state, or `null` for an unknown, malformed or expired nonce.
+	 */
+	async peek(nonce?: string): Promise<IGithubOAuthState | null> {
+		if (!nonce) {
+			return null;
+		}
+		const value = await this.cacheManager.get<string>(this.key(nonce));
+		return this.deserialize(value);
+	}
+
+	/**
+	 * Resolve and invalidate a nonce so it can bind at most one installation (single-use).
+	 *
+	 * @returns The bound state, or `null` for an unknown, malformed or expired nonce.
+	 */
+	async consume(nonce?: string): Promise<IGithubOAuthState | null> {
+		if (!nonce) {
+			return null;
+		}
+		const cacheKey = this.key(nonce);
+		const value = await this.cacheManager.get<string>(cacheKey);
+		const parsed = this.deserialize(value);
+		if (parsed) {
+			// Best-effort single-use: remove the nonce so a replay cannot reuse it.
+			await this.cacheManager.del(cacheKey);
+		}
+		return parsed;
+	}
+
+	/** Safely parse a cached state value, returning `null` for anything malformed. */
+	private deserialize(value: unknown): IGithubOAuthState | null {
+		if (!value || typeof value !== 'string') {
+			return null;
+		}
+		try {
+			const parsed = JSON.parse(value) as IGithubOAuthState;
+			return parsed && parsed.tenantId && parsed.organizationId ? parsed : null;
+		} catch (error) {
+			this.logger.warn(`Failed to parse GitHub OAuth state: ${(error as Error)?.message}`);
+			return null;
+		}
+	}
+}

--- a/packages/plugins/integration-github/src/lib/github/github.controller.ts
+++ b/packages/plugins/integration-github/src/lib/github/github.controller.ts
@@ -1,16 +1,47 @@
 import { Controller, Post, Body, UseGuards, HttpException, HttpStatus, HttpCode } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { PermissionsEnum } from '@gauzy/contracts';
-import { PermissionGuard, Permissions, TenantPermissionGuard, UseValidationPipe } from '@gauzy/core';
+import { PermissionGuard, Permissions, RequestContext, TenantPermissionGuard, UseValidationPipe } from '@gauzy/core';
 import { GithubService } from './github.service';
-import { GithubAppInstallDTO, GithubOAuthDTO } from './dto';
+import { GithubOAuthStateService } from './github-oauth-state.service';
+import { GithubAppInstallDTO, GithubInstallStateDTO, GithubOAuthDTO } from './dto';
 
 @ApiTags('GitHub Integrations')
 @UseGuards(TenantPermissionGuard, PermissionGuard)
 @Permissions(PermissionsEnum.INTEGRATION_ADD, PermissionsEnum.INTEGRATION_EDIT)
 @Controller('/integration/github')
 export class GitHubController {
-	constructor(private readonly _githubService: GithubService) {}
+	constructor(
+		private readonly _githubService: GithubService,
+		private readonly _githubOAuthStateService: GithubOAuthStateService
+	) {}
+
+	/**
+	 * Mint a single-use, tenant-bound state nonce used to start a GitHub App installation.
+	 *
+	 * The nonce is handed to GitHub as the `state` query param and echoed back on the post-install
+	 * callback, so the resulting installation is bound to the tenant/organization that actually
+	 * initiated the flow — closing the cross-tenant installation hijack (GHSA-4rwq-65wh-45h4).
+	 *
+	 * @param input The tenant/organization initiating the installation.
+	 * @returns The opaque `state` nonce to pass to GitHub.
+	 */
+	@Post('/install/state')
+	@HttpCode(HttpStatus.CREATED)
+	@UseValidationPipe()
+	async createInstallationState(@Body() input: GithubInstallStateDTO): Promise<{ state: string }> {
+		const tenantId = RequestContext.currentTenantId() || input.tenantId;
+		const organizationId = input.organizationId;
+		if (!tenantId || !organizationId) {
+			throw new HttpException('Invalid tenant or organization', HttpStatus.BAD_REQUEST);
+		}
+		const state = await this._githubOAuthStateService.create({
+			tenantId,
+			organizationId,
+			userId: RequestContext.currentUserId()
+		});
+		return { state };
+	}
 
 	/**
 	 *
@@ -23,11 +54,34 @@ export class GitHubController {
 	async addGithubAppInstallation(@Body() input: GithubAppInstallDTO) {
 		try {
 			// Validate the input data (You can use class-validator for validation)
-			if (!input || !input.installation_id || !input.setup_action) {
+			if (!input || !input.installation_id || !input.setup_action || !input.state) {
 				throw new HttpException('Invalid github input data', HttpStatus.BAD_REQUEST);
 			}
-			// Add the GitHub installation using the service
-			return await this._githubService.addGithubAppInstallation(input);
+			// Resolve and invalidate the single-use state nonce minted when this flow was initiated.
+			// The installation is bound to the tenant/organization recorded against the nonce — NOT to
+			// client-supplied identifiers — which closes the cross-tenant IDOR (GHSA-4rwq-65wh-45h4).
+			const stateData = await this._githubOAuthStateService.consume(input.state);
+			if (!stateData) {
+				throw new HttpException(
+					'Invalid or expired GitHub installation state. Please restart the GitHub App connection.',
+					HttpStatus.BAD_REQUEST
+				);
+			}
+			// Defense in depth: the authenticated caller must be the tenant that initiated the flow.
+			const currentTenantId = RequestContext.currentTenantId();
+			if (currentTenantId && String(stateData.tenantId) !== String(currentTenantId)) {
+				throw new HttpException(
+					'GitHub installation state does not belong to the current tenant.',
+					HttpStatus.FORBIDDEN
+				);
+			}
+			// Add the GitHub installation using the service, bound to the nonce's tenant/organization.
+			return await this._githubService.addGithubAppInstallation({
+				installation_id: input.installation_id,
+				setup_action: input.setup_action,
+				tenantId: stateData.tenantId,
+				organizationId: stateData.organizationId
+			});
 		} catch (error) {
 			// Preserve intentional HTTP exceptions (e.g. the cross-tenant uniqueness 400) instead of
 			// masking them as a generic 500.

--- a/packages/plugins/integration-github/src/lib/github/github.controller.ts
+++ b/packages/plugins/integration-github/src/lib/github/github.controller.ts
@@ -30,10 +30,15 @@ export class GitHubController {
 	@HttpCode(HttpStatus.CREATED)
 	@UseValidationPipe()
 	async createInstallationState(@Body() input: GithubInstallStateDTO): Promise<{ state: string }> {
-		const tenantId = RequestContext.currentTenantId() || input.tenantId;
+		// Require an authenticated tenant from the request context — do NOT trust a client-supplied
+		// tenantId for this security boundary (the minted nonce is later trusted to bind an install).
+		const tenantId = RequestContext.currentTenantId();
+		if (!tenantId) {
+			throw new HttpException('Missing authenticated tenant context', HttpStatus.FORBIDDEN);
+		}
 		const organizationId = input.organizationId;
-		if (!tenantId || !organizationId) {
-			throw new HttpException('Invalid tenant or organization', HttpStatus.BAD_REQUEST);
+		if (!organizationId) {
+			throw new HttpException('Invalid organization', HttpStatus.BAD_REQUEST);
 		}
 		const state = await this._githubOAuthStateService.create({
 			tenantId,
@@ -67,9 +72,10 @@ export class GitHubController {
 					HttpStatus.BAD_REQUEST
 				);
 			}
-			// Defense in depth: the authenticated caller must be the tenant that initiated the flow.
+			// The authenticated caller MUST be the tenant that initiated the flow. Require a tenant
+			// context — do not silently skip this check when it is absent (security boundary).
 			const currentTenantId = RequestContext.currentTenantId();
-			if (currentTenantId && String(stateData.tenantId) !== String(currentTenantId)) {
+			if (!currentTenantId || String(stateData.tenantId) !== String(currentTenantId)) {
 				throw new HttpException(
 					'GitHub installation state does not belong to the current tenant.',
 					HttpStatus.FORBIDDEN

--- a/packages/plugins/integration-github/src/lib/github/github.module.ts
+++ b/packages/plugins/integration-github/src/lib/github/github.module.ts
@@ -20,6 +20,7 @@ import { GitHubAuthorizationController } from './github-authorization.controller
 import { GitHubIntegrationController } from './github-integration.controller';
 import { GitHubController } from './github.controller';
 import { GithubService } from './github.service';
+import { GithubOAuthStateService } from './github-oauth-state.service';
 import { GithubMiddleware } from './github.middleware';
 import { GitHubHooksController } from './github.hooks.controller';
 import { GithubHooksService } from './github.hooks.service';
@@ -88,6 +89,7 @@ const { github } = environment;
 		// Define services heres
 		GithubEventSubscriber,
 		GithubService,
+		GithubOAuthStateService,
 		GithubSyncService,
 		GithubHooksService,
 		GithubRepositoryService,

--- a/packages/ui-core/core/src/lib/services/github/github.service.ts
+++ b/packages/ui-core/core/src/lib/services/github/github.service.ts
@@ -41,7 +41,9 @@ export class GithubService {
 
 	/**
 	 * Add a GitHub app installation.
-	 * @param input The input data for the GitHub app installation.
+	 * @param input The input data for the GitHub app installation. `input.state` (the single-use nonce
+	 * from {@link createInstallState}) is REQUIRED — the server binds the installation to the tenant
+	 * recorded against that nonce and rejects requests without a valid one (GHSA-4rwq-65wh-45h4).
 	 * @returns A promise that resolves to the integration tenant object.
 	 */
 	async addInstallationApp(input: IGithubAppInstallInput): Promise<IIntegrationTenant> {

--- a/packages/ui-core/core/src/lib/services/github/github.service.ts
+++ b/packages/ui-core/core/src/lib/services/github/github.service.ts
@@ -25,6 +25,21 @@ export class GithubService {
 	constructor(private readonly _http: HttpClient) {}
 
 	/**
+	 * Mint a single-use, tenant-bound state nonce before starting a GitHub App installation.
+	 *
+	 * The returned `state` is passed to GitHub and echoed back on the post-install callback so the
+	 * resulting installation is bound to the initiating tenant/organization, preventing cross-tenant
+	 * installation hijacking (GHSA-4rwq-65wh-45h4).
+	 *
+	 * @param input The tenant/organization initiating the installation.
+	 * @returns A promise resolving to the opaque `state` nonce.
+	 */
+	async createInstallState(input: IBasePerTenantAndOrganizationEntityModel): Promise<{ state: string }> {
+		const url = `${API_PREFIX}/integration/github/install/state`;
+		return firstValueFrom(this._http.post<{ state: string }>(url, input));
+	}
+
+	/**
 	 * Add a GitHub app installation.
 	 * @param input The input data for the GitHub app installation.
 	 * @returns A promise that resolves to the integration tenant object.


### PR DESCRIPTION
Closes the GitHub App **installation-binding** half of the cross-tenant IDOR (GHSA-4rwq-65wh-45h4) with a server-minted **state nonce**. Complements [#9754](https://github.com/ever-co/ever-gauzy/pull/9754) (first-claimant-wins uniqueness guard), already on `develop`.

## The problem

The GitHub App install flow bound an **attacker-supplied `installation_id` to the caller's tenant** with no proof the flow was deliberately initiated by that tenant, and the public post-install callback redirected to a client-supplied `state` (`state.startsWith('http')` → **open redirect**).

## The fix (end-to-end)

A cryptographically-random, single-use, **tenant-bound** nonce is minted server-side at initiation and required to finalize the install. The installation is bound to the tenant/organization recorded against the nonce — never to client-supplied identifiers.

**Backend** (`plugins/integration-github`)
- New `GithubOAuthStateService` — mints a 32-byte hex nonce keyed to `{tenantId, organizationId, userId}`, 10-min TTL. **Single-use is atomic**: node-redis `GETDEL` via the global `EVER_REDIS_CLIENT` when Redis is on (cross-replica safe), falling back to `cache-manager` get+del otherwise — mirroring `AuthService`'s single-use OAuth-code pattern.
- New `POST /integration/github/install/state` mints the nonce (auth + `INTEGRATION_ADD/EDIT`).
- `POST /integration/github/install` now **requires** `state` (`@Matches(/^[a-f0-9]{64}$/)`): it consumes the nonce, binds to the nonce's tenant/org, and rejects a nonce whose tenant ≠ the authenticated caller.
- `GET /integration/github/callback` validates the nonce and **always** redirects to the server-side `postInstallUrl` (open redirect removed).

**Frontend**
- `ui-core` `GithubService.createInstallState()` calls the mint endpoint.
- Wizard fetches the nonce and passes it as `state` (instead of the static post-install URL).
- Installation component forwards the nonce and no longer sends a client-supplied tenant/org.

## Security ceiling (honest scope)

Gauzy cannot prove which tenant "owns" a GitHub installation, so cross-tenant **ownership** is inherently first-claimant-wins — that is enforced by #9754. This PR closes everything the app *can* close: **CSRF, replay, open-redirect, and client-supplied-tenant IDOR**. The only residual (pre-claiming an *unclaimed* `installation_id` with one's own valid nonce) is inherent and is already mitigated by #9754 for any already-connected installation.

## Verification

- Backend typechecks clean (`tsc --noEmit`, plugin lib).
- Ran a 4-dimension adversarial review (security / NestJS-DI / Angular-flow / breakage-scan). **No blockers.** Its one MAJOR — non-atomic `consume()` — is fixed in this PR (atomic `GETDEL`). All in-repo callers of `/install` were updated to send `state`; there are no other server-side `GithubAppInstallDTO` consumers and no automated tests for this flow.

## ⚠️ Needs a manual smoke-test before promotion to prod

There is **no automated coverage** of the GitHub connect popup flow and it can't be run in CI. Before `develop → master`, please click-through once: **Connect GitHub → install on a repo → confirm the integration binds and lands on the integration page.** Per maintainer direction the nonce is **required**, so any in-flight/older install without a `state` nonce will be rejected and must restart the connection.

> Note: the external Kiota SDKs (`SDKs/`) should be regenerated for the new `/install/state` route + required `state` field (separate repo, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure the GitHub App install flow by requiring a server-minted, single-use state nonce and removing the open redirect. Also enforce an authenticated tenant context at mint and install to prevent cross-tenant installation hijacking (GHSA-4rwq-65wh-45h4).

- **Bug Fixes**
  - Backend: added `GithubOAuthStateService` (32-byte hex nonce, 10-min TTL, atomic GETDEL via `EVER_REDIS_CLIENT`; non-Redis fallback now guarded by an in-process lock); new `POST /integration/github/install/state`; both mint and install require an authenticated tenant (`RequestContext`) and reject when absent; `POST /integration/github/install` now requires `state`, consumes it, and binds to the nonce’s tenant/org; callback peeks `state` and always redirects to server `postInstallUrl`.
  - Frontend: wizard now awaits popup after minting the nonce to avoid race conditions; installation component no longer waits for a hydrated store and forwards only `installation_id`, `setup_action`, and `state` (no client tenant/org).
  - Validation: added `state` to `GithubAppInstallDTO` with 64-char lowercase hex check; new `GithubInstallStateDTO`.

- **Migration**
  - Restart any in-flight installs; requests without `state` are rejected.
  - Smoke test the connect flow once before prod.
  - Regenerate external SDKs for the new `/install/state` route and required `state` field.

<sup>Written for commit 887e2f807614fd1012093ca94204240e4d566ef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

