### PR TITLE
ci(demo): publish versioned GHCR image tags (0.1.<run_number>) alongside :latest

### DIFF
--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -39,6 +39,7 @@ jobs:
           platforms: linux/amd64
           tags: |
             ghcr.io/ever-co/gauzy-api-demo:latest
+            ghcr.io/ever-co/gauzy-api-demo:0.1.${{ github.run_number }}
             everco/gauzy-api-demo:latest
             registry.digitalocean.com/ever/gauzy-api-demo:latest
             ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-api-demo:latest
@@ -99,6 +100,7 @@ jobs:
       - name: Push to Github Registry
         run: |
           docker push ghcr.io/ever-co/gauzy-api-demo:latest
+          docker push ghcr.io/ever-co/gauzy-api-demo:0.1.${{ github.run_number }}
 
     #   - name: Login to CW Container Registry
     #    uses: docker/login-action@v4
@@ -139,6 +141,7 @@ jobs:
           platforms: linux/amd64
           tags: |
             ghcr.io/ever-co/gauzy-webapp-demo:latest
+            ghcr.io/ever-co/gauzy-webapp-demo:0.1.${{ github.run_number }}
             everco/gauzy-webapp-demo:latest
             registry.digitalocean.com/ever/gauzy-webapp-demo:latest
             ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-webapp-demo:latest
@@ -199,6 +202,7 @@ jobs:
       - name: Push to Github Registry
         run: |
           docker push ghcr.io/ever-co/gauzy-webapp-demo:latest
+          docker push ghcr.io/ever-co/gauzy-webapp-demo:0.1.${{ github.run_number }}
 
       # - name: Login to CW Container Registry
       #  uses: docker/login-action@v4
@@ -239,6 +243,7 @@ jobs:
           platforms: linux/amd64
           tags: |
             ghcr.io/ever-co/gauzy-worker-demo:latest
+            ghcr.io/ever-co/gauzy-worker-demo:0.1.${{ github.run_number }}
             everco/gauzy-worker-demo:latest
             registry.digitalocean.com/ever/gauzy-worker-demo:latest
             ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-worker-demo:latest
@@ -302,6 +307,7 @@ jobs:
       - name: Push to Github Registry
         run: |
           docker push ghcr.io/ever-co/gauzy-worker-demo:latest
+          docker push ghcr.io/ever-co/gauzy-worker-demo:0.1.${{ github.run_number }}
 
     #   - name: Login to CW Container Registry
     #    uses: docker/login-action@v4


### PR DESCRIPTION
Phase 2 of k8s auto-deploy: start publishing semver-tagged images (`ghcr.io/ever-co/gauzy-{api,webapp,worker}-demo:0.1.<run_number>`) alongside `:latest`, so deployments can track exact versions and Keel can use a semver policy instead of `force`/latest. Additive — `:latest` kept during transition. First repo of the versioning rollout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish versioned GHCR tags for demo images (`0.1.<run_number>`) alongside `:latest`. This lets deployments pin exact versions and enables Keel’s semver policy for safer auto-deploys and rollbacks.

- **New Features**
  - Build and push `ghcr.io/ever-co/gauzy-{api,webapp,worker}-demo:0.1.${{ github.run_number }}` in CI.
  - Keep `:latest` during the transition.

<sup>Written for commit dda2ed3e0b6ed507a35de770199f8907a73c7a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

