### PR TITLE
Promote develop → stage: plane proxy 0.1.6 (null-deref hardening)

### DIFF
--- a/packages/plugins/integration-plane/package.json
+++ b/packages/plugins/integration-plane/package.json
@@ -33,7 +33,7 @@
 		"@gauzy/core": "^0.1.0",
 		"@gauzy/plugin": "^0.1.0",
 		"@gauzy/utils": "^0.1.0",
-		"@ever-gauzy/plugin-integration-plane-api": "^0.1.5",
+		"@ever-gauzy/plugin-integration-plane-api": "^0.1.6",
 		"@ever-gauzy/plugin-integration-plane-models": "^0.1.3",
 		"@nestjs/axios": "github:ever-co/nestjs-axios#master",
 		"@nestjs/cqrs": "^11.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,10 +5710,10 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
-"@ever-gauzy/plugin-integration-plane-api@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.npmjs.org/@ever-gauzy/plugin-integration-plane-api/-/plugin-integration-plane-api-0.1.5.tgz#723f2745f6616d491b933cdfb6930e55566cf771"
-  integrity sha512-0jv9nTSJyIOQ5gPnlGVP0eI6lxnNH83j0pY1WnSmuBpOGLCzGxOYqSfTvpjrz7bMAyeCLsgQRcr2wIcAgRpjcA==
+"@ever-gauzy/plugin-integration-plane-api@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/@ever-gauzy/plugin-integration-plane-api/-/plugin-integration-plane-api-0.1.6.tgz#beec9de448ea06050c49a9897c234fb015a4dfa1"
+  integrity sha512-Wopj/QDU1Q40gyTnnuHcLsqDFXsInxQoG9MjJZxghrNWYZ17w103FW1wqDNy+6xD+lKE/rIBSgzvr9bBg3xhQQ==
   dependencies:
     "@ever-gauzy/plugin-integration-plane-models" "^0.1.3"
     "@nestjs/axios" "^4.0.1"


### PR DESCRIPTION
Promotes proxy 0.1.5→0.1.6 (38 null-safety guards, PR #9774) to stage. Dep + lockfile only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes Plane proxy to 0.1.6 to harden against null derefs and prevent latent 500s on partial Gauzy relation data. Includes 38 null-safety guards and a fix for an assignment-in-predicate bug.

- **Dependencies**
  - Bump `@ever-gauzy/plugin-integration-plane-api` from `0.1.5` to `0.1.6`

<sup>Written for commit 979ef9d101240d78cf770f97aa3cdbf7d2a78bf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

