### PR TITLE
ci(demo): registry mode=max build cache for ARC (fix ~3h cold builds)

### DIFF
--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -23,8 +23,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      # Log in to GHCR BEFORE the build so buildx can PUSH the mode=max layer cache to the
+      # :buildcache tag (cache-to needs registry auth at build time).
+      - name: Login to GitHub Container Registry (build cache)
+        uses: docker/login-action@v4
         with:
-          driver: docker
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         uses: docker/build-push-action@v7
@@ -38,8 +45,14 @@ jobs:
             everco/gauzy-api-demo:latest
             registry.digitalocean.com/ever/gauzy-api-demo:latest
             ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-api-demo:latest
-          cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:latest
-          cache-to: type=inline
+          # mode=max caches ALL stages (incl. the multi-minute yarn-install layers) to a dedicated
+          # :buildcache tag; every ephemeral runner restores it → no more fully-cold rebuilds.
+          # Needs the default docker-container buildx driver — the classic `docker` driver only
+          # supports inline (final-stage) cache, which is why the yarn-install stages were cold.
+          cache-from: |
+            type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:buildcache
+            type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:latest
+          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:buildcache,mode=max
           build-args: |
             NODE_ENV=development
             DEMO=true
@@ -111,6 +124,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # Log in to GHCR BEFORE the build so buildx can PUSH the mode=max layer cache to the
+      # :buildcache tag (cache-to needs registry auth at build time).
+      - name: Login to GitHub Container Registry (build cache)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build
         uses: docker/build-push-action@v7
         with:
@@ -123,8 +145,14 @@ jobs:
             everco/gauzy-webapp-demo:latest
             registry.digitalocean.com/ever/gauzy-webapp-demo:latest
             ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-webapp-demo:latest
-          cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:latest
-          cache-to: type=inline
+          # mode=max caches ALL stages (incl. the multi-minute yarn-install layers) to a dedicated
+          # :buildcache tag; every ephemeral runner restores it → no more fully-cold rebuilds.
+          # Needs the default docker-container buildx driver — the classic `docker` driver only
+          # supports inline (final-stage) cache, which is why the yarn-install stages were cold.
+          cache-from: |
+            type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:buildcache
+            type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:latest
+          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:buildcache,mode=max
           build-args: |
             NODE_ENV=development
             DEMO=true
@@ -195,8 +223,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      # Log in to GHCR BEFORE the build so buildx can PUSH the mode=max layer cache to the
+      # :buildcache tag (cache-to needs registry auth at build time).
+      - name: Login to GitHub Container Registry (build cache)
+        uses: docker/login-action@v4
         with:
-          driver: docker
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         uses: docker/build-push-action@v7
@@ -210,8 +245,14 @@ jobs:
             everco/gauzy-worker-demo:latest
             registry.digitalocean.com/ever/gauzy-worker-demo:latest
             ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-worker-demo:latest
-          cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:latest
-          cache-to: type=inline
+          # mode=max caches ALL stages (incl. the multi-minute yarn-install layers) to a dedicated
+          # :buildcache tag; every ephemeral runner restores it → no more fully-cold rebuilds.
+          # Needs the default docker-container buildx driver — the classic `docker` driver only
+          # supports inline (final-stage) cache, which is why the yarn-install stages were cold.
+          cache-from: |
+            type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:buildcache
+            type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:latest
+          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:buildcache,mode=max
           build-args: |
             NODE_ENV=development
             DEMO=true


### PR DESCRIPTION
## Why

The `docker-build-publish-demo.yml` jobs (`gauzy-api`, `gauzy-webapp`, `gauzy-worker`) on the self-hosted **ARC** runners were running **~3h and getting cancelled without finishing** — vs ~30 min previously. Root cause, confirmed from the build log ([run 28782300929](https://github.com/ever-co/ever-gauzy/actions/runs/28782300929)):

- The build imported the cache manifest but still ran **`yarn install` fully cold** — one stage logged **`#100 4296.6`** (71 min) and the worker **`#100 6015.6`** (100 min) in a single install, plus native recompiles (`bcrypt`, `better-sqlite3`, `@sentry/profiling-node`).
- `cache-to: type=inline` only stores the **final image stage**, so the expensive multi-stage `dependencies` / `proddependencies` (yarn install) layers were **never cached**.
- `driver: docker` (on the api + worker jobs) uses the classic builder, which can't import registry cache effectively.

## What

For each of the 3 jobs:
- **Drop `driver: docker`** → use the default **`docker-container`** buildx driver (required for `mode=max`).
- **`cache-to: type=registry,ref=…:buildcache,mode=max`** — caches **all** stages (incl. the yarn-install layers) to a dedicated `:buildcache` tag.
- **`cache-from`** now reads `:buildcache` (with `:latest` as fallback).
- Move a **GHCR login before the Build step** so `cache-to` can push the cache.

Because the cache lives in GHCR, it's restored by **every fresh ephemeral runner** — this is the cross-runner cache persistence. First run after merge is still cold (it populates `:buildcache`); subsequent runs should drop back to minutes.

## Notes
- No change to the pushed image tags or target registries.
- `Set up QEMU` is left as-is; it's unused (`platforms: linux/amd64`) and could be removed in a follow-up to shave ~2 min.
- Infra side (separate, already applied): the ARC `-8` runner pool now **guarantees the build 8 vCPU / 16 GiB** (the docker build runs in the dind sidecar, which previously had *no* resource limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ARC demo Docker builds by enabling registry-backed Buildx cache (`mode=max`) and dropping the classic Docker driver. This stops cold `yarn install` stages and returns builds to minutes.

- **Bug Fixes**
  - Apply to `gauzy-api`, `gauzy-webapp`, and `gauzy-worker` demo jobs on ARC.
  - Switch from `driver: docker` to Buildx `docker-container`.
  - Use GHCR `:buildcache` with `cache-to: type=registry,mode=max` and `cache-from` (fallback to `:latest`).
  - Log in to GHCR before build so cache push works.
  - No change to image tags/registries; first run warms the cache.

<sup>Written for commit 869ac19f3651e01ffd65809bad84b4e939cb8e69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

