### PR TITLE
fix: apply patch-package on plain yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"doc:build": "compodoc -p tsconfig.json -d dist/docs",
 		"doc:serve": "compodoc -s -d dist/docs",
 		"doc:build-serve": "compodoc -p tsconfig.json -d docs -s",
+		"postinstall": "patch-package",
 		"postinstall.manual": "patch-package && yarn node ./.scripts/postinstall.js",
 		"postinstall.electron": "yarn electron-builder install-app-deps && yarn node tools/electron/postinstall",
 		"postinstall.web": "yarn node ./decorate-angular-cli.js && yarn node tools/web/postinstall",


### PR DESCRIPTION
## Problem

Devs running plain `yarn install` end up with an **unpatched** `typeorm@1.0.0` and `core:build` fails with dozens of errors like:

```
error TS2559: Type 'string[]' has no properties in common with type 'FindOptionsRelations<User>'.
```

Root cause: since the switch to manual postinstall scripts (70015bc3c3), `patches/typeorm+1.0.0.patch` is only applied by `yarn bootstrap` / `yarn postinstall.manual`. There is no root `postinstall` lifecycle script, so a plain `yarn install` silently skips patch-package.

## Fix

Add a root `postinstall` script that runs **only** `patch-package` (not the heavy `.scripts/postinstall.js` native-rebuild logic, which is meant exclusively for `--ignore-scripts` installs):

- plain `yarn install` (dev machines) → yarn runs root `postinstall` → patches applied ✅
- `yarn bootstrap` / Dockerfiles / CI (`yarn install --ignore-scripts && yarn postinstall.manual`) → root lifecycle skipped, `postinstall.manual` applies patches exactly as before ✅ (patch-package is idempotent anyway)

## Verification

Reproduced locally: reversed the patch (`npx patch-package --reverse`), ran plain `yarn install --frozen-lockfile` → log shows `$ patch-package … typeorm@1.0.0 ✔` and `FindOneOptions.d.ts` again contains `relations?: FindOptionsRelations<Entity> | string[]`. A production worker build (`yarn build:worker:prod`) then compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `patch-package` on plain `yarn install` by adding a root `postinstall` script. This keeps the `typeorm@1.0.0` patch applied and stops `core:build` type errors.

- **Bug Fixes**
  - Add root `postinstall` that runs only `patch-package`.
  - Plain installs now apply `patches/typeorm+1.0.0.patch`; builds compile.
  - `--ignore-scripts` flows (`yarn bootstrap`, Docker, CI) still use `postinstall.manual`; behavior unchanged.

<sup>Written for commit aa87bee731994a32399e986c4092dfbf02b25bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

