### PR TITLE
ci(verdaccio): route in-cluster demo builds through the internal k8s Verdaccio

### DIFF
--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -106,9 +106,15 @@ COPY --chown=node:node patches ./patches
 # VERDACCIO_TOKEN arrives as a BuildKit secret (optional; absent file → private registry
 # skipped). Registry rewrite, install and .npmrc/.yarnrc cleanup happen in ONE RUN so the
 # token never persists in any layer.
+ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    if [ -n "$VERDACCIO_TOKEN" ]; then \
+    if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+    echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+    sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+    sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+    elif [ -n "$VERDACCIO_TOKEN" ]; then \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -198,9 +204,15 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 COPY --chown=node:node patches ./patches
 
 # VERDACCIO_TOKEN as a BuildKit secret — same single-RUN hygiene as the dependencies stage.
+ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    if [ -n "$VERDACCIO_TOKEN" ]; then \
+    if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+    echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+    sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+    sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+    elif [ -n "$VERDACCIO_TOKEN" ]; then \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -123,9 +123,15 @@ COPY --chown=node:node patches ./patches
 # skipped). Registry rewrite, install and .npmrc/.yarnrc cleanup happen in ONE RUN so the
 # token never persists in any layer.
 # Must be without --production because we need dev deps installed.
+ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
 	VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-	if [ -n "$VERDACCIO_TOKEN" ]; then \
+	if [ -n "$VERDACCIO_REGISTRY" ]; then \
+	echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+	echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+	sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+	sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+	elif [ -n "$VERDACCIO_TOKEN" ]; then \
 	echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
 	echo "registry=https://packages.ever.co/" >> .npmrc && \
 	echo "always-auth=true" >> .npmrc && \

--- a/.deploy/worker/Dockerfile
+++ b/.deploy/worker/Dockerfile
@@ -106,9 +106,15 @@ COPY --chown=node:node patches ./patches
 # VERDACCIO_TOKEN arrives as a BuildKit secret (optional; absent file → private registry
 # skipped). Registry rewrite, install and .npmrc/.yarnrc cleanup happen in ONE RUN so the
 # token never persists in any layer.
+ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    if [ -n "$VERDACCIO_TOKEN" ]; then \
+    if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+    echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+    sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+    sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+    elif [ -n "$VERDACCIO_TOKEN" ]; then \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -198,9 +204,15 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 COPY --chown=node:node patches ./patches
 
 # VERDACCIO_TOKEN as a BuildKit secret — same single-RUN hygiene as the dependencies stage.
+ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    if [ -n "$VERDACCIO_TOKEN" ]; then \
+    if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+    echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+    sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+    sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+    elif [ -n "$VERDACCIO_TOKEN" ]; then \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -66,6 +66,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
+            VERDACCIO_REGISTRY=http://192.168.1.183:4873/
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
@@ -182,6 +183,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
+            VERDACCIO_REGISTRY=http://192.168.1.183:4873/
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
@@ -298,6 +300,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
+            VERDACCIO_REGISTRY=http://192.168.1.183:4873/
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}


### PR DESCRIPTION
## What
Point the **in-cluster** demo Docker builds at our **self-hosted Verdaccio** on the ever-db SSD nodes (internal MetalLB VIP `http://192.168.1.183:4873/`) instead of the Cloudflare→Railway `packages.ever.co`. Gives `yarn install` a LAN + SSD npm cache (verified: a buildkit RUN step reaches it in ~0.2s).

## How — backward compatible
`.deploy/{api,webapp,worker}/Dockerfile` now take a `VERDACCIO_REGISTRY` build-arg:
- **Set** (ARC/in-cluster builds) → registry = internal Verdaccio, **anonymous** (internal instance allows `$all` reads, no token).
- **Empty** (any other build) → existing `packages.ever.co` + `VERDACCIO_TOKEN` path, **unchanged**. Local builds with no token still use public npm.

Only `docker-build-publish-demo.yml` opts in (already runs on `RUNNER_LINUX_X64_8`, our in-cluster ARC runner). Stage/prod + mcp images untouched; migrated once their CI is confirmed on ARC.

## Why
Faster installs (internal SSD cache vs external round-trip); removes Railway from the hot build path (full decommission tracked separately). The VIP is reachable only from in-cluster runners — the ARC egress network policy now allows port 4873 to the `verdaccio` namespace/VIP only.

Generated with Claude Code


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route in-cluster demo Docker builds through the internal k8s `verdaccio` to speed up installs and remove Railway from the hot path. Adds a `VERDACCIO_REGISTRY` build arg that only the demo workflow uses; all other builds keep the existing `packages.ever.co` + token flow.

- **New Features**
  - Added `ARG VERDACCIO_REGISTRY` to `.deploy/{api,webapp,worker}/Dockerfile`; when set, writes the registry to `.npmrc`/`.yarnrc` and rewrites `yarn.lock`. Otherwise falls back to `packages.ever.co` using `VERDACCIO_TOKEN`.
  - Single RUN with BuildKit secret for token hygiene; no credentials persist in layers.
  - Demo workflow now passes `VERDACCIO_REGISTRY=http://192.168.1.183:4873/` for API/Webapp/Worker builds on the in-cluster ARC runner; stage/prod remain unchanged.

<sup>Written for commit e60efa6f73cf6e92aeb4c513edbeb4717c0cbc58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

