### PR TITLE
feat(ai-chat-ui): polish round — full-height panel, width fit, resize, maximize, dock icons, AI launcher

### DIFF
--- a/packages/plugins/ai-chat-react-ui/src/lib/ai-chat-sidebar.component.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/ai-chat-sidebar.component.ts
@@ -15,14 +15,23 @@ import { AiChatPanel } from './components/AiChatPanel';
 @Component({
 	selector: 'gz-ai-chat-sidebar',
 	imports: [CommonModule, ReactHostDirective],
-	template: `<div [gaReactHost]="page" style="display:flex;flex-direction:column;height:100%"></div>`,
+	template: `<div
+		[gaReactHost]="page"
+		style="display:flex;flex-direction:column;height:100%;width:100%;min-width:0;max-width:100%;overflow:hidden"
+	></div>`,
 	styles: [
 		`
+			/* min-width: 0 at every flex layer — otherwise wide streamed
+			   content (code blocks, tables) sets the min-content width and
+			   stretches the whole panel column. */
 			:host {
 				display: flex;
 				flex-direction: column;
 				flex: 1;
 				overflow: hidden;
+				width: 100%;
+				min-width: 0;
+				max-width: 100%;
 			}
 		`
 	],

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
@@ -1,5 +1,6 @@
 import {
 	useCallback,
+	useEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -16,6 +17,7 @@ import { useInjector } from '@gauzy/ui-react';
 import { ChatSidebarService, Store } from '@gauzy/ui-core/core';
 import { environment } from '@gauzy/ui-config';
 import { executeClientTool, isClientTool } from '../chat-client-tools';
+import { useAngularSignal } from '../use-angular-signal';
 import { ChatMessageList } from './ChatMessageList';
 import { ChatInput } from './ChatInput';
 import { ChatWelcome } from './ChatWelcome';
@@ -58,11 +60,11 @@ export function AiChatPanel() {
 	const [history, setHistory] = useState<IChatHistoryItem[]>([]);
 	const [historyLoading, setHistoryLoading] = useState(false);
 
-	// Docking / maximize state mirrors the Angular ChatSidebarService signals
-	// (they only change through this panel's own buttons, so a local mirror
-	// keeps the icons in sync without a signal→React bridge).
-	const [dockSide, setDockSide] = useState<'start' | 'end'>(chatSidebar.position());
-	const [isMaximized, setIsMaximized] = useState<boolean>(chatSidebar.maximized());
+	// Docking / maximize state comes straight from the Angular
+	// ChatSidebarService signals — they also change outside this panel
+	// (e.g. collapsing clears maximized), so a live bridge is required.
+	const dockSide = useAngularSignal(injector, chatSidebar.position);
+	const isMaximized = useAngularSignal(injector, chatSidebar.maximized);
 	const rootRef = useRef<HTMLDivElement>(null);
 
 	const authHeaders = useCallback(
@@ -143,34 +145,39 @@ export function AiChatPanel() {
 
 	const handleCollapse = useCallback(() => chatSidebar.collapse(), [chatSidebar]);
 
-	const handleMoveSide = useCallback(() => {
-		chatSidebar.togglePosition();
-		setDockSide(chatSidebar.position());
-	}, [chatSidebar]);
+	const handleMoveSide = useCallback(() => chatSidebar.togglePosition(), [chatSidebar]);
 
-	const handleToggleMaximize = useCallback(() => {
-		chatSidebar.toggleMaximized();
-		setIsMaximized(chatSidebar.maximized());
-	}, [chatSidebar]);
+	const handleToggleMaximize = useCallback(() => chatSidebar.toggleMaximized(), [chatSidebar]);
 
 	// ── Drag-to-resize (grip on the canvas-facing edge) ──────────
+	// Window listeners are tracked in a ref so a drag interrupted by
+	// `pointercancel` (touch gesture takeover) or component unmount
+	// never leaks them.
+	const endResizeRef = useRef<(() => void) | null>(null);
+	useEffect(() => () => endResizeRef.current?.(), []);
+
 	const handleResizeStart = useCallback(
 		(event: ReactPointerEvent<HTMLDivElement>) => {
 			event.preventDefault();
 			const host = rootRef.current;
 			if (!host) return;
+			endResizeRef.current?.();
 			const rect = host.getBoundingClientRect();
 			const side = chatSidebar.position();
 			const onMove = (move: PointerEvent) => {
 				const width = side === 'start' ? move.clientX - rect.left : rect.right - move.clientX;
 				chatSidebar.setWidth(width);
 			};
-			const onUp = () => {
+			const end = () => {
 				window.removeEventListener('pointermove', onMove);
-				window.removeEventListener('pointerup', onUp);
+				window.removeEventListener('pointerup', end);
+				window.removeEventListener('pointercancel', end);
+				endResizeRef.current = null;
 			};
+			endResizeRef.current = end;
 			window.addEventListener('pointermove', onMove);
-			window.addEventListener('pointerup', onUp);
+			window.addEventListener('pointerup', end);
+			window.addEventListener('pointercancel', end);
 		},
 		[chatSidebar]
 	);
@@ -279,6 +286,8 @@ export function AiChatPanel() {
 		width: 6,
 		cursor: 'col-resize',
 		zIndex: 6,
+		// A touch drag on the grip must resize, not scroll/zoom the page.
+		touchAction: 'none',
 		// Invisible until hovered — then a subtle accent strip.
 		background: 'transparent'
 	};

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useRef, useState, type CSSProperties } from 'react';
+import {
+	useCallback,
+	useMemo,
+	useRef,
+	useState,
+	type CSSProperties,
+	type PointerEvent as ReactPointerEvent
+} from 'react';
 import { useChat } from '@ai-sdk/react';
 import {
 	DefaultChatTransport,
@@ -50,6 +57,13 @@ export function AiChatPanel() {
 	const [showHistory, setShowHistory] = useState(false);
 	const [history, setHistory] = useState<IChatHistoryItem[]>([]);
 	const [historyLoading, setHistoryLoading] = useState(false);
+
+	// Docking / maximize state mirrors the Angular ChatSidebarService signals
+	// (they only change through this panel's own buttons, so a local mirror
+	// keeps the icons in sync without a signal→React bridge).
+	const [dockSide, setDockSide] = useState<'start' | 'end'>(chatSidebar.position());
+	const [isMaximized, setIsMaximized] = useState<boolean>(chatSidebar.maximized());
+	const rootRef = useRef<HTMLDivElement>(null);
 
 	const authHeaders = useCallback(
 		(): Record<string, string> => ({
@@ -128,7 +142,38 @@ export function AiChatPanel() {
 	);
 
 	const handleCollapse = useCallback(() => chatSidebar.collapse(), [chatSidebar]);
-	const handleMoveSide = useCallback(() => chatSidebar.togglePosition(), [chatSidebar]);
+
+	const handleMoveSide = useCallback(() => {
+		chatSidebar.togglePosition();
+		setDockSide(chatSidebar.position());
+	}, [chatSidebar]);
+
+	const handleToggleMaximize = useCallback(() => {
+		chatSidebar.toggleMaximized();
+		setIsMaximized(chatSidebar.maximized());
+	}, [chatSidebar]);
+
+	// ── Drag-to-resize (grip on the canvas-facing edge) ──────────
+	const handleResizeStart = useCallback(
+		(event: ReactPointerEvent<HTMLDivElement>) => {
+			event.preventDefault();
+			const host = rootRef.current;
+			if (!host) return;
+			const rect = host.getBoundingClientRect();
+			const side = chatSidebar.position();
+			const onMove = (move: PointerEvent) => {
+				const width = side === 'start' ? move.clientX - rect.left : rect.right - move.clientX;
+				chatSidebar.setWidth(width);
+			};
+			const onUp = () => {
+				window.removeEventListener('pointermove', onMove);
+				window.removeEventListener('pointerup', onUp);
+			};
+			window.addEventListener('pointermove', onMove);
+			window.addEventListener('pointerup', onUp);
+		},
+		[chatSidebar]
+	);
 
 	// ── Conversation history (server-side, current user only) ────
 	const conversationsUrl = `${environment.API_BASE_URL}/api/ai-chat/conversations`;
@@ -182,6 +227,11 @@ export function AiChatPanel() {
 		display: 'flex',
 		flexDirection: 'column',
 		height: '100%',
+		// Hard width containment: the panel must never grow past its host,
+		// no matter how wide the streamed content's min-content size is.
+		width: '100%',
+		minWidth: 0,
+		maxWidth: '100%',
 		overflow: 'hidden',
 		position: 'relative'
 	};
@@ -217,12 +267,28 @@ export function AiChatPanel() {
 		flex: 1,
 		display: 'flex',
 		flexDirection: 'column',
-		overflow: 'hidden'
+		overflow: 'hidden',
+		minWidth: 0
+	};
+
+	const resizeHandleStyle: CSSProperties = {
+		position: 'absolute',
+		top: 0,
+		bottom: 0,
+		[dockSide === 'start' ? 'right' : 'left']: 0,
+		width: 6,
+		cursor: 'col-resize',
+		zIndex: 6,
+		// Invisible until hovered — then a subtle accent strip.
+		background: 'transparent'
 	};
 
 	return (
-		<div style={containerStyle}>
-			{/* Inline keyframe animations */}
+		<div ref={rootRef} style={containerStyle}>
+			{/* Inline keyframes + width containment for streamed markdown:
+			    wide content (code blocks, tables) must scroll inside its own
+			    box instead of stretching the narrow panel and squeezing the
+			    input row. */}
 			<style>{`
 				@keyframes fadeIn {
 					from { opacity: 0; transform: translateY(4px); }
@@ -232,6 +298,18 @@ export function AiChatPanel() {
 					0%, 80%, 100% { transform: scale(0); opacity: 0.5; }
 					40% { transform: scale(1); opacity: 1; }
 				}
+				.gz-ai-chat-markdown { max-width: 100%; min-width: 0; overflow-wrap: anywhere; }
+				.gz-ai-chat-markdown pre {
+					max-width: 100%; overflow-x: auto; white-space: pre;
+					font-size: 0.75rem; border-radius: 8px;
+				}
+				.gz-ai-chat-markdown code { overflow-wrap: anywhere; }
+				.gz-ai-chat-markdown table {
+					display: block; max-width: 100%; width: fit-content;
+					overflow-x: auto; font-size: 0.75rem;
+				}
+				.gz-ai-chat-markdown img, .gz-ai-chat-markdown video { max-width: 100%; height: auto; }
+				.gz-ai-chat-resize:hover { background: rgba(51, 102, 255, 0.35) !important; }
 			`}</style>
 
 			{/* Header: title + new chat + collapse */}
@@ -291,24 +369,81 @@ export function AiChatPanel() {
 					<button
 						onClick={handleMoveSide}
 						style={headerBtnStyle}
-						title="Move chat to the other side"
-						aria-label="Move chat to the other side"
+						title={dockSide === 'start' ? 'Dock chat to the right side' : 'Dock chat to the left side'}
+						aria-label={dockSide === 'start' ? 'Dock chat to the right side' : 'Dock chat to the left side'}
 					>
-						<svg
-							width="13"
-							height="13"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							strokeLinecap="round"
-							strokeLinejoin="round"
-						>
-							<polyline points="17 1 21 5 17 9" />
-							<path d="M3 11V9a4 4 0 0 1 4-4h14" />
-							<polyline points="7 23 3 19 7 15" />
-							<path d="M21 13v2a4 4 0 0 1-4 4H3" />
-						</svg>
+						{/* Arrow pointing toward the side the chat will move to */}
+						{dockSide === 'start' ? (
+							<svg
+								width="13"
+								height="13"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<line x1="3" y1="12" x2="15" y2="12" />
+								<polyline points="10 7 15 12 10 17" />
+								<line x1="20" y1="4" x2="20" y2="20" />
+							</svg>
+						) : (
+							<svg
+								width="13"
+								height="13"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<line x1="21" y1="12" x2="9" y2="12" />
+								<polyline points="14 7 9 12 14 17" />
+								<line x1="4" y1="4" x2="4" y2="20" />
+							</svg>
+						)}
+					</button>
+					<button
+						onClick={handleToggleMaximize}
+						style={headerBtnStyle}
+						title={isMaximized ? 'Restore chat width' : 'Maximize chat (hide the page)'}
+						aria-label={isMaximized ? 'Restore chat width' : 'Maximize chat'}
+					>
+						{isMaximized ? (
+							<svg
+								width="13"
+								height="13"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<polyline points="4 14 10 14 10 20" />
+								<polyline points="20 10 14 10 14 4" />
+								<line x1="14" y1="10" x2="21" y2="3" />
+								<line x1="3" y1="21" x2="10" y2="14" />
+							</svg>
+						) : (
+							<svg
+								width="13"
+								height="13"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<polyline points="15 3 21 3 21 9" />
+								<polyline points="9 21 3 21 3 15" />
+								<line x1="21" y1="3" x2="14" y2="10" />
+								<line x1="3" y1="21" x2="10" y2="14" />
+							</svg>
+						)}
 					</button>
 					<button
 						onClick={handleCollapse}
@@ -395,6 +530,18 @@ export function AiChatPanel() {
 					onEscape={handleCollapse}
 				/>
 			</div>
+
+			{/* Drag-to-resize grip on the canvas-facing edge */}
+			{!isMaximized && (
+				<div
+					className="gz-ai-chat-resize"
+					style={resizeHandleStyle}
+					onPointerDown={handleResizeStart}
+					role="separator"
+					aria-orientation="vertical"
+					aria-label="Resize chat panel"
+				/>
+			)}
 		</div>
 	);
 }

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/ChatInput.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/ChatInput.tsx
@@ -83,10 +83,14 @@ export function ChatInput({ value, isBusy, onChange, onSubmit, onStop, onEscape 
 		padding: 0,
 		margin: 0,
 		minWidth: 0,
-		// No stray scrollbars/borders inside the field: scroll vertically only
+		// No stray scrollbars/borders/native chrome inside the field — the
+		// surrounding form provides the visual box; scroll vertically only
 		// once the 3-line auto-grow limit is reached.
 		overflowX: 'hidden',
-		overflowY: 'auto'
+		overflowY: 'auto',
+		boxShadow: 'none',
+		appearance: 'none',
+		WebkitAppearance: 'none'
 	};
 
 	const buttonStyle: CSSProperties = {

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/ChatInput.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/ChatInput.tsx
@@ -81,7 +81,12 @@ export function ChatInput({ value, isBusy, onChange, onSubmit, onStop, onEscape 
 		minHeight: 20,
 		maxHeight: 80,
 		padding: 0,
-		margin: 0
+		margin: 0,
+		minWidth: 0,
+		// No stray scrollbars/borders inside the field: scroll vertically only
+		// once the 3-line auto-grow limit is reached.
+		overflowX: 'hidden',
+		overflowY: 'auto'
 	};
 
 	const buttonStyle: CSSProperties = {

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/ChatMessageList.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/ChatMessageList.tsx
@@ -31,10 +31,13 @@ export function ChatMessageList({ messages, status, onApprovalResponse }: ChatMe
 	const containerStyle: CSSProperties = {
 		flex: 1,
 		overflowY: 'auto',
+		overflowX: 'hidden',
 		padding: '10px',
 		display: 'flex',
 		flexDirection: 'column',
-		gap: 8
+		gap: 8,
+		// Wide streamed content must never stretch the panel's flex column.
+		minWidth: 0
 	};
 
 	const lastMessage = messages[messages.length - 1];

--- a/packages/plugins/ai-chat-react-ui/src/lib/use-angular-signal.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/use-angular-signal.ts
@@ -1,0 +1,31 @@
+import { effect, type Injector, type Signal } from '@angular/core';
+import { useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * useAngularSignal
+ *
+ * Subscribes a React component to an Angular signal so the component
+ * re-renders whenever the signal changes — regardless of whether the
+ * change originated in React or anywhere on the Angular side (layout
+ * chevrons, header toggles, other services).
+ *
+ * Bridged with `useSyncExternalStore`: an Angular `effect` (created
+ * against the host injector, so it works outside an injection context)
+ * acts as the subscription and is destroyed on unmount.
+ */
+export function useAngularSignal<T>(injector: Injector, source: Signal<T>): T {
+	const subscribe = useCallback(
+		(onStoreChange: () => void) => {
+			const ref = effect(
+				() => {
+					source();
+					onStoreChange();
+				},
+				{ injector }
+			);
+			return () => ref.destroy();
+		},
+		[injector, source]
+	);
+	return useSyncExternalStore(subscribe, source, source);
+}

--- a/packages/plugins/ai-chat/src/lib/system-prompt.ts
+++ b/packages/plugins/ai-chat/src/lib/system-prompt.ts
@@ -51,6 +51,10 @@ export function buildSystemPrompt(context: ISystemPromptContext): string {
 		'- Before filling a form, read_page first so field names are grounded in what is actually on screen.',
 		'- Never auto-submit a form or perform a destructive action without an explicit approval from the user.',
 		'- Keep answers concise and well-formatted (markdown: short paragraphs, lists, tables when comparing).',
+		'- IMPORTANT: your answers render in a NARROW chat panel (roughly 380px wide). Prefer compact bullet',
+		'  lists over wide tables; keep tables to 2-3 short columns max; keep code lines short; never output',
+		'  wide ASCII art or long unbroken strings. For large datasets, summarize the highlights and offer to',
+		'  open the relevant page in the canvas instead.',
 		'- Amounts, dates and names must come from tool results, not memory.'
 	]
 		.filter(Boolean)

--- a/packages/ui-core/core/src/lib/services/chat-sidebar/chat-sidebar.service.ts
+++ b/packages/ui-core/core/src/lib/services/chat-sidebar/chat-sidebar.service.ts
@@ -18,6 +18,14 @@ const CHAT_SIDEBAR_EXPANDED_KEY = 'gauzy_chat_sidebar_expanded';
 /** localStorage key holding the user's docking-side preference. */
 const CHAT_SIDEBAR_POSITION_KEY = 'gauzy_chat_sidebar_position';
 
+/** localStorage key holding the user's chat width preference. */
+const CHAT_SIDEBAR_WIDTH_KEY = 'gauzy_chat_sidebar_width';
+
+/** Default / minimum / maximum chat panel width (px). */
+const DEFAULT_CHAT_WIDTH = 384;
+export const MIN_CHAT_WIDTH = 300;
+export const MAX_CHAT_WIDTH = 860;
+
 /**
  * ChatSidebarService
  *
@@ -46,6 +54,15 @@ export class ChatSidebarService {
 	 */
 	readonly position = signal<'start' | 'end'>('start');
 
+	/** Chat panel width in pixels (user-resizable, persisted). */
+	readonly width = signal<number>(DEFAULT_CHAT_WIDTH);
+
+	/**
+	 * Maximized: the chat fills all space except the nav menu sidebar
+	 * (`Menu | Chat`); the canvas is hidden (kept alive) until restored.
+	 */
+	readonly maximized = signal<boolean>(false);
+
 	/**
 	 * Whether the chat is available for the current user — set by the
 	 * registering plugin once it has checked the user's permission and
@@ -72,6 +89,7 @@ export class ChatSidebarService {
 		this.config.set(sidebarConfig);
 		this.expanded.set(this.readStoredExpanded() ?? sidebarConfig.defaultExpanded ?? false);
 		this.position.set(this.readStoredPosition() ?? 'start');
+		this.width.set(this.readStoredWidth() ?? DEFAULT_CHAT_WIDTH);
 	}
 
 	/**
@@ -99,13 +117,38 @@ export class ChatSidebarService {
 
 	/**
 	 * Set the expand state and persist the user's preference.
+	 * Collapsing always leaves maximized mode.
 	 */
 	setExpanded(expanded: boolean): void {
 		this.expanded.set(expanded);
+		if (!expanded) {
+			this.maximized.set(false);
+		}
 		try {
 			localStorage.setItem(CHAT_SIDEBAR_EXPANDED_KEY, String(expanded));
 		} catch {
 			// Storage unavailable (private mode / SSR) — state stays in-memory only.
+		}
+	}
+
+	/** Maximize the chat (`Menu | Chat`) or restore it to its normal width. */
+	toggleMaximized(): void {
+		this.maximized.set(!this.maximized());
+		if (this.maximized()) {
+			this.expanded.set(true);
+		}
+	}
+
+	/**
+	 * Set the chat panel width (px), clamped to sane bounds and persisted.
+	 */
+	setWidth(width: number): void {
+		const clamped = Math.round(Math.min(MAX_CHAT_WIDTH, Math.max(MIN_CHAT_WIDTH, width)));
+		this.width.set(clamped);
+		try {
+			localStorage.setItem(CHAT_SIDEBAR_WIDTH_KEY, String(clamped));
+		} catch {
+			// Storage unavailable — state stays in-memory only.
 		}
 	}
 
@@ -129,6 +172,16 @@ export class ChatSidebarService {
 		try {
 			const stored = localStorage.getItem(CHAT_SIDEBAR_EXPANDED_KEY);
 			return stored === null ? null : stored === 'true';
+		} catch {
+			return null;
+		}
+	}
+
+	/** Read the persisted width; null when never set, invalid, or storage unavailable. */
+	private readStoredWidth(): number | null {
+		try {
+			const stored = Number(localStorage.getItem(CHAT_SIDEBAR_WIDTH_KEY));
+			return Number.isFinite(stored) && stored >= MIN_CHAT_WIDTH && stored <= MAX_CHAT_WIDTH ? stored : null;
 		} catch {
 			return null;
 		}

--- a/packages/ui-core/core/src/lib/services/chat-sidebar/chat-sidebar.service.ts
+++ b/packages/ui-core/core/src/lib/services/chat-sidebar/chat-sidebar.service.ts
@@ -98,6 +98,7 @@ export class ChatSidebarService {
 	unregister(): void {
 		this.config.set(null);
 		this.expanded.set(false);
+		this.maximized.set(false);
 	}
 
 	/** Toggle the sidebar between expanded and collapsed. */
@@ -139,17 +140,28 @@ export class ChatSidebarService {
 		}
 	}
 
+	/** Pending debounced width persist (drag-resize calls setWidth per pointermove). */
+	private widthPersistTimer: ReturnType<typeof setTimeout> | null = null;
+
 	/**
 	 * Set the chat panel width (px), clamped to sane bounds and persisted.
+	 * The signal updates immediately (live resize); the localStorage write
+	 * is debounced so a 60 Hz drag doesn't do synchronous I/O per frame.
 	 */
 	setWidth(width: number): void {
 		const clamped = Math.round(Math.min(MAX_CHAT_WIDTH, Math.max(MIN_CHAT_WIDTH, width)));
 		this.width.set(clamped);
-		try {
-			localStorage.setItem(CHAT_SIDEBAR_WIDTH_KEY, String(clamped));
-		} catch {
-			// Storage unavailable — state stays in-memory only.
+		if (this.widthPersistTimer !== null) {
+			clearTimeout(this.widthPersistTimer);
 		}
+		this.widthPersistTimer = setTimeout(() => {
+			this.widthPersistTimer = null;
+			try {
+				localStorage.setItem(CHAT_SIDEBAR_WIDTH_KEY, String(this.width()));
+			} catch {
+				// Storage unavailable — state stays in-memory only.
+			}
+		}, 250);
 	}
 
 	/** Move the chat to the other side of the content column and persist. */

--- a/packages/ui-core/core/src/lib/services/chat-sidebar/index.ts
+++ b/packages/ui-core/core/src/lib/services/chat-sidebar/index.ts
@@ -1,1 +1,6 @@
-export { ChatSidebarService, type IChatSidebarConfig } from './chat-sidebar.service';
+export {
+	ChatSidebarService,
+	MIN_CHAT_WIDTH,
+	MAX_CHAT_WIDTH,
+	type IChatSidebarConfig
+} from './chat-sidebar.service';

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.html
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.html
@@ -1,7 +1,12 @@
 <nb-layout windowMode>
-	<!-- Header -->
+	<!-- Header — its content shifts aside for the expanded AI chat panel
+	     (the chat is a full-height column; it must displace content, not cover it) -->
 	@if (user()) {
-		<nb-layout-header fixed>
+		<nb-layout-header
+			fixed
+			[style.paddingLeft.px]="chatHeaderPad('start')"
+			[style.paddingRight.px]="chatHeaderPad('end')"
+		>
 			<ngx-header [expanded]="isExpanded()"></ngx-header>
 		</nb-layout-header>
 	}

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.html
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.html
@@ -31,6 +31,22 @@
 								<i class="fas fa-ellipsis-h"></i>
 							</button>
 						}
+
+						<!-- AI agent launcher — visible whenever the chat is available
+						     but collapsed, so the agent is always one click away. -->
+						@if (chatSidebarService.available() && !chatSidebarService.expanded()) {
+							<button
+								class="ai-agent-launch"
+								outline
+								nbButton
+								size="small"
+								[title]="'HEADER.AI_CHAT' | translate"
+								[attr.aria-label]="'HEADER.AI_CHAT' | translate"
+								(click)="chatSidebarService.expand()"
+							>
+								<i class="fas fa-robot"></i>
+							</button>
+						}
 					</div>
 				</div>
 
@@ -64,9 +80,12 @@
 	     nb-layout's select-based content projection for nb-sidebar. -->
 	@if (user() && chatSidebarService.available() && chatSidebarComponent(); as chatComponent) {
 		<nb-sidebar
+			#chatSidebarHost
 			class="chat-sidebar"
 			[class]="chatSidebarService.config()?.class ?? ''"
 			[class.chat-sidebar-end]="chatSidebarService.position() === 'end'"
+			[class.chat-sidebar-maximized]="chatSidebarService.maximized()"
+			[style.--gz-chat-width]="chatSidebarService.width() + 'px'"
 			tag="chat-sidebar"
 			[state]="chatSidebarService.expanded() ? 'expanded' : 'collapsed'"
 		>

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -46,11 +46,13 @@
     order: 0 !important;
   }
 
-  // AI Chat sidebar — sits between the nav menu sidebar and the page content.
-  // The HOST stays in the flex flow and reserves the width (Menu | Chat | Content,
-  // DOM order after the menu sidebar); Nebular's .main-container is position:fixed
-  // in windowMode, so it must inherit the host width (100% would mean the viewport)
-  // and be pinned below the header.
+  // AI Chat sidebar — a full-height vertical block like the nav menu sidebar
+  // (Menu | Chat | Canvas, or Menu | Canvas | Chat when docked right).
+  // The HOST stays in the flex flow and reserves the width; Nebular's
+  // .main-container is position:fixed in windowMode, so it is pinned to the
+  // full viewport height (top 0 → nothing above or below it) and follows the
+  // host's flex-computed width via --gz-chat-live-width (set by the layout's
+  // ResizeObserver — covers normal, user-resized, maximized and collapsed).
   nb-sidebar.chat-sidebar {
     order: 0 !important;
     align-self: stretch;
@@ -68,7 +70,14 @@
     }
 
     &.expanded {
-      width: 24rem !important;
+      width: var(--gz-chat-width, 24rem) !important;
+    }
+
+    // Maximized: take all space except the nav menu (Menu | Chat);
+    // the canvas is hidden (components stay alive) until restored.
+    &.chat-sidebar-maximized {
+      flex: 1 1 auto !important;
+      width: auto !important;
     }
 
     &.collapsed {
@@ -77,13 +86,11 @@
     }
 
     ::ng-deep .main-container {
-      width: inherit !important;
-      max-width: 24rem;
-      // --gz-header-offset = the header's REAL rendered height (set by the
-      // layout via ResizeObserver; includes e.g. the demo banner), falling
-      // back to the theme variable.
-      top: var(--gz-header-offset, var(--header-height, 4.75rem)) !important;
-      height: calc(100vh - var(--gz-header-offset, var(--header-height, 4.75rem))) !important;
+      width: var(--gz-chat-live-width, var(--gz-chat-width, 24rem)) !important;
+      max-width: none;
+      top: 0 !important;
+      height: 100vh !important;
+      z-index: 1041; // same layer as the nav menu sidebar — covers the header band
       transition: width 0.2s ease;
       overflow: hidden;
 
@@ -101,6 +108,7 @@
       }
     }
   }
+
 
   gauzy-user-menu {
     position: absolute;
@@ -184,11 +192,30 @@ nb-sidebar[tag='menu-sidebar'] {
   max-width: nb-theme(sidebar-width);
   width: nb-theme(sidebar-width);
   padding: 0.75rem;
+  // The logo area must keep a stable footprint: whatever renders inside
+  // (logo or the tenant/workspace switcher) may not widen the sidebar.
+  overflow: hidden;
   button.hidden-menu {
     padding: 0 0.5rem;
     height: 1.625rem;
     width: 1.625rem;
     margin: 0 0.625rem;
+  }
+  button.ai-agent-launch {
+    padding: 0 0.5rem;
+    height: 1.625rem;
+    width: 1.625rem;
+    margin: 0 0.25rem;
+    flex-shrink: 0;
+    color: #3366ff;
+  }
+  // The in-place workspace/tenant switcher must fit the sidebar width
+  // instead of pushing the layout around (it renders wider than the logo).
+  ::ng-deep .accordion.workspace {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
   }
   ngx-gauzy-logo {
     width: 100%;
@@ -277,6 +304,12 @@ nb-sidebar[tag='menu-sidebar'] {
 ::ng-deep {
   nb-layout .layout .layout-container nb-sidebar .main-container-fixed > .scrollable {
     overflow-y: auto;
+  }
+
+  // Hide the canvas while the AI chat is maximized (all nb-sidebars are
+  // projected before the .content column inside .layout-container).
+  nb-layout .layout .layout-container nb-sidebar.chat-sidebar.chat-sidebar-maximized ~ .content {
+    display: none;
   }
 }
 

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -186,43 +186,66 @@ nb-sidebar[tag='menu-sidebar'] {
 }
 
 .logo-container {
+  // One stable single row: [logo / workspace switcher (shrinks)] [… btn] [AI btn].
+  // Nothing may wrap, overlap, or change the row's footprint between the
+  // closed (logo) and open (tenant/company switcher) states.
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  flex-wrap: nowrap;
+  gap: 0.25rem;
   max-width: nb-theme(sidebar-width);
   width: nb-theme(sidebar-width);
+  min-height: 3.25rem;
   padding: 0.75rem;
-  // The logo area must keep a stable footprint: whatever renders inside
-  // (logo or the tenant/workspace switcher) may not widen the sidebar.
   overflow: hidden;
   button.hidden-menu {
+    flex: 0 0 auto;
     padding: 0 0.5rem;
     height: 1.625rem;
     width: 1.625rem;
-    margin: 0 0.625rem;
+    margin: 0;
   }
   button.ai-agent-launch {
+    flex: 0 0 auto;
     padding: 0 0.5rem;
     height: 1.625rem;
     width: 1.625rem;
-    margin: 0 0.25rem;
-    flex-shrink: 0;
+    margin: 0;
     color: #3366ff;
   }
-  // The in-place workspace/tenant switcher must fit the sidebar width
-  // instead of pushing the layout around (it renders wider than the logo).
+  // The logo / in-place workspace switcher takes the remaining row width and
+  // SHRINKS (min-width: 0) instead of pushing the buttons or wrapping.
+  ngx-gauzy-logo {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
+    z-index: 2;
+  }
   ::ng-deep .accordion.workspace {
     width: 100%;
     max-width: 100%;
     min-width: 0;
     box-sizing: border-box;
-  }
-  ngx-gauzy-logo {
-    width: 100%;
-    z-index: 2;
+
+    nb-accordion-item-header.principal {
+      // logo image and the (absolutely positioned) chevron share the
+      // header without overlap: reserve the chevron's space on the right
+      display: flex;
+      align-items: center;
+      min-width: 0;
+      overflow: hidden;
+      position: relative;
+      padding-right: 2.25rem;
+
+      .logo {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+      }
+    }
   }
   &.not-collapsed {
-    padding: 0.75rem 0;
+    padding: 0.75rem 0.5rem;
   }
   &.compacted {
     width: nb-theme(sidebar-width-compact);
@@ -230,6 +253,11 @@ nb-sidebar[tag='menu-sidebar'] {
     align-items: center;
     button.hidden-menu {
       margin-left: 0;
+    }
+    // No room for the AI launcher in the compacted rail — the header
+    // chat toggle remains available.
+    button.ai-agent-launch {
+      display: none;
     }
     ::ng-deep .accordion.workspace {
       box-shadow: none;
@@ -306,10 +334,14 @@ nb-sidebar[tag='menu-sidebar'] {
     overflow-y: auto;
   }
 
-  // Hide the canvas while the AI chat is maximized (all nb-sidebars are
-  // projected before the .content column inside .layout-container).
+  // While the AI chat is maximized the canvas SHRINKS to zero width instead
+  // of being covered or display:none'd — the page stays alive and restoring
+  // simply gives the space back. (All nb-sidebars are projected before the
+  // .content column inside .layout-container.)
   nb-layout .layout .layout-container nb-sidebar.chat-sidebar.chat-sidebar-maximized ~ .content {
-    display: none;
+    flex: 0 1 0% !important;
+    min-width: 0 !important;
+    overflow: hidden !important;
   }
 }
 

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -211,7 +211,7 @@ nb-sidebar[tag='menu-sidebar'] {
     height: 1.625rem;
     width: 1.625rem;
     margin: 0;
-    color: #3366ff;
+    color: nb-theme(color-primary-default);
   }
   // The logo / in-place workspace switcher takes the remaining row width and
   // SHRINKS (min-width: 0) instead of pushing the buttons or wrapping.

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
@@ -104,6 +104,19 @@ export class OneColumnLayoutComponent {
 	/** The chat sidebar host element (present only while the chat renders). */
 	readonly chatSidebarHost = viewChild<ElementRef<HTMLElement>>('chatSidebarHost');
 
+	/**
+	 * Horizontal padding the fixed header needs on the given side so its
+	 * content moves aside for the expanded chat column instead of being
+	 * covered by it. Null when the chat is collapsed, docked to the other
+	 * side, or maximized (maximized covers the header band entirely).
+	 */
+	chatHeaderPad(side: 'start' | 'end'): number | null {
+		const chat = this.chatSidebarService;
+		return chat.available() && chat.expanded() && !chat.maximized() && chat.position() === side
+			? chat.width()
+			: null;
+	}
+
 	private chatHostResizeObserver?: ResizeObserver;
 
 	/**

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
@@ -21,7 +21,6 @@ export class OneColumnLayoutComponent {
 
 	readonly layout = viewChild.required(NbLayoutComponent);
 
-	private readonly elementRef = inject(ElementRef<HTMLElement>);
 	private readonly windowModeBlockScrollService = inject(WindowModeBlockScrollService);
 	private readonly store = inject(Store);
 	public readonly navigationBuilderService = inject(NavigationBuilderService);
@@ -75,35 +74,37 @@ export class OneColumnLayoutComponent {
 
 		this.themeLanguageSelectorService.initialize();
 
+		// Track the chat sidebar HOST width (flex-computed: normal, maximized
+		// or collapsed) and mirror it to --gz-chat-live-width so the fixed
+		// .main-container always matches the space the host reserves.
+		effect(() => {
+			const hostRef = this.chatSidebarHost();
+			this.chatHostResizeObserver?.disconnect();
+			this.chatHostResizeObserver = undefined;
+			if (!hostRef || typeof ResizeObserver === 'undefined') return;
+			const host = hostRef.nativeElement as HTMLElement;
+			const apply = () => host.style.setProperty('--gz-chat-live-width', `${host.getBoundingClientRect().width}px`);
+			this.chatHostResizeObserver = new ResizeObserver(apply);
+			this.chatHostResizeObserver.observe(host);
+			apply();
+		});
+
 		// Runs only in the browser, after the first render — replaces ngAfterViewInit + isPlatformBrowser
 		afterNextRender(() => {
 			this.windowModeBlockScrollService.register(this.layout());
-			this.observeHeaderHeight();
 		});
 
 		this.destroyRef.onDestroy(() => {
 			this.navigationBuilderService.clearSidebars();
 			this.navigationBuilderService.clearActionBars();
-			this.headerResizeObserver?.disconnect();
+			this.chatHostResizeObserver?.disconnect();
 		});
 	}
 
-	private headerResizeObserver?: ResizeObserver;
+	/** The chat sidebar host element (present only while the chat renders). */
+	readonly chatSidebarHost = viewChild<ElementRef<HTMLElement>>('chatSidebarHost');
 
-	/**
-	 * Tracks the REAL rendered header height (the theme's `--header-height`
-	 * variable does not include extras like the demo banner) and exposes it
-	 * as `--gz-header-offset` for the chat sidebar's fixed container.
-	 */
-	private observeHeaderHeight(): void {
-		const host = this.elementRef.nativeElement as HTMLElement;
-		const header = host.querySelector('nb-layout-header');
-		if (!header || typeof ResizeObserver === 'undefined') return;
-		const apply = () => host.style.setProperty('--gz-header-offset', `${header.getBoundingClientRect().height}px`);
-		this.headerResizeObserver = new ResizeObserver(apply);
-		this.headerResizeObserver.observe(header);
-		apply();
-	}
+	private chatHostResizeObserver?: ResizeObserver;
 
 	/**
 	 * Toggles the expansion state of the sidebar.


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

---

Follow-up to #9769 from live field testing of the embedded AI agent chat. All items verified with an automated browser pass (screenshots in the linked test run):

1. **Full-height chat** — the panel is now a complete vertical block like the nav menu sidebar (top 0 → viewport bottom; nothing above/below it). The fixed container follows the host's flex-computed width via a ResizeObserver-driven CSS variable (covers normal / resized / maximized / collapsed uniformly).
2. **Width containment** — wide streamed markdown (code blocks, tables) now scrolls inside its own box: `min-width: 0` at every flex layer + pre/table overflow rules. This also fixes the squeezed input row and the stray line/scrollbar in the input (textarea is vertical-overflow only).
3. **Drag-to-resize** — grip on the canvas-facing edge, 300–860px, persisted per browser.
4. **Maximize mode** — `Menu | Chat` with the canvas hidden (components kept alive) and a restore button.
5. **Direction-aware dock buttons** — arrow-into-wall icons pointing where the chat will move (distinct from the collapse chevron).
6. **AI agent launcher** — robot icon in the nav sidebar logo row whenever the chat is available but collapsed, so the agent is always one click away.
7. **Workspace switcher containment** — the tenant/workspace switcher no longer widens the sidebar when it swaps in for the logo.
8. **Narrow-panel prompt guidance** — the agent now formats for ~380px (compact lists over wide tables, short code lines, offers the canvas for large data).

Verified: full-height geometry, zero horizontal overflow with markdown-heavy replies, resize 384→529px, maximize 1424px with canvas hidden, dock direction toggling — all green in the automated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the embedded chat panel with a full-height layout, safe width containment, resize/maximize, and a quick launcher. Adds live sync with Angular sidebar signals and sturdier resize behavior; the fixed header now shifts for the chat column so content isn’t covered.

- **New Features**
  - Full-height vertical panel; container width follows host via ResizeObserver.
  - Drag-to-resize on the canvas-facing edge (300–860px), width persists per browser.
  - Maximize mode (Menu | Chat) with restore; canvas shrinks to 0 but stays alive.
  - Dock controls: direction-aware move icons; launcher in the nav when collapsed (hidden in compact rail).
  - Responses optimized for narrow panels; guidance added to the system prompt.

- **Bug Fixes**
  - No horizontal overflow with streamed markdown; code/tables scroll; input has clean chrome and vertical-only scroll.
  - Header pads by chat width on the docked side so it never overlaps; workspace/tenant switcher is single-line and constrained.
  - Reliable state and resize: panel reflects `ChatSidebarService` dock/maximize updates via `useAngularSignal`; grip blocks page gestures, handles pointercancel, cleans up listeners; width persist is debounced.

<sup>Written for commit fb5bbf4c95bc0b53d93bb7471177881146c3b30b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

