### PR TITLE
fix(ci): resolve @electron/node-gyp to npm package (fixes Docker/MCP image builds)

### DIFF
--- a/package.json
+++ b/package.json
@@ -603,6 +603,7 @@
 		"node-abi": "^3.78.0",
 		"@electron/rebuild/node-abi": "^3.78.0",
 		"app-builder-lib/node-abi": "^3.78.0",
+		"@electron/node-gyp": "10.2.0-electron.1",
 		"camelcase": "^9.0.0",
 		"caniuse-lite": "^1.0.30001699",
 		"browserslist": "^4.24.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,9 +4685,10 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
+"@electron/node-gyp@10.2.0-electron.1", "@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
-  resolved "https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2"
+  resolved "https://registry.npmjs.org/@electron/node-gyp/-/node-gyp-10.2.0-electron.1.tgz#ca5f125dcd0ffb275797c0c418c0d64005e0f815"
+  integrity sha512-YdpRE6qSNYyf7gBv1LBDc8OAs8f/mZthzM1k4pFzodNq8dBGf64MWC5Bq8VVlgdafjQXLpINHvtRAUC9uinoqw==
   dependencies:
     env-paths "^2.2.0"
     exponential-backoff "^3.1.1"


### PR DESCRIPTION
## Problem

Every Docker image build (**gauzy-api, gauzy-webapp, gauzy MCP / MCP-auth**) fails at the `yarn install --frozen-lockfile` step:

```
error Couldn't find match for "06b29aafb7708acef8b3669835c8a7857ebc92d2"
  ... for "https://github.com/electron/node-gyp".
```

`@electron/rebuild@3.7.0` and `@3.7.2` declare a dependency on `@electron/node-gyp` pinned to the git commit `electron/node-gyp#06b29aaf…`, and that commit has been **deleted from the upstream repo** (it's gone from all refs). So a fresh `yarn install` can't resolve it and the whole monorepo install dies — which is why the api/webapp/MCP images all fail at install, before any compile step.

This is **pre-existing upstream dependency rot**, not a code regression — it was simply masked while GitHub Actions was billing-locked (the image builds never ran) and surfaced the moment they did.

## Fix

`@electron/node-gyp` is now **published to npm**, and the dead commit corresponded to version **`10.2.0-electron.1`**. Add a yarn `resolutions` override forcing `@electron/node-gyp` to that npm-published version, so yarn resolves the **registry tarball** instead of fetching the vanished git commit:

```jsonc
"resolutions": {
  ...
  "@electron/node-gyp": "10.2.0-electron.1",
  ...
}
```

`yarn.lock`'s `@electron/node-gyp` entry now points at `registry.npmjs.org/.../node-gyp-10.2.0-electron.1.tgz` with a valid integrity hash. The version is unchanged (content-identical to what the git ref claimed), so `@electron/rebuild` behaviour is unaffected.

## Verification

- `yarn install --frozen-lockfile --ignore-scripts` (the Dockerfiles' **exact** install command) now completes successfully (`success Already up-to-date`).
- Diff is intentionally minimal: `package.json` +1 line, and **only** the `@electron/node-gyp` lock entry changes — no other dependency versions move (verified via `git diff --numstat`: 3 added / 2 removed in `yarn.lock`).
- The CI Docker-image builds on this PR are the end-to-end confirmation.

> Separately, the MCP image build also hit a one-off `ghcr.io` docker-login **network timeout** (`Client.Timeout exceeded`) — transient infra, cleared by a re-run; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing Docker image builds (api, webapp, MCP) by forcing Yarn to resolve `@electron/node-gyp` from npm instead of a deleted git ref used by `@electron/rebuild`. `yarn install --frozen-lockfile` now completes successfully.

- **Dependencies**
  - Add `resolutions["@electron/node-gyp"] = "10.2.0-electron.1"`; `yarn.lock` now points to the npm tarball. No other dependencies change.

<sup>Written for commit 7baf9b441e56448b3fb79a8da0d8b80246193e11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

