### PR TITLE
fix(docker): add AI chat plugin workspace manifests to api/worker/webapp images

### DIFF
--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -175,6 +175,12 @@ COPY --chown=node:node packages/plugins/job-search/package.json ./packages/plugi
 COPY --chown=node:node packages/plugins/job-proposal/package.json ./packages/plugins/job-proposal/
 COPY --chown=node:node packages/plugins/soundshot/package.json ./packages/plugins/soundshot/
 COPY --chown=node:node packages/plugins/registry/package.json ./packages/plugins/registry/
+COPY --chown=node:node packages/plugins/ai-chat/package.json ./packages/plugins/ai-chat/
+COPY --chown=node:node packages/plugins/ai-provider-anthropic/package.json ./packages/plugins/ai-provider-anthropic/
+COPY --chown=node:node packages/plugins/ai-provider-openai/package.json ./packages/plugins/ai-provider-openai/
+COPY --chown=node:node packages/plugins/ai-provider-openrouter/package.json ./packages/plugins/ai-provider-openrouter/
+COPY --chown=node:node packages/plugins/ai-provider-vercel-gateway/package.json ./packages/plugins/ai-provider-vercel-gateway/
+COPY --chown=node:node packages/plugins/ai-provider-gauzy-ai/package.json ./packages/plugins/ai-provider-gauzy-ai/
 
 # We do not build Wakatime plugin here, because it is used in Desktop Apps for now
 # COPY --chown=node:node packages/plugins/integration-wakatime/package.json ./packages/plugins/integration-wakatime/
@@ -260,6 +266,12 @@ COPY --chown=node:node packages/plugins/job-search/package.json ./packages/plugi
 COPY --chown=node:node packages/plugins/job-proposal/package.json ./packages/plugins/job-proposal/
 COPY --chown=node:node packages/plugins/soundshot/package.json ./packages/plugins/soundshot/
 COPY --chown=node:node packages/plugins/registry/package.json ./packages/plugins/registry/
+COPY --chown=node:node packages/plugins/ai-chat/package.json ./packages/plugins/ai-chat/
+COPY --chown=node:node packages/plugins/ai-provider-anthropic/package.json ./packages/plugins/ai-provider-anthropic/
+COPY --chown=node:node packages/plugins/ai-provider-openai/package.json ./packages/plugins/ai-provider-openai/
+COPY --chown=node:node packages/plugins/ai-provider-openrouter/package.json ./packages/plugins/ai-provider-openrouter/
+COPY --chown=node:node packages/plugins/ai-provider-vercel-gateway/package.json ./packages/plugins/ai-provider-vercel-gateway/
+COPY --chown=node:node packages/plugins/ai-provider-gauzy-ai/package.json ./packages/plugins/ai-provider-gauzy-ai/
 
 # We do not build here Wakatime plugin, because it used in Desktop Apps for now
 # COPY --chown=node:node packages/plugins/integration-wakatime/package.json ./packages/plugins/integration-wakatime/
@@ -407,7 +419,13 @@ RUN cp -r ./packages/plugins/changelog/node_modules ./node_modules/@gauzy/plugin
     cp -r ./packages/plugins/posthog/node_modules ./node_modules/@gauzy/plugin-posthog/ && \
     cp -r ./packages/plugins/videos/node_modules ./node_modules/@gauzy/plugin-videos/ && \
     cp -r ./packages/plugins/soundshot/node_modules ./node_modules/@gauzy/plugin-soundshot/ && \
-    cp -r ./packages/plugins/registry/node_modules ./node_modules/@gauzy/plugin-registry/
+    cp -r ./packages/plugins/registry/node_modules ./node_modules/@gauzy/plugin-registry/ && \
+    cp -r ./packages/plugins/ai-chat/node_modules ./node_modules/@gauzy/plugin-ai-chat/ && \
+    cp -r ./packages/plugins/ai-provider-anthropic/node_modules ./node_modules/@gauzy/plugin-ai-provider-anthropic/ && \
+    cp -r ./packages/plugins/ai-provider-openai/node_modules ./node_modules/@gauzy/plugin-ai-provider-openai/ && \
+    cp -r ./packages/plugins/ai-provider-openrouter/node_modules ./node_modules/@gauzy/plugin-ai-provider-openrouter/ && \
+    cp -r ./packages/plugins/ai-provider-vercel-gateway/node_modules ./node_modules/@gauzy/plugin-ai-provider-vercel-gateway/ && \
+    cp -r ./packages/plugins/ai-provider-gauzy-ai/node_modules ./node_modules/@gauzy/plugin-ai-provider-gauzy-ai/
 
 # We do not copy node_modules for Wakatime plugin here, because it is used in Desktop Apps for now
 # RUN cp -r ./packages/plugins/integration-wakatime/node_modules ./node_modules/@gauzy/plugin-integration-wakatime/

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -150,6 +150,7 @@ COPY --chown=node:node packages/plugins/soundshot/package.json ./packages/plugin
 COPY --chown=node:node packages/plugins/registry/package.json ./packages/plugins/registry/
 COPY --chown=node:node packages/plugins/dashboard-time-track-angular-ui/package.json ./packages/plugins/dashboard-time-track-angular-ui/
 COPY --chown=node:node packages/plugins/dashboard-time-track-react-ui/package.json ./packages/plugins/dashboard-time-track-react-ui/
