### PR TITLE
Promote develop → stage: plane proxy 0.1.5 (null-safe SSO /user/me + invite join)

### DIFF
--- a/packages/plugins/integration-plane/package.json
+++ b/packages/plugins/integration-plane/package.json
@@ -33,7 +33,7 @@
 		"@gauzy/core": "^0.1.0",
 		"@gauzy/plugin": "^0.1.0",
 		"@gauzy/utils": "^0.1.0",
-		"@ever-gauzy/plugin-integration-plane-api": "^0.1.4",
+		"@ever-gauzy/plugin-integration-plane-api": "^0.1.5",
 		"@ever-gauzy/plugin-integration-plane-models": "^0.1.3",
 		"@nestjs/axios": "github:ever-co/nestjs-axios#master",
 		"@nestjs/cqrs": "^11.0.3",

--- a/packages/plugins/integration-plane/package.json
+++ b/packages/plugins/integration-plane/package.json
@@ -33,7 +33,7 @@
 		"@gauzy/core": "^0.1.0",
 		"@gauzy/plugin": "^0.1.0",
 		"@gauzy/utils": "^0.1.0",
-		"@ever-gauzy/plugin-integration-plane-api": "^0.1.3",
+		"@ever-gauzy/plugin-integration-plane-api": "^0.1.4",
 		"@ever-gauzy/plugin-integration-plane-models": "^0.1.3",
 		"@nestjs/axios": "github:ever-co/nestjs-axios#master",
 		"@nestjs/cqrs": "^11.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,10 +5710,10 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
-"@ever-gauzy/plugin-integration-plane-api@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.npmjs.org/@ever-gauzy/plugin-integration-plane-api/-/plugin-integration-plane-api-0.1.3.tgz#a28cc2d538dab421f33921b5e18e0bdb5e722ba1"
-  integrity sha512-0JHW+yauSkbrBrfqvtjswvQRvsHOGiaBoH+QUbGRzmGKPN+sPBAmCUrc+NOANCW7y9TdXfm3t9D62woWPVa4Pw==
+"@ever-gauzy/plugin-integration-plane-api@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/@ever-gauzy/plugin-integration-plane-api/-/plugin-integration-plane-api-0.1.4.tgz#1de7e68a7ee02da64b0fed1301127ffc90d68299"
+  integrity sha512-Z4WLuDNtNZZoQpiQXcPCVTmfqOYV6tRJ1UOeDor6S2jMXiaD+bT6gjGEPZ7wjEiqh1C1h52mibPV8mvWJ4Mq9g==
   dependencies:
     "@ever-gauzy/plugin-integration-plane-models" "^0.1.3"
     "@nestjs/axios" "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,10 +5710,10 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
-"@ever-gauzy/plugin-integration-plane-api@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.npmjs.org/@ever-gauzy/plugin-integration-plane-api/-/plugin-integration-plane-api-0.1.4.tgz#1de7e68a7ee02da64b0fed1301127ffc90d68299"
-  integrity sha512-Z4WLuDNtNZZoQpiQXcPCVTmfqOYV6tRJ1UOeDor6S2jMXiaD+bT6gjGEPZ7wjEiqh1C1h52mibPV8mvWJ4Mq9g==
+"@ever-gauzy/plugin-integration-plane-api@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/@ever-gauzy/plugin-integration-plane-api/-/plugin-integration-plane-api-0.1.5.tgz#723f2745f6616d491b933cdfb6930e55566cf771"
+  integrity sha512-0jv9nTSJyIOQ5gPnlGVP0eI6lxnNH83j0pY1WnSmuBpOGLCzGxOYqSfTvpjrz7bMAyeCLsgQRcr2wIcAgRpjcA==
   dependencies:
     "@ever-gauzy/plugin-integration-plane-models" "^0.1.3"
     "@nestjs/axios" "^4.0.1"


### PR DESCRIPTION
Promotes the Plane proxy 0.1.3→0.1.5 dep bump (PR #9771) to stage. Fixes the employee-less SSO 500 (`admin@ever.co`) + the public invite-join 500. Dep + lockfile only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@ever-gauzy/plugin-integration-plane-api` to 0.1.5 to fix null-safety crashes. Resolves 500s on SSO `/api/plane/api/users/me` for users without employee records and on public invite join `/workspace-invitations/:token/join` for org-less invites.

<sup>Written for commit 33656881f9042cfc1e1e95008200d44de98e9b6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

