### PR TITLE
ci: run Snyk analysis on self-hosted ARC runner (develop)

### DIFF
--- a/.github/workflows/snyk-analysis.yml
+++ b/.github/workflows/snyk-analysis.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     timeout-minutes: 300
 
     steps:


### PR DESCRIPTION
Migrates the last GitHub-hosted `ubuntu-latest` runner label on **develop** to our self-hosted ARC org var.

- `snyk-analysis.yml` `analyze` job: `ubuntu-latest` → `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` (Snyk + upload-sarif → smallest ARC pool per policy).

All other `develop` workflows already use `vars.RUNNER_LINUX_X64_*`; arm / windows / macos / `[self-hosted, Windows, X64]` legs left untouched. YAML validated with js-yaml (all 64 workflow files parse).

Scope: **develop only** (will cascade develop → stage). master is deliberately not touched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Snyk analysis workflow on develop to our self-hosted ARC Linux x64 runner with a fallback to GitHub-hosted if the org var is unset. Aligns the last remaining `ubuntu-latest` job with the rest of CI to reduce hosted runner usage.

- **Refactors**
  - `.github/workflows/snyk-analysis.yml`: `runs-on: ubuntu-latest` → `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` for the Analyze job.

<sup>Written for commit 18fcb2f1b49ec539d8fa086cb4dc1fcee77f2fdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

