### PR TITLE
fix(worker): pin swc jsc.target=es2021 to stop QueueWorkerHost CrashLoop

### DIFF
--- a/apps/worker/config/webpack.config.js
+++ b/apps/worker/config/webpack.config.js
@@ -45,30 +45,27 @@ module.exports = composePlugins(
 
 		// ever-gauzy fix (worker CrashLoop): @nx/webpack's swc-loader (compiler-loaders.js)
 		// configures `jsc` WITHOUT a `target`, so SWC falls back to its es3 default and
-		// downlevels `class extends` to `_inherits`/`_call_super`. The worker's own
+		// lowers `class extends` to `_inherits`/`_call_super`. The worker's own
 		// app-source `WorkerLifecycleProcessor` then invokes the prebuilt, NATIVE
 		// `@gauzy/scheduler` `QueueWorkerHost` constructor as a plain function ->
 		// "TypeError: Class constructor QueueWorkerHost cannot be invoked without 'new'"
 		// on boot (background jobs down). Pin the swc target so the worker's app classes
 		// stay native and match the prebuilt @gauzy/* packages (and @nestjs/bullmq's
 		// WorkerHost), making the `super()` call a native class construction.
+		const setSwcTargetOnEntry = (entry) => {
+			if (entry && typeof entry === 'object' && String(entry.loader || '').includes('swc-loader')) {
+				entry.options = entry.options || {};
+				entry.options.jsc = entry.options.jsc || {};
+				entry.options.jsc.target = 'es2021';
+			}
+		};
 		const pinSwcTarget = (rules) => {
 			for (const rule of rules || []) {
 				if (!rule || typeof rule !== 'object') continue;
-				if (String(rule.loader || '').includes('swc-loader')) {
-					rule.options = rule.options || {};
-					rule.options.jsc = rule.options.jsc || {};
-					rule.options.jsc.target = 'es2021';
-				}
-				if (Array.isArray(rule.use)) {
-					for (const u of rule.use) {
-						if (u && typeof u === 'object' && String(u.loader || '').includes('swc-loader')) {
-							u.options = u.options || {};
-							u.options.jsc = u.options.jsc || {};
-							u.options.jsc.target = 'es2021';
-						}
-					}
-				}
+				setSwcTargetOnEntry(rule); // rule with a top-level `loader`
+				// `use` can be a single loader object or an array of them
+				if (Array.isArray(rule.use)) rule.use.forEach(setSwcTargetOnEntry);
+				else setSwcTargetOnEntry(rule.use);
 				if (Array.isArray(rule.oneOf)) pinSwcTarget(rule.oneOf);
 				if (Array.isArray(rule.rules)) pinSwcTarget(rule.rules);
 			}

--- a/apps/worker/config/webpack.config.js
+++ b/apps/worker/config/webpack.config.js
@@ -43,6 +43,38 @@ module.exports = composePlugins(
 		};
 		config.devtool = 'source-map';
 
+		// ever-gauzy fix (worker CrashLoop): @nx/webpack's swc-loader (compiler-loaders.js)
+		// configures `jsc` WITHOUT a `target`, so SWC falls back to its es3 default and
+		// downlevels `class extends` to `_inherits`/`_call_super`. The worker's own
+		// app-source `WorkerLifecycleProcessor` then invokes the prebuilt, NATIVE
+		// `@gauzy/scheduler` `QueueWorkerHost` constructor as a plain function ->
+		// "TypeError: Class constructor QueueWorkerHost cannot be invoked without 'new'"
+		// on boot (background jobs down). Pin the swc target so the worker's app classes
+		// stay native and match the prebuilt @gauzy/* packages (and @nestjs/bullmq's
+		// WorkerHost), making the `super()` call a native class construction.
+		const pinSwcTarget = (rules) => {
+			for (const rule of rules || []) {
+				if (!rule || typeof rule !== 'object') continue;
+				if (String(rule.loader || '').includes('swc-loader')) {
+					rule.options = rule.options || {};
+					rule.options.jsc = rule.options.jsc || {};
+					rule.options.jsc.target = 'es2021';
+				}
+				if (Array.isArray(rule.use)) {
+					for (const u of rule.use) {
+						if (u && typeof u === 'object' && String(u.loader || '').includes('swc-loader')) {
+							u.options = u.options || {};
+							u.options.jsc = u.options.jsc || {};
+							u.options.jsc.target = 'es2021';
+						}
+					}
+				}
+				if (Array.isArray(rule.oneOf)) pinSwcTarget(rule.oneOf);
+				if (Array.isArray(rule.rules)) pinSwcTarget(rule.rules);
+			}
+		};
+		pinSwcTarget(config.module && config.module.rules);
+
 		// Generate copy patterns for built packages
 		// Logs timing to track performance
 		console.time('✔️ Copying all built package folders to dist node_modules');


### PR DESCRIPTION
## Incident
`gauzy-worker` (prod + stage) CrashLoops at boot — **background jobs are down**:
```
TypeError: Class constructor QueueWorkerHost cannot be invoked without 'new'
```

## Root cause (confirmed from the actual bundle)
`@nx/webpack`'s swc-loader (`compiler-loaders.js`) configures `jsc` **without a `target`**, so `@swc/core` falls back to its **es3** default and downlevels `class extends` to `_inherits`/`_call_super`. The worker's own app-source `WorkerLifecycleProcessor` is bundled by that SWC pass (ES5) and extends `QueueWorkerHost` from the **prebuilt, native-ES2021** `@gauzy/scheduler` (copied into `node_modules`, not re-transpiled). The ES5 subclass then invokes the native super constructor as a plain function → TypeError on every boot.

Confirmed in `dist/apps/worker/1.js`: `_inherits(WorkerLifecycleProcessor, QueueWorkerHost)` + `_ts_generator` (async downleveled) — while `dist/packages/scheduler` keeps `class QueueWorkerHost extends bullmq_…` native.

The API survives only because its `QueueWorkerHost` subclass (`TokenCleanupWorker`) lives in prebuilt `@gauzy/core` (also native) — consistent.

## Fix
Inject `jsc.target: 'es2021'` into the worker's swc-loader options so app classes stay native and match the prebuilt `@gauzy/*` packages (and `@nestjs/bullmq`'s `WorkerHost`), making `super()` a native class construction.

## Verification
With `@swc/core@1.15.11` + the exact Nx loader options:
- **before** (no target → es3): emits `_inherits(subClass, superClass)` → crashes on native super *(reproduces the bug)*
- **after** (`+ jsc.target: es2021`): emits `class WorkerLifecycleProcessor extends QueueWorkerHost` native → `super()` works

## Note
`apps/api` has the same latent config (swc es3 default) but no app-source class extending a prebuilt native class, so it's unaffected; a follow-up could pin its target too for consistency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the worker CrashLoop by pinning the SWC target to ES2021 so class inheritance stays native and `super()` works. Restores background jobs at boot.

- **Bug Fixes**
  - Root cause: `@nx/webpack` `swc-loader` omitted `jsc.target`, so `@swc/core` downleveled to ES3 and broke extending native `@gauzy/scheduler` classes.
  - Fix: In `apps/worker/config/webpack.config.js`, set `jsc.target: 'es2021'` for all `swc-loader` rules, covering `loader`, `use` (array or single object), `oneOf`, and nested `rules` so the pin is never skipped.
  - Verification: ES3 output emitted `_inherits(...)` and crashed; ES2021 keeps `class ... extends` native and boots successfully.

<sup>Written for commit 9ce621c2de5e16aa1fc48f026148fe18396d5b9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

