### PR TITLE
fix(ci): unblock prod Electron builds (snapcraft 7.x + Python 3.11 for native rebuild)

### DIFF
--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -70,16 +70,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -207,16 +209,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -62,10 +62,24 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -182,13 +196,27 @@ jobs:
           org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
 
       - name: Install Multipass
         run: 'sudo snap install multipass'
 
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -70,16 +70,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -207,16 +209,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -62,10 +62,24 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -182,13 +196,27 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
 
       - name: Install Multipass
         run: 'sudo snap install multipass'
 
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -70,16 +70,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -207,16 +209,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -62,10 +62,24 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -182,13 +196,27 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
 
       - name: Install Multipass
         run: 'sudo snap install multipass'
 
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -70,16 +70,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -207,16 +209,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -62,10 +62,24 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -182,13 +196,27 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
 
       - name: Install Multipass
         run: 'sudo snap install multipass'
 
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -53,10 +53,24 @@ jobs:
         run: 'sudo apt-get update && sudo apt install -y curl gnupg git libappindicator3-1 ca-certificates binutils icnsutils graphicsmagick'
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -164,13 +178,27 @@ jobs:
           sudo gem install --no-document fpm
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
 
       - name: Install Multipass
         run: 'sudo snap install multipass'
 
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -61,16 +61,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -189,16 +191,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -70,16 +70,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -243,16 +245,18 @@ jobs:
       - name: Use Python 3.11 for native rebuilds (Linux)
         # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
         # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
-        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
-        uses: actions/setup-python@v5
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine. Pinned to a SHA.
+        id: py311
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Fix node-gyp and Python
+        # Install build deps into, and point node-gyp at, the SAME 3.11 interpreter (not a stray python3).
         run: |
-          python3 -m pip install packaging setuptools
-          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
-          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
+          "${{ steps.py311.outputs.python-path }}" -m pip install packaging setuptools
+          echo "npm_config_python=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
+          echo "PYTHON=${{ steps.py311.outputs.python-path }}" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -62,10 +62,24 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
+
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'
@@ -218,13 +232,27 @@ jobs:
             org.electronjs.Electron2.BaseApp//24.08
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin snapcraft 7.x: 8.0+ renamed the `snap` command to `pack`, but electron-builder's
+        # app-builder still invokes `snapcraft snap` (ERR_ELECTRON_BUILDER_CANNOT_EXECUTE). 7.x keeps
+        # the `snap` command and still supports the core22 base.
+        run: sudo snap install snapcraft --classic --channel=7.x/stable
 
       - name: Install Multipass
         run: 'sudo snap install multipass'
 
+      - name: Use Python 3.11 for native rebuilds (Linux)
+        # node-gyp's gyp eval()-parses Electron 38's common.gypi; Python 3.12's stricter tokenizer
+        # rejects it ("unterminated string literal"), breaking better-sqlite3's source rebuild
+        # (no prebuilt exists for Electron 38's ABI). Python 3.11 parses it fine.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Fix node-gyp and Python
-        run: python3 -m pip install packaging setuptools
+        run: |
+          python3 -m pip install packaging setuptools
+          echo "npm_config_python=$(which python3.11)" >> "$GITHUB_ENV"
+          echo "PYTHON=$(which python3.11)" >> "$GITHUB_ENV"
 
       - name: Install latest version of NPM
         run: 'sudo npm install -g npm@11.6.2'


### PR DESCRIPTION
fix(ci): unblock prod Electron builds (snapcraft 7.x pin + Python 3.11 for native rebuild)

The prod "* Build Prod" Electron app workflows fail on their Linux jobs with two independent,
pre-existing issues that surfaced once the @electron/node-gyp install fix (#9761) let the build
progress past `yarn install`:

1. snapcraft: action-snapcraft@v2 installs snapcraft 8.x, which renamed the `snap` command to
   `pack`. electron-builder's app-builder still invokes `snapcraft snap`, so snap packaging dies
   with ERR_ELECTRON_BUILDER_CANNOT_EXECUTE. Pin snapcraft to 7.x/stable (keeps `snap`, still
   supports the core22 base).

2. native rebuild: better-sqlite3 ships no prebuilt for Electron 38's ABI (electron-v139), so it
   compiles from source; node-gyp's gyp eval()-parses Electron 38's common.gypi and Python 3.12's
   stricter tokenizer rejects it ("SyntaxError: unterminated string literal"). Pin the Linux jobs'
   node-gyp Python to 3.11 (actions/setup-python@v5 + npm_config_python/PYTHON), which parses fine.

Scope: ONLY the Linux jobs of the 6 app-build workflows (server-api, server, desktop-app,
desktop-timer-app, server-mcp, agent). Windows/mac jobs are intentionally untouched (they pass; the
demo Windows build is green). No dependency/lockfile changes; the deployed Docker API is unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks Linux prod Electron builds by pinning `snapcraft` to 7.x and using Python 3.11 for native rebuilds. Fixes snap packaging and `node-gyp` compile errors so `.snap` artifacts build again.

- **Bug Fixes**
  - Pin `snapcraft` to 7.x/stable in Linux jobs (8.x renames `snap` to `pack`; `electron-builder` still calls `snapcraft snap`). Keep default LXD env; no `SNAPCRAFT_BUILD_ENVIRONMENT=host`.
  - Use Python 3.11 via `actions/setup-python` pinned to a commit SHA; install `packaging`/`setuptools` and set `npm_config_python`/`PYTHON` to the same interpreter path to fix `better-sqlite3` rebuilds on Electron 38.
  - Scope: Linux jobs only in prod workflows (`server-api`, `server`, `desktop-app`, `desktop-timer-app`, `server-mcp`, `agent`); macOS/Windows unchanged.

<sup>Written for commit f910ea1b312ee3e1bb367d32aa58bf2e2b1f352f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

