### PR TITLE
Fix/screencapture wayland

### DIFF
--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -5,7 +5,7 @@ import {
 	TimerSyncStateEnum,
 	ILogRequest,
 	ILogRequestPage,
-    IOSInfo
+	IOSInfo
 } from '@gauzy/contracts';
 import { AkitaStorageEngine, WindowManager, logger as log } from '@gauzy/desktop-core';
 import { ScreenCaptureNotification } from '@gauzy/desktop-window';
@@ -44,7 +44,7 @@ import {
 	TimerService,
 	TimerTO,
 	UserService,
-	Screenshot,
+	Screenshot
 } from './offline';
 import { pluginListeners } from './plugin-system';
 import { AkitaStorageHandler } from './storage/akita-storage.handler';
@@ -69,7 +69,6 @@ let _appWindowManager: AppWindowManager | null = null;
 let _screenshotService: ScreenshotService | null = null;
 let _activeWindow: ActivityWindow | null = null;
 let _auditLogHandler: AuditLogHandler | null = null;
-
 
 function getTimerHandler(): TimerHandler {
 	if (!_timerHandler) _timerHandler = new TimerHandler();
@@ -233,13 +232,13 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 					synced: false,
 					activityId,
 					recordedAt: new Date(arg?.recordedAt)
-				}
+				};
 				await getScreenshotService().saveAndReturn(new Screenshot(screenshotImage));
 			}
 		} catch (error) {
 			console.error('failed to save failed upload screenshot image');
 		}
-	})
+	});
 
 	ipcMain.on('set_project_task', (event, arg) => {
 		event.sender.send('set_project_task_reply', arg);
@@ -343,7 +342,6 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 	});
 
 	ipcMain.on('auth_failed', (event, arg) => {
-
 		event.sender.send('show_toast_message', {
 			type: 'error',
 			message: arg.message
@@ -501,7 +499,6 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 		};
 	});
 
-
 	ipcMain.handle('TEST_SCREENSHOT', async () => {
 		if (process.platform === 'darwin' && isScreenUnauthorized()) {
 			return { success: false, reason: 'unauthorized' };
@@ -517,14 +514,18 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 				? { success: true, thumbnail: sources[0].thumbnail.toDataURL() }
 				: { success: false, reason: 'no_sources' };
 		} catch (err) {
-			await getAuditLogHandler().logAudit('error', 'screenshot', `Error testing screenshot capture: ${err.message}`);
+			await getAuditLogHandler().logAudit(
+				'error',
+				'screenshot',
+				`Error testing screenshot capture: ${err.message}`
+			);
 			return { success: false, reason: err.message };
 		}
 	});
 
 	ipcMain.handle('TEST_GET_ACTIVE_WINDOW', async () => {
 		if (process.platform === 'darwin' && !systemPreferences.isTrustedAccessibilityClient(false)) {
-			return { success: false, reason: 'unauthorized' }
+			return { success: false, reason: 'unauthorized' };
 		}
 		try {
 			const windowList = await getActiveWindow().getActiveWindow({
@@ -538,12 +539,12 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 					appName: windowList?.owner?.name,
 					bundleId: windowList?.owner?.bundleId
 				}
-			}
+			};
 		} catch (error) {
 			return {
 				success: false,
 				reason: error.message
-			}
+			};
 		}
 	});
 
