### PR TITLE
fix(ci): gauzy demo cache-to mode=max -> mode=min (RAM-disk scratch overflow)

### DIFF
--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -49,7 +49,7 @@ jobs:
           cache-from: |
             type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:buildcache
             type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:latest
-          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:buildcache,mode=max
+          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
             DEMO=true
@@ -146,7 +146,7 @@ jobs:
           cache-from: |
             type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:buildcache
             type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:latest
-          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:buildcache,mode=max
+          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
             DEMO=true
@@ -243,7 +243,7 @@ jobs:
           cache-from: |
             type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:buildcache
             type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:latest
-          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:buildcache,mode=max
+          cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
             DEMO=true


### PR DESCRIPTION
gauzy demo builds ENOSPC on the ARC RAM-disk scratch at the image-export stage even at 44Gi: the 5-stage Dockerfiles + `cache-to: mode=max` make buildkit keep every stage's layers locally to export them. `mode=min` exports only the final production layers, fitting comfortably in RAM. `load: true` and all push steps are unchanged. Part of the self-hosted-only + RAM-disk build migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `cache-to` from `mode=max` to `mode=min` in the demo Docker build workflow to prevent ENOSPC on the ARC RAM-disk during image export. Exports only final production layers; `load: true` and push steps remain unchanged.

<sup>Written for commit cc7b0ab40901a268d995599b08f44db98f576cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

