### PR TITLE
perf(activity): make Time & Activity reports index-driven via recordedAt + always persist recordedAt

### DIFF
--- a/packages/core/src/lib/database/migrations/1784469645043-AddActivityRecordedAtCompositeIndexes.ts
+++ b/packages/core/src/lib/database/migrations/1784469645043-AddActivityRecordedAtCompositeIndexes.ts
@@ -1,0 +1,138 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { DatabaseTypeEnum } from '@gauzy/config';
+import * as chalk from 'chalk';
+
+export class AddActivityRecordedAtCompositeIndexes1784469645043 implements MigrationInterface {
+	name = 'AddActivityRecordedAtCompositeIndexes1784469645043';
+
+	/**
+	 * Up Migration
+	 *
+	 * Adds composite indexes on `activity` to support the Time & Activity reports, which filter
+	 * by `(organizationId, employeeId, recordedAt)` (per-employee) and `(organizationId, recordedAt)`
+	 * (org-wide) over a date range. Previously those reports filtered on a non-sargable
+	 * `concat(date, time)::timestamp` expression and could not use any index, forcing a full scan
+	 * of the (multi-million row) activity table.
+	 *
+	 * NOTE: On existing large deployments these indexes should be created out-of-band with
+	 * `CREATE INDEX CONCURRENTLY` first (the Postgres branch below uses `IF NOT EXISTS`, so it is a
+	 * no-op when they already exist). Existing rows with a NULL `recordedAt` should likewise be
+	 * backfilled out-of-band (`UPDATE activity SET "recordedAt" = concat(date,' ',time)::timestamp
+	 * WHERE "recordedAt" IS NULL AND date IS NOT NULL AND time IS NOT NULL`) so the new
+	 * `recordedAt`-based filter does not omit them.
+	 *
+	 * @param queryRunner
+	 */
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		console.log(chalk.yellow(this.name + ' start running!'));
+
+		switch (queryRunner.connection.options.type as DatabaseTypeEnum) {
+			case DatabaseTypeEnum.sqlite:
+			case DatabaseTypeEnum.betterSqlite3:
+				await this.sqliteUpQueryRunner(queryRunner);
+				break;
+			case DatabaseTypeEnum.postgres:
+				await this.postgresUpQueryRunner(queryRunner);
+				break;
+			case DatabaseTypeEnum.mysql:
+				await this.mysqlUpQueryRunner(queryRunner);
+				break;
+			default:
+				throw Error(`Unsupported database: ${queryRunner.connection.options.type}`);
+		}
+	}
+
+	/**
+	 * Down Migration
+	 *
+	 * @param queryRunner
+	 */
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		switch (queryRunner.connection.options.type as DatabaseTypeEnum) {
+			case DatabaseTypeEnum.sqlite:
+			case DatabaseTypeEnum.betterSqlite3:
+				await this.sqliteDownQueryRunner(queryRunner);
+				break;
+			case DatabaseTypeEnum.postgres:
+				await this.postgresDownQueryRunner(queryRunner);
+				break;
+			case DatabaseTypeEnum.mysql:
+				await this.mysqlDownQueryRunner(queryRunner);
+				break;
+			default:
+				throw Error(`Unsupported database: ${queryRunner.connection.options.type}`);
+		}
+	}
+
+	/**
+	 * PostgreSQL Up Migration
+	 *
+	 * @param queryRunner
+	 */
+	public async postgresUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query(
+			`CREATE INDEX IF NOT EXISTS "idx_activity_org_emp_recordedat" ON "activity" ("organizationId", "employeeId", "recordedAt")`
+		);
+		await queryRunner.query(
+			`CREATE INDEX IF NOT EXISTS "idx_activity_org_recordedat" ON "activity" ("organizationId", "recordedAt")`
+		);
+	}
+
+	/**
+	 * PostgreSQL Down Migration
+	 *
+	 * @param queryRunner
+	 */
+	public async postgresDownQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_recordedat"`);
+		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_emp_recordedat"`);
+	}
+
+	/**
+	 * SQLite Up Migration
+	 *
+	 * @param queryRunner
+	 */
+	public async sqliteUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query(
+			`CREATE INDEX IF NOT EXISTS "idx_activity_org_emp_recordedat" ON "activity" ("organizationId", "employeeId", "recordedAt")`
+		);
+		await queryRunner.query(
+			`CREATE INDEX IF NOT EXISTS "idx_activity_org_recordedat" ON "activity" ("organizationId", "recordedAt")`
+		);
+	}
+
+	/**
+	 * SQLite Down Migration
+	 *
+	 * @param queryRunner
+	 */
+	public async sqliteDownQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_recordedat"`);
+		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_emp_recordedat"`);
+	}
+
+	/**
+	 * MySQL Up Migration
+	 *
+	 * @param queryRunner
+	 */
+	public async mysqlUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query(
+			`CREATE INDEX \`idx_activity_org_emp_recordedat\` ON \`activity\` (\`organizationId\`, \`employeeId\`, \`recordedAt\`)`
+		);
+		await queryRunner.query(
+			`CREATE INDEX \`idx_activity_org_recordedat\` ON \`activity\` (\`organizationId\`, \`recordedAt\`)`
+		);
+	}
+
+	/**
+	 * MySQL Down Migration
+	 *
+	 * @param queryRunner
+	 */
+	public async mysqlDownQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query(`DROP INDEX \`idx_activity_org_recordedat\` ON \`activity\``);
+		await queryRunner.query(`DROP INDEX \`idx_activity_org_emp_recordedat\` ON \`activity\``);
+	}
+}

