### PR TITLE
Promote develop → stage: plane-integration mode/validation correctness fixes

### DIFF
--- a/packages/plugins/integration-plane/src/lib/dto/configure-plane-integration.dto.ts
+++ b/packages/plugins/integration-plane/src/lib/dto/configure-plane-integration.dto.ts
@@ -25,19 +25,25 @@ export class ConfigurePlaneIntegrationDto {
 	readonly planeWebUrl!: string;
 
 	@ApiPropertyOptional({
-		description: 'Plane admin panel URL',
+		description: 'Plane admin panel URL (optional; not used in shared mode)',
 		example: 'https://admin.plane.example.com'
 	})
-	@IsOptional()
+	// Admin URL is always optional. Validate the URL only when a non-empty value is
+	// supplied, so a blank string (common from a cleared form field) is treated as
+	// absent instead of failing @IsUrl — which would 400 an otherwise-valid request.
+	@ValidateIf((o) => o.planeAdminUrl != null && o.planeAdminUrl !== '')
 	@IsString()
 	@IsUrl({ require_tld: false, require_protocol: true })
 	readonly planeAdminUrl?: string;
 
 	@ApiPropertyOptional({
-		description: 'Plane public space URL',
+		description: 'Plane public space URL (required in custom mode)',
 		example: 'https://space.plane.example.com'
 	})
-	@IsOptional()
+	// Required (and validated) only in custom mode; in shared mode the space URL is
+	// irrelevant, so validation is skipped and a blank/absent value is accepted.
+	@ValidateIf((o) => o.mode === 'custom')
+	@IsNotEmpty()
 	@IsString()
 	@IsUrl({ require_tld: false, require_protocol: true })
 	readonly planeSpaceUrl?: string;

--- a/packages/plugins/integration-plane/src/lib/plane-integration.service.ts
+++ b/packages/plugins/integration-plane/src/lib/plane-integration.service.ts
@@ -179,11 +179,35 @@ export class PlaneIntegrationService {
 					[PlaneSettingName.PLANE_SPACE_URL, SHARED_PLANE_SPACE_URL]
 				);
 			} else {
-				updates.push(
-					[PlaneSettingName.PLANE_WEB_URL, dto.planeWebUrl],
-					[PlaneSettingName.PLANE_ADMIN_URL, dto.planeAdminUrl],
-					[PlaneSettingName.PLANE_SPACE_URL, dto.planeSpaceUrl]
-				);
+				// Switching to custom mode: UpdatePlaneSettingsDto is a PartialType, so a
+				// bare `{ mode: 'custom' }` passes validation. Guard here so we never
+				// persist mode='custom' while the URLs stay empty or on the shared hosted
+				// defaults. Resolve the effective web/space URLs (from this request or
+				// already stored) and reject the switch unless both are real tenant URLs.
+				const effectiveWebUrl =
+					dto.planeWebUrl ?? settingsIndex.get(PlaneSettingName.PLANE_WEB_URL)?.settingsValue;
+				const effectiveSpaceUrl =
+					dto.planeSpaceUrl ?? settingsIndex.get(PlaneSettingName.PLANE_SPACE_URL)?.settingsValue;
+				if (
+					!effectiveWebUrl ||
+					effectiveWebUrl === SHARED_PLANE_WEB_URL ||
+					!effectiveSpaceUrl ||
+					effectiveSpaceUrl === SHARED_PLANE_SPACE_URL
+				) {
+					throw new HttpException(
+						'Switching to custom mode requires planeWebUrl and planeSpaceUrl.',
+						HttpStatus.BAD_REQUEST
+					);
+				}
+				if (dto.planeWebUrl !== undefined) {
+					updates.push([PlaneSettingName.PLANE_WEB_URL, dto.planeWebUrl]);
+				}
+				if (dto.planeAdminUrl !== undefined) {
+					updates.push([PlaneSettingName.PLANE_ADMIN_URL, dto.planeAdminUrl]);
+				}
+				if (dto.planeSpaceUrl !== undefined) {
+					updates.push([PlaneSettingName.PLANE_SPACE_URL, dto.planeSpaceUrl]);
+				}
 			}
 		} else {
 			updates.push(

--- a/packages/plugins/integration-plane/src/lib/plane-integration.service.ts
+++ b/packages/plugins/integration-plane/src/lib/plane-integration.service.ts
@@ -163,12 +163,35 @@ export class PlaneIntegrationService {
 			settingsIndex.set(s.settingsName, s);
 		}
 
-		// Update only the provided fields
-		const updates: Array<[string, string | undefined]> = [
-			[PlaneSettingName.PLANE_WEB_URL, dto.planeWebUrl],
-			[PlaneSettingName.PLANE_ADMIN_URL, dto.planeAdminUrl],
-			[PlaneSettingName.PLANE_SPACE_URL, dto.planeSpaceUrl]
-		];
+		// Build the set of settings to update. When the caller changes `mode` we must
+		// persist PLANE_MODE and keep the URLs consistent with it (mirroring
+		// setupIntegration): switching to 'shared' overwrites the URLs with the global
+		// hosted PM constants; switching to 'custom' applies the tenant-provided URLs.
+		// When `mode` is omitted we leave PLANE_MODE untouched and patch only the URLs
+		// that were supplied.
+		const updates: Array<[string, string | undefined]> = [];
+		if (dto.mode !== undefined) {
+			updates.push([PlaneSettingName.PLANE_MODE, dto.mode]);
+			if (dto.mode === 'shared') {
+				updates.push(
+					[PlaneSettingName.PLANE_WEB_URL, SHARED_PLANE_WEB_URL],
+					[PlaneSettingName.PLANE_ADMIN_URL, SHARED_PLANE_ADMIN_URL],
+					[PlaneSettingName.PLANE_SPACE_URL, SHARED_PLANE_SPACE_URL]
+				);
+			} else {
+				updates.push(
+					[PlaneSettingName.PLANE_WEB_URL, dto.planeWebUrl],
+					[PlaneSettingName.PLANE_ADMIN_URL, dto.planeAdminUrl],
+					[PlaneSettingName.PLANE_SPACE_URL, dto.planeSpaceUrl]
+				);
+			}
+		} else {
+			updates.push(
+				[PlaneSettingName.PLANE_WEB_URL, dto.planeWebUrl],
+				[PlaneSettingName.PLANE_ADMIN_URL, dto.planeAdminUrl],
+				[PlaneSettingName.PLANE_SPACE_URL, dto.planeSpaceUrl]
+			);
+		}
 
 		for (const [name, value] of updates) {
 			if (value !== undefined) {


### PR DESCRIPTION
Promotes PR #9777 (B1: persist PLANE_MODE on update + reject inconsistent custom switch; B2/B3: DTO URL validation) to stage. Backend logic/validation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Plane integration settings to persist mode correctly and tighten URL validation, preventing inconsistent configs and avoidable 400s. Switching between shared and custom now behaves as expected.

- **Bug Fixes**
  - Persist `PLANE_MODE` and keep URLs in sync: switching to `shared` sets `SHARED_PLANE_*`; switching to `custom` requires tenant `planeWebUrl` and `planeSpaceUrl`; if `mode` is omitted, only provided URLs are patched.
  - DTO validation: `planeSpaceUrl` is required only in `custom` mode; `planeAdminUrl` is validated only when non-empty to avoid 400s from cleared fields.

<sup>Written for commit 5c9b18cbd06e4258c5d1e65903daa10083ff3591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

