### PR TITLE
ci(verdaccio): route gauzy stage + mcp builds through the internal VIP (not prod)

### DIFF
--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -69,7 +69,13 @@ COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
-RUN if [ -n "$VERDACCIO_TOKEN" ]; then \
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+    echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+    sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+    sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+    elif [ -n "$VERDACCIO_TOKEN" ]; then \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -151,7 +157,13 @@ COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
-RUN if [ -n "$VERDACCIO_TOKEN" ]; then \
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+    echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+    sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+    sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+    elif [ -n "$VERDACCIO_TOKEN" ]; then \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -114,7 +114,13 @@ COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
-RUN if [ -n "$VERDACCIO_TOKEN" ]; then \
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+    echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+    sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+    sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+    elif [ -n "$VERDACCIO_TOKEN" ]; then \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -190,7 +196,13 @@ COPY --chown=node:node lerna.json package.json yarn.lock ./
 COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
-RUN if [ -n "$VERDACCIO_TOKEN" ]; then \
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+    echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
+    sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
+    sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
+    elif [ -n "$VERDACCIO_TOKEN" ]; then \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.github/workflows/docker-build-publish-mcp-auth-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-demo.yml
@@ -45,6 +45,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NX_CLOUD_ACCESS_TOKEN=${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
             NX_BRANCH=${{ github.ref_name }}
             VERDACCIO_TOKEN=${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/docker-build-publish-mcp-auth-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-stage.yml
@@ -44,6 +44,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NX_CLOUD_ACCESS_TOKEN=${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
             NX_BRANCH=${{ github.ref_name }}
             VERDACCIO_TOKEN=${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/docker-build-publish-mcp-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-demo.yml
@@ -45,6 +45,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NX_CLOUD_ACCESS_TOKEN=${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
             NX_BRANCH=${{ github.ref_name }}
             VERDACCIO_TOKEN=${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -44,6 +44,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NX_CLOUD_ACCESS_TOKEN=${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
             NX_BRANCH=${{ github.ref_name }}
             VERDACCIO_TOKEN=${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -52,6 +52,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
@@ -153,6 +154,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
@@ -256,6 +258,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}


### PR DESCRIPTION
Route gauzy **stage + mcp** in-cluster builds through the fast internal Verdaccio VIP (org var `VERDACCIO_REGISTRY`), matching what demo already does. **Prod is intentionally left on the external `packages.ever.co` path** per owner request.

- `.deploy/mcp/Dockerfile`, `.deploy/mcp-auth/Dockerfile`: add backward-compatible `VERDACCIO_REGISTRY` support (when set → internal registry anonymous; when empty → legacy `packages.ever.co` + token path, unchanged; forks with neither → public npm).
- `docker-build-publish-stage.yml` + `docker-build-publish-mcp-{demo,stage}.yml` + `docker-build-publish-mcp-auth-{demo,stage}.yml`: pass `VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}` (empty for forks → public npm; set in our org → internal VIP).

Untouched: `docker-build-publish-prod.yml`, `docker-build-publish-mcp-prod.yml`, `docker-build-publish-mcp-auth-prod.yml` (prod stays external). Fork-safe (org var empty off our infra). api/webapp/worker Dockerfiles already supported this from #9799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Gauzy stage and MCP builds through the internal Verdaccio VIP via `VERDACCIO_REGISTRY` to speed installs and match demo. Prod stays on external `packages.ever.co` by request.

- **Refactors**
  - Add `VERDACCIO_REGISTRY` support in MCP and MCP Auth Dockerfiles; update npm/yarn registries and lockfile URLs when set, else fallback to `packages.ever.co` with `VERDACCIO_TOKEN`, else public npm for forks.
  - Pass `VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}` in stage and demo MCP workflows and the stage app workflow; forks default to public npm when the org var is empty.

<sup>Written for commit 09332bf91f88cf1ee6425cffd7a41959c703d924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