@@ -567,9 +568,7 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 	ipcMain.handle('OPEN_PRIVACY_SETTINGS', () => {
 		switch (process.platform) {
 			case 'darwin':
-				shell.openExternal(
-					'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture'
-				);
+				shell.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture');
 				break;
 			default:
 				return;
@@ -584,7 +583,7 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 			await getActiveWindow().getActiveWindow({
 				screenRecordingPermission: false,
 				accessibilityPermission: true
-			})
+			});
 			return { success: true };
 		} catch (err) {
 			log.error('Failed to reset Accessibility TCC permission', err);
@@ -595,9 +594,7 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 	ipcMain.handle('OPEN_ACCESSIBILITY_SETTINGS', () => {
 		switch (process.platform) {
 			case 'darwin':
-				shell.openExternal(
-					'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'
-				);
+				shell.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility');
 				break;
 			default:
 				return;
@@ -611,20 +608,11 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 
 	// Channel 2: Just for the Diary/Log
 	ipcMain.on('WRITE_AUDIT_LOG', async (_, arg: ILogRequest) => {
-		return getAuditLogHandler().logAudit(
-			arg.logLevel || 'info',
-			arg.serviceName || 'timer',
-			arg.message,
-		);
+		return getAuditLogHandler().logAudit(arg.logLevel || 'info', arg.serviceName || 'timer', arg.message);
 	});
 
 	ipcMain.handle('GET_AUDIT_LOGS', async (_, arg: ILogRequestPage) => {
-		return getAuditLogHandler().getAuditLogs(
-			arg.logLevel,
-			arg.serviceName,
-			arg.page,
-			arg.limit
-		);
+		return getAuditLogHandler().getAuditLogs(arg.logLevel, arg.serviceName, arg.page, arg.limit);
 	});
 
 	ipcMain.handle('GET_HARDWARE_ACCELERATION_STATE', async () => {
@@ -638,26 +626,30 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 		});
 	});
 
-	ipcMain.handle('UPDATE_SCREENSHOT_SYNC_STATUS', async (_, arg: { id: number; remove: boolean; failedReason: string; synced: boolean; retries: number }) => {
-		try {
-			if (arg.remove) {
-				await getScreenshotService().remove({ id: arg.id });
-			} else {
-				await getScreenshotService().update(new Screenshot({
-					id: arg.id,
-					synced: arg.synced,
-					lastAttemptAt: new Date(),
-					message: arg.failedReason,
-					retries: 1
-				}));
+	ipcMain.handle(
+		'UPDATE_SCREENSHOT_SYNC_STATUS',
+		async (_, arg: { id: number; remove: boolean; failedReason: string; synced: boolean; retries: number }) => {
+			try {
+				if (arg.remove) {
+					await getScreenshotService().remove({ id: arg.id });
+				} else {
+					await getScreenshotService().update(
+						new Screenshot({
+							id: arg.id,
+							synced: arg.synced,
+							lastAttemptAt: new Date(),
+							message: arg.failedReason,
+							retries: 1
+						})
+					);
+				}
+			} catch (error) {
+				console.error('Failed to update screenshot sync status', error);
 			}
-		} catch (error) {
-			console.error('Failed to update screenshot sync status', error);
 		}
+	);
 
-	});
-
-	ipcMain.handle('EXPORT_AUDIT_LOGS', async() => {
+	ipcMain.handle('EXPORT_AUDIT_LOGS', async () => {
 		try {
 			const result = await exportAuditLogs();
 			return result;
@@ -665,8 +657,12 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 			console.error(`Failed export logs to file, ${error.message}`);
 			return {
 				success: false
-			}
+			};
 		}
+	});
+
+	ipcMain.handle('GET_IS_WAYLAND', () => {
+		return process.platform === 'linux' && process.env.XDG_SESSION_TYPE === 'wayland';
 	});
 
 	pluginListeners();
@@ -1532,17 +1528,15 @@ export function ipcTimer(
 	});
 
 	ipcMain.handle('SHOW_PERMISSION_CONFIRM', () => {
-		const desktopPermissionHandler = DesktopPermissionHandler.getInstance(
-			timeTrackerWindow, windowPath
-		);
+		const desktopPermissionHandler = DesktopPermissionHandler.getInstance(timeTrackerWindow, windowPath);
 		desktopPermissionHandler.showDialogPermissionConfirm();
 	});
 
-	ipcMain.handle('GET_TIMER_SESSIONS', async ( _, args: { start: Date | string; end: Date | string }) => {
+	ipcMain.handle('GET_TIMER_SESSIONS', async (_, args: { start: Date | string; end: Date | string }) => {
 		try {
 			const range = {
 				start: new Date(args.start),
-				end: new Date(args.end),
+				end: new Date(args.end)
 			};
 			const timerSessions = await getTimerService().getListByDate(range);
 			return timerSessions;
@@ -1551,14 +1545,14 @@ export function ipcTimer(
 		}
 	});
 
-	ipcMain.handle('GET_TIMER_SESSION', async ( _, args: { timerSessionId: number }) => {
+	ipcMain.handle('GET_TIMER_SESSION', async (_, args: { timerSessionId: number }) => {
 		try {
 			const timerSession = await getTimerService().findById({ id: args.timerSessionId });
 			return timerSession;
 		} catch (error) {
 			return null;
 		}
-	})
+	});
 }
 
 export function removeMainListener() {
@@ -1573,7 +1567,7 @@ export function removeMainListener() {
 		'update_app_setting',
 		'update_project_on',
 		'request_permission',
-		'WRITE_AUDIT_LOG',
+		'WRITE_AUDIT_LOG'
 	];
 
 	mainListeners.forEach((listener) => {
@@ -1629,7 +1623,8 @@ export function removeAllHandlers() {
 		'GET_HARDWARE_ACCELERATION_STATE',
 		'SET_HARDWARE_ACCELERATION',
 		'UPDATE_SCREENSHOT_SYNC_STATUS',
-		'EXPORT_AUDIT_LOGS'
+		'EXPORT_AUDIT_LOGS',
+		'GET_IS_WAYLAND'
 	];
 	channels.forEach((channel: string) => {
 		ipcMain.removeHandler(channel);
@@ -1709,12 +1704,12 @@ async function screenshotErrorSync(window: BrowserWindow) {
 		isScreenshotTreadLocked = true;
 		const list = await getScreenshotService().findUnSyncedScreenshot();
 		const mapList = list.map((item) => {
-			const {imagePath, ...restItem} = item;
+			const { imagePath, ...restItem } = item;
 			return {
 				...restItem,
 				base64Image: imagePath
 			};
-		})
+		});
 
 		if (list.length > 0) {
 			window.webContents.send('sync-screenshot-error', mapList);
@@ -1725,7 +1720,6 @@ async function screenshotErrorSync(window: BrowserWindow) {
 		console.log(`Failed get screenshot error sync ${error.message}`);
 		isScreenshotTreadLocked = false;
 	}
-
 }
 
 let size = Infinity;

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -70,6 +70,14 @@ let _screenshotService: ScreenshotService | null = null;
 let _activeWindow: ActivityWindow | null = null;
 let _auditLogHandler: AuditLogHandler | null = null;
 
+let _cachedScreen:
+	| {
+			id: string;
+			name: string;
+			display_id: string;
+	  }[]
+	| null = null;
+
 function getTimerHandler(): TimerHandler {
 	if (!_timerHandler) _timerHandler = new TimerHandler();
 	return _timerHandler;
@@ -667,6 +675,17 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 
 	ipcMain.handle('GET_ALL_DISPLAYS', () => {
 		return screen.getAllDisplays();
+	});
+
+	ipcMain.handle('GET_SCREEN_SOURCES', async (_, opts: { resetScreen: boolean }) => {
+		if (opts.resetScreen || !_cachedScreen) {
+			const sources = await desktopCapturer.getSources({
+				types: ['screen']
+			});
+			_cachedScreen = sources;
+			return _cachedScreen;
+		}
+		return _cachedScreen;
 	});
 
 	pluginListeners();

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -677,13 +677,13 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 		return screen.getAllDisplays();
 	});
 
-	ipcMain.handle('GET_SCREEN_SOURCES', async (_, opts: { resetScreen: boolean }) => {
-		if (opts.resetScreen || !_cachedScreen) {
+	ipcMain.handle('GET_SCREEN_SOURCES', async (_, opts?: { resetScreen?: boolean }) => {
+		if (opts?.resetScreen || !_cachedScreen) {
 			const sources = await desktopCapturer.getSources({
-				types: ['screen']
+				types: ['screen'],
+				thumbnailSize: { width: 0, height: 0 } // ids only — skip thumbnail capture
 			});
-			_cachedScreen = sources;
-			return _cachedScreen;
+			_cachedScreen = sources.map(({ id, name, display_id }) => ({ id, name, display_id }));
 		}
 		return _cachedScreen;
 	});

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -665,6 +665,10 @@ export function ipcMainHandler(store, startServer, knex, config, timeTrackerWind
 		return process.platform === 'linux' && process.env.XDG_SESSION_TYPE === 'wayland';
 	});
 
+	ipcMain.handle('GET_ALL_DISPLAYS', () => {
+		return screen.getAllDisplays();
+	});
+
 	pluginListeners();
 }
 
@@ -1624,7 +1628,8 @@ export function removeAllHandlers() {
 		'SET_HARDWARE_ACCELERATION',
 		'UPDATE_SCREENSHOT_SYNC_STATUS',
 		'EXPORT_AUDIT_LOGS',
-		'GET_IS_WAYLAND'
+		'GET_IS_WAYLAND',
+		'GET_ALL_DISPLAYS'
 	];
 	channels.forEach((channel: string) => {
 		ipcMain.removeHandler(channel);

--- a/packages/desktop-lib/src/lib/desktop-ipc.ts
+++ b/packages/desktop-lib/src/lib/desktop-ipc.ts
@@ -1648,7 +1648,8 @@ export function removeAllHandlers() {
 		'UPDATE_SCREENSHOT_SYNC_STATUS',
 		'EXPORT_AUDIT_LOGS',
 		'GET_IS_WAYLAND',
-		'GET_ALL_DISPLAYS'
+		'GET_ALL_DISPLAYS',
+		'GET_SCREEN_SOURCES'
 	];
 	channels.forEach((channel: string) => {
 		ipcMain.removeHandler(channel);

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -45,10 +45,18 @@ export class ScreenCaptureWebRTSService {
 
 	private async getSourceId(): Promise<ScreenSources[]> {
 		if (this.cachedSourceIds) {
-			return this.cachedSourceIds;
+			const allScreens: { id: number }[] = await this.electronService.invoke('GET_ALL_DISPLAYS');
+			const currentIds = new Set(allScreens.map((d) => String(d.id)));
+			const cachedIds = new Set(this.cachedSourceIds.map((s) => s.display_id));
+			const screensChanged =
+				currentIds.size !== cachedIds.size || [...currentIds].some((id) => !cachedIds.has(id));
+			if (screensChanged) {
+				this.cachedSourceIds = null;
+			} else {
+				return this.cachedSourceIds;
+			}
 		}
 		const sources = await this.electronService.desktopCapturer.getSources({ types: ['screen'] });
-
 		this.cachedSourceIds = sources;
 		return this.cachedSourceIds;
 	}

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -7,17 +7,20 @@ interface ScreenSources {
 	display_id: string;
 }
 
+export interface IScreenCaptureFrame {
+	screenshot: string;
+	thumbnail: string;
+	name: string;
+	display_id: string;
+}
+
 @Injectable({
 	providedIn: 'root'
 })
 export class ScreenCaptureWebRTCService {
 	private readonly electronService: ElectronService = inject(ElectronService);
 
-	async takeScreenshot({
-		resetScreen
-	}: {
-		resetScreen: boolean;
-	}): Promise<{ screenshot: string; thumbnail: string }[]> {
+	async takeScreenshot({ resetScreen }: { resetScreen: boolean }): Promise<IScreenCaptureFrame[]> {
 		const sourceIds = await this.getSourceId(resetScreen);
 		const allDisplays: { id: number; bounds: { width: number; height: number } }[] =
 			await this.electronService.invoke('GET_ALL_DISPLAYS');
@@ -37,32 +40,41 @@ export class ScreenCaptureWebRTCService {
 							maxHeight: height
 						}
 					}
-				} as any);
+				} as any) as Promise<MediaStream>;
 			})
 		);
 
-		const streams = streamResults
-			.filter((r): r is PromiseFulfilledResult<MediaStream> => r.status === 'fulfilled')
-			.map((r) => r.value);
-
-		streamResults
-			.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
-			.forEach((r) => console.error('[ScreenCapture] getUserMedia failed:', r.reason));
+		// Keep each stream paired with its source so frames retain display metadata
+		const streams: { stream: MediaStream; source: ScreenSources }[] = [];
+		streamResults.forEach((result, index) => {
+			if (result.status === 'fulfilled') {
+				streams.push({ stream: result.value, source: sourceIds[index] });
+			} else {
+				console.error('[ScreenCapture] getUserMedia failed:', result.reason);
+			}
+		});
 
 		try {
-			return await Promise.all(streams.map((stream) => this.grabFrame(stream)));
+			const frameResults = await Promise.allSettled(streams.map(({ stream }) => this.grabFrame(stream)));
+			const frames: IScreenCaptureFrame[] = [];
+			frameResults.forEach((result, index) => {
+				if (result.status === 'fulfilled') {
+					const { name, display_id } = streams[index].source;
+					frames.push({ ...result.value, name, display_id });
+				} else {
+					console.error('[ScreenCapture] grabFrame failed:', result.reason);
+				}
+			});
+			return frames;
 		} finally {
-			streams.forEach((stream) => stream.getTracks().forEach((track) => track.stop()));
+			streams.forEach(({ stream }) => stream.getTracks().forEach((track) => track.stop()));
 		}
 	}
 
-	async testScreenshot(): Promise<{ screenshot: string; thumbnail: string } | null> {
+	async testScreenshot(): Promise<IScreenCaptureFrame | null> {
 		// Reset cache to get the latest screen sources
 		const images = await this.takeScreenshot({ resetScreen: true });
-		if (images.length === 0) {
-			return images[0];
-		}
-		return null;
+		return images.length > 0 ? images[0] : null;
 	}
 
 	private async getSourceId(resetScreen = false): Promise<ScreenSources[]> {
@@ -145,9 +157,9 @@ export class ScreenCaptureWebRTCService {
 				}
 			};
 
-			video.onerror = (err) => {
+			video.onerror = () => {
 				cleanup();
-				settle(() => reject(err));
+				settle(() => reject(new Error(video.error?.message || 'Video element failed to load the capture stream.')));
 			};
 		});
 	}

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -39,22 +39,15 @@ export class ScreenCaptureWebRTSService {
 	}
 
 	async testScreenshot(): Promise<{ screenshot: string; thumbnail: string }> {
+		// Reset cache to get the latest screen sources
+		this.cachedSourceIds = null;
 		const images = await this.takeScreenshot();
 		return images[0];
 	}
 
 	private async getSourceId(): Promise<ScreenSources[]> {
 		if (this.cachedSourceIds) {
-			const allScreens: { id: number }[] = await this.electronService.invoke('GET_ALL_DISPLAYS');
-			const currentIds = new Set(allScreens.map((d) => String(d.id)));
-			const cachedIds = new Set(this.cachedSourceIds.map((s) => s.display_id));
-			const screensChanged =
-				currentIds.size !== cachedIds.size || [...currentIds].some((id) => !cachedIds.has(id));
-			if (screensChanged) {
-				this.cachedSourceIds = null;
-			} else {
-				return this.cachedSourceIds;
-			}
+			return this.cachedSourceIds;
 		}
 		const sources = await this.electronService.desktopCapturer.getSources({ types: ['screen'] });
 		this.cachedSourceIds = sources;

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -25,8 +25,13 @@ export class ScreenCaptureWebRTCService {
 		const allDisplays: { id: number; bounds: { width: number; height: number } }[] =
 			await this.electronService.invoke('GET_ALL_DISPLAYS');
 		const streamResults = await Promise.allSettled(
-			sourceIds.map((source) => {
-				const display = allDisplays.find((d) => String(d.id) === source.display_id);
+			sourceIds.map((source, index) => {
+				// display_id can be empty or mismatched on Wayland/PipeWire —
+				// fall back to positional mapping, then the first display.
+				const display =
+					allDisplays.find((d) => String(d.id) === source.display_id) ??
+					allDisplays[index] ??
+					allDisplays[0];
 				const width = display?.bounds.width ?? 1920;
 				const height = display?.bounds.height ?? 1080;
 				return (navigator.mediaDevices as any).getUserMedia({

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -1,73 +1,56 @@
 import { Injectable, inject } from '@angular/core';
 import { ElectronService } from './electron.service';
 
+interface ScreenSources {
+	id: string;
+	name: string;
+	display_id: string;
+}
+
 @Injectable({
 	providedIn: 'root'
 })
 export class ScreenCaptureWebRTSService {
-	// Cache the source id so we don't need to re-enumerate sources on every
-	// screenshot — enumerating sources is cheap and doesn't itself prompt,
-	// but no need to repeat it if the source list won't change mid-session.
 	private readonly electronService: ElectronService = inject(ElectronService);
-	private cachedSourceId: string | null = null;
+	private cachedSourceIds: ScreenSources[] | null = null;
 
-	/**
-	 * IPC handler entry point for 'take_screenshot'.
-	 *
-	 * Opens a short-lived getUserMedia stream, grabs exactly one frame via
-	 * canvas, then immediately stops the stream. No stream is held open
-	 * between screenshots — this relies on the portal/Chromium reusing the
-	 * permission grant (restore token) instead of re-prompting.
-	 *
-	 * IMPORTANT: verify this actually avoids re-prompting on your target
-	 * Electron version + Linux DE/compositor before relying on it. See the
-	 * notes at the bottom of this file.
-	 */
-	async takeScreenshot(): Promise<{ screenshot: string; thumbnail: string }> {
-		const sourceId = await this.getSourceId();
-
-		const stream = await (navigator.mediaDevices as any).getUserMedia({
-			audio: false,
-			video: {
-				mandatory: {
-					chromeMediaSource: 'desktop',
-					chromeMediaSourceId: sourceId,
-					// No need for continuous high frame rate — we only want one frame.
-					maxFrameRate: 5
-				}
-			}
-		} as any);
+	async takeScreenshot(): Promise<{ screenshot: string; thumbnail: string }[]> {
+		const sourceIds = await this.getSourceId();
+		const streams = await Promise.all(
+			sourceIds.map((source) => {
+				return (navigator.mediaDevices as any).getUserMedia({
+					audio: false,
+					video: {
+						mandatory: {
+							chromeMediaSource: 'desktop',
+							chromeMediaSourceId: source.id,
+							maxFrameRate: 5
+						}
+					}
+				} as any);
+			})
+		);
 
 		try {
-			return await this.grabFrame(stream);
+			return await Promise.all(streams.map((stream) => this.grabFrame(stream)));
 		} finally {
-			// Always stop tracks, even if grabFrame throws, so we never leak
-			// an open capture session.
-			stream.getTracks().forEach((track) => track.stop());
+			streams.forEach((stream) => stream.getTracks().forEach((track) => track.stop()));
 		}
 	}
 
-	/**
-	 * Returns the screen source id, using a cached value if we already have one.
-	 * If your app lets the user pick a monitor, don't cache — re-fetch and let
-	 * them choose each time instead.
-	 */
-	private async getSourceId(): Promise<string> {
-		if (this.cachedSourceId) {
-			return this.cachedSourceId;
-		}
+	async testScreenshot(): Promise<{ screenshot: string; thumbnail: string }> {
+		const images = await this.takeScreenshot();
+		return images[0];
+	}
 
-		// No thumbnailSize needed — we only want the source id, not an image.
+	private async getSourceId(): Promise<ScreenSources[]> {
+		if (this.cachedSourceIds) {
+			return this.cachedSourceIds;
+		}
 		const sources = await this.electronService.desktopCapturer.getSources({ types: ['screen'] });
 
-		if (!sources.length) {
-			throw new Error('No screen sources available from desktopCapturer');
-		}
-
-		// If you support multi-monitor selection, let the user pick here instead
-		// of always taking sources[0].
-		this.cachedSourceId = sources[0].id;
-		return this.cachedSourceId;
+		this.cachedSourceIds = sources;
+		return this.cachedSourceIds;
 	}
 
 	/**

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -23,7 +23,7 @@ export class ScreenCaptureWebRTSService {
 	 * Electron version + Linux DE/compositor before relying on it. See the
 	 * notes at the bottom of this file.
 	 */
-	async takeScreenshot(): Promise<string> {
+	async takeScreenshot(): Promise<{ screenshot: string; thumbnail: string }> {
 		const sourceId = await this.getSourceId();
 
 		const stream = await (navigator.mediaDevices as any).getUserMedia({
@@ -74,7 +74,7 @@ export class ScreenCaptureWebRTSService {
 	 * Attaches a stream to a detached <video>, waits for a frame to be
 	 * available, draws it to an offscreen <canvas>, and returns the PNG data URL.
 	 */
-	private grabFrame(stream: MediaStream): Promise<string> {
+	private grabFrame(stream: MediaStream): Promise<{ screenshot: string; thumbnail: string }> {
 		return new Promise((resolve, reject) => {
 			const video = document.createElement('video');
 			video.muted = true;
@@ -109,7 +109,23 @@ export class ScreenCaptureWebRTSService {
 					}
 
 					ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-					resolve(canvas.toDataURL('image/png'));
+
+					// Create thumbnail canvas of size 320x240
+					const thumbCanvas = document.createElement('canvas');
+					thumbCanvas.width = 320;
+					thumbCanvas.height = 240;
+
+					const thumbCtx = thumbCanvas.getContext('2d');
+					if (!thumbCtx) {
+						throw new Error('Failed to get 2D canvas context for thumbnail.');
+					}
+
+					thumbCtx.drawImage(video, 0, 0, thumbCanvas.width, thumbCanvas.height);
+
+					resolve({
+						screenshot: canvas.toDataURL('image/png'),
+						thumbnail: thumbCanvas.toDataURL('image/png')
+					});
 				} catch (err) {
 					reject(err);
 				} finally {

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -16,15 +16,22 @@ export class ScreenCaptureWebRTSService {
 
 	async takeScreenshot(): Promise<{ screenshot: string; thumbnail: string }[]> {
 		const sourceIds = await this.getSourceId();
+		const allDisplays: { id: number; bounds: { width: number; height: number } }[] =
+			await this.electronService.invoke('GET_ALL_DISPLAYS');
 		const streams = await Promise.all(
 			sourceIds.map((source) => {
+				const display = allDisplays.find((d) => String(d.id) === source.display_id);
+				const width = display?.bounds.width ?? 1920;
+				const height = display?.bounds.height ?? 1080;
 				return (navigator.mediaDevices as any).getUserMedia({
 					audio: false,
 					video: {
 						mandatory: {
 							chromeMediaSource: 'desktop',
 							chromeMediaSourceId: source.id,
-							maxFrameRate: 5
+							maxFrameRate: 5,
+							maxWidth: width,
+							maxHeight: height
 						}
 					}
 				} as any);

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -1,0 +1,126 @@
+import { Injectable, inject } from '@angular/core';
+import { ElectronService } from './electron.service';
+
+@Injectable({
+	providedIn: 'root'
+})
+export class ScreenCaptureWebRTSService {
+	// Cache the source id so we don't need to re-enumerate sources on every
+	// screenshot — enumerating sources is cheap and doesn't itself prompt,
+	// but no need to repeat it if the source list won't change mid-session.
+	private readonly electronService: ElectronService = inject(ElectronService);
+	private cachedSourceId: string | null = null;
+
+	/**
+	 * IPC handler entry point for 'take_screenshot'.
+	 *
+	 * Opens a short-lived getUserMedia stream, grabs exactly one frame via
+	 * canvas, then immediately stops the stream. No stream is held open
+	 * between screenshots — this relies on the portal/Chromium reusing the
+	 * permission grant (restore token) instead of re-prompting.
+	 *
+	 * IMPORTANT: verify this actually avoids re-prompting on your target
+	 * Electron version + Linux DE/compositor before relying on it. See the
+	 * notes at the bottom of this file.
+	 */
+	async takeScreenshot(): Promise<string> {
+		const sourceId = await this.getSourceId();
+
+		const stream = await (navigator.mediaDevices as any).getUserMedia({
+			audio: false,
+			video: {
+				mandatory: {
+					chromeMediaSource: 'desktop',
+					chromeMediaSourceId: sourceId,
+					// No need for continuous high frame rate — we only want one frame.
+					maxFrameRate: 5
+				}
+			}
+		} as any);
+
+		try {
+			return await this.grabFrame(stream);
+		} finally {
+			// Always stop tracks, even if grabFrame throws, so we never leak
+			// an open capture session.
+			stream.getTracks().forEach((track) => track.stop());
+		}
+	}
+
+	/**
+	 * Returns the screen source id, using a cached value if we already have one.
+	 * If your app lets the user pick a monitor, don't cache — re-fetch and let
+	 * them choose each time instead.
+	 */
+	private async getSourceId(): Promise<string> {
+		if (this.cachedSourceId) {
+			return this.cachedSourceId;
+		}
+
+		// No thumbnailSize needed — we only want the source id, not an image.
+		const sources = await this.electronService.desktopCapturer.getSources({ types: ['screen'] });
+
+		if (!sources.length) {
+			throw new Error('No screen sources available from desktopCapturer');
+		}
+
+		// If you support multi-monitor selection, let the user pick here instead
+		// of always taking sources[0].
+		this.cachedSourceId = sources[0].id;
+		return this.cachedSourceId;
+	}
+
+	/**
+	 * Attaches a stream to a detached <video>, waits for a frame to be
+	 * available, draws it to an offscreen <canvas>, and returns the PNG data URL.
+	 */
+	private grabFrame(stream: MediaStream): Promise<string> {
+		return new Promise((resolve, reject) => {
+			const video = document.createElement('video');
+			video.muted = true;
+			video.srcObject = stream;
+
+			const cleanup = () => {
+				video.pause();
+				video.srcObject = null;
+				video.remove();
+			};
+
+			video.onloadedmetadata = async () => {
+				try {
+					await video.play();
+
+					// Wait one extra frame tick to make sure a real frame has been
+					// decoded — videoWidth/videoHeight can be set slightly before
+					// the first frame is actually painted.
+					await new Promise((r) => requestAnimationFrame(r));
+
+					if (!video.videoWidth || !video.videoHeight) {
+						throw new Error('Video stream has no dimensions.');
+					}
+
+					const canvas = document.createElement('canvas');
+					canvas.width = video.videoWidth;
+					canvas.height = video.videoHeight;
+
+					const ctx = canvas.getContext('2d');
+					if (!ctx) {
+						throw new Error('Failed to get 2D canvas context.');
+					}
+
+					ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+					resolve(canvas.toDataURL('image/png'));
+				} catch (err) {
+					reject(err);
+				} finally {
+					cleanup();
+				}
+			};
+
+			video.onerror = (err) => {
+				cleanup();
+				reject(err);
+			};
+		});
+	}
+}

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -10,14 +10,18 @@ interface ScreenSources {
 @Injectable({
 	providedIn: 'root'
 })
-export class ScreenCaptureWebRTSService {
+export class ScreenCaptureWebRTCService {
 	private readonly electronService: ElectronService = inject(ElectronService);
 
-	async takeScreenshot({ resetScreen }: { resetScreen: boolean }): Promise<{ screenshot: string; thumbnail: string }[]> {
+	async takeScreenshot({
+		resetScreen
+	}: {
+		resetScreen: boolean;
+	}): Promise<{ screenshot: string; thumbnail: string }[]> {
 		const sourceIds = await this.getSourceId(resetScreen);
 		const allDisplays: { id: number; bounds: { width: number; height: number } }[] =
 			await this.electronService.invoke('GET_ALL_DISPLAYS');
-		const streams = await Promise.all(
+		const streamResults = await Promise.allSettled(
 			sourceIds.map((source) => {
 				const display = allDisplays.find((d) => String(d.id) === source.display_id);
 				const width = display?.bounds.width ?? 1920;
@@ -37,6 +41,14 @@ export class ScreenCaptureWebRTSService {
 			})
 		);
 
+		const streams = streamResults
+			.filter((r): r is PromiseFulfilledResult<MediaStream> => r.status === 'fulfilled')
+			.map((r) => r.value);
+
+		streamResults
+			.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+			.forEach((r) => console.error('[ScreenCapture] getUserMedia failed:', r.reason));
+
 		try {
 			return await Promise.all(streams.map((stream) => this.grabFrame(stream)));
 		} finally {
@@ -44,10 +56,13 @@ export class ScreenCaptureWebRTSService {
 		}
 	}
 
-	async testScreenshot(): Promise<{ screenshot: string; thumbnail: string }> {
+	async testScreenshot(): Promise<{ screenshot: string; thumbnail: string } | null> {
 		// Reset cache to get the latest screen sources
 		const images = await this.takeScreenshot({ resetScreen: true });
-		return images[0];
+		if (images.length === 0) {
+			return images[0];
+		}
+		return null;
 	}
 
 	private async getSourceId(resetScreen = false): Promise<ScreenSources[]> {
@@ -69,6 +84,16 @@ export class ScreenCaptureWebRTSService {
 				video.pause();
 				video.srcObject = null;
 				video.remove();
+			};
+
+			const timeout = setTimeout(() => {
+				cleanup();
+				reject(new Error('grabFrame timed out: video metadata never loaded'));
+			}, 10_000);
+
+			const settle = (fn: () => void) => {
+				clearTimeout(timeout);
+				fn();
 			};
 
 			video.onloadedmetadata = async () => {
@@ -107,12 +132,14 @@ export class ScreenCaptureWebRTSService {
 
 					thumbCtx.drawImage(video, 0, 0, thumbCanvas.width, thumbCanvas.height);
 
-					resolve({
-						screenshot: canvas.toDataURL('image/png'),
-						thumbnail: thumbCanvas.toDataURL('image/png')
-					});
+					settle(() =>
+						resolve({
+							screenshot: canvas.toDataURL('image/png'),
+							thumbnail: thumbCanvas.toDataURL('image/png')
+						})
+					);
 				} catch (err) {
-					reject(err);
+					settle(() => reject(err));
 				} finally {
 					cleanup();
 				}
@@ -120,7 +147,7 @@ export class ScreenCaptureWebRTSService {
 
 			video.onerror = (err) => {
 				cleanup();
-				reject(err);
+				settle(() => reject(err));
 			};
 		});
 	}

--- a/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
+++ b/packages/desktop-ui-lib/src/lib/electron/services/electron/screen-capture.service.ts
@@ -12,10 +12,9 @@ interface ScreenSources {
 })
 export class ScreenCaptureWebRTSService {
 	private readonly electronService: ElectronService = inject(ElectronService);
-	private cachedSourceIds: ScreenSources[] | null = null;
 
-	async takeScreenshot(): Promise<{ screenshot: string; thumbnail: string }[]> {
-		const sourceIds = await this.getSourceId();
+	async takeScreenshot({ resetScreen }: { resetScreen: boolean }): Promise<{ screenshot: string; thumbnail: string }[]> {
+		const sourceIds = await this.getSourceId(resetScreen);
 		const allDisplays: { id: number; bounds: { width: number; height: number } }[] =
 			await this.electronService.invoke('GET_ALL_DISPLAYS');
 		const streams = await Promise.all(
@@ -47,18 +46,13 @@ export class ScreenCaptureWebRTSService {
 
 	async testScreenshot(): Promise<{ screenshot: string; thumbnail: string }> {
 		// Reset cache to get the latest screen sources
-		this.cachedSourceIds = null;
-		const images = await this.takeScreenshot();
+		const images = await this.takeScreenshot({ resetScreen: true });
 		return images[0];
 	}
 
-	private async getSourceId(): Promise<ScreenSources[]> {
-		if (this.cachedSourceIds) {
-			return this.cachedSourceIds;
-		}
-		const sources = await this.electronService.desktopCapturer.getSources({ types: ['screen'] });
-		this.cachedSourceIds = sources;
-		return this.cachedSourceIds;
+	private async getSourceId(resetScreen = false): Promise<ScreenSources[]> {
+		const sources: ScreenSources[] = await this.electronService.invoke('GET_SCREEN_SOURCES', { resetScreen });
+		return sources;
 	}
 
 	/**

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, OnInit, OnDestroy, Optional, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, input, OnInit, OnDestroy, Optional, ChangeDetectionStrategy, signal, inject } from '@angular/core';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import {
 	NbCardModule,
@@ -12,6 +12,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { PermissionManagerService } from './permission-manager.service';
 import { take, filter } from 'rxjs';
+import { ScreenCaptureWebRTSService } from '../electron/services/electron/screen-capture.service';
 
 @UntilDestroy()
 @Component({
@@ -33,6 +34,7 @@ import { take, filter } from 'rxjs';
 })
 export class PermissionManagerComponent implements OnInit, OnDestroy {
 	/** When true: renders as a dialog with Cancel/Start Anyway buttons */
+	private readonly screenCaptureService: ScreenCaptureWebRTSService = inject(ScreenCaptureWebRTSService);
 	isDialog = input(false);
 	timerStarted = input(false);
 
@@ -99,8 +101,13 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 
 	async testScreenshot() {
 		this.testInProgress = true;
-		const result = await this.permissionService.testScreenshot();
-		this.thumbnail = result.success ? result.thumbnail : null;
+		if (this.isMac || this.isWindows) {
+			const result = await this.permissionService.testScreenshot();
+			this.thumbnail = result.success ? result.thumbnail : null;
+		} else {
+			const result = await this.screenCaptureService.takeScreenshot();
+			this.thumbnail = result;
+		}
 		this.testInProgress = false;
 	}
 

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
@@ -12,7 +12,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { PermissionManagerService } from './permission-manager.service';
 import { take, filter } from 'rxjs';
-import { ScreenCaptureWebRTSService } from '../electron/services/electron/screen-capture.service';
+import { ScreenCaptureWebRTCService } from '../electron/services/electron/screen-capture.service';
 
 @UntilDestroy()
 @Component({
@@ -34,7 +34,7 @@ import { ScreenCaptureWebRTSService } from '../electron/services/electron/screen
 })
 export class PermissionManagerComponent implements OnInit, OnDestroy {
 	/** When true: renders as a dialog with Cancel/Start Anyway buttons */
-	private readonly screenCaptureService: ScreenCaptureWebRTSService = inject(ScreenCaptureWebRTSService);
+	private readonly screenCaptureService: ScreenCaptureWebRTCService = inject(ScreenCaptureWebRTCService);
 	isDialog = input(false);
 	timerStarted = input(false);
 
@@ -108,7 +108,7 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 		this.testInProgress = true;
 		if (this.isWayland()) {
 			const result = await this.screenCaptureService.testScreenshot();
-			this.thumbnail = result.screenshot;
+			this.thumbnail = result && result.screenshot;
 		} else {
 			const result = await this.permissionService.testScreenshot();
 			this.thumbnail = result.success ? result.thumbnail : null;

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
@@ -108,7 +108,7 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 		this.testInProgress = true;
 		if (this.isWayland()) {
 			const result = await this.screenCaptureService.testScreenshot();
-			this.thumbnail = result.thumbnail;
+			this.thumbnail = result.screenshot;
 		} else {
 			const result = await this.permissionService.testScreenshot();
 			this.thumbnail = result.success ? result.thumbnail : null;

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
@@ -106,7 +106,7 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 			this.thumbnail = result.success ? result.thumbnail : null;
 		} else {
 			const result = await this.screenCaptureService.takeScreenshot();
-			this.thumbnail = result;
+			this.thumbnail = result.thumbnail;
 		}
 		this.testInProgress = false;
 	}

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
@@ -106,14 +106,22 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 
 	async testScreenshot() {
 		this.testInProgress = true;
-		if (this.isWayland()) {
-			const result = await this.screenCaptureService.testScreenshot();
-			this.thumbnail = result && result.screenshot;
-		} else {
-			const result = await this.permissionService.testScreenshot();
-			this.thumbnail = result.success ? result.thumbnail : null;
+		try {
+			// Check Wayland at click time — the isWayland() signal may not be set yet
+			// if the user clicks before platformSet() resolves.
+			if (await this.permissionService.getIsWayland()) {
+				const result = await this.screenCaptureService.testScreenshot();
+				this.thumbnail = result?.thumbnail ?? null;
+			} else {
+				const result = await this.permissionService.testScreenshot();
+				this.thumbnail = result.success ? result.thumbnail : null;
+			}
+		} catch (error) {
+			console.error('Error testing screenshot:', error);
+			this.thumbnail = null;
+		} finally {
+			this.testInProgress = false;
 		}
-		this.testInProgress = false;
 	}
 
 	async testGetActiveWindow() {

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.component.ts
@@ -60,6 +60,8 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 	// ── Platform flags ───────────────────────────────────────────────────────
 	readonly isMac = signal(false);
 	readonly isWindows = signal(false);
+	readonly isLinux = signal(false);
+	readonly isWayland = signal(false);
 	readonly hardwareAccelerationDisabled = signal(false);
 
 	constructor(
@@ -80,9 +82,12 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 
 	async platformSet() {
 		const platform = await this.permissionService.getPlatform();
+		const isWayland = await this.permissionService.getIsWayland();
 		const hardwareAccelerationDisabled = await this.permissionService.getHardwareAccelerationState();
 		this.isMac.set(platform?.os === 'darwin');
 		this.isWindows.set(platform?.os === 'win32');
+		this.isLinux.set(platform?.os === 'linux');
+		this.isWayland.set(isWayland);
 		this.hardwareAccelerationDisabled.set(hardwareAccelerationDisabled);
 	}
 
@@ -101,12 +106,12 @@ export class PermissionManagerComponent implements OnInit, OnDestroy {
 
 	async testScreenshot() {
 		this.testInProgress = true;
-		if (this.isMac || this.isWindows) {
+		if (this.isWayland()) {
+			const result = await this.screenCaptureService.testScreenshot();
+			this.thumbnail = result.thumbnail;
+		} else {
 			const result = await this.permissionService.testScreenshot();
 			this.thumbnail = result.success ? result.thumbnail : null;
-		} else {
-			const result = await this.screenCaptureService.takeScreenshot();
-			this.thumbnail = result.thumbnail;
 		}
 		this.testInProgress = false;
 	}

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.service.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.service.ts
@@ -40,7 +40,6 @@ export class PermissionManagerService {
 	/** Check once */
 	async checkStatus(): Promise<string> {
 		const result = await this.electronService.ipcRenderer.invoke('CHECK_MACOS_PERMISSIONS');
-		console.log('permissions check result', result);
 		this._status$.next(result.screen);
 		this._accessibilityStatus$.next(result.accessibility ?? 'unknown');
 		return result.screen;

--- a/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.service.ts
+++ b/packages/desktop-ui-lib/src/lib/permission-manager/permission-manager.service.ts
@@ -1,6 +1,4 @@
-import {
-	Injectable
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 import {
 	BehaviorSubject,
 	Subscription,
@@ -23,17 +21,21 @@ export class PermissionManagerService {
 	private _accessibilityStatus$ = new BehaviorSubject<PermissionStatus>('unknown');
 	private _polling$: Subscription | null = null;
 
-	public get status$() { return this._status$.asObservable(); }
+	public get status$() {
+		return this._status$.asObservable();
+	}
 	public get isGranted$() {
-		return this._status$.pipe(map(s => s === 'granted'));
+		return this._status$.pipe(map((s) => s === 'granted'));
 	}
 
-	public get accessibilityStatus$() { return this._accessibilityStatus$.asObservable(); }
+	public get accessibilityStatus$() {
+		return this._accessibilityStatus$.asObservable();
+	}
 	public get isAccessibilityGranted$() {
-		return this._accessibilityStatus$.pipe(map(s => s === 'granted'));
+		return this._accessibilityStatus$.pipe(map((s) => s === 'granted'));
 	}
 
-	constructor(private readonly electronService: ElectronService) { }
+	constructor(private readonly electronService: ElectronService) {}
 
 	/** Check once */
 	async checkStatus(): Promise<string> {
@@ -50,9 +52,11 @@ export class PermissionManagerService {
 
 		const polling$ = interval(2000).pipe(
 			switchMap(() => from(this.checkStatus())),
-			map(status => status === 'granted'),
+			map((status) => status === 'granted'),
 			distinctUntilChanged(),
-			tap(granted => { if (granted) this.stopPolling(); })
+			tap((granted) => {
+				if (granted) this.stopPolling();
+			})
 		);
 
 		// Track the subscription so stopPolling() (called from ngOnDestroy) actually works
@@ -70,7 +74,11 @@ export class PermissionManagerService {
 		return this.electronService.ipcRenderer.invoke('TEST_SCREENSHOT');
 	}
 
-	async testGetWindow(): Promise<{ success: boolean; reason?: string; window?: { title?: string; bundleId?: string; appName?: string } }> {
+	async testGetWindow(): Promise<{
+		success: boolean;
+		reason?: string;
+		window?: { title?: string; bundleId?: string; appName?: string };
+	}> {
 		return this.electronService.ipcRenderer.invoke('TEST_GET_ACTIVE_WINDOW');
 	}
 
@@ -103,6 +111,10 @@ export class PermissionManagerService {
 	/** Returns the current OS platform information including os, architecture, and system version. */
 	getPlatform(): Promise<IOSInfo> {
 		return this.electronService.ipcRenderer.invoke('GET_PLATFORM');
+	}
+
+	async getIsWayland(): Promise<boolean> {
+		return this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
 	}
 
 	/** Returns whether hardware acceleration is currently disabled (Windows). */

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2313,7 +2313,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 				const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
 				if (!isWayland) {
 					this._loggerService.info('Wayland detected, using WebRTC screen capture');
-					const frames = await this._screenCaptureService.takeScreenshot();
+					const frames = await this._screenCaptureService.takeScreenshot({ resetScreen: false });
 					HighResolutionScreenshots = frames.map((frame, index) => ({
 						img: Buffer.from(frame.screenshot.replace(/^data:image\/\w+;base64,/, ''), 'base64'),
 						name: `screen-${index}`,

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2311,7 +2311,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			this._loggerService.info('Take screen capture');
 			if (!arg.displays) {
 				const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
-				if (!isWayland) {
+				if (isWayland) {
 					this._loggerService.info('Wayland detected, using WebRTC screen capture');
 					const frames = await this._screenCaptureService.takeScreenshot({ resetScreen: false });
 					HighResolutionScreenshots = frames.map((frame, index) => ({

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -69,7 +69,7 @@ import { AlwaysOnService, AlwaysOnStateEnum } from '../always-on/always-on.servi
 import { AuthStrategy } from '../auth';
 import { BLOCK_DELAY, GAUZY_ENV } from '../constants';
 import { ElectronService, LoggerService } from '../electron/services';
-import { ScreenCaptureWebRTSService } from '../electron/services/electron/screen-capture.service';
+import { ScreenCaptureWebRTCService } from '../electron/services/electron/screen-capture.service';
 import { ImageViewerService } from '../image-viewer/image-viewer.service';
 import { ActivityWatchViewService } from '../integrations';
 import { ActivityWatchComponent } from '../integrations/activity-watch/view/activity-watch.component';
@@ -261,7 +261,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		private readonly cdr: ChangeDetectorRef,
 		private readonly router: Router,
 		private readonly _auditLogService: AuditLogService,
-		private readonly _screenCaptureService: ScreenCaptureWebRTSService
+		private readonly _screenCaptureService: ScreenCaptureWebRTCService
 	) {
 		this.iconLibraries.registerFontPack('font-awesome', {
 			packClass: 'fas',

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2314,9 +2314,16 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 				if (isWayland) {
 					this._loggerService.info('Wayland detected, using WebRTC screen capture');
 					let frames = await this._screenCaptureService.takeScreenshot({ resetScreen: false });
-					// Respect the "active-only" monitor setting, same as getScreenshot()
+					// Respect the "active-only" monitor setting, same as getScreenshot().
+					// display_id can be empty on Wayland/PipeWire — only trust the filter
+					// when it actually matches, otherwise keep all captured frames.
 					if (this.appSetting?.monitor?.captured === 'active-only' && arg.activeWindow) {
-						frames = frames.filter((frame) => frame.display_id === arg.activeWindow.id.toString());
+						const filtered = frames.filter(
+							(frame) => frame.display_id && frame.display_id === arg.activeWindow.id.toString()
+						);
+						if (filtered.length > 0) {
+							frames = filtered;
+						}
 					}
 					HighResolutionScreenshots = frames.map((frame) => ({
 						img: Buffer.from(frame.screenshot.replace(/^data:image\/\w+;base64,/, ''), 'base64'),

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -994,7 +994,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		/* initiate screenshot to prevent window sizing */
 		setTimeout(async () => {
 			const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
-			if (isWayland) {
+			if (!isWayland) {
 				try {
 					const thumbSize = {
 						width: 320,

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2311,7 +2311,7 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 			this._loggerService.info('Take screen capture');
 			if (!arg.displays) {
 				const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
-				if (isWayland) {
+				if (!isWayland) {
 					this._loggerService.info('Wayland detected, using WebRTC screen capture');
 					const frames = await this._screenCaptureService.takeScreenshot();
 					HighResolutionScreenshots = frames.map((frame, index) => ({

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -2313,16 +2313,20 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 				const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
 				if (isWayland) {
 					this._loggerService.info('Wayland detected, using WebRTC screen capture');
-					const frames = await this._screenCaptureService.takeScreenshot({ resetScreen: false });
-					HighResolutionScreenshots = frames.map((frame, index) => ({
+					let frames = await this._screenCaptureService.takeScreenshot({ resetScreen: false });
+					// Respect the "active-only" monitor setting, same as getScreenshot()
+					if (this.appSetting?.monitor?.captured === 'active-only' && arg.activeWindow) {
+						frames = frames.filter((frame) => frame.display_id === arg.activeWindow.id.toString());
+					}
+					HighResolutionScreenshots = frames.map((frame) => ({
 						img: Buffer.from(frame.screenshot.replace(/^data:image\/\w+;base64,/, ''), 'base64'),
-						name: `screen-${index}`,
-						id: String(index)
+						name: frame.name,
+						id: frame.display_id
 					}));
-					lowResolutionScreenshots = frames.map((frame, index) => ({
+					lowResolutionScreenshots = frames.map((frame) => ({
 						img: Buffer.from(frame.thumbnail.replace(/^data:image\/\w+;base64,/, ''), 'base64'),
-						name: `screen-${index}`,
-						id: String(index)
+						name: frame.name,
+						id: frame.display_id
 					}));
 				} else {
 					HighResolutionScreenshots = await this.getScreenshot(arg, false);

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -69,6 +69,7 @@ import { AlwaysOnService, AlwaysOnStateEnum } from '../always-on/always-on.servi
 import { AuthStrategy } from '../auth';
 import { BLOCK_DELAY, GAUZY_ENV } from '../constants';
 import { ElectronService, LoggerService } from '../electron/services';
+import { ScreenCaptureWebRTSService } from '../electron/services/electron/screen-capture.service';
 import { ImageViewerService } from '../image-viewer/image-viewer.service';
 import { ActivityWatchViewService } from '../integrations';
 import { ActivityWatchComponent } from '../integrations/activity-watch/view/activity-watch.component';
@@ -259,7 +260,8 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 		private readonly timeTrackerFormService: TimeTrackerFormService,
 		private readonly cdr: ChangeDetectorRef,
 		private readonly router: Router,
-		private readonly _auditLogService: AuditLogService
+		private readonly _auditLogService: AuditLogService,
+		private readonly _screenCaptureService: ScreenCaptureWebRTSService
 	) {
 		this.iconLibraries.registerFontPack('font-awesome', {
 			packClass: 'fas',
@@ -991,14 +993,17 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 	prepareWindow() {
 		/* initiate screenshot to prevent window sizing */
 		setTimeout(async () => {
-			try {
-				const thumbSize = {
-					width: 320,
-					height: 240
-				};
-				await this.electronService.desktopCapturer.getSources({ types: ['screen'], thumbnailSize: thumbSize });
-			} catch (error) {
-				console.error('Error preparing window:', error);
+			const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
+			if (isWayland) {
+				try {
+					const thumbSize = {
+						width: 320,
+						height: 240
+					};
+					await this.electronService.desktopCapturer.getSources({ types: ['screen'], thumbnailSize: thumbSize });
+				} catch (error) {
+					console.error('Error preparing window:', error);
+				}
 			}
 		}, 500);
 	}
@@ -2299,14 +2304,30 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 	}
 
 	public async takeScreenCapture(arg: { displays: IScreenshotResult[] } & IScreenshotRequest): Promise<IScreenshotResult[]> {
-		let HighResolutionScreenshots = [];
-		let lowResolutionScreenshots = [];
+		let HighResolutionScreenshots: IScreenshotResult[] = [];
+		let lowResolutionScreenshots: IScreenshotResult[] = [];
 
 		try {
 			this._loggerService.info('Take screen capture');
 			if (!arg.displays) {
-				HighResolutionScreenshots = await this.getScreenshot(arg, false);
-				lowResolutionScreenshots = await this.getScreenshot(arg, true);
+				const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
+				if (isWayland) {
+					this._loggerService.info('Wayland detected, using WebRTC screen capture');
+					const frames = await this._screenCaptureService.takeScreenshot();
+					HighResolutionScreenshots = frames.map((frame, index) => ({
+						img: Buffer.from(frame.screenshot.replace(/^data:image\/\w+;base64,/, ''), 'base64'),
+						name: `screen-${index}`,
+						id: String(index)
+					}));
+					lowResolutionScreenshots = frames.map((frame, index) => ({
+						img: Buffer.from(frame.thumbnail.replace(/^data:image\/\w+;base64,/, ''), 'base64'),
+						name: `screen-${index}`,
+						id: String(index)
+					}));
+				} else {
+					HighResolutionScreenshots = await this.getScreenshot(arg, false);
+					lowResolutionScreenshots = await this.getScreenshot(arg, true);
+				}
 			} else {
 				HighResolutionScreenshots = arg.displays;
 			}

--- a/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
+++ b/packages/desktop-ui-lib/src/lib/time-tracker/time-tracker.component.ts
@@ -993,17 +993,17 @@ export class TimeTrackerComponent implements OnInit, AfterViewInit {
 	prepareWindow() {
 		/* initiate screenshot to prevent window sizing */
 		setTimeout(async () => {
-			const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
-			if (!isWayland) {
-				try {
+			try {
+				const isWayland = await this.electronService.ipcRenderer.invoke('GET_IS_WAYLAND');
+				if (!isWayland) {
 					const thumbSize = {
 						width: 320,
 						height: 240
 					};
 					await this.electronService.desktopCapturer.getSources({ types: ['screen'], thumbnailSize: thumbSize });
-				} catch (error) {
-					console.error('Error preparing window:', error);
 				}
+			} catch (error) {
+				console.error('Error preparing window:', error);
 			}
 		}, 500);
 	}


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linux Wayland screen capture via WebRTC across all displays with hi‑res frames and 320x240 thumbnails. Detects Wayland, caches and reuses screen sources to reduce prompts, tolerates missing display IDs, and respects the active‑only monitor setting.

- **New Features**
  - `ScreenCaptureWebRTCService` uses `getUserMedia` to capture all displays and returns hi‑res + 320x240 thumbnails with display metadata.
  - IPC: `GET_IS_WAYLAND`, `GET_ALL_DISPLAYS`, `GET_SCREEN_SOURCES` (with optional reset). Returns only id/name/display_id and skips thumbnails; sources are cached.
  - Time Tracker uses WebRTC on Wayland and Electron elsewhere; Permission Manager tests via WebRTC on Wayland and shows the 320x240 thumbnail.

- **Bug Fixes**
  - Multi‑display capture is resilient: `Promise.allSettled`, stream/source pairing, proper errors, and track cleanup; corrected testScreenshot result handling.
  - Wayland: tolerate empty/mismatched `display_id` (fallback to positional/first display and display bounds), apply active‑only filter only when it matches, and skip initial Electron capture; permission test spinner reliably resets.

<sup>Written for commit 52007eb52074fe2fe06e8badf5fe8270b13dce5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

