### PR TITLE
fix(plane): shared-mode login — env API-key fallback in getDefaultProxyConfig

### DIFF
--- a/packages/plugins/integration-plane/src/lib/plane-proxy.service.ts
+++ b/packages/plugins/integration-plane/src/lib/plane-proxy.service.ts
@@ -184,10 +184,17 @@ export class PlaneProxyService implements OnModuleInit, OnModuleDestroy {
 	 */
 	private getDefaultProxyConfig() {
 		const baseUrl = environment.baseUrl || 'http://localhost:3000';
+		// Shared mode: pre-auth bootstrap requests (auth/email-check, login) carry no
+		// tenant, so this default config is what authenticates the proxy's internal
+		// email-check call. Empty strings here would SHADOW the proxy's own
+		// GAUZY_API_KEY/GAUZY_API_SECRET env fallback ('' is not nullish), so resolve
+		// the env pair explicitly — otherwise every shared-mode login degrades to the
+		// magic-code flow. The pair is tenant-scoped and only ever grants the
+		// email-existence check (ApiKeyAuthGuard sets tenantId only; single guarded route).
 		return {
 			externalBaseApiUrl: `${baseUrl}/api`,
-			apiKey: '',
-			apiSecret: '',
+			apiKey: process.env['GAUZY_API_KEY'] || '',
+			apiSecret: process.env['GAUZY_API_SECRET'] || '',
 			clientBaseUrl: process.env['PLANE_CLIENT_BASE_URL'] || 'http://localhost:3001',
 			clientAdminUrl: process.env['PLANE_CLIENT_ADMIN_URL'] || 'http://localhost:3002',
 			clientSpaceUrl: process.env['PLANE_CLIENT_SPACE_URL'] || 'http://localhost:3003'


### PR DESCRIPTION
## What
Shared-mode (tenant-less) Plane bootstrap requests resolve `getDefaultProxyConfig()`, which returned an **empty** `apiKey`/`apiSecret`. The empty strings **shadow** the proxy package's own `GAUZY_API_KEY`/`GAUZY_API_SECRET` env fallback (`'' ?? env` keeps `''`), so the proxy's internal `POST /auth/email-check` call always 401s ("Missing API credentials") and **every shared-mode login degrades to the magic-code flow** — the long-standing pm.gauzy.co login bug. This resolves the env pair explicitly.

## Why it's safe (security review, 2026-07-19)
- `ApiKeyAuthGuard` validates the pair against `tenant_api_key` (SHA-256 secret, constant-time compare) and sets **only** `request.user.tenantId` — no user identity, no roles.
- The pair is accepted on **exactly one route** repo-wide: `POST /api/auth/email-check`, which returns a boolean and is **tenant-scoped** (TenantAwareCrudService forces `tenantId` of the key into the WHERE). No cross-tenant data is reachable with the key.
- On the proxy side, the pair is attached at exactly one call site (`checkExistingUser`). All Plane data routes require the user's session JWT; Gauzy re-derives the tenant from the verified JWT.
- Net change: the tenant-less default config gains the SAME capability the tenant-path config already has today. No new anonymous surface.

## Notes / follow-ups (pre-existing, not introduced here)
- `/auth/email-check` has no route-level `@Throttle` → inherits the 60000/60s global default; consider a tight limit (tenant-scoped email-existence oracle).
- Gauzy API keys are per-tenant; a single env pair only answers email-checks for that tenant. True multi-tenant shared hosting would need a global app-level key concept.
- Deployment: prod rollout deliberately **held** — needs `GAUZY_API_KEY`/`GAUZY_API_SECRET` set on gauzy-prod-api (values = the Plane integration's stored pair) whenever this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shared-mode login by adding env fallback for API key/secret in `getDefaultProxyConfig()`. This lets the proxy authenticate email checks and restores password login when env vars are set.

- **Bug Fixes**
  - Resolve `GAUZY_API_KEY`/`GAUZY_API_SECRET` in `getDefaultProxyConfig()` so `POST /api/auth/email-check` no longer 401s in shared mode.

- **Migration**
  - Set `GAUZY_API_KEY` and `GAUZY_API_SECRET` in the API environment to enable shared-mode password login.

<sup>Written for commit d83a8a720c03bfbc0bfa8b91e4d949b484a586e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

