### PR TITLE
ci(playwright): run e2e only on push to develop (not PRs/other branches)

### DIFF
--- a/.github/workflows/test_playwright.yml
+++ b/.github/workflows/test_playwright.yml
@@ -3,9 +3,10 @@ name: Playwright Tests
 # Replaces the dormant Cypress workflows (test_cypress.yml / test_currents.yml, which trigger on
 # branch `nope`). Runs the migrated Playwright e2e suite against a locally-started API + Web.
 on:
+  # Run the e2e suite ONLY when code lands on develop (merge/push). Deliberately NOT on pull_request or
+  # any other branch: the suite is long (~1.3h) and shared-DB flaky, so it's gated to the integration
+  # branch. Use the manual "Run workflow" button (workflow_dispatch) to run it on demand from any ref.
   push:
-    branches: [develop, feat/e2e-playwright]
-  pull_request:
     branches: [develop]
   workflow_dispatch:
 


### PR DESCRIPTION
The Playwright e2e suite is long (~1.3h) and shared-DB flaky, so running it on every PR and feature branch is costly + noisy. Gate it to the integration branch: trigger **only on `push` to `develop`** (when code is merged in), plus manual `workflow_dispatch` for on-demand runs from any ref. Drops the `pull_request` trigger and the leftover `feat/e2e-playwright` push branch (now merged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Playwright e2e to run only on `push` to `develop` to reduce cost and noise. Remove `pull_request` and old `feat/e2e-playwright` triggers, and enable `workflow_dispatch` for manual runs from any ref.

<sup>Written for commit 84b590e9553686de4282016fa7d69ec8616f16af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