--- a/packages/core/src/lib/database/migrations/1784469645043-AddActivityRecordedAtCompositeIndexes.ts
+++ b/packages/core/src/lib/database/migrations/1784469645043-AddActivityRecordedAtCompositeIndexes.ts
@@ -8,18 +8,17 @@ export class AddActivityRecordedAtCompositeIndexes1784469645043 implements Migra
 	/**
 	 * Up Migration
 	 *
-	 * Adds composite indexes on `activity` to support the Time & Activity reports, which filter
-	 * by `(organizationId, employeeId, recordedAt)` (per-employee) and `(organizationId, recordedAt)`
-	 * (org-wide) over a date range. Previously those reports filtered on a non-sargable
-	 * `concat(date, time)::timestamp` expression and could not use any index, forcing a full scan
-	 * of the (multi-million row) activity table.
+	 * (1) Backfills `activity.recordedAt` from `date` + `time` for legacy rows where it is NULL,
+	 *     so the report/statistic queries — which now filter on `recordedAt` — do not silently
+	 *     omit those rows.
+	 * (2) Adds composite indexes on `activity` to support the Time & Activity reports and the
+	 *     dashboard activity statistics, which filter by `(organizationId, employeeId, recordedAt)`
+	 *     (per-employee) and `(organizationId, recordedAt)` (org-wide) over a date range.
 	 *
-	 * NOTE: On existing large deployments these indexes should be created out-of-band with
-	 * `CREATE INDEX CONCURRENTLY` first (the Postgres branch below uses `IF NOT EXISTS`, so it is a
-	 * no-op when they already exist). Existing rows with a NULL `recordedAt` should likewise be
-	 * backfilled out-of-band (`UPDATE activity SET "recordedAt" = concat(date,' ',time)::timestamp
-	 * WHERE "recordedAt" IS NULL AND date IS NOT NULL AND time IS NOT NULL`) so the new
-	 * `recordedAt`-based filter does not omit them.
+	 * NOTE: On existing large deployments, create the indexes out-of-band first with
+	 * `CREATE INDEX CONCURRENTLY` (the Postgres/SQLite branches use `IF NOT EXISTS`, so this
+	 * migration is then a no-op for them) and run the backfill out-of-band too, so this migration's
+	 * in-transaction backfill + index build stays fast and does not hold a write lock.
 	 *
 	 * @param queryRunner
 	 */
@@ -38,7 +37,7 @@ export class AddActivityRecordedAtCompositeIndexes1784469645043 implements Migra
 				await this.mysqlUpQueryRunner(queryRunner);
 				break;
 			default:
-				throw Error(`Unsupported database: ${queryRunner.connection.options.type}`);
+				throw new Error(`Unsupported database: ${queryRunner.connection.options.type}`);
 		}
 	}
 
@@ -60,8 +59,26 @@ export class AddActivityRecordedAtCompositeIndexes1784469645043 implements Migra
 				await this.mysqlDownQueryRunner(queryRunner);
 				break;
 			default:
-				throw Error(`Unsupported database: ${queryRunner.connection.options.type}`);
+				throw new Error(`Unsupported database: ${queryRunner.connection.options.type}`);
 		}
