### PR TITLE
fix(plane-ui): integration-page UX polish — surface errors, dialog + settings-load fixes (B4–B9)

### DIFF
--- a/packages/plugins/integration-plane-ui/src/lib/components/api-key-dialog/api-key-dialog.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/api-key-dialog/api-key-dialog.component.ts
@@ -1,5 +1,8 @@
-import { Component, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, signal, ChangeDetectionStrategy } from '@angular/core';
 import { NbDialogRef } from '@nebular/theme';
+
+/** How long the "Copied!" confirmation stays visible before resetting. */
+const COPIED_RESET_MS = 2000;
 
 @Component({
 	selector: 'ngx-plane-api-key-dialog',
@@ -8,26 +11,25 @@ import { NbDialogRef } from '@nebular/theme';
 	standalone: false,
 	changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PlaneApiKeyDialogComponent {
+export class PlaneApiKeyDialogComponent implements OnDestroy {
 	apiKey = '';
 	apiSecret = '';
 
 	readonly apiKeyCopied = signal(false);
 	readonly apiSecretCopied = signal(false);
 
+	private _keyResetTimer?: ReturnType<typeof setTimeout>;
+	private _secretResetTimer?: ReturnType<typeof setTimeout>;
+
 	constructor(private readonly dialogRef: NbDialogRef<PlaneApiKeyDialogComponent>) {}
 
 	/**
-	 * Copy value to clipboard and show check mark.
+	 * Copy value to clipboard and show a transient check mark.
 	 */
 	async copyToClipboard(value: string, field: 'key' | 'secret'): Promise<void> {
 		try {
 			await navigator.clipboard.writeText(value);
-			if (field === 'key') {
-				this.apiKeyCopied.set(true);
-			} else {
-				this.apiSecretCopied.set(true);
-			}
+			this._markCopied(field);
 		} catch {
 			// Fallback for older browsers
 			const textarea = document.createElement('textarea');
@@ -39,16 +41,33 @@ export class PlaneApiKeyDialogComponent {
 			const success = document.execCommand('copy');
 			document.body.removeChild(textarea);
 			if (success) {
-				if (field === 'key') {
-					this.apiKeyCopied.set(true);
-				} else {
-					this.apiSecretCopied.set(true);
-				}
+				this._markCopied(field);
 			}
+		}
+	}
+
+	/**
+	 * Flag the field as copied and auto-reset the flag shortly after, so a repeat
+	 * copy re-confirms (instead of the check mark being stuck for the dialog's life).
+	 */
+	private _markCopied(field: 'key' | 'secret'): void {
+		if (field === 'key') {
+			this.apiKeyCopied.set(true);
+			clearTimeout(this._keyResetTimer);
+			this._keyResetTimer = setTimeout(() => this.apiKeyCopied.set(false), COPIED_RESET_MS);
+		} else {
+			this.apiSecretCopied.set(true);
+			clearTimeout(this._secretResetTimer);
+			this._secretResetTimer = setTimeout(() => this.apiSecretCopied.set(false), COPIED_RESET_MS);
 		}
 	}
 
 	close(): void {
 		this.dialogRef.close();
+	}
+
+	ngOnDestroy(): void {
+		clearTimeout(this._keyResetTimer);
+		clearTimeout(this._secretResetTimer);
 	}
 }

--- a/packages/plugins/integration-plane-ui/src/lib/components/api-key-dialog/api-key-dialog.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/api-key-dialog/api-key-dialog.component.ts
@@ -20,6 +20,7 @@ export class PlaneApiKeyDialogComponent implements OnDestroy {
 
 	private _keyResetTimer?: ReturnType<typeof setTimeout>;
 	private _secretResetTimer?: ReturnType<typeof setTimeout>;
+	private _destroyed = false;
 
 	constructor(private readonly dialogRef: NbDialogRef<PlaneApiKeyDialogComponent>) {}
 
@@ -51,6 +52,9 @@ export class PlaneApiKeyDialogComponent implements OnDestroy {
 	 * copy re-confirms (instead of the check mark being stuck for the dialog's life).
 	 */
 	private _markCopied(field: 'key' | 'secret'): void {
+		// A pending clipboard write can resolve after the dialog is torn down; don't
+		// mutate a destroyed component or schedule a timer the cleanup won't catch.
+		if (this._destroyed) return;
 		if (field === 'key') {
 			this.apiKeyCopied.set(true);
 			clearTimeout(this._keyResetTimer);
@@ -67,6 +71,7 @@ export class PlaneApiKeyDialogComponent implements OnDestroy {
 	}
 
 	ngOnDestroy(): void {
+		this._destroyed = true;
 		clearTimeout(this._keyResetTimer);
 		clearTimeout(this._secretResetTimer);
 	}

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-authorize/plane-authorize.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-authorize/plane-authorize.component.ts
@@ -8,7 +8,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { filter, tap, take } from 'rxjs';
 import { IntegrationEnum, IIntegrationTenant, IOrganization } from '@gauzy/contracts';
-import { IntegrationsService, IPlaneSetupResponse, PlaneService, Store } from '@gauzy/ui-core/core';
+import { ErrorHandlingService, IntegrationsService, IPlaneSetupResponse, PlaneService, Store } from '@gauzy/ui-core/core';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 import { INTEGRATION_PLANE_PAGE_LINK } from '../../integration-plane.routes';
 import { PlaneApiKeyDialogComponent } from '../api-key-dialog/api-key-dialog.component';
@@ -36,6 +36,7 @@ export class PlaneAuthorizeComponent extends TranslationBaseComponent implements
 	private readonly _planeService = inject(PlaneService);
 	private readonly _integrationsService = inject(IntegrationsService);
 	private readonly _dialogService = inject(NbDialogService);
+	private readonly _errorHandlingService = inject(ErrorHandlingService);
 
 	readonly organization = signal<IOrganization | null>(null);
 	readonly loading = signal<boolean>(false);
@@ -169,8 +170,9 @@ export class PlaneAuthorizeComponent extends TranslationBaseComponent implements
 					this.loading.set(false);
 					this._showApiKeyDialog(result.apiKey, result.apiSecret, result.integrationTenantId);
 				},
-				error: () => {
+				error: (error: HttpErrorResponse) => {
 					this.loading.set(false);
+					this._errorHandlingService.handleError(error);
 				}
 			});
 	}

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.html
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.html
@@ -15,33 +15,35 @@
 			<h5 class="mb-0 ml-4">{{ 'INTEGRATIONS.PLANE_PAGE.TITLE' | translate }}</h5>
 		</div>
 		<div class="header-actions">
-			@if (!isEditing() && mode === 'custom') {
+			@if (!loadFailed()) {
+				@if (!isEditing() && mode === 'custom') {
+					<button
+						nbButton
+						size="small"
+						type="button"
+						status="basic"
+						outline
+						(click)="toggleEdit()"
+						nbTooltip="{{ 'BUTTONS.EDIT' | translate }}"
+						[attr.aria-label]="'BUTTONS.EDIT' | translate"
+					>
+						<nb-icon icon="edit-outline"></nb-icon>
+					</button>
+				}
 				<button
 					nbButton
-					size="small"
 					type="button"
-					status="basic"
+					size="small"
+					status="danger"
 					outline
-					(click)="toggleEdit()"
-					nbTooltip="{{ 'BUTTONS.EDIT' | translate }}"
-					[attr.aria-label]="'BUTTONS.EDIT' | translate"
+					(click)="removeIntegration()"
+					[disabled]="loading() || saving()"
+					nbTooltip="{{ 'BUTTONS.DELETE' | translate }}"
+					[attr.aria-label]="'BUTTONS.DELETE' | translate"
 				>
-					<nb-icon icon="edit-outline"></nb-icon>
+					<nb-icon icon="trash-2-outline"></nb-icon>
 				</button>
 			}
-			<button
-				nbButton
-				type="button"
-				size="small"
-				status="danger"
-				outline
-				(click)="removeIntegration()"
-				[disabled]="loading() || saving()"
-				nbTooltip="{{ 'BUTTONS.DELETE' | translate }}"
-				[attr.aria-label]="'BUTTONS.DELETE' | translate"
-			>
-				<nb-icon icon="trash-2-outline"></nb-icon>
-			</button>
 		</div>
 	</nb-card-header>
 
@@ -50,6 +52,23 @@
 			<div class="text-center p-4" role="status" aria-live="polite">
 				<nb-icon icon="loader-outline" class="spin"></nb-icon>
 				<span class="sr-only">{{ 'INTEGRATIONS.PLANE_PAGE.LOADING' | translate }}</span>
+			</div>
+		} @else if (loadFailed()) {
+			<div class="text-center p-4" role="alert">
+				<nb-icon icon="alert-triangle-outline" status="danger"></nb-icon>
+				<p class="mt-2">{{ 'INTEGRATIONS.PLANE_PAGE.LOAD_FAILED' | translate }}</p>
+				<button
+					nbButton
+					status="primary"
+					size="small"
+					type="button"
+					outline
+					(click)="retryLoad()"
+					[disabled]="loading()"
+				>
+					<nb-icon icon="refresh-outline"></nb-icon>
+					{{ 'INTEGRATIONS.PLANE_PAGE.RETRY' | translate }}
+				</button>
 			</div>
 		} @else {
 			@if (mode === 'shared') {

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
@@ -89,6 +89,10 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 							if (error?.status === 404) {
 								this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
 							} else {
+								// Clear any previously-loaded settings so a failed org switch
+								// doesn't leave the prior org's settings on screen, then surface
+								// the error.
+								this.settings.set(null);
 								this._errorHandlingService.handleError(error);
 							}
 							return EMPTY;

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { NbDialogService } from '@nebular/theme';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
-import { catchError, EMPTY, filter, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, EMPTY, filter, startWith, Subject, switchMap, tap } from 'rxjs';
 import { IOrganization } from '@gauzy/contracts';
 import {
 	ErrorHandlingService,
@@ -53,6 +53,9 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 	 * state instead of rendering a misleading empty shared-mode page. */
 	readonly loadFailed = signal<boolean>(false);
 
+	/** Emits to re-trigger the settings load (retry after a failed load). */
+	private readonly _retry$ = new Subject<void>();
+
 	form = new FormGroup({
 		planeWebUrl: new FormControl('', [Validators.required, Validators.pattern(URL_PATTERN)]),
 		planeAdminUrl: new FormControl('', [Validators.pattern(URL_PATTERN)]),
@@ -73,12 +76,16 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 			)
 			.subscribe();
 
-		// Load settings when organization is available
-		this._store.selectedOrganization$
+		// Load settings whenever the organization changes or a retry is requested.
+		// combineLatest + switchMap means an org switch (or a retry) cancels any
+		// in-flight load, so a stale response can't overwrite the current org.
+		combineLatest([
+			this._store.selectedOrganization$.pipe(filter((org): org is IOrganization => !!org)),
+			this._retry$.pipe(startWith(undefined))
+		])
 			.pipe(
-				filter((org): org is IOrganization => !!org),
-				tap((org) => this.organization.set(org)),
-				switchMap((org) => {
+				tap(([org]) => this.organization.set(org)),
+				switchMap(([org]) => {
 					this.loading.set(true);
 					return this._planeService.getSettings(org.id).pipe(
 						catchError((error: HttpErrorResponse) => {
@@ -122,33 +129,11 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 	}
 
 	/**
-	 * Retry loading settings for the current organization after a failed load.
+	 * Retry loading settings after a failed load. Re-triggers the same reactive
+	 * load pipeline, so an in-flight retry is cancelled if the organization changes.
 	 */
 	retryLoad(): void {
-		const organizationId = this.organization()?.id;
-		if (!organizationId) return;
-
-		this.loading.set(true);
-		this._planeService
-			.getSettings(organizationId)
-			.pipe(untilDestroyed(this))
-			.subscribe({
-				next: (settings) => {
-					this.loading.set(false);
-					this.loadFailed.set(false);
-					this.settings.set(settings);
-					this._patchForm(settings);
-				},
-				error: (error: HttpErrorResponse) => {
-					this.loading.set(false);
-					if (error?.status === 404) {
-						this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
-					} else {
-						this.loadFailed.set(true);
-						this._errorHandlingService.handleError(error);
-					}
-				}
-			});
+		this._retry$.next();
 	}
 
 	/**

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
@@ -49,6 +49,9 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 	readonly saving = signal<boolean>(false);
 	readonly settings = signal<IPlaneSettingsResponse | null>(null);
 	readonly isEditing = signal<boolean>(false);
+	/** True when a settings load failed (non-404), so the UI shows an error/retry
+	 * state instead of rendering a misleading empty shared-mode page. */
+	readonly loadFailed = signal<boolean>(false);
 
 	form = new FormGroup({
 		planeWebUrl: new FormControl('', [Validators.required, Validators.pattern(URL_PATTERN)]),
@@ -95,6 +98,7 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 								// error.
 								this.settings.set(null);
 								this.isEditing.set(false);
+								this.loadFailed.set(true);
 								this.form.reset({ planeWebUrl: '', planeAdminUrl: '', planeSpaceUrl: '' });
 								this._errorHandlingService.handleError(error);
 							}
@@ -105,6 +109,7 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 				tap((settings: IPlaneSettingsResponse) => {
 					this.settings.set(settings);
 					this._patchForm(settings);
+					this.loadFailed.set(false);
 					this.loading.set(false);
 				}),
 				untilDestroyed(this)
@@ -114,6 +119,36 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 
 	goBack(): void {
 		this._location.back();
+	}
+
+	/**
+	 * Retry loading settings for the current organization after a failed load.
+	 */
+	retryLoad(): void {
+		const organizationId = this.organization()?.id;
+		if (!organizationId) return;
+
+		this.loading.set(true);
+		this._planeService
+			.getSettings(organizationId)
+			.pipe(untilDestroyed(this))
+			.subscribe({
+				next: (settings) => {
+					this.loading.set(false);
+					this.loadFailed.set(false);
+					this.settings.set(settings);
+					this._patchForm(settings);
+				},
+				error: (error: HttpErrorResponse) => {
+					this.loading.set(false);
+					if (error?.status === 404) {
+						this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
+					} else {
+						this.loadFailed.set(true);
+						this._errorHandlingService.handleError(error);
+					}
+				}
+			});
 	}
 
 	/**

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
@@ -129,7 +129,11 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 		}
 
 		const url = this.settings()?.planeWebUrl?.trim() || SHARED_PLANE_WEB_URL;
-		window.open(`${url}/?sso=${token}`, '_blank');
+		// Pass the token in the URL fragment (#sso=) rather than the query (?sso=):
+		// fragments are never sent to the server, so the token stays out of the Plane
+		// web server's access logs / Referer / CDN. The fork's entry.client reads the
+		// fragment first and falls back to the query for backward compatibility.
+		window.open(`${url}/#sso=${token}`, '_blank');
 	}
 
 	/**

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
@@ -129,11 +129,7 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 		}
 
 		const url = this.settings()?.planeWebUrl?.trim() || SHARED_PLANE_WEB_URL;
-		// Pass the token in the URL fragment (#sso=) rather than the query (?sso=):
-		// fragments are never sent to the server, so the token stays out of the Plane
-		// web server's access logs / Referer / CDN. The fork's entry.client reads the
-		// fragment first and falls back to the query for backward compatibility.
-		window.open(`${url}/#sso=${token}`, '_blank');
+		window.open(`${url}/?sso=${token}`, '_blank');
 	}
 
 	/**

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
@@ -89,10 +89,13 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 							if (error?.status === 404) {
 								this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
 							} else {
-								// Clear any previously-loaded settings so a failed org switch
-								// doesn't leave the prior org's settings on screen, then surface
-								// the error.
+								// Clear ALL loaded state (settings, form values, edit mode) so a
+								// failed org switch doesn't leave the previous org's settings/URLs
+								// on screen as a misleading "shared-mode" page, then surface the
+								// error.
 								this.settings.set(null);
+								this.isEditing.set(false);
+								this.form.reset({ planeWebUrl: '', planeAdminUrl: '', planeSpaceUrl: '' });
 								this._errorHandlingService.handleError(error);
 							}
 							return EMPTY;

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { NbDialogService } from '@nebular/theme';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
-import { filter, switchMap, tap } from 'rxjs';
+import { catchError, EMPTY, filter, switchMap, tap } from 'rxjs';
 import { IOrganization } from '@gauzy/contracts';
 import {
 	ErrorHandlingService,
@@ -77,7 +77,23 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 				tap((org) => this.organization.set(org)),
 				switchMap((org) => {
 					this.loading.set(true);
-					return this._planeService.getSettings(org.id);
+					return this._planeService.getSettings(org.id).pipe(
+						catchError((error: HttpErrorResponse) => {
+							this.loading.set(false);
+							// Only bounce to the setup screen when the integration is
+							// genuinely not configured (HTTP 404). A transient/5xx error is
+							// surfaced and the user stays put, instead of a configured tenant
+							// being silently kicked back to "set up Plane". Recover to EMPTY
+							// so the outer organization stream stays alive and future org
+							// switches still reload settings.
+							if (error?.status === 404) {
+								this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
+							} else {
+								this._errorHandlingService.handleError(error);
+							}
+							return EMPTY;
+						})
+					);
 				}),
 				tap((settings: IPlaneSettingsResponse) => {
 					this.settings.set(settings);
@@ -86,23 +102,7 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 				}),
 				untilDestroyed(this)
 			)
-			.subscribe({
-				error: (error: HttpErrorResponse) => {
-					this.loading.set(false);
-					// Only bounce to the setup screen when the integration genuinely
-					// isn't configured (404). On a transient error (network/5xx) surface
-					// it and stay put, instead of silently kicking a configured tenant
-					// back to "set up Plane".
-					const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
-					const notConfigured =
-						error?.status === 404 || message.includes('not configured') || message.includes('not found');
-					if (notConfigured) {
-						this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
-					} else {
-						this._errorHandlingService.handleError(error);
-					}
-				}
-			});
+			.subscribe();
 	}
 
 	goBack(): void {

--- a/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
+++ b/packages/plugins/integration-plane-ui/src/lib/components/plane-settings/plane-settings.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, signal, inject, ChangeDetectionStrategy } from '@angular/core';
 import { Location } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NbDialogService } from '@nebular/theme';
@@ -7,7 +8,14 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { filter, switchMap, tap } from 'rxjs';
 import { IOrganization } from '@gauzy/contracts';
-import { IPlaneRegenerateKeyResponse, PlaneService, IPlaneSettingsResponse, Store } from '@gauzy/ui-core/core';
+import {
+	ErrorHandlingService,
+	IPlaneRegenerateKeyResponse,
+	PlaneService,
+	IPlaneSettingsResponse,
+	Store,
+	ToastrService
+} from '@gauzy/ui-core/core';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 import { INTEGRATION_PLANE_PAGE_LINK } from '../../integration-plane.routes';
 import { PlaneApiKeyDialogComponent } from '../api-key-dialog/api-key-dialog.component';
@@ -32,6 +40,8 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 	private readonly _store = inject(Store);
 	private readonly _planeService = inject(PlaneService);
 	private readonly _dialogService = inject(NbDialogService);
+	private readonly _toastrService = inject(ToastrService);
+	private readonly _errorHandlingService = inject(ErrorHandlingService);
 
 	readonly organization = signal<IOrganization | null>(null);
 	readonly integrationTenantId = signal<string | null>(null);
@@ -77,9 +87,20 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 				untilDestroyed(this)
 			)
 			.subscribe({
-				error: () => {
+				error: (error: HttpErrorResponse) => {
 					this.loading.set(false);
-					this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
+					// Only bounce to the setup screen when the integration genuinely
+					// isn't configured (404). On a transient error (network/5xx) surface
+					// it and stay put, instead of silently kicking a configured tenant
+					// back to "set up Plane".
+					const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
+					const notConfigured =
+						error?.status === 404 || message.includes('not configured') || message.includes('not found');
+					if (notConfigured) {
+						this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
+					} else {
+						this._errorHandlingService.handleError(error);
+					}
 				}
 			});
 	}
@@ -101,7 +122,11 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 	 */
 	openPlane(): void {
 		const token = this._store.token;
-		if (!token) return;
+		if (!token) {
+			// Surface why nothing opened instead of a silent no-op.
+			this._toastrService.warning('INTEGRATIONS.PLANE_PAGE.SESSION_EXPIRED');
+			return;
+		}
 
 		const url = this.settings()?.planeWebUrl?.trim() || SHARED_PLANE_WEB_URL;
 		window.open(`${url}/?sso=${token}`, '_blank');
@@ -151,11 +176,13 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 				next: () => {
 					this.saving.set(false);
 					this.isEditing.set(false);
+					this._toastrService.success('INTEGRATIONS.PLANE_PAGE.SETTINGS_SAVED');
 					// Refresh settings
 					this._refreshSettings();
 				},
-				error: () => {
+				error: (error: HttpErrorResponse) => {
 					this.saving.set(false);
+					this._errorHandlingService.handleError(error);
 				}
 			});
 	}
@@ -178,10 +205,12 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 			.subscribe({
 				next: () => {
 					this.loading.set(false);
+					this._toastrService.success('INTEGRATIONS.PLANE_PAGE.INTEGRATION_REMOVED');
 					this._router.navigate([INTEGRATION_PLANE_PAGE_LINK]);
 				},
-				error: () => {
+				error: (error: HttpErrorResponse) => {
 					this.loading.set(false);
+					this._errorHandlingService.handleError(error);
 				}
 			});
 	}
@@ -206,8 +235,9 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 					this.loading.set(false);
 					this._showApiKeyDialog(result.apiKey, result.apiSecret);
 				},
-				error: () => {
+				error: (error: HttpErrorResponse) => {
 					this.loading.set(false);
+					this._errorHandlingService.handleError(error);
 				}
 			});
 	}
@@ -241,7 +271,8 @@ export class PlaneSettingsComponent extends TranslationBaseComponent implements 
 				next: (settings) => {
 					this.settings.set(settings);
 					this._patchForm(settings);
-				}
+				},
+				error: (error: HttpErrorResponse) => this._errorHandlingService.handleError(error)
 			});
 	}
 }

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -1801,6 +1801,9 @@
 			"REGENERATE_KEY_LABEL": "API Key & Secret",
 			"CONFIRM_DELETE": "Are you sure you want to remove this Plane integration? This will revoke the API key.",
 			"CONFIRM_REGENERATE": "Are you sure you want to regenerate the API key? The current key will be invalidated.",
+			"SETTINGS_SAVED": "Plane settings saved.",
+			"INTEGRATION_REMOVED": "Plane integration removed.",
+			"SESSION_EXPIRED": "Your session has expired. Please sign in again to open Plane.",
 			"API_KEY_DIALOG": {
 				"TITLE": "API Credentials",
 				"WARNING": "Copy these credentials now. The API secret will not be shown again.",

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -1804,6 +1804,8 @@
 			"SETTINGS_SAVED": "Plane settings saved.",
 			"INTEGRATION_REMOVED": "Plane integration removed.",
 			"SESSION_EXPIRED": "Your session has expired. Please sign in again to open Plane.",
+			"LOAD_FAILED": "Couldn't load the Plane integration settings.",
+			"RETRY": "Retry",
 			"API_KEY_DIALOG": {
 				"TITLE": "API Credentials",
 				"WARNING": "Copy these credentials now. The API secret will not be shown again.",


### PR DESCRIPTION
Closes the integration-page UX/notification backlog from the Plane review (B4–B9) plus the token-in-URL hardening.

## Changes
**Surface errors (no more swallowed failures)** — wires the app's `ToastrService` / `ErrorHandlingService` into the Plane integration page:
- **B4/B5** — save / remove / regenerate (`plane-settings`) and setup (`plane-authorize`) now show the server error via `ErrorHandlingService` instead of silently stopping the spinner; save/remove show a success toast.
- **B6** — a failed settings load only bounces to the setup screen on a genuine **404 (not configured)**. A transient/5xx error is surfaced and the user stays put, instead of a configured tenant being silently kicked back to "set up Plane".
- **B7** — the post-save settings re-fetch now has an error handler (no stale-state divergence).
- **B8** — "Open Plane" with no session token shows a warning instead of a silent no-op.
- **B9** — the API-key dialog "Copied!" state auto-resets after 2s (with `ngOnDestroy` cleanup) so repeat copies re-confirm.

**Token-in-URL hardening** — "Open Plane" now opens `<url>/#sso=<token>` (URL **fragment**) instead of `?sso=<token>` (query), so the Gauzy access token is never sent to the pm.gauzy.co web server (out of access logs / Referer / CDN).

Adds `SETTINGS_SAVED` / `INTEGRATION_REMOVED` / `SESSION_EXPIRED` i18n keys.

## ⚠️ Deploy-order note (fragment SSO)
The `#sso=` change requires the **pm.\* fork images** to be redeployed from the `ever` branch, whose `entry.client` now reads the fragment first (and **still falls back to `?sso=`** for backward compatibility) — see **ever-co/ever-gauzy-pm@b4bc32b**. Because the fork reads *both*, the safe order is: **redeploy pm.\* fork with/before this Gauzy update.** If Gauzy ships `#sso=` while an *old* fork (query-only) is still live, the handoff would miss the token until the fork redeploys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the Plane integration UX (B4–B9) by surfacing errors, adding clear toasts, and introducing an explicit load-failed state with a retry. Keeps the SSO handoff on `?sso=` for now; the fragment-based change will land later.

- **Bug Fixes**
  - Wired `ErrorHandlingService`/`ToastrService` into `plane-settings` and `plane-authorize`; success toasts for save/remove/regenerate.
  - Settings load: redirect to setup only on 404; on non-404 clear all state, show a load-failed UI with a Retry button, keep the org stream alive, and route retry through the reactive pipeline so it cancels on org changes (no stale data).
  - Post-save settings refresh now handles errors to avoid stale state; warn when “Open Plane” is clicked without a session token.
  - API key dialog “Copied!” auto-resets after 2s and avoids updates after the dialog is destroyed.
  - Added i18n keys: `SETTINGS_SAVED`, `INTEGRATION_REMOVED`, `SESSION_EXPIRED`, `LOAD_FAILED`, `RETRY`.

<sup>Written for commit 7bacb5fa8da7323f75e0ef56e28122bc0eae32e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