+COPY --chown=node:node packages/plugins/ai-chat-react-ui/package.json ./packages/plugins/ai-chat-react-ui/
 COPY --chown=node:node packages/ui-core/package.json ./packages/ui-core/
 COPY --chown=node:node packages/ui-config/package.json ./packages/ui-config/
 COPY --chown=node:node packages/ui-auth/package.json ./packages/ui-auth/

--- a/.deploy/worker/Dockerfile
+++ b/.deploy/worker/Dockerfile
@@ -179,6 +179,12 @@ COPY --chown=node:node packages/plugins/job-search/package.json ./packages/plugi
 COPY --chown=node:node packages/plugins/job-proposal/package.json ./packages/plugins/job-proposal/
 COPY --chown=node:node packages/plugins/soundshot/package.json ./packages/plugins/soundshot/
 COPY --chown=node:node packages/plugins/registry/package.json ./packages/plugins/registry/
+COPY --chown=node:node packages/plugins/ai-chat/package.json ./packages/plugins/ai-chat/
+COPY --chown=node:node packages/plugins/ai-provider-anthropic/package.json ./packages/plugins/ai-provider-anthropic/
+COPY --chown=node:node packages/plugins/ai-provider-openai/package.json ./packages/plugins/ai-provider-openai/
+COPY --chown=node:node packages/plugins/ai-provider-openrouter/package.json ./packages/plugins/ai-provider-openrouter/
+COPY --chown=node:node packages/plugins/ai-provider-vercel-gateway/package.json ./packages/plugins/ai-provider-vercel-gateway/
+COPY --chown=node:node packages/plugins/ai-provider-gauzy-ai/package.json ./packages/plugins/ai-provider-gauzy-ai/
 
 # We do not build Wakatime plugin here, because it is used in Desktop Apps for now
 # COPY --chown=node:node packages/plugins/integration-wakatime/package.json ./packages/plugins/integration-wakatime/
@@ -264,6 +270,12 @@ COPY --chown=node:node packages/plugins/job-search/package.json ./packages/plugi
 COPY --chown=node:node packages/plugins/job-proposal/package.json ./packages/plugins/job-proposal/
 COPY --chown=node:node packages/plugins/soundshot/package.json ./packages/plugins/soundshot/
 COPY --chown=node:node packages/plugins/registry/package.json ./packages/plugins/registry/
+COPY --chown=node:node packages/plugins/ai-chat/package.json ./packages/plugins/ai-chat/
+COPY --chown=node:node packages/plugins/ai-provider-anthropic/package.json ./packages/plugins/ai-provider-anthropic/
+COPY --chown=node:node packages/plugins/ai-provider-openai/package.json ./packages/plugins/ai-provider-openai/
+COPY --chown=node:node packages/plugins/ai-provider-openrouter/package.json ./packages/plugins/ai-provider-openrouter/
+COPY --chown=node:node packages/plugins/ai-provider-vercel-gateway/package.json ./packages/plugins/ai-provider-vercel-gateway/
+COPY --chown=node:node packages/plugins/ai-provider-gauzy-ai/package.json ./packages/plugins/ai-provider-gauzy-ai/
 
 # We do not build here Wakatime plugin, because it used in Desktop Apps for now
 # COPY --chown=node:node packages/plugins/integration-wakatime/package.json ./packages/plugins/integration-wakatime/
@@ -411,7 +423,13 @@ RUN cp -r ./packages/plugins/changelog/node_modules ./node_modules/@gauzy/plugin
     cp -r ./packages/plugins/posthog/node_modules ./node_modules/@gauzy/plugin-posthog/ && \
     cp -r ./packages/plugins/videos/node_modules ./node_modules/@gauzy/plugin-videos/ && \
     cp -r ./packages/plugins/soundshot/node_modules ./node_modules/@gauzy/plugin-soundshot/ && \
