### PR TITLE
feat(footer): deployed version + commit with web/API drift detection

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"ignoreRegExpList": ["GHSA-[A-Za-z0-9-]+"],
 	"words": [
+		"relver",
 		"fontobject",
 		"textareas",
 		"ababa",

--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -378,6 +378,14 @@ ENV CI=true
 ENV NODE_OPTIONS="--max-old-space-size=12288"
 ENV NODE_ENV=production
 
+# Deployed release version (git tag) + commit SHA — exposed at runtime by
+# GET /api/version so the web footer can show them and flag an API/web drift.
+# Public build info (not secrets); safe to bake into the image.
+ARG GAUZY_APP_VERSION
+ARG GAUZY_APP_COMMIT
+ENV GAUZY_APP_VERSION=${GAUZY_APP_VERSION}
+ENV GAUZY_APP_COMMIT=${GAUZY_APP_COMMIT}
+
 ENV API_HOST=api
 ENV API_PORT=3000
 

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -174,9 +174,18 @@ ARG DEMO
 ARG NODE_OPTIONS
 ARG NX_BRANCH
 
+# Deployed release version (git tag) + commit SHA. Baked into the Angular bundle
+# at build time by .scripts/configure.ts (env.GAUZY_APP_VERSION/COMMIT) so the
+# footer shows them — they are image constants, not runtime-substituted.
+ARG GAUZY_APP_VERSION
+ARG GAUZY_APP_COMMIT
+
 ENV NODE_OPTIONS=${NODE_OPTIONS:-"--max-old-space-size=30000"}
 ENV NODE_ENV=${NODE_ENV:-production}
 ENV DEMO=${DEMO:-false}
+
+ENV GAUZY_APP_VERSION=${GAUZY_APP_VERSION}
+ENV GAUZY_APP_COMMIT=${GAUZY_APP_COMMIT}
 
 ENV IS_DOCKER=true
 

--- a/.deploy/worker/Dockerfile
+++ b/.deploy/worker/Dockerfile
@@ -378,6 +378,12 @@ ENV CI=true
 ENV NODE_OPTIONS="--max-old-space-size=12288"
 ENV NODE_ENV=production
 
+# Deployed release version (git tag) + commit SHA — kept in sync with the API image.
+ARG GAUZY_APP_VERSION
+ARG GAUZY_APP_COMMIT
+ENV GAUZY_APP_VERSION=${GAUZY_APP_VERSION}
+ENV GAUZY_APP_COMMIT=${GAUZY_APP_COMMIT}
+
 ENV API_HOST=api
 ENV API_PORT=3000
 

--- a/.env.sample
+++ b/.env.sample
@@ -19,6 +19,12 @@ APP_MAGIC_SIGN_URL="http://localhost:4200/#/auth/magic-sign-in"
 # Set true if running inside the Docker container
 IS_DOCKER=false
 
+# Deployed release version (git tag, e.g. v111.2.10) and full commit SHA, shown in the
+# web UI footer and returned by GET /api/version. Normally injected automatically at
+# Docker build time (build-args, see .deploy/*/Dockerfile); leave empty for source runs.
+GAUZY_APP_VERSION=
+GAUZY_APP_COMMIT=
+
 # Format: https://hook.{region}.make.com/{webhook-id}
 GAUZY_MAKE_WEBHOOK_URL=
 

--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -68,6 +68,8 @@ jobs:
             NODE_ENV=development
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
+            GAUZY_APP_COMMIT=${{ github.event.workflow_run.head_sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           secrets: |
@@ -182,6 +184,8 @@ jobs:
             NODE_ENV=development
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
+            GAUZY_APP_COMMIT=${{ github.event.workflow_run.head_sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           secrets: |
@@ -296,6 +300,8 @@ jobs:
             NODE_ENV=development
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
+            GAUZY_APP_COMMIT=${{ github.event.workflow_run.head_sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           # WORKER_* build-args were dropped: they never reached the image (the global

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: relver
+        run: |
+          VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION:-<none>}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -43,6 +53,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
             GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
@@ -107,6 +118,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: relver
+        run: |
+          VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION:-<none>}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -132,6 +153,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
             GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
@@ -196,6 +218,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: relver
+        run: |
+          VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION:-<none>}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -223,6 +255,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
             GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -43,6 +43,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           secrets: |
@@ -131,6 +132,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           secrets: |
@@ -221,6 +223,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           # WORKER_* build-args were dropped: they never reached the image (the global

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -22,8 +22,10 @@ jobs:
       - name: Resolve release version
         id: relver
         run: |
+          # Only the tag that points AT the built commit — no `git describe` fallback,
+          # which would surface a stale ancestor tag as this build's version. When the
+          # commit is untagged the footer shows the commit alone (accurate).
           VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
-          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release version: ${VERSION:-<none>}"
 
@@ -124,8 +126,10 @@ jobs:
       - name: Resolve release version
         id: relver
         run: |
+          # Only the tag that points AT the built commit — no `git describe` fallback,
+          # which would surface a stale ancestor tag as this build's version. When the
+          # commit is untagged the footer shows the commit alone (accurate).
           VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
-          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release version: ${VERSION:-<none>}"
 
@@ -224,8 +228,10 @@ jobs:
       - name: Resolve release version
         id: relver
         run: |
+          # Only the tag that points AT the built commit — no `git describe` fallback,
+          # which would surface a stale ancestor tag as this build's version. When the
+          # commit is untagged the footer shows the commit alone (accurate).
           VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
-          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release version: ${VERSION:-<none>}"
 

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: relver
+        run: |
+          VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION:-<none>}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -43,6 +53,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
             GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
@@ -107,6 +118,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: relver
+        run: |
+          VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION:-<none>}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -132,6 +153,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
             GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
@@ -196,6 +218,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: relver
+        run: |
+          VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION:-<none>}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -223,6 +255,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
             GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -43,6 +43,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           secrets: |
@@ -131,6 +132,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           secrets: |
@@ -221,6 +223,7 @@ jobs:
             NODE_ENV=production
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
+            GAUZY_APP_COMMIT=${{ github.sha }}
           # VERDACCIO_TOKEN / NX_CLOUD_ACCESS_TOKEN are BuildKit build secrets (mounted
           # per-RUN, never embedded in image layers) — see the Dockerfile header.
           # WORKER_* build-args were dropped: they never reached the image (the global

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -22,8 +22,10 @@ jobs:
       - name: Resolve release version
         id: relver
         run: |
+          # Only the tag that points AT the built commit — no `git describe` fallback,
+          # which would surface a stale ancestor tag as this build's version. When the
+          # commit is untagged the footer shows the commit alone (accurate).
           VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
-          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release version: ${VERSION:-<none>}"
 
@@ -124,8 +126,10 @@ jobs:
       - name: Resolve release version
         id: relver
         run: |
+          # Only the tag that points AT the built commit — no `git describe` fallback,
+          # which would surface a stale ancestor tag as this build's version. When the
+          # commit is untagged the footer shows the commit alone (accurate).
           VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
-          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release version: ${VERSION:-<none>}"
 
@@ -224,8 +228,10 @@ jobs:
       - name: Resolve release version
         id: relver
         run: |
+          # Only the tag that points AT the built commit — no `git describe` fallback,
+          # which would surface a stale ancestor tag as this build's version. When the
+          # commit is untagged the footer shows the commit alone (accurate).
           VERSION=$(git tag --points-at HEAD | grep -E '^v[0-9]' | sort -V | tail -1)
-          if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true); fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Release version: ${VERSION:-<none>}"
 