+	}
+
+	/**
+	 * Postgres and SQLite share identical index DDL (both accept double-quoted identifiers and
+	 * `IF NOT EXISTS`), so the creation/removal is factored out to avoid duplicated SQL.
+	 */
+	private async createStandardIndexes(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE INDEX IF NOT EXISTS "idx_activity_org_emp_recordedat" ON "activity" ("organizationId", "employeeId", "recordedAt")`
+		);
+		await queryRunner.query(
+			`CREATE INDEX IF NOT EXISTS "idx_activity_org_recordedat" ON "activity" ("organizationId", "recordedAt")`
+		);
+	}
+
+	private async dropStandardIndexes(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_recordedat"`);
+		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_emp_recordedat"`);
 	}
 
 	/**
@@ -71,11 +88,9 @@ export class AddActivityRecordedAtCompositeIndexes1784469645043 implements Migra
 	 */
 	public async postgresUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
 		await queryRunner.query(
-			`CREATE INDEX IF NOT EXISTS "idx_activity_org_emp_recordedat" ON "activity" ("organizationId", "employeeId", "recordedAt")`
+			`UPDATE "activity" SET "recordedAt" = CONCAT("date", ' ', "time")::timestamp WHERE "recordedAt" IS NULL AND "date" IS NOT NULL AND "time" IS NOT NULL`
 		);
-		await queryRunner.query(
-			`CREATE INDEX IF NOT EXISTS "idx_activity_org_recordedat" ON "activity" ("organizationId", "recordedAt")`
-		);
+		await this.createStandardIndexes(queryRunner);
 	}
 
 	/**
@@ -84,8 +99,7 @@ export class AddActivityRecordedAtCompositeIndexes1784469645043 implements Migra
 	 * @param queryRunner
 	 */
 	public async postgresDownQueryRunner(queryRunner: QueryRunner): Promise<any> {
-		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_recordedat"`);
-		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_emp_recordedat"`);
+		await this.dropStandardIndexes(queryRunner);
 	}
 
 	/**
@@ -95,11 +109,9 @@ export class AddActivityRecordedAtCompositeIndexes1784469645043 implements Migra
 	 */
 	public async sqliteUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
 		await queryRunner.query(
-			`CREATE INDEX IF NOT EXISTS "idx_activity_org_emp_recordedat" ON "activity" ("organizationId", "employeeId", "recordedAt")`
+			`UPDATE "activity" SET "recordedAt" = datetime("date" || ' ' || "time") WHERE "recordedAt" IS NULL AND "date" IS NOT NULL AND "time" IS NOT NULL`
 		);
-		await queryRunner.query(
-			`CREATE INDEX IF NOT EXISTS "idx_activity_org_recordedat" ON "activity" ("organizationId", "recordedAt")`
-		);
+		await this.createStandardIndexes(queryRunner);
 	}
 
 	/**
@@ -108,16 +120,22 @@ export class AddActivityRecordedAtCompositeIndexes1784469645043 implements Migra
 	 * @param queryRunner
 	 */
 	public async sqliteDownQueryRunner(queryRunner: QueryRunner): Promise<any> {
-		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_recordedat"`);
-		await queryRunner.query(`DROP INDEX IF EXISTS "idx_activity_org_emp_recordedat"`);
+		await this.dropStandardIndexes(queryRunner);
 	}
 
 	/**
 	 * MySQL Up Migration
 	 *
+	 * MySQL has no `CREATE INDEX ... IF NOT EXISTS`, so these run as plain statements. MySQL is not
+	 * part of the out-of-band `CREATE INDEX CONCURRENTLY` pre-creation path, so a fresh migration
+	 * run does not encounter pre-existing indexes.
+	 *
 	 * @param queryRunner
 	 */
 	public async mysqlUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query(
+			`UPDATE \`activity\` SET \`recordedAt\` = STR_TO_DATE(CONCAT(\`date\`, ' ', \`time\`), '%Y-%m-%d %H:%i:%s') WHERE \`recordedAt\` IS NULL AND \`date\` IS NOT NULL AND \`time\` IS NOT NULL`
+		);
 		await queryRunner.query(
 			`CREATE INDEX \`idx_activity_org_emp_recordedat\` ON \`activity\` (\`organizationId\`, \`employeeId\`, \`recordedAt\`)`
 		);

--- a/packages/core/src/lib/time-tracking/activity/activity.service.ts
+++ b/packages/core/src/lib/time-tracking/activity/activity.service.ts
@@ -390,21 +390,26 @@ export class ActivityService extends TenantAwareCrudService<Activity> {
 				}
 			})
 		);
