### PR TITLE
ci: security scans to ubuntu-latest — ubicloud x64 label is dead, jobs queue forever

### DIFF
--- a/.github/workflows/snyk-analysis.yml
+++ b/.github/workflows/snyk-analysis.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     timeout-minutes: 300
 
     steps:


### PR DESCRIPTION
The `ubicloud-standard-4` runner label no longer exists, so security-scan jobs queue forever (runs observed stuck 13-17h). Security scans (CodeQL/Snyk) are sanctioned on GitHub-hosted `ubuntu-latest` per policy.

Only change: `runs-on: ubicloud-standard-4` -> `runs-on: ubuntu-latest`. Nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Snyk security scan jobs queuing indefinitely by switching the workflow runner from `ubicloud-standard-4` (no longer available) to `ubuntu-latest`. Aligns scans with our policy to use GitHub-hosted runners.

<sup>Written for commit 9d0481a374a244c68c9f9d2cefabb097929f8072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