--- a/.scripts/configure.ts
+++ b/.scripts/configure.ts
@@ -85,6 +85,9 @@ if (!isDocker) {
 	{
 		production:  ${isProd},
 
+		version: '${env.GAUZY_APP_VERSION}',
+		commit: '${env.GAUZY_APP_COMMIT}',
+
 		API_BASE_URL: API_BASE_URL,
 		CLIENT_BASE_URL: CLIENT_BASE_URL,
 		COOKIE_DOMAIN: '${env.COOKIE_DOMAIN}',
@@ -246,6 +249,9 @@ if (!isDocker) {
 	export const environment: Environment =
 	{
 		production:  ${isProd},
+
+		version: '${env.GAUZY_APP_VERSION}',
+		commit: '${env.GAUZY_APP_COMMIT}',
 
 		API_BASE_URL: API_BASE_URL,
 		CLIENT_BASE_URL: CLIENT_BASE_URL,

--- a/.scripts/configure.ts
+++ b/.scripts/configure.ts
@@ -10,6 +10,13 @@ import { env } from './env';
 const environment = argv.environment;
 const isProd = environment === 'prod';
 
+// Version + commit are interpolated into single-quoted TS string literals below.
+// They only ever come from `git tag` / `git describe` / a commit SHA, but strip
+// anything outside the safe charset defensively so a malformed value can never
+// break out of the quotes and corrupt the generated environment file.
+const safeAppVersion = (env.GAUZY_APP_VERSION || '').replace(/[^\w.\-/]/g, '');
+const safeAppCommit = (env.GAUZY_APP_COMMIT || '').replace(/[^\w.\-/]/g, '');
+
 let envFileContent = `// NOTE: Auto-generated file
 // The file contents for the current environment will overwrite these during build.
 // The build system defaults to the dev environment which uses 'environment.ts', but if you do
@@ -85,8 +92,8 @@ if (!isDocker) {
 	{
 		production:  ${isProd},
 
-		version: '${env.GAUZY_APP_VERSION}',
-		commit: '${env.GAUZY_APP_COMMIT}',
+		version: '${safeAppVersion}',
+		commit: '${safeAppCommit}',
 
 		API_BASE_URL: API_BASE_URL,
 		CLIENT_BASE_URL: CLIENT_BASE_URL,
@@ -250,8 +257,8 @@ if (!isDocker) {
 	{
 		production:  ${isProd},
 
-		version: '${env.GAUZY_APP_VERSION}',
-		commit: '${env.GAUZY_APP_COMMIT}',
+		version: '${safeAppVersion}',
+		commit: '${safeAppCommit}',
 
 		API_BASE_URL: API_BASE_URL,
 		CLIENT_BASE_URL: CLIENT_BASE_URL,

--- a/.scripts/env.ts
+++ b/.scripts/env.ts
@@ -162,6 +162,11 @@ export type Env = Readonly<{
 	GAUZY_DESKTOP_TRAY_ICON: string;
 	DESKTOP_JWT_SECRET: string;
 	DESKTOP_JWT_REFRESH_TOKEN_SECRET: string;
+
+	// Deployed release version (git tag, e.g. 'v111.2.10') and commit SHA,
+	// embedded at Docker build time. Shown in the web UI footer.
+	GAUZY_APP_VERSION: string;
+	GAUZY_APP_COMMIT: string;
 }>;
 
 export const env: Env = cleanEnv(
@@ -420,7 +425,11 @@ export const env: Env = cleanEnv(
 		}),
 		DESKTOP_JWT_REFRESH_TOKEN_SECRET: str({
 			default: 'refreshTokenSecretKey'
-		})
+		}),
+
+		// Deployed release version (git tag) + commit SHA, embedded at build time.
+		GAUZY_APP_VERSION: str({ default: '' }),
+		GAUZY_APP_COMMIT: str({ default: '' })
 	},
 	{ strict: true, dotEnvPath: __dirname + '/../.env' }
 );

--- a/packages/contracts/src/lib/app.model.ts
+++ b/packages/contracts/src/lib/app.model.ts
@@ -1,4 +1,20 @@
 /**
+ * Version information for a running application (API or web UI), embedded at
+ * build/deploy time. Used by the web footer to show the deployed version +
+ * commit and to detect a drift between the web app and the API.
+ */
+export interface IAppVersionInfo {
+    /** Which application this describes: 'api' or 'web'. */
+    name: 'api' | 'web';
+
+    /** Release version, i.e. the git tag the image was built from (e.g. 'v111.2.10'). Empty when unknown. */
+    version: string;
+
+    /** Full git commit SHA the image was built from. Empty when unknown. */
+    commit: string;
+}
+
+/**
  * Interface representing the application configuration.
  */
 export interface IAppConfig extends IAppSetting {

--- a/packages/core/src/lib/app/app.controller.ts
+++ b/packages/core/src/lib/app/app.controller.ts
@@ -2,7 +2,13 @@ import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as moment from 'moment';
 import { Public } from '@gauzy/common';
-import { IAppSetting } from '@gauzy/contracts';
+import { IAppSetting, IAppVersionInfo } from '@gauzy/contracts';
+
+// Application version + deployed commit, embedded at Docker build time via
+// GAUZY_APP_VERSION / GAUZY_APP_COMMIT env vars (see .deploy/*/Dockerfile).
+// Empty when running from source without those set.
+const APP_VERSION = process.env.GAUZY_APP_VERSION || '';
+const APP_COMMIT = process.env.GAUZY_APP_COMMIT || '';
 
 @Controller()
 @Public() // This seems to be a custom decorator indicating that this controller's endpoints are public
@@ -31,6 +37,23 @@ export class AppController {
 		return {
 			status: HttpStatus.OK,
 			message: `${app_name} API`
+		};
+	}
+
+	/**
+	 * Returns the running API's version and deployed commit, so clients (e.g. the
+	 * web UI footer) can display it and detect a version drift between the API and
+	 * the web app. Public — no secrets, safe to expose unauthenticated.
+	 *
+	 * @returns {IAppVersionInfo} `{ name: 'api', version, commit }`.
+	 */
+	@HttpCode(HttpStatus.OK)
+	@Get('/version')
+	getAppVersion(): IAppVersionInfo {
+		return {
+			name: 'api',
+			version: APP_VERSION,
+			commit: APP_COMMIT
 		};
 	}
 

--- a/packages/ui-config/src/lib/environments/model.ts
+++ b/packages/ui-config/src/lib/environments/model.ts
@@ -1,6 +1,11 @@
 export interface Environment {
 	production: boolean;
 
+	/** Deployed release version — the git tag the web build came from (e.g. 'v111.2.10'). Empty when unknown. */
+	version?: string;
+	/** Full git commit SHA the web build came from. Empty when unknown. */
+	commit?: string;
+
 	API_BASE_URL: string;
 	CLIENT_BASE_URL: string;
 	COOKIE_DOMAIN?: string;

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -4111,7 +4111,11 @@
 		"RIGHTS_RESERVED": "All rights reserved.",
 		"PRESENT": "Present",
 		"TERMS_OF_SERVICE": "Terms Of Service",
-		"PRIVACY_POLICY": "Privacy Policy"
+		"PRIVACY_POLICY": "Privacy Policy",
+		"VERSION": "Release version — open on GitHub",
+		"COMMIT": "Deployed commit — open on GitHub",
+		"WEB": "Web",
+		"API": "API"
 	},
 	"TOASTR": {
 		"TITLE": {

--- a/packages/ui-core/theme/src/lib/components/footer/footer.component.html
+++ b/packages/ui-core/theme/src/lib/components/footer/footer.component.html
@@ -5,6 +5,72 @@
   <a href="{{ companyLink }}" target="_blank">{{ companyName }}</a
     >. {{ 'FOOTER.RIGHTS_RESERVED' | translate }}
   </span>
+
+  @if (hasVersionInfo) {
+    <span class="app-version">
+      @if (!isVersionMismatch) {
+        @if (primary.version) {
+          <a
+            [href]="releaseUrl(primary.version)"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="ver"
+            [title]="'FOOTER.VERSION' | translate"
+            >{{ primary.version }}</a
+          >
+        }
+        @if (primary.version && primary.commit) {
+          <span class="bullet">•</span>
+        }
+        @if (primary.commit) {
+          <a
+            [href]="commitUrl(primary.commit)"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="sha"
+            [title]="'FOOTER.COMMIT' | translate"
+            >{{ shortCommit(primary.commit) }}</a
+          >
+        }
+      } @else {
+        <span class="scope">
+          <span class="scope-label">{{ 'FOOTER.WEB' | translate }}</span>
+          @if (web.version) {
+            <a [href]="releaseUrl(web.version)" target="_blank" rel="noopener noreferrer" class="ver">{{
+              web.version
+            }}</a>
+          }
+          @if (web.version && web.commit) {
+            <span class="bullet">•</span>
+          }
+          @if (web.commit) {
+            <a [href]="commitUrl(web.commit)" target="_blank" rel="noopener noreferrer" class="sha">{{
+              shortCommit(web.commit)
+            }}</a>
+          }
+        </span>
+        @if (api) {
+          <span class="scope">
+            <span class="scope-label">{{ 'FOOTER.API' | translate }}</span>
+            @if (api.version) {
+              <a [href]="releaseUrl(api.version)" target="_blank" rel="noopener noreferrer" class="ver">{{
+                api.version
+              }}</a>
+            }
+            @if (api.version && api.commit) {
+              <span class="bullet">•</span>
+            }
+            @if (api.commit) {
+              <a [href]="commitUrl(api.commit)" target="_blank" rel="noopener noreferrer" class="sha">{{
+                shortCommit(api.commit)
+              }}</a>
+            }
+          </span>
+        }
+      }
+    </span>
+  }
+
   <div class="right-side">
     @if (user) {
       <div class="mr-2">

--- a/packages/ui-core/theme/src/lib/components/footer/footer.component.html
+++ b/packages/ui-core/theme/src/lib/components/footer/footer.component.html
@@ -36,34 +36,54 @@
         <span class="scope">
           <span class="scope-label">{{ 'FOOTER.WEB' | translate }}</span>
           @if (web.version) {
-            <a [href]="releaseUrl(web.version)" target="_blank" rel="noopener noreferrer" class="ver">{{
-              web.version
-            }}</a>
+            <a
+              [href]="releaseUrl(web.version)"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ver"
+              [title]="'FOOTER.VERSION' | translate"
+              >{{ web.version }}</a
+            >
           }
           @if (web.version && web.commit) {
             <span class="bullet">•</span>
           }
           @if (web.commit) {
-            <a [href]="commitUrl(web.commit)" target="_blank" rel="noopener noreferrer" class="sha">{{
-              shortCommit(web.commit)
-            }}</a>
+            <a
+              [href]="commitUrl(web.commit)"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="sha"
+              [title]="'FOOTER.COMMIT' | translate"
+              >{{ shortCommit(web.commit) }}</a
+            >
           }
         </span>
         @if (api) {
           <span class="scope">
             <span class="scope-label">{{ 'FOOTER.API' | translate }}</span>
             @if (api.version) {
-              <a [href]="releaseUrl(api.version)" target="_blank" rel="noopener noreferrer" class="ver">{{
-                api.version
-              }}</a>
+              <a
+                [href]="releaseUrl(api.version)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="ver"
+                [title]="'FOOTER.VERSION' | translate"
+                >{{ api.version }}</a
+              >
             }
             @if (api.version && api.commit) {
               <span class="bullet">•</span>
             }
             @if (api.commit) {
-              <a [href]="commitUrl(api.commit)" target="_blank" rel="noopener noreferrer" class="sha">{{
-                shortCommit(api.commit)
-              }}</a>
+              <a
+                [href]="commitUrl(api.commit)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="sha"
+                [title]="'FOOTER.COMMIT' | translate"
+                >{{ shortCommit(api.commit) }}</a
+              >
             }
           </span>
         }

--- a/packages/ui-core/theme/src/lib/components/footer/footer.component.scss
+++ b/packages/ui-core/theme/src/lib/components/footer/footer.component.scss
@@ -33,6 +33,48 @@
       width: 1.25rem;
     }
   }
+  .app-version {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    white-space: nowrap;
+
+    .scope {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+
+      & + .scope {
+        margin-left: 0.5rem;
+      }
+    }
+
+    .scope-label {
+      text-transform: uppercase;
+      font-size: 10px;
+      letter-spacing: 0.04em;
+      opacity: 0.7;
+    }
+
+    a {
+      color: nb-theme(text-hint-color);
+      transition: color ease-out 0.1s;
+
+      &:hover {
+        color: nb-theme(text-basic-color);
+        text-decoration: underline;
+      }
+    }
+
+    .sha {
+      font-family: monospace;
+    }
+
+    .bullet {
+      opacity: 0.5;
+    }
+  }
+
   .right-side {
     display: flex;
     align-items: center;

--- a/packages/ui-core/theme/src/lib/components/footer/footer.component.ts
+++ b/packages/ui-core/theme/src/lib/components/footer/footer.component.ts
@@ -1,16 +1,24 @@
 import { Component, Inject, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
-import { IUser } from '@gauzy/contracts';
-import { filter, tap } from 'rxjs/operators';
+import { IAppVersionInfo, IUser } from '@gauzy/contracts';
+import { of } from 'rxjs';
+import { catchError, filter, tap } from 'rxjs/operators';
 import { Environment, GAUZY_ENV } from '@gauzy/ui-config';
 import { Store } from '@gauzy/ui-core/core';
 
+/** Version + commit of one side (web or api) for the footer build-info line. */
+interface IVersionDisplay {
+	version: string;
+	commit: string;
+}
+
 @Component({
-    selector: 'ngx-footer',
-    styleUrls: ['./footer.component.scss'],
-    templateUrl: './footer.component.html',
-    standalone: false
+	selector: 'ngx-footer',
+	styleUrls: ['./footer.component.scss'],
+	templateUrl: './footer.component.html',
+	standalone: false
 })
 export class FooterComponent extends TranslationBaseComponent implements OnInit {
 	companyName: string;
@@ -24,9 +32,19 @@ export class FooterComponent extends TranslationBaseComponent implements OnInit 
 	companyLinkedinLink: string;
 	user: IUser;
 
+	/** GitHub repo base (no trailing `.git`), e.g. `https://github.com/ever-co/ever-gauzy`. */
+	private readonly repoBaseUrl: string;
+
+	/** This web build's version + commit (baked at build time). */
+	readonly web: IVersionDisplay;
+
+	/** The running API's version + commit (fetched from `/api/version`); null until/if it loads. */
+	api: IVersionDisplay | null = null;
+
 	constructor(
 		public translationService: TranslateService,
 		private readonly store: Store,
+		private readonly http: HttpClient,
 		@Inject(GAUZY_ENV) readonly environment: Environment
 	) {
 		super(translationService);
@@ -40,6 +58,9 @@ export class FooterComponent extends TranslationBaseComponent implements OnInit 
 		this.companyFacebookLink = environment.COMPANY_FACEBOOK_LINK;
 		this.companyTwitterLink = environment.COMPANY_TWITTER_LINK;
 		this.companyLinkedinLink = environment.COMPANY_IN_LINK;
+
+		this.repoBaseUrl = (environment.PROJECT_REPO ?? 'https://github.com/ever-co/ever-gauzy.git').replace(/\.git$/, '');
+		this.web = { version: environment.version ?? '', commit: environment.commit ?? '' };
 	}
 
 	ngOnInit() {
@@ -49,5 +70,58 @@ export class FooterComponent extends TranslationBaseComponent implements OnInit 
 				tap((user: IUser) => (this.user = user))
 			)
 			.subscribe();
+
+		// Fetch the running API's version so the footer can flag a drift between
+		// the deployed web app and API. Public endpoint — works pre-login too.
+		this.http
+			.get<IAppVersionInfo>(`${this.environment.API_BASE_URL}/api/version`)
+			.pipe(
+				catchError(() => of(null)),
+				tap((info) => {
+					this.api = info ? { version: info.version ?? '', commit: info.commit ?? '' } : null;
+				})
+			)
+			.subscribe();
+	}
+
+	/** Whether there is any build info at all to display. */
+	get hasVersionInfo(): boolean {
+		return this.hasInfo(this.web) || this.hasInfo(this.api);
+	}
+
+	/**
+	 * True when the web and API report different builds (both known and not equal).
+	 * When true the footer lists Web and API separately; otherwise it shows one line.
+	 */
+	get isVersionMismatch(): boolean {
+		return (
+			this.hasInfo(this.web) &&
+			this.hasInfo(this.api) &&
+			(this.web.version !== this.api.version || this.web.commit !== this.api.commit)
+		);
+	}
+
+	/** The single build to show when web and API agree (or only one is known). */
+	get primary(): IVersionDisplay {
+		return this.hasInfo(this.web) ? this.web : (this.api ?? this.web);
+	}
+
+	/** GitHub release/tag page for a version (empty when no version). */
+	releaseUrl(version: string): string | null {
+		return version ? `${this.repoBaseUrl}/releases/tag/${version}` : null;
+	}
+
+	/** GitHub commit page for a full commit SHA (empty when no commit). */
+	commitUrl(commit: string): string | null {
+		return commit ? `${this.repoBaseUrl}/commit/${commit}` : null;
+	}
+
+	/** Short 7-char commit for display. */
+	shortCommit(commit: string): string {
+		return commit ? commit.substring(0, 7) : '';
+	}
+
+	private hasInfo(info: IVersionDisplay | null): info is IVersionDisplay {
+		return !!info && (!!info.version || !!info.commit);
 	}
 }


### PR DESCRIPTION
## What

Adds a build-info line to the platform footer — between the copyright and *Terms Of Service* — showing the deployed release version and commit:

> Copyright © 2019-Present, Gauzy by Ever Co. LTD. All rights reserved.  **v111.2.10 • 8cbaf83**  Terms Of Service | Privacy Policy | (icons)

- **version** (`v111.2.10`) links to the GitHub **release/tag** page; **short SHA** (`8cbaf83`) links to the **commit** — both open in a new tab.
- If the **web app and API report different builds**, they're shown separately: `Web v…•hash` and `API v…•hash`, so a drift between the deployed web and API images is immediately visible.
- Hidden entirely when no version/commit is known (source/dev runs).

## How it's wired

| Layer | Change |
|---|---|
| **API** | Public `GET /api/version` → `{ name, version, commit }` from `GAUZY_APP_VERSION` / `GAUZY_APP_COMMIT` (added to `AppController`, already `@Public`). |
| **Web** | Values baked into `@gauzy/ui-config` `environment` at build time (`.scripts/env.ts` + `configure.ts`, dev + docker templates). Footer reads its own and fetches `/api/version` to compare. Repo base from `environment.PROJECT_REPO`. |
| **Contracts** | `IAppVersionInfo`. |
| **Docker** | `GAUZY_APP_VERSION`/`GAUZY_APP_COMMIT` build-args → **webapp** bakes into the Angular bundle (build stage), **api/worker** expose at runtime (production stage). Empty defaults, so builds without the args keep working. |
| **CI** | **Demo** workflow passes the resolved release tag (`steps.relver.outputs.version`, from #9796) + released commit (`workflow_run.head_sha`). **prod/stage** pass `github.sha` for the commit; their release-version wiring stays with the versioning workflow. |

## Verification
- `yarn config:{dev,prod}` with the vars set bakes `version`/`commit` into both generated environment files ✅.
- Local webapp build with the footer in progress (will confirm before merge).
- The version/commit values come from the same source the versioned demo images use (#9796), so the footer matches the image tag.

Note: this only surfaces version info — the images being **versioned** (not `:latest`) is handled by the release-versioning workflow (#9796); this PR consumes those values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the deployed version and commit in the footer with GitHub links. Detect and display when the web app and API are built from different versions; CI now injects version/commit across demo, stage, and prod.

- New Features
  - Footer shows version and short SHA with links; hides when unknown. Shows separate Web/API on drift and adds tooltips for version/commit links in mismatch mode.
  - API: public GET `/api/version` returns `{ name, version, commit }` from `GAUZY_APP_VERSION`/`GAUZY_APP_COMMIT` (contract `IAppVersionInfo`).
  - Web: version/commit baked into `@gauzy/ui-config` `environment`; footer compares with API and builds links from `environment.PROJECT_REPO`.
  - Docker/CI: pass `GAUZY_APP_VERSION` and `GAUZY_APP_COMMIT` as build args for web/api/worker images; local/source runs work without them.

- Bug Fixes
  - CI: prod/stage resolve the release tag and pass `GAUZY_APP_VERSION`; removed the `git describe` fallback to avoid stale tags on untagged commits.
  - Build config: sanitize version/commit before generating env files to prevent malformed interpolation.

<sup>Written for commit d5ce1b819e8f6be32c5040dfdf0094c7e6488a4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