-		query.andWhere(
-			new Brackets((qb: WhereExpressionBuilder) => {
-				// Filter on the indexed `recordedAt` timestamp column instead of a
-				// non-sargable `concat(date, time)::timestamp` expression. The old form had
-				// to compute the expression for every row, so it could not use any index and
-				// forced a full scan of the (very large) activity table. `recordedAt` holds
-				// the same instant (date + time) and is covered by the
-				// (organizationId, employeeId, recordedAt) / (organizationId, recordedAt)
-				// indexes, turning the range filter into an index range scan.
-				qb.andWhere(p(`"${query.alias}"."recordedAt" BETWEEN :startDate AND :endDate`), {
-					startDate,
-					endDate
-				});
-			})
-		);
+		// Only apply the date-range filter when both bounds are provided, matching the MikroORM
+		// branches. Applying it unconditionally would produce `recordedAt BETWEEN NULL AND NULL`
+		// (which matches nothing) when a caller omits the range.
+		if (startDate && endDate) {
+			query.andWhere(
+				new Brackets((qb: WhereExpressionBuilder) => {
+					// Filter on the indexed `recordedAt` timestamp column instead of a
+					// non-sargable `concat(date, time)::timestamp` expression. The old form had
+					// to compute the expression for every row, so it could not use any index and
+					// forced a full scan of the (very large) activity table. `recordedAt` holds
+					// the same instant (date + time) and is covered by the
+					// (organizationId, employeeId, recordedAt) / (organizationId, recordedAt)
+					// indexes, turning the range filter into an index range scan.
+					qb.andWhere(p(`"${query.alias}"."recordedAt" BETWEEN :startDate AND :endDate`), {
+						startDate,
+						endDate
+					});
+				})
+			);
+		}
 		query.andWhere(
 			new Brackets((qb: WhereExpressionBuilder) => {
 				const { projectIds = [] } = request;

--- a/packages/core/src/lib/time-tracking/activity/activity.service.ts
+++ b/packages/core/src/lib/time-tracking/activity/activity.service.ts
@@ -15,7 +15,7 @@ import { CommandBus } from '@nestjs/cqrs';
 import { BulkActivitiesSaveCommand } from './commands/bulk-activities-save.command';
 import { indexBy, pluck } from 'underscore';
 import { isNotEmpty } from '@gauzy/utils';
-import { DatabaseTypeEnum, getConfig, isSqlite, isBetterSqlite3, isMySQL, isPostgres } from '@gauzy/config';
+import { DatabaseTypeEnum, getConfig } from '@gauzy/config';
 import { prepareSQLQuery as p } from './../../database/database.helper';
 import { TypeOrmActivityRepository } from './repository/type-orm-activity.repository';
 import { MikroOrmActivityRepository } from './repository/mikro-orm-activity.repository';
@@ -392,21 +392,17 @@ export class ActivityService extends TenantAwareCrudService<Activity> {
 		);
 		query.andWhere(
 			new Brackets((qb: WhereExpressionBuilder) => {
-				qb.andWhere(
-					isSqlite() || isBetterSqlite3()
-						? `datetime("${query.alias}"."date" || ' ' || "${query.alias}"."time") Between :startDate AND :endDate`
-						: isPostgres()
-						? `concat("${query.alias}"."date", ' ', "${query.alias}"."time")::timestamp Between :startDate AND :endDate`
-						: isMySQL()
-						? p(
-								`concat("${query.alias}"."date", ' ', "${query.alias}"."time") Between :startDate AND :endDate`
-						  )
-						: '',
-					{
-						startDate,
-						endDate
-					}
-				);
+				// Filter on the indexed `recordedAt` timestamp column instead of a
+				// non-sargable `concat(date, time)::timestamp` expression. The old form had
+				// to compute the expression for every row, so it could not use any index and
+				// forced a full scan of the (very large) activity table. `recordedAt` holds
+				// the same instant (date + time) and is covered by the
+				// (organizationId, employeeId, recordedAt) / (organizationId, recordedAt)
+				// indexes, turning the range filter into an index range scan.
+				qb.andWhere(p(`"${query.alias}"."recordedAt" BETWEEN :startDate AND :endDate`), {
+					startDate,
+					endDate
+				});
 			})
 		);
 		query.andWhere(

--- a/packages/core/src/lib/time-tracking/activity/activity.subscriber.ts
+++ b/packages/core/src/lib/time-tracking/activity/activity.subscriber.ts
@@ -15,22 +15,14 @@ export class ActivitySubscriber extends BaseEntityEventSubscriber<Activity> {
 
 	/**
 	 * Called before an Activity entity is inserted or created in the database.
-	 * This method prepares the entity for insertion by (1) guaranteeing `recordedAt` is populated
-	 * and (2) serializing the metaData property to a JSON string for SQLite databases.
+	 * This method prepares the entity for insertion by (1) guaranteeing `recordedAt` holds a valid
+	 * timestamp and (2) serializing the metaData property to a JSON string for SQLite databases.
 	 *
 	 * @param entity The Activity entity that is about to be created.
 	 * @returns {Promise<void>} A promise that resolves when the pre-creation processing is complete.
 	 */
 	async beforeEntityCreate(entity: Activity): Promise<void> {
-		// Guarantee `recordedAt` is always set to a VALID timestamp, regardless of the write path
-		// (bulk save, single create, or third-party imports). Reports/statistics filter on
-		// `recordedAt`, and a NULL value makes the row invisible to the time-range query. Prefer an
-		// explicit value, else derive it from the activity's date + time, else fall back to now.
-		if (!entity.recordedAt) {
-			const derived = entity.date && entity.time ? new Date(`${entity.date}T${entity.time}`) : null;
-			// Guard against malformed date/time producing an `Invalid Date`, which would fail on insert.
-			entity.recordedAt = derived && !isNaN(derived.getTime()) ? derived : new Date();
-		}
+		this.ensureRecordedAt(entity);
 
 		try {
 			// Check if the database is SQLite and the entity's metaData is a JavaScript object
@@ -42,5 +34,38 @@ export class ActivitySubscriber extends BaseEntityEventSubscriber<Activity> {
 			entity.metaData = JSON.stringify({});
 			console.error('ActivitySubscriber: Error during the beforeEntityCreate process:', error);
 		}
+	}
+
+	/**
+	 * Called before an Activity entity is updated. Guarantees `recordedAt` here too, since a bulk
+	 * `save` of an entity that carries an existing id follows the update path (which does not fire
+	 * `beforeEntityCreate`).
+	 *
+	 * @param entity The Activity entity that is about to be updated.
+	 */
+	async beforeEntityUpdate(entity: Activity): Promise<void> {
+		this.ensureRecordedAt(entity);
+	}
+
+	/**
+	 * Guarantees `entity.recordedAt` is a VALID timestamp regardless of the write path (bulk save,
+	 * single create, imports) or source. Reports/statistics filter on `recordedAt`, and a NULL or
+	 * `Invalid Date` value makes the row invisible to the time-range query (or fails on persist).
+	 * Prefer a valid explicit value, else derive it from the activity's date + time, else fall back
+	 * to the current time.
+	 *
+	 * @param entity The Activity entity being persisted.
+	 */
+	private ensureRecordedAt(entity: Activity): void {
+		const isValidDate = (value: unknown): boolean => value != null && !isNaN(new Date(value as any).getTime());
+
+		// Keep a valid explicitly-supplied value as-is.
+		if (isValidDate(entity.recordedAt)) {
+			return;
+		}
+
+		// Otherwise derive from date + time, guarding against a malformed `Invalid Date`.
+		const derived = entity.date && entity.time ? new Date(`${entity.date}T${entity.time}`) : null;
+		entity.recordedAt = isValidDate(derived) ? (derived as Date) : new Date();
 	}
 }

--- a/packages/core/src/lib/time-tracking/activity/activity.subscriber.ts
+++ b/packages/core/src/lib/time-tracking/activity/activity.subscriber.ts
@@ -15,13 +15,21 @@ export class ActivitySubscriber extends BaseEntityEventSubscriber<Activity> {
 
 	/**
 	 * Called before an Activity entity is inserted or created in the database.
-	 * This method prepares the entity for insertion, particularly by serializing the metaData property to a JSON string
-	 * for SQLite databases.
+	 * This method prepares the entity for insertion by (1) guaranteeing `recordedAt` is populated
+	 * and (2) serializing the metaData property to a JSON string for SQLite databases.
 	 *
 	 * @param entity The Activity entity that is about to be created.
 	 * @returns {Promise<void>} A promise that resolves when the pre-creation processing is complete.
 	 */
 	async beforeEntityCreate(entity: Activity): Promise<void> {
+		// Guarantee `recordedAt` is always set, regardless of the write path (bulk save, single
+		// create, or third-party imports). Reports/statistics filter on `recordedAt`, and a NULL
+		// value makes the row invisible to the time-range query. Prefer an explicit value, else
+		// derive it from the activity's date + time, else fall back to the current time.
+		entity.recordedAt =
+			entity.recordedAt ??
+			(entity.date && entity.time ? new Date(`${entity.date}T${entity.time}`) : new Date());
+
 		try {
 			// Check if the database is SQLite and the entity's metaData is a JavaScript object
 			if ((isSqlite() || isBetterSqlite3()) && isObject(entity.metaData)) {

--- a/packages/core/src/lib/time-tracking/activity/activity.subscriber.ts
+++ b/packages/core/src/lib/time-tracking/activity/activity.subscriber.ts
@@ -22,13 +22,15 @@ export class ActivitySubscriber extends BaseEntityEventSubscriber<Activity> {
 	 * @returns {Promise<void>} A promise that resolves when the pre-creation processing is complete.
 	 */
 	async beforeEntityCreate(entity: Activity): Promise<void> {
-		// Guarantee `recordedAt` is always set, regardless of the write path (bulk save, single
-		// create, or third-party imports). Reports/statistics filter on `recordedAt`, and a NULL
-		// value makes the row invisible to the time-range query. Prefer an explicit value, else
-		// derive it from the activity's date + time, else fall back to the current time.
-		entity.recordedAt =
-			entity.recordedAt ??
-			(entity.date && entity.time ? new Date(`${entity.date}T${entity.time}`) : new Date());
+		// Guarantee `recordedAt` is always set to a VALID timestamp, regardless of the write path
+		// (bulk save, single create, or third-party imports). Reports/statistics filter on
+		// `recordedAt`, and a NULL value makes the row invisible to the time-range query. Prefer an
+		// explicit value, else derive it from the activity's date + time, else fall back to now.
+		if (!entity.recordedAt) {
+			const derived = entity.date && entity.time ? new Date(`${entity.date}T${entity.time}`) : null;
+			// Guard against malformed date/time producing an `Invalid Date`, which would fail on insert.
+			entity.recordedAt = derived && !isNaN(derived.getTime()) ? derived : new Date();
+		}
 
 		try {
 			// Check if the database is SQLite and the entity's metaData is a JavaScript object

--- a/packages/core/src/lib/time-tracking/activity/commands/handlers/bulk-activities-save.handler.ts
+++ b/packages/core/src/lib/time-tracking/activity/commands/handlers/bulk-activities-save.handler.ts
@@ -1,5 +1,4 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import * as moment from 'moment';
 import { IActivity, PermissionsEnum } from '@gauzy/contracts';
 import { isEmpty, isNotEmpty } from '@gauzy/utils';
 import { Activity } from '../../activity.entity';
@@ -59,7 +58,7 @@ export class BulkActivitiesSaveHandler implements ICommandHandler<BulkActivities
 				const recordedAt =
 					activity.recordedAt ??
 					(activity.date && activity.time
-						? moment(`${activity.date} ${activity.time}`, 'YYYY-MM-DD HH:mm:ss').toDate()
+						? new Date(`${activity.date}T${activity.time}`)
 						: new Date());
 
 				return new Activity({

--- a/packages/core/src/lib/time-tracking/activity/commands/handlers/bulk-activities-save.handler.ts
+++ b/packages/core/src/lib/time-tracking/activity/commands/handlers/bulk-activities-save.handler.ts
@@ -50,26 +50,18 @@ export class BulkActivitiesSaveHandler implements ICommandHandler<BulkActivities
 
 		activities = activities
 			.filter((activity: IActivity) => Object.keys(activity).length !== 0)
-			.map((activity: IActivity) => {
-				// Always persist `recordedAt`: reports filter on it, and a NULL value makes the
-				// row invisible to (and non-indexable by) the time-range query. Prefer the value
-				// sent by the client; otherwise derive it from the activity's date + time; and as
-				// a last resort fall back to the current time so it is never left NULL.
-				const recordedAt =
-					activity.recordedAt ??
-					(activity.date && activity.time
-						? new Date(`${activity.date}T${activity.time}`)
-						: new Date());
-
-				return new Activity({
-					...activity,
-					...(projectId ? { projectId } : {}),
-					employeeId,
-					organizationId,
-					tenantId,
-					recordedAt
-				});
-			});
+			.map(
+				(activity: IActivity) =>
+					// `recordedAt` is guaranteed by `ActivitySubscriber.beforeEntityCreate`, which
+					// runs for every Activity write path (bulk save, single create, imports).
+					new Activity({
+						...activity,
+						...(projectId ? { projectId } : {}),
+						employeeId,
+						organizationId,
+						tenantId
+					})
+			);
 
 		// Log the activities that will be inserted into the database
 		console.log(`Activities should be inserted into database for employee (${user.name})`, { activities });

--- a/packages/core/src/lib/time-tracking/activity/commands/handlers/bulk-activities-save.handler.ts
+++ b/packages/core/src/lib/time-tracking/activity/commands/handlers/bulk-activities-save.handler.ts
@@ -1,4 +1,5 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import * as moment from 'moment';
 import { IActivity, PermissionsEnum } from '@gauzy/contracts';
 import { isEmpty, isNotEmpty } from '@gauzy/utils';
 import { Activity } from '../../activity.entity';
@@ -50,16 +51,26 @@ export class BulkActivitiesSaveHandler implements ICommandHandler<BulkActivities
 
 		activities = activities
 			.filter((activity: IActivity) => Object.keys(activity).length !== 0)
-			.map(
-				(activity: IActivity) =>
-					new Activity({
-						...activity,
-						...(projectId ? { projectId } : {}),
-						employeeId,
-						organizationId,
-						tenantId
-					})
-			);
+			.map((activity: IActivity) => {
+				// Always persist `recordedAt`: reports filter on it, and a NULL value makes the
+				// row invisible to (and non-indexable by) the time-range query. Prefer the value
+				// sent by the client; otherwise derive it from the activity's date + time; and as
+				// a last resort fall back to the current time so it is never left NULL.
+				const recordedAt =
+					activity.recordedAt ??
+					(activity.date && activity.time
+						? moment(`${activity.date} ${activity.time}`, 'YYYY-MM-DD HH:mm:ss').toDate()
+						: new Date());
+
+				return new Activity({
+					...activity,
+					...(projectId ? { projectId } : {}),
+					employeeId,
+					organizationId,
+					tenantId,
+					recordedAt
+				});
+			});
 
 		// Log the activities that will be inserted into the database
 		console.log(`Activities should be inserted into database for employee (${user.name})`, { activities });

--- a/packages/core/src/lib/time-tracking/statistic/statistic.helper.ts
+++ b/packages/core/src/lib/time-tracking/statistic/statistic.helper.ts
@@ -112,6 +112,14 @@ export const getTotalDurationQueryString = (dbType: string, queryAlias: string):
 /**
  * Generates the SQL query string for filtering activity duration based on database type.
  *
+ * Filters on the indexed `recordedAt` timestamp column instead of a non-sargable
+ * `concat(date, time)::timestamp` expression. The old form had to compute the value for every
+ * row, so it could not use an index and forced a full scan of the (very large) activity table.
+ * `recordedAt` holds the same instant (date + time) and is covered by the
+ * (organizationId, employeeId, recordedAt) / (organizationId, recordedAt) indexes, turning the
+ * range filter into an index range scan. Since it is a plain column comparison, the per-dialect
+ * concat/cast branching is no longer needed — only identifier quoting differs, handled by `p()`.
+ *
  * @param dbType The type of the database (e.g., sqlite, postgres, mysql).
  * @param queryAlias The alias used for the query table in SQL.
  * @returns The SQL query string for filtering activity duration.
@@ -120,11 +128,10 @@ export const getActivityDurationQueryString = (dbType: string, queryAlias: strin
 	switch (dbType) {
 		case DatabaseTypeEnum.sqlite:
 		case DatabaseTypeEnum.betterSqlite3:
-			return `datetime("${queryAlias}"."date" || ' ' || "${queryAlias}"."time") Between :start AND :end`;
 		case DatabaseTypeEnum.postgres:
-			return `CONCAT("${queryAlias}"."date", ' ', "${queryAlias}"."time")::timestamp Between :start AND :end`;
+			return `"${queryAlias}"."recordedAt" BETWEEN :start AND :end`;
 		case DatabaseTypeEnum.mysql:
-			return p(`CONCAT(\`${queryAlias}\`.\`date\`, ' ', \`${queryAlias}\`.\`time\`) BETWEEN :start AND :end`);
+			return p(`"${queryAlias}"."recordedAt" BETWEEN :start AND :end`);
 		default:
 			throw Error(`cannot create statistic query due to unsupported database type: ${dbType}`);
 	}


### PR DESCRIPTION
## Problem
The **Time & Activity** reports (`/pages/reports/time-activity` → `ActivityService.getActivities` / `getDailyActivities` / `getDailyActivitiesReport`) filter the `activity` table by date range using a **non-sargable** expression:

```sql
concat("activity"."date", ' ', "activity"."time")::timestamp BETWEEN :startDate AND :endDate
```

Because the value is computed per row, Postgres cannot use any index and does a **full sequential scan** of `activity` (which is ~20M rows / 10GB on our production tenant). `EXPLAIN` of the org-wide weekly report showed **plan cost ~1.24M** and a `Parallel Seq Scan on activity`. Under load these queries saturate the DB, hold connections, and the API's DB-backed `/api/health` liveness probe then times out — so the pod gets restarted mid-request and the report fails/timeouts.

## Changes
1. **`activity.service.ts` — sargable filter.** Replace the `concat(date,' ',time)::timestamp` range predicate in `filterQuery` with `"activity"."recordedAt" BETWEEN :startDate AND :endDate`. `recordedAt` holds the same instant and is a real indexed timestamp column, so the range filter becomes an index scan. (Removed the now-unused `isSqlite/isBetterSqlite3/isMySQL/isPostgres` imports.)

2. **Migration `…-AddActivityRecordedAtCompositeIndexes`.** Adds two composite indexes matching the report's filter shape:
   - `(organizationId, employeeId, recordedAt)` — per-employee reports
   - `(organizationId, recordedAt)` — org-wide reports

   The Postgres branch uses `CREATE INDEX IF NOT EXISTS` so it is a **no-op** on deployments where they were already created out-of-band with `CREATE INDEX CONCURRENTLY` (recommended for large tables to avoid a write-lock at migration time).

3. **`bulk-activities-save.handler.ts` — always persist `recordedAt`.** The write path previously only set `recordedAt` if the client sent it (it spreads the client payload), which is why legacy/edge rows have `NULL recordedAt`. Now it is always set: **client value → else derived from `date`+`time` → else `now()`**. This keeps the new `recordedAt`-based filter complete going forward.

## Correctness / equivalence
`recordedAt` is the same instant as `concat(date, time)` — verified on production data (e.g. `date=2026-07-19, time=12:21:35 → recordedAt=2026-07-19 12:21:35`). Rows with `NULL recordedAt` were already excluded by the old predicate too (`concat(NULL…)::timestamp` is `NULL`), so results are equivalent once existing rows are backfilled.

## Rollout notes (large existing deployments)
For big `activity` tables, run these **out-of-band before/independently of** deploy (already done on our prod + stage):
```sql
-- indexes (no write lock)
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_org_emp_recordedat ON activity ("organizationId","employeeId","recordedAt");
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_org_recordedat     ON activity ("organizationId","recordedAt");
-- backfill legacy NULLs (batch in chunks on very large tables)
UPDATE activity SET "recordedAt" = concat(date,' ',"time")::timestamp
  WHERE "recordedAt" IS NULL AND date IS NOT NULL AND "time" IS NOT NULL;
```

## Scope notes
- Focused on the TypeORM path (our production ORM). The MikroORM/Knex report branches already filter on the indexed `date` column and are left unchanged.
- No API/response shape changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Time & Activity reports and stats to filter on the indexed recordedAt column, replacing the non-sargable concat(date,time) to avoid full scans. Guarantee and validate recordedAt on create and update (client value → date+time → now, with Invalid Date guard), and only apply the date-range filter when both bounds are provided.

- **Refactors**
  - Replace concat(date,' ',time)::timestamp with "recordedAt" BETWEEN :startDate AND :endDate in ActivityService; apply only when both bounds exist.
  - Guarantee/validate recordedAt in ActivitySubscriber on create and update; keep a valid client value, else derive from date+time, else use now; guard against Invalid Date.
  - Use "recordedAt" BETWEEN :start AND :end in statistic.helper; remove per-dialect concat/cast logic.

- **Migration**
  - Backfill recordedAt where NULL, then add composite indexes: (organizationId, employeeId, recordedAt) and (organizationId, recordedAt).
  - Postgres/SQLite use IF NOT EXISTS; for large tables, create indexes concurrently and backfill out-of-band.

<sup>Written for commit 66eda97dd03369eaff6e8ec937330651646f522f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

