### PR TITLE
config(plane): shared Plane UI client URLs on prod API (k8s)

### DIFF
--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -132,6 +132,14 @@ spec:
                         value: 'https://api.gauzy.co'
                       - name: CLIENT_BASE_URL
                         value: 'https://app.gauzy.co'
+                      - name: PLANE_CLIENT_BASE_URL
+                        value: 'https://plane.gauzy.co'
+                      - name: PLANE_CLIENT_ADMIN_URL
+                        value: 'https://plane-admin.gauzy.co'
+                      - name: PLANE_CLIENT_SPACE_URL
+                        value: 'https://plane-space.gauzy.co'
+                      - name: PLANE_SHARED_ORIGINS
+                        value: 'https://plane.gauzy.co,https://plane-space.gauzy.co,https://plane-admin.gauzy.co'
                       - name: DB_URI
                         value: '$DB_URI'
                       - name: DB_HOST


### PR DESCRIPTION
Adds PLANE_CLIENT_BASE_URL/_ADMIN_URL/_SPACE_URL + PLANE_SHARED_ORIGINS to the **gauzy-prod-api** Deployment env in `.deploy/k8s/k8s-manifest.prod.yaml` (applied by deploy-do-prod.yml to k8s-gauzy — the real api.gauzy.co surface). Enables shared-origin CORS for plane*.gauzy.co on the deployed 0.1.0 proxy. Replaces the wrong-surface #9758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable CORS for Plane UIs on prod by adding PLANE_CLIENT_*_URL and PLANE_SHARED_ORIGINS env vars to the `gauzy-prod-api` Kubernetes manifest. The Plane proxy now accepts requests from plane.gauzy.co, plane-admin.gauzy.co, and plane-space.gauzy.co.

<sup>Written for commit ab028b96b2e536c2f93df8bd6660f907155f4191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

