### PR TITLE
ci: route runners to self-hosted ARC pools

### DIFF
--- a/.github/workflows/test_currents.yml
+++ b/.github/workflows/test_currents.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "Generated Unique Build ID ${{ steps.uuid.outputs.value }}"
 
   e2e-tests:
-    runs-on: [self-hosted]
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 360
     needs: ['prepare']
 

--- a/.github/workflows/test_cypress.yml
+++ b/.github/workflows/test_cypress.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   e2e-tests:
-    runs-on: [self-hosted]
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 360
 
     # we can try to run tests in the Docker containers later

--- a/.github/workflows/test_playwright.yml
+++ b/.github/workflows/test_playwright.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   e2e-playwright:
-    runs-on: [self-hosted]
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 360
 
     steps:


### PR DESCRIPTION
Migrates the three e2e workflows off the bare `runs-on: [self-hosted]` label (which wrongly matches our Windows desktop runners) onto the self-hosted Linux ARC pool var, keeping `ubuntu-latest` as a fork-safe fallback. Unblocks stuck/off-policy CI.

- **test_playwright.yml** — `e2e-playwright` job: `[self-hosted]` -> `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}` (heavy e2e/Playwright suite -> _8 tier).
- **test_cypress.yml** — `e2e-tests` job: `[self-hosted]` -> `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}` (heavy Cypress e2e -> _8 tier).
- **test_currents.yml** — `e2e-tests` job: `[self-hosted]` -> `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}` (heavy Cypress/Currents e2e -> _8 tier).

Every other job (already on `vars.RUNNER_LINUX_X64_4`, etc.) is left untouched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route e2e GitHub Actions jobs from the generic `self-hosted` label to the Linux ARC pool via `vars.RUNNER_LINUX_X64_8`, with a safe `ubuntu-latest` fallback. This avoids Windows runner matches and unblocks heavy e2e CI.

- **Bug Fixes**
  - Updated `test_playwright.yml`, `test_cypress.yml`, and `test_currents.yml` to use `runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}`.
  - Keeps other jobs (already on `vars.RUNNER_LINUX_X64_4`, etc.) unchanged.

<sup>Written for commit 87ffff16a225775dc6fa96b733b7d8c1f0b2f714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

