### PR TITLE
fix(core): relax prod CORP to same-site so app.gauzy.co can embed API assets + enable Secure session cookie

### DIFF
--- a/packages/core/src/lib/bootstrap/index.ts
+++ b/packages/core/src/lib/bootstrap/index.ts
@@ -176,8 +176,8 @@ export async function bootstrap(pluginConfig?: Partial<ApplicationPluginConfig>)
 				? undefined // use Helmet's strict default CSP in production
 				: false, // disable CSP in dev/stage so Swagger/Scalar inline scripts work
 			crossOriginResourcePolicy: isProduction
-        		? { policy: 'same-origin' }  // Strict in prod — resources come from S3 or other storage anyway
-        		: { policy: 'cross-origin' }, // Relaxed in dev/stage — resources served from API
+				? { policy: 'same-site' } // Prod: same-site lets *.gauzy.co (e.g. app.gauzy.co) embed API-served assets like /public icons, while still blocking third-party origins
+				: { policy: 'cross-origin' }, // Relaxed in dev/stage — resources served from API
     		crossOriginEmbedderPolicy: isProduction // strict in production, relaxed in dev/stage for Electron/desktop
 		})
 	);

--- a/packages/core/src/lib/bootstrap/redis-store.ts
+++ b/packages/core/src/lib/bootstrap/redis-store.ts
@@ -106,8 +106,10 @@ export async function configureRedisSession(app: any): Promise<void> {
 					store: redisStore,
 					secret: environment.EXPRESS_SESSION_SECRET,
 					resave: false, // Required for lightweight session keep alive (touch)
-					saveUninitialized: true
-					// cookie: { secure: true } // TODO: Enable if HTTPS is configured
+					saveUninitialized: true,
+					// 'auto' sets the Secure flag only over HTTPS: on (prod/stage/demo run behind the proxy with
+					// `trust proxy` enabled in bootstrap) and off on plain-HTTP local dev so sessions keep working there.
+					cookie: { secure: 'auto' }
 				})
 			);
 
@@ -122,8 +124,10 @@ export async function configureRedisSession(app: any): Promise<void> {
 			expressSession({
 				secret: environment.EXPRESS_SESSION_SECRET,
 				resave: true, // Required as MemoryStore doesn't support `touch` method
-				saveUninitialized: true
-				// cookie: { secure: true } // TODO: Enable if HTTPS is configured
+				saveUninitialized: true,
+				// 'auto' sets the Secure flag only over HTTPS: on (prod/stage/demo run behind the proxy with
+				// `trust proxy` enabled in bootstrap) and off on plain-HTTP local dev so sessions keep working there.
+				cookie: { secure: 'auto' }
 			})
 		);
 	}


### PR DESCRIPTION
## Problem

Images hosted on the API (`https://api.gauzy.co/public/...`, e.g. the built-in integration
icon `/public/integrations/sim.svg`) fail to render when embedded on the web app
(`https://app.gauzy.co`, e.g. the *Plugins → Built-in* page). Browser console shows:

> Specify a more permissive Cross-Origin Resource Policy to prevent a resource from being blocked …
> `Cross-Origin-Resource-Policy: same-origin`

## Root cause

This is **CORP, not CORS**. CORS (which governs `fetch`/XHR) is configured correctly
(`ALLOWED_ORIGINS=https://app.gauzy.co` on the prod pod, verified). But **embedded** resources
(`<img>`, `<script>`, …) are gated by `Cross-Origin-Resource-Policy`, which Helmet set to
`same-origin` in production:

```ts
// packages/core/src/lib/bootstrap/index.ts
crossOriginResourcePolicy: isProduction
    ? { policy: 'same-origin' }   // ← blocks app.gauzy.co from embedding api.gauzy.co assets
    : { policy: 'cross-origin' }
```

`app.gauzy.co` and `api.gauzy.co` are different origins, so `same-origin` blocks the `<img>`.
The code comment assumed prod assets "come from S3 anyway", but the built-in integration icons
are served straight from the API's own `/public` folder by `ServeStaticModule` (no per-route
headers), so they inherit the strict global policy.

Confirmed on live prod headers for `api.gauzy.co/public/integrations/sim.svg`:
`Cross-Origin-Resource-Policy: same-origin`. The embedding document (`app.gauzy.co`) sets no
COEP, so the resource's CORP is the only gate.

## Changes

1. **CORP `same-origin` → `same-site` in production.** Both hosts share the `gauzy.co` site, so
   `same-site` lets `app.gauzy.co` embed API-served assets while still blocking true third-party
   origins. (Dev/stage already use `cross-origin`.)

2. **Enable the `Secure` flag on the express-session cookie** via `secure: 'auto'` (was a
   commented-out TODO). `'auto'` keys off the actual connection: Secure over HTTPS (prod/stage/demo
   behind the proxy, where `trust proxy` is already set in bootstrap) and **non-Secure on
   plain-HTTP local dev**, so local sessions keep working. Existing sessions without the flag
   simply require a one-time re-login.

## Risk / testing

- Low blast radius — header policy + cookie flag only.
- `secure: 'auto'` was chosen over a hardcoded `true` specifically so a plain-HTTP environment
  can't silently drop the cookie (which would cause a login loop).
- After deploy: built-in integration icons render on `app.gauzy.co`; users may need to log in
  again once, after which sessions work normally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken images on app.gauzy.co by changing production Cross-Origin-Resource-Policy from same-origin to same-site so the app can load assets from api.gauzy.co. Also enables Secure session cookies (secure: 'auto') to use Secure over HTTPS while keeping local HTTP dev working; users may need a one-time re-login.

<sup>Written for commit 581a996460c7a985ddf5493906d49a0155750a70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

