### PR TITLE
ci(fork-safety): Verdaccio URL from org var + drop dead CW registry tag

### DIFF
--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -55,7 +55,6 @@ jobs:
             ghcr.io/ever-co/gauzy-api-demo:${{ steps.relver.outputs.version }}
             everco/gauzy-api-demo:latest
             registry.digitalocean.com/ever/gauzy-api-demo:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-api-demo:latest
           # mode=max caches ALL stages (incl. the multi-minute yarn-install layers) to a dedicated
           # :buildcache tag; every ephemeral runner restores it → no more fully-cold rebuilds.
           # Needs the default docker-container buildx driver — the classic `docker` driver only
@@ -66,7 +65,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-api-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
-            VERDACCIO_REGISTRY=http://192.168.1.183:4873/
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
@@ -172,7 +171,6 @@ jobs:
             ghcr.io/ever-co/gauzy-webapp-demo:${{ steps.relver.outputs.version }}
             everco/gauzy-webapp-demo:latest
             registry.digitalocean.com/ever/gauzy-webapp-demo:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-webapp-demo:latest
           # mode=max caches ALL stages (incl. the multi-minute yarn-install layers) to a dedicated
           # :buildcache tag; every ephemeral runner restores it → no more fully-cold rebuilds.
           # Needs the default docker-container buildx driver — the classic `docker` driver only
@@ -183,7 +181,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-webapp-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
-            VERDACCIO_REGISTRY=http://192.168.1.183:4873/
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
@@ -289,7 +287,6 @@ jobs:
             ghcr.io/ever-co/gauzy-worker-demo:${{ steps.relver.outputs.version }}
             everco/gauzy-worker-demo:latest
             registry.digitalocean.com/ever/gauzy-worker-demo:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-worker-demo:latest
           # mode=max caches ALL stages (incl. the multi-minute yarn-install layers) to a dedicated
           # :buildcache tag; every ephemeral runner restores it → no more fully-cold rebuilds.
           # Needs the default docker-container buildx driver — the classic `docker` driver only
@@ -300,7 +297,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/ever-co/gauzy-worker-demo:buildcache,mode=min
           build-args: |
             NODE_ENV=development
-            VERDACCIO_REGISTRY=http://192.168.1.183:4873/
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=true
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}

--- a/.github/workflows/docker-build-publish-mcp-auth-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-demo.yml
@@ -41,7 +41,6 @@ jobs:
             ghcr.io/ever-co/gauzy-mcp-auth-demo:latest
             everco/gauzy-mcp-auth-demo:latest
             registry.digitalocean.com/ever/gauzy-mcp-auth-demo:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-mcp-auth-demo:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-mcp-auth-demo:latest
           cache-to: type=inline
           build-args: |

--- a/.github/workflows/docker-build-publish-mcp-auth-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-prod.yml
@@ -40,7 +40,6 @@ jobs:
             ghcr.io/ever-co/gauzy-mcp-auth:latest
             everco/gauzy-mcp-auth:latest
             registry.digitalocean.com/ever/gauzy-mcp-auth:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-mcp-auth:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-mcp-auth:latest
           cache-to: type=inline
           build-args: |

--- a/.github/workflows/docker-build-publish-mcp-auth-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-stage.yml
@@ -40,7 +40,6 @@ jobs:
             ghcr.io/ever-co/gauzy-mcp-auth-stage:latest
             everco/gauzy-mcp-auth-stage:latest
             registry.digitalocean.com/ever/gauzy-mcp-auth-stage:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-mcp-auth-stage:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-mcp-auth-stage:latest
           cache-to: type=inline
           build-args: |

--- a/.github/workflows/docker-build-publish-mcp-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-demo.yml
@@ -41,7 +41,6 @@ jobs:
             ghcr.io/ever-co/gauzy-mcp-demo:latest
             everco/gauzy-mcp-demo:latest
             registry.digitalocean.com/ever/gauzy-mcp-demo:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-mcp-demo:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-mcp-demo:latest
           cache-to: type=inline
           build-args: |

--- a/.github/workflows/docker-build-publish-mcp-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-prod.yml
@@ -40,7 +40,6 @@ jobs:
             ghcr.io/ever-co/gauzy-mcp:latest
             everco/gauzy-mcp:latest
             registry.digitalocean.com/ever/gauzy-mcp:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-mcp:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-mcp:latest
           cache-to: type=inline
           build-args: |

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -40,7 +40,6 @@ jobs:
             ghcr.io/ever-co/gauzy-mcp-stage:latest
             everco/gauzy-mcp-stage:latest
             registry.digitalocean.com/ever/gauzy-mcp-stage:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-mcp-stage:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-mcp-stage:latest
           cache-to: type=inline
           build-args: |

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -48,7 +48,6 @@ jobs:
             ghcr.io/ever-co/gauzy-api:latest
             everco/gauzy-api:latest
             registry.digitalocean.com/ever/gauzy-api:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-api:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-api:latest
           cache-to: type=inline
           build-args: |
