### PR TITLE
config(plane): shared Plane UI client URLs + CORS origins

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -37,6 +37,18 @@ services:
           - key: CLIENT_BASE_URL
             scope: RUN_TIME
             value: '$CLIENT_BASE_URL'
+          - key: PLANE_CLIENT_BASE_URL
+            scope: RUN_TIME
+            value: 'https://plane.gauzy.co'
+          - key: PLANE_CLIENT_ADMIN_URL
+            scope: RUN_TIME
+            value: 'https://plane-admin.gauzy.co'
+          - key: PLANE_CLIENT_SPACE_URL
+            scope: RUN_TIME
+            value: 'https://plane-space.gauzy.co'
+          - key: PLANE_SHARED_ORIGINS
+            scope: RUN_TIME
+            value: 'https://plane.gauzy.co,https://plane-space.gauzy.co,https://plane-admin.gauzy.co'
           - key: DB_TYPE
             scope: RUN_TIME
             value: '$DB_TYPE'


### PR DESCRIPTION
Sets prod API env so the shared Plane UIs at **plane.gauzy.co / plane-space.gauzy.co / plane-admin.gauzy.co** are allowed by the Plane proxy's CORS.

**Why this works on the already-deployed proxy (0.1.0):**
- `getDefaultProxyConfig()` (used for shared/no-tenant requests) reads `PLANE_CLIENT_BASE_URL`/`_ADMIN_URL`/`_SPACE_URL`.
- The proxy's `mount.ts` builds its CORS allowlist from the resolved config's `clientBaseUrl/clientAdminUrl/clientSpaceUrl`.
- So setting these envs makes `plane*.gauzy.co` allowed origins against `api.gauzy.co/api/plane` — **no proxy-lib bump needed**.

`PLANE_SHARED_ORIGINS` is also set (no-op on 0.1.0, forward-compatible with proxy 0.1.2's `sharedOrigins`, which additionally covers tenants with custom per-tenant configs).

Part of bringing the shared multi-tenant Plane integration live. UI images already built+pushed to DOCR; k8s deploy on the gauzy cluster in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable CORS for the shared Plane UIs. Sets `PLANE_CLIENT_*_URL` and `PLANE_SHARED_ORIGINS` so `plane.gauzy.co`, `plane-space.gauzy.co`, and `plane-admin.gauzy.co` can call `api.gauzy.co/api/plane`.

- **Migration**
  - No proxy release needed; current proxy reads these envs for its CORS allowlist.
  - Forward-compatible with proxy 0.1.2 via `PLANE_SHARED_ORIGINS`.

<sup>Written for commit f306f16338aaddc51608cdf602fba539dfb28bbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

