### PR TITLE
Release: Plane shared CORS env (PLANE_CLIENT_*) to prod

### DIFF
--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -132,6 +132,14 @@ spec:
                         value: 'https://api.gauzy.co'
                       - name: CLIENT_BASE_URL
                         value: 'https://app.gauzy.co'
+                      - name: PLANE_CLIENT_BASE_URL
+                        value: 'https://plane.gauzy.co'
+                      - name: PLANE_CLIENT_ADMIN_URL
+                        value: 'https://plane-admin.gauzy.co'
+                      - name: PLANE_CLIENT_SPACE_URL
+                        value: 'https://plane-space.gauzy.co'
+                      - name: PLANE_SHARED_ORIGINS
+                        value: 'https://plane.gauzy.co,https://plane-space.gauzy.co,https://plane-admin.gauzy.co'
                       - name: DB_URI
                         value: '$DB_URI'
                       - name: DB_HOST


### PR DESCRIPTION
Promotes the gauzy-prod-api PLANE_CLIENT_*_URL + PLANE_SHARED_ORIGINS env (#9759) to master so deploy-do-prod persists the shared-origin CORS config in the manifest (currently live via kubectl set env; this makes it durable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Plane UI CORS allowlist in prod by adding PLANE_CLIENT_*_URL and PLANE_SHARED_ORIGINS envs to the k8s manifest. This makes the Plane proxy consistently allow requests from plane.gauzy.co, plane-space.gauzy.co, and plane-admin.gauzy.co across deployments.

<sup>Written for commit 69659b7db7c5614170438b17f388f57cd7646b73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