@@ -150,7 +149,6 @@ jobs:
             ghcr.io/ever-co/gauzy-webapp:latest
             everco/gauzy-webapp:latest
             registry.digitalocean.com/ever/gauzy-webapp:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-webapp:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-webapp:latest
           cache-to: type=inline
           build-args: |
@@ -254,7 +252,6 @@ jobs:
             ghcr.io/ever-co/gauzy-worker:latest
             everco/gauzy-worker:latest
             registry.digitalocean.com/ever/gauzy-worker:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-worker:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-worker:latest
           cache-to: type=inline
           build-args: |

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -48,7 +48,6 @@ jobs:
             ghcr.io/ever-co/gauzy-api-stage:latest
             everco/gauzy-api-stage:latest
             registry.digitalocean.com/ever/gauzy-api-stage:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-api-stage:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-api-stage:latest
           cache-to: type=inline
           build-args: |
@@ -150,7 +149,6 @@ jobs:
             ghcr.io/ever-co/gauzy-webapp-stage:latest
             everco/gauzy-webapp-stage:latest
             registry.digitalocean.com/ever/gauzy-webapp-stage:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-webapp-stage:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-webapp-stage:latest
           cache-to: type=inline
           build-args: |
@@ -254,7 +252,6 @@ jobs:
             ghcr.io/ever-co/gauzy-worker-stage:latest
             everco/gauzy-worker-stage:latest
             registry.digitalocean.com/ever/gauzy-worker-stage:latest
-            ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-worker-stage:latest
           cache-from: type=registry,ref=ghcr.io/ever-co/gauzy-worker-stage:latest
           cache-to: type=inline
           build-args: |


### PR DESCRIPTION
Makes the demo/prod/stage Docker build workflows safe for anyone who **forks or clones** the repo, per owner directive. Two fork-breakers fixed (both adversarially verified by an audit of all 25 build files):

## 1. Verdaccio URL was a hardcoded internal IP (demo workflow) — HIGH
`docker-build-publish-demo.yml` hardcoded `VERDACCIO_REGISTRY=http://192.168.1.183:4873/` in all three build-args. On a fork that literal is non-empty, so the Dockerfile points `yarn install` at our private RFC1918 VIP (unreachable for them → build fails) — and it leaked our internal network topology into a public repo.

**Fix:** source it from an org variable → `VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}`.
- **Our org:** `vars.VERDACCIO_REGISTRY` is set → internal Verdaccio (anonymous cache on the ever-db SSD nodes).
- **A fork:** the var is absent → empty → the Dockerfile falls through to the **public** npm/yarn registry and builds cleanly.
- **Anyone else:** set their own `VERDACCIO_REGISTRY` var → their own registry.
The internal IP no longer appears anywhere in the repo. (The Dockerfiles were already fork-safe: `ARG VERDACCIO_REGISTRY=""` default + a token-gated legacy branch, both empty for a fork.)

## 2. Dead `CW_DOCKER_REGISTRY` tag broke buildx on forks — all 9 publish workflows
Every `docker-build-publish-*` workflow tagged images with `${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/…:latest`. On a fork the secret is empty → the tag renders `/ever-co/…:latest` (leading slash, empty host), which **buildx rejects up front** as `invalid reference format`, aborting the Build step. The matching CW *push* steps are already commented out, so this tag is dead.

**Fix:** removed the dead CW tag line from all 9 workflows. Zero effect on our builds (never pushed there); unblocks forks.

No change to what our CI publishes. Trivially revertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Docker build workflows fork-safe by sourcing the Verdaccio URL from an org variable and removing a dead registry tag that broke builds. Prevents internal IP leakage and lets forks build cleanly.

- **Bug Fixes**
  - Demo workflow: replace hardcoded Verdaccio URL with `${{ vars.VERDACCIO_REGISTRY }}`; if unset (forks), builds use the public npm/yarn registry and no internal IP appears in the repo.
  - All publish workflows: remove dead `CW_DOCKER_REGISTRY` image tags that caused buildx “invalid reference format” errors on forks; no change to published images.

<sup>Written for commit 404eadfc108b14237930c946fd42f3a4cdb592e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