-    cp -r ./packages/plugins/registry/node_modules ./node_modules/@gauzy/plugin-registry/
+    cp -r ./packages/plugins/registry/node_modules ./node_modules/@gauzy/plugin-registry/ && \
+    cp -r ./packages/plugins/ai-chat/node_modules ./node_modules/@gauzy/plugin-ai-chat/ && \
+    cp -r ./packages/plugins/ai-provider-anthropic/node_modules ./node_modules/@gauzy/plugin-ai-provider-anthropic/ && \
+    cp -r ./packages/plugins/ai-provider-openai/node_modules ./node_modules/@gauzy/plugin-ai-provider-openai/ && \
+    cp -r ./packages/plugins/ai-provider-openrouter/node_modules ./node_modules/@gauzy/plugin-ai-provider-openrouter/ && \
+    cp -r ./packages/plugins/ai-provider-vercel-gateway/node_modules ./node_modules/@gauzy/plugin-ai-provider-vercel-gateway/ && \
+    cp -r ./packages/plugins/ai-provider-gauzy-ai/node_modules ./node_modules/@gauzy/plugin-ai-provider-gauzy-ai/
 
 # We do not copy node_modules for Wakatime plugin here, because it is used in Desktop Apps for now
 # RUN cp -r ./packages/plugins/integration-wakatime/node_modules ./node_modules/@gauzy/plugin-integration-wakatime/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@ dist
 
 tmp
 .cache
+# Local build caches — huge (multi-GB) and never needed inside images
+.angular
+**/.angular
+.nx
 .github
 .circle
 .circleci

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ tmp
 .angular
 **/.angular
 .nx
+**/.nx
 .github
 .circle
 .circleci


### PR DESCRIPTION
## Problem

The develop Docker image builds broke after the AI chat plugins merged ([run 28758305537](https://github.com/ever-co/ever-gauzy/actions/runs/28758305537)):

- **gauzy-api / gauzy-worker**: `packages/plugins/ai-chat` + the 5 `ai-provider-*` manifests were missing from both yarn-install stages, so `ai` / `@ai-sdk/*` were never installed → `TS2307: Cannot find module 'ai'` during the Nx build.
- **gauzy-webapp**: `apps/gauzy` depends on `@gauzy/plugin-ai-chat-react-ui`, whose workspace manifest was not copied → `yarn install --frozen-lockfile` tried to resolve it from the npm registry and failed.

## Fix

- Add the 6 backend AI plugin `package.json`s to both install stages of `.deploy/api/Dockerfile` and `.deploy/worker/Dockerfile`, plus the production-stage per-plugin `node_modules` copy list.
- Add `packages/plugins/ai-chat-react-ui/package.json` to `.deploy/webapp/Dockerfile`.
- `.dockerignore`: exclude `.angular` / `.nx` local caches (multi-GB — they ballooned local build contexts to 8GB+).

## Local Docker verification (api image, NODE_ENV=development DEMO=true — same as the demo workflow)

- Image builds end-to-end (926MB), including the previously failing yarn installs, TS compile of all 37 packages, and the new per-plugin node_modules copies.
- Container **runs**: migrations incl. `CreateAiChatConversationTable` executed, all plugins bootstrapped (`Bootstrapped Plugin [AiChatPlugin]`, `[AiProviderAnthropicPlugin]`, …), Nest listens, and `GET /api/ai-chat/config` returns 401 without a JWT (route mounted + guarded).
- webapp: `yarn install --frozen-lockfile` passes dependency resolution with the added manifest (the CI failure point).

The MCP Dockerfiles reference no plugins and are unaffected. Same Dockerfiles are used by the demo/stage/prod workflows, so this fixes all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker builds for `api`, `worker`, and `webapp` by including AI chat plugin workspace manifests and trimming build context. Installs and builds now succeed across images.

- **Bug Fixes**
  - Add `package.json` for `packages/plugins/ai-chat` and the five `ai-provider-*` plugins to both install stages in `.deploy/api/Dockerfile` and `.deploy/worker/Dockerfile`.
  - Copy production `node_modules` for those plugins into the image.
  - Copy `packages/plugins/ai-chat-react-ui/package.json` in `.deploy/webapp/Dockerfile` so `apps/gauzy` resolves `@gauzy/plugin-ai-chat-react-ui`.
  - Update `.dockerignore` to exclude `.angular` and `.nx` (including `**/.nx`) to reduce build context size.

<sup>Written for commit 5b31693fddae5eebee6f146d5d55b79fa71ae2d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

