### PR TITLE
ci: accept PR-merge promotions in the app release-tag gate

### DIFF
--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -2,7 +2,7 @@ name: Agent App Build Demo
 
 # The packaged desktop & server demo apps are built ONLY when 'develop' is promoted to the
 # 'local-apps' branch. The build version is resolved at build time
-# (.scripts/bump-version-electron.js) from the release tag pointing at this commit, which
+# (.scripts/bump-version-electron.js) from the release tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
 # 'Release Demo' creates on every merge to 'develop'.
 on:
   push:
@@ -16,37 +16,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'local-apps' was fast-forwarded to a 'develop'
-    # commit that 'Release Demo' has already tagged. Retries absorb the short merge -> tag delay.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'local-apps' is promoted from 'develop' either by
+    # fast-forwarding to the tagged 'develop' commit (tag on HEAD) or by merging the
+    # 'develop' -> 'local-apps' promotion PR (the tag then points at the merged
+    # 'develop' tip, HEAD^2). Retries absorb the short delay until 'Release Demo' tags
+    # the 'develop' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "local-apps" ]; then
             echo "::error::This workflow only releases from the 'local-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'develop' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/develop 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/develop" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'develop' tip -
+              # i.e. this is the promotion merge of 'develop', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Demo' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'local-apps' to the tagged 'develop' commit (git push origin origin/develop:local-apps) after 'Release Demo' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'develop' tip. Promote by merging the 'develop' -> 'local-apps' PR (or fast-forwarding: git push origin origin/develop:local-apps) after 'Release Demo' has created the tag; if 'develop' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-windows:
@@ -139,6 +174,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           # Demo electron releases go to the same repo

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -3,9 +3,10 @@ name: Agent Build Prod
 # The packaged desktop & server apps are built ONLY when 'master' is promoted to the 'apps' branch
 # (branch flow: develop -> stage -> master -> apps).
 # The build version is resolved at build time (.scripts/bump-version-electron.js) from the release
-# tag pointing at this commit, which 'Release Prod' creates on the merge to 'master' - so app releases
-# always carry the same version as the corresponding platform release and publish to the
-# same targets (each app repo's GitHub Releases + DigitalOcean Spaces).
+# tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Prod' creates on the merge to 'master' - so app releases always carry the same version
+# as the corresponding platform release and publish to the same targets (each app repo's GitHub
+# Releases + DigitalOcean Spaces).
 on:
   push:
     branches:
@@ -18,38 +19,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'apps' was fast-forwarded
-    # to a 'master' commit that 'Release Prod' has already tagged. Retries absorb the short
-    # merge -> tag delay when 'apps' is promoted right after the 'master' merge.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'apps' is promoted from 'master' either by
+    # fast-forwarding to the tagged 'master' commit (tag on HEAD) or by merging the
+    # 'master' -> 'apps' promotion PR (the tag then points at the merged
+    # 'master' tip, HEAD^2). Retries absorb the short delay until 'Release Prod' tags
+    # the 'master' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "apps" ]; then
             echo "::error::This workflow only releases from the 'apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'master' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/master 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/master" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'master' tip -
+              # i.e. this is the promotion merge of 'master', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Prod' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'apps' to the tagged 'master' commit (git push origin origin/master:apps) after 'Release Prod' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'master' tip. Promote by merging the 'master' -> 'apps' PR (or fast-forwarding: git push origin origin/master:apps) after 'Release Prod' has created the tag; if 'master' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -155,6 +190,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'
@@ -295,6 +331,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'
@@ -397,6 +434,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'
@@ -530,6 +568,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'
@@ -711,6 +750,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -2,8 +2,8 @@ name: Agent Build Stage
 
 # The packaged desktop & server stage apps are built ONLY when 'stage' is promoted to the 'stage-apps' branch
 # ('temp' is kept for ad-hoc testing). No new platform version is created here: the build
-# version is resolved at build time (.scripts/bump-version-electron.js) from the release tag
-# pointing at this commit, which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
+# version is resolved at build time (.scripts/bump-version-electron.js) from the release tag of the promoted commit
+# (on HEAD, or on the merge parent for PR-merge promotions), which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
 # carry the same version as the corresponding platform stage release.
 on:
   push:
@@ -18,21 +18,30 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'stage-apps' was
-    # fast-forwarded to a 'stage' commit that 'Release Stage' has already tagged. Retries
-    # absorb the short merge -> tag delay. Ad-hoc pushes to 'temp' skip the check.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'stage-apps' is promoted from 'stage' either by
+    # fast-forwarding to the tagged 'stage' commit (tag on HEAD) or by merging the
+    # 'stage' -> 'stage-apps' promotion PR (the tag then points at the merged
+    # 'stage' tip, HEAD^2). Retries absorb the short delay until 'Release Stage' tags
+    # the 'stage' commit.
+    # Ad-hoc pushes to 'temp' skip the check.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" = "temp" ]; then
@@ -43,17 +52,43 @@ jobs:
             echo "::error::This workflow only releases from the 'stage-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'stage' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/stage 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/stage" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'stage' tip -
+              # i.e. this is the promotion merge of 'stage', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Stage' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'stage-apps' to the tagged 'stage' commit (git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'stage' tip. Promote by merging the 'stage' -> 'stage-apps' PR (or fast-forwarding: git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag; if 'stage' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -143,6 +178,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'
@@ -267,6 +303,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'
@@ -369,6 +406,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'
@@ -502,6 +540,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'
@@ -683,6 +722,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'
           AGENT_APP_REPO_NAME: 'ever-gauzy-agent'

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -2,8 +2,9 @@ name: Desktop App Build Demo
 
 # The packaged desktop & server demo apps are built ONLY when 'develop' is promoted to the
 # 'local-apps' branch. The build version is resolved at build time
-# (.scripts/bump-version-electron.js) from the release tag pointing at this commit, which
-# 'Release Demo' creates on every merge to 'develop'.
+# (.scripts/bump-version-electron.js) from the release tag of the promoted commit (on HEAD,
+# or on the merge parent for PR-merge promotions), which 'Release Demo' creates on every
+# merge to 'develop'.
 on:
   push:
     branches:
@@ -16,37 +17,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'local-apps' was fast-forwarded to a 'develop'
-    # commit that 'Release Demo' has already tagged. Retries absorb the short merge -> tag delay.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'local-apps' is promoted from 'develop' either by
+    # fast-forwarding to the tagged 'develop' commit (tag on HEAD) or by merging the
+    # 'develop' -> 'local-apps' promotion PR (the tag then points at the merged
+    # 'develop' tip, HEAD^2). Retries absorb the short delay until 'Release Demo' tags
+    # the 'develop' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "local-apps" ]; then
             echo "::error::This workflow only releases from the 'local-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'develop' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/develop 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/develop" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'develop' tip -
+              # i.e. this is the promotion merge of 'develop', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Demo' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'local-apps' to the tagged 'develop' commit (git push origin origin/develop:local-apps) after 'Release Demo' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'develop' tip. Promote by merging the 'develop' -> 'local-apps' PR (or fast-forwarding: git push origin origin/develop:local-apps) after 'Release Demo' has created the tag; if 'develop' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-windows:
@@ -139,6 +175,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           # Demo electron releases go to the same repo

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -3,7 +3,8 @@ name: Desktop App Build Prod
 # The packaged desktop & server apps are built ONLY when 'master' is promoted to the 'apps' branch
 # (branch flow: develop -> stage -> master -> apps).
 # The build version is resolved at build time (.scripts/bump-version-electron.js) from the release
-# tag pointing at this commit, which 'Release Prod' creates on the merge to 'master' - so app releases
+# tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Prod' creates on the merge to 'master' - so app releases
 # always carry the same version as the corresponding platform release and publish to the
 # same targets (each app repo's GitHub Releases + DigitalOcean Spaces).
 on:
@@ -18,38 +19,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'apps' was fast-forwarded
-    # to a 'master' commit that 'Release Prod' has already tagged. Retries absorb the short
-    # merge -> tag delay when 'apps' is promoted right after the 'master' merge.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'apps' is promoted from 'master' either by
+    # fast-forwarding to the tagged 'master' commit (tag on HEAD) or by merging the
+    # 'master' -> 'apps' promotion PR (the tag then points at the merged
+    # 'master' tip, HEAD^2). Retries absorb the short delay until 'Release Prod' tags
+    # the 'master' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "apps" ]; then
             echo "::error::This workflow only releases from the 'apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'master' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/master 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/master" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'master' tip -
+              # i.e. this is the promotion merge of 'master', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Prod' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'apps' to the tagged 'master' commit (git push origin origin/master:apps) after 'Release Prod' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'master' tip. Promote by merging the 'master' -> 'apps' PR (or fast-forwarding: git push origin origin/master:apps) after 'Release Prod' has created the tag; if 'master' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -155,6 +190,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'
@@ -295,6 +331,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'
@@ -397,6 +434,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'
@@ -530,6 +568,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'
@@ -715,6 +754,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -2,8 +2,9 @@ name: Desktop App Build Stage
 
 # The packaged desktop & server stage apps are built ONLY when 'stage' is promoted to the 'stage-apps' branch
 # ('temp' is kept for ad-hoc testing). No new platform version is created here: the build
-# version is resolved at build time (.scripts/bump-version-electron.js) from the release tag
-# pointing at this commit, which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
+# version is resolved at build time (.scripts/bump-version-electron.js) from the release tag of
+# the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
 # carry the same version as the corresponding platform stage release.
 on:
   push:
@@ -18,21 +19,30 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'stage-apps' was
-    # fast-forwarded to a 'stage' commit that 'Release Stage' has already tagged. Retries
-    # absorb the short merge -> tag delay. Ad-hoc pushes to 'temp' skip the check.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'stage-apps' is promoted from 'stage' either by
+    # fast-forwarding to the tagged 'stage' commit (tag on HEAD) or by merging the
+    # 'stage' -> 'stage-apps' promotion PR (the tag then points at the merged
+    # 'stage' tip, HEAD^2). Retries absorb the short delay until 'Release Stage' tags
+    # the 'stage' commit.
+    # Ad-hoc pushes to 'temp' skip the check.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" = "temp" ]; then
@@ -43,17 +53,43 @@ jobs:
             echo "::error::This workflow only releases from the 'stage-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'stage' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/stage 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/stage" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'stage' tip -
+              # i.e. this is the promotion merge of 'stage', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Stage' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'stage-apps' to the tagged 'stage' commit (git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'stage' tip. Promote by merging the 'stage' -> 'stage-apps' PR (or fast-forwarding: git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag; if 'stage' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -143,6 +179,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'
@@ -267,6 +304,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'
@@ -369,6 +407,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'
@@ -502,6 +541,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'
@@ -687,6 +727,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'
           DESKTOP_APP_REPO_NAME: 'ever-gauzy-desktop'

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -2,7 +2,7 @@ name: Desktop Timer App Build Demo
 
 # The packaged desktop & server demo apps are built ONLY when 'develop' is promoted to the
 # 'local-apps' branch. The build version is resolved at build time
-# (.scripts/bump-version-electron.js) from the release tag pointing at this commit, which
+# (.scripts/bump-version-electron.js) from the release tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
 # 'Release Demo' creates on every merge to 'develop'.
 on:
   push:
@@ -16,37 +16,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'local-apps' was fast-forwarded to a 'develop'
-    # commit that 'Release Demo' has already tagged. Retries absorb the short merge -> tag delay.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'local-apps' is promoted from 'develop' either by
+    # fast-forwarding to the tagged 'develop' commit (tag on HEAD) or by merging the
+    # 'develop' -> 'local-apps' promotion PR (the tag then points at the merged
+    # 'develop' tip, HEAD^2). Retries absorb the short delay until 'Release Demo' tags
+    # the 'develop' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "local-apps" ]; then
             echo "::error::This workflow only releases from the 'local-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'develop' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/develop 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/develop" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'develop' tip -
+              # i.e. this is the promotion merge of 'develop', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Demo' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'local-apps' to the tagged 'develop' commit (git push origin origin/develop:local-apps) after 'Release Demo' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'develop' tip. Promote by merging the 'develop' -> 'local-apps' PR (or fast-forwarding: git push origin origin/develop:local-apps) after 'Release Demo' has created the tag; if 'develop' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-windows:
@@ -139,6 +174,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           # Demo electron releases go to the same repo

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -3,7 +3,8 @@ name: Desktop Timer App Build Prod
 # The packaged desktop & server apps are built ONLY when 'master' is promoted to the 'apps' branch
 # (branch flow: develop -> stage -> master -> apps).
 # The build version is resolved at build time (.scripts/bump-version-electron.js) from the release
-# tag pointing at this commit, which 'Release Prod' creates on the merge to 'master' - so app releases
+# tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Prod' creates on the merge to 'master' - so app releases
 # always carry the same version as the corresponding platform release and publish to the
 # same targets (each app repo's GitHub Releases + DigitalOcean Spaces).
 on:
@@ -18,38 +19,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'apps' was fast-forwarded
-    # to a 'master' commit that 'Release Prod' has already tagged. Retries absorb the short
-    # merge -> tag delay when 'apps' is promoted right after the 'master' merge.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'apps' is promoted from 'master' either by
+    # fast-forwarding to the tagged 'master' commit (tag on HEAD) or by merging the
+    # 'master' -> 'apps' promotion PR (the tag then points at the merged
+    # 'master' tip, HEAD^2). Retries absorb the short delay until 'Release Prod' tags
+    # the 'master' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "apps" ]; then
             echo "::error::This workflow only releases from the 'apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'master' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/master 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/master" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'master' tip -
+              # i.e. this is the promotion merge of 'master', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Prod' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'apps' to the tagged 'master' commit (git push origin origin/master:apps) after 'Release Prod' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'master' tip. Promote by merging the 'master' -> 'apps' PR (or fast-forwarding: git push origin origin/master:apps) after 'Release Prod' has created the tag; if 'master' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -155,6 +190,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'
@@ -295,6 +331,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'
@@ -397,6 +434,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'
@@ -530,6 +568,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'
@@ -715,6 +754,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -2,8 +2,8 @@ name: Desktop Timer App Build Stage
 
 # The packaged desktop & server stage apps are built ONLY when 'stage' is promoted to the 'stage-apps' branch
 # ('temp' is kept for ad-hoc testing). No new platform version is created here: the build
-# version is resolved at build time (.scripts/bump-version-electron.js) from the release tag
-# pointing at this commit, which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
+# version is resolved at build time (.scripts/bump-version-electron.js) from the release tag of the
+# promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
 # carry the same version as the corresponding platform stage release.
 on:
   push:
@@ -18,21 +18,30 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'stage-apps' was
-    # fast-forwarded to a 'stage' commit that 'Release Stage' has already tagged. Retries
-    # absorb the short merge -> tag delay. Ad-hoc pushes to 'temp' skip the check.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'stage-apps' is promoted from 'stage' either by
+    # fast-forwarding to the tagged 'stage' commit (tag on HEAD) or by merging the
+    # 'stage' -> 'stage-apps' promotion PR (the tag then points at the merged
+    # 'stage' tip, HEAD^2). Retries absorb the short delay until 'Release Stage' tags
+    # the 'stage' commit.
+    # Ad-hoc pushes to 'temp' skip the check.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" = "temp" ]; then
@@ -43,17 +52,43 @@ jobs:
             echo "::error::This workflow only releases from the 'stage-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'stage' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/stage 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/stage" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'stage' tip -
+              # i.e. this is the promotion merge of 'stage', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Stage' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'stage-apps' to the tagged 'stage' commit (git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'stage' tip. Promote by merging the 'stage' -> 'stage-apps' PR (or fast-forwarding: git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag; if 'stage' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -143,6 +178,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'
@@ -267,6 +303,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'
@@ -369,6 +406,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'
@@ -502,6 +540,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'
@@ -687,6 +726,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'
           DESKTOP_TIMER_APP_REPO_NAME: 'ever-gauzy-desktop-timer'

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -2,7 +2,7 @@ name: Server API App Build Demo
 
 # The packaged desktop & server demo apps are built ONLY when 'develop' is promoted to the
 # 'local-apps' branch. The build version is resolved at build time
-# (.scripts/bump-version-electron.js) from the release tag pointing at this commit, which
+# (.scripts/bump-version-electron.js) from the release tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
 # 'Release Demo' creates on every merge to 'develop'.
 on:
   push:
@@ -16,37 +16,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'local-apps' was fast-forwarded to a 'develop'
-    # commit that 'Release Demo' has already tagged. Retries absorb the short merge -> tag delay.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'local-apps' is promoted from 'develop' either by
+    # fast-forwarding to the tagged 'develop' commit (tag on HEAD) or by merging the
+    # 'develop' -> 'local-apps' promotion PR (the tag then points at the merged
+    # 'develop' tip, HEAD^2). Retries absorb the short delay until 'Release Demo' tags
+    # the 'develop' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "local-apps" ]; then
             echo "::error::This workflow only releases from the 'local-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'develop' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/develop 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/develop" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'develop' tip -
+              # i.e. this is the promotion merge of 'develop', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Demo' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'local-apps' to the tagged 'develop' commit (git push origin origin/develop:local-apps) after 'Release Demo' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'develop' tip. Promote by merging the 'develop' -> 'local-apps' PR (or fast-forwarding: git push origin origin/develop:local-apps) after 'Release Demo' has created the tag; if 'develop' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-windows:
@@ -139,6 +174,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           # Demo electron releases go to the same repo

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -3,7 +3,8 @@ name: API Server Build Prod
 # The packaged desktop & server apps are built ONLY when 'master' is promoted to the 'apps' branch
 # (branch flow: develop -> stage -> master -> apps).
 # The build version is resolved at build time (.scripts/bump-version-electron.js) from the release
-# tag pointing at this commit, which 'Release Prod' creates on the merge to 'master' - so app releases
+# tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Prod' creates on the merge to 'master' - so app releases
 # always carry the same version as the corresponding platform release and publish to the
 # same targets (each app repo's GitHub Releases + DigitalOcean Spaces).
 on:
@@ -18,38 +19,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'apps' was fast-forwarded
-    # to a 'master' commit that 'Release Prod' has already tagged. Retries absorb the short
-    # merge -> tag delay when 'apps' is promoted right after the 'master' merge.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'apps' is promoted from 'master' either by
+    # fast-forwarding to the tagged 'master' commit (tag on HEAD) or by merging the
+    # 'master' -> 'apps' promotion PR (the tag then points at the merged
+    # 'master' tip, HEAD^2). Retries absorb the short delay until 'Release Prod' tags
+    # the 'master' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "apps" ]; then
             echo "::error::This workflow only releases from the 'apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'master' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/master 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/master" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'master' tip -
+              # i.e. this is the promotion merge of 'master', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Prod' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'apps' to the tagged 'master' commit (git push origin origin/master:apps) after 'Release Prod' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'master' tip. Promote by merging the 'master' -> 'apps' PR (or fast-forwarding: git push origin origin/master:apps) after 'Release Prod' has created the tag; if 'master' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -155,6 +190,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'
@@ -295,6 +331,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'
@@ -397,6 +434,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'
@@ -530,6 +568,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'
@@ -711,6 +750,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -3,7 +3,8 @@ name: API Server Build Stage
 # The packaged desktop & server stage apps are built ONLY when 'stage' is promoted to the 'stage-apps' branch
 # ('temp' is kept for ad-hoc testing). No new platform version is created here: the build
 # version is resolved at build time (.scripts/bump-version-electron.js) from the release tag
-# pointing at this commit, which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
+# of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
 # carry the same version as the corresponding platform stage release.
 on:
   push:
@@ -18,21 +19,30 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'stage-apps' was
-    # fast-forwarded to a 'stage' commit that 'Release Stage' has already tagged. Retries
-    # absorb the short merge -> tag delay. Ad-hoc pushes to 'temp' skip the check.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'stage-apps' is promoted from 'stage' either by
+    # fast-forwarding to the tagged 'stage' commit (tag on HEAD) or by merging the
+    # 'stage' -> 'stage-apps' promotion PR (the tag then points at the merged
+    # 'stage' tip, HEAD^2). Retries absorb the short delay until 'Release Stage' tags
+    # the 'stage' commit.
+    # Ad-hoc pushes to 'temp' skip the check.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" = "temp" ]; then
@@ -43,17 +53,43 @@ jobs:
             echo "::error::This workflow only releases from the 'stage-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'stage' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/stage 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/stage" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'stage' tip -
+              # i.e. this is the promotion merge of 'stage', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Stage' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'stage-apps' to the tagged 'stage' commit (git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'stage' tip. Promote by merging the 'stage' -> 'stage-apps' PR (or fast-forwarding: git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag; if 'stage' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -143,6 +179,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'
@@ -267,6 +304,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'
@@ -369,6 +407,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'
@@ -502,6 +541,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'
@@ -683,6 +723,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'
           DESKTOP_API_SERVER_REPO_NAME: 'ever-gauzy-api-server'

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -2,7 +2,7 @@ name: Server App Build Demo
 
 # The packaged desktop & server demo apps are built ONLY when 'develop' is promoted to the
 # 'local-apps' branch. The build version is resolved at build time
-# (.scripts/bump-version-electron.js) from the release tag pointing at this commit, which
+# (.scripts/bump-version-electron.js) from the release tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
 # 'Release Demo' creates on every merge to 'develop'.
 on:
   push:
@@ -16,37 +16,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'local-apps' was fast-forwarded to a 'develop'
-    # commit that 'Release Demo' has already tagged. Retries absorb the short merge -> tag delay.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'local-apps' is promoted from 'develop' either by
+    # fast-forwarding to the tagged 'develop' commit (tag on HEAD) or by merging the
+    # 'develop' -> 'local-apps' promotion PR (the tag then points at the merged
+    # 'develop' tip, HEAD^2). Retries absorb the short delay until 'Release Demo' tags
+    # the 'develop' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "local-apps" ]; then
             echo "::error::This workflow only releases from the 'local-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'develop' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/develop 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/develop" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'develop' tip -
+              # i.e. this is the promotion merge of 'develop', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Demo' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'local-apps' to the tagged 'develop' commit (git push origin origin/develop:local-apps) after 'Release Demo' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'develop' tip. Promote by merging the 'develop' -> 'local-apps' PR (or fast-forwarding: git push origin origin/develop:local-apps) after 'Release Demo' has created the tag; if 'develop' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-windows:
@@ -139,6 +174,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           # Demo electron releases go to the same repo

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -2,7 +2,7 @@ name: Server MCP App Build Demo
 
 # The packaged desktop & server demo apps are built ONLY when 'develop' is promoted to the
 # 'local-apps' branch. The build version is resolved at build time
-# (.scripts/bump-version-electron.js) from the release tag pointing at this commit, which
+# (.scripts/bump-version-electron.js) from the release tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
 # 'Release Demo' creates on every merge to 'develop'.
 on:
   push:
@@ -16,37 +16,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'local-apps' was fast-forwarded to a 'develop'
-    # commit that 'Release Demo' has already tagged. Retries absorb the short merge -> tag delay.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'local-apps' is promoted from 'develop' either by
+    # fast-forwarding to the tagged 'develop' commit (tag on HEAD) or by merging the
+    # 'develop' -> 'local-apps' promotion PR (the tag then points at the merged
+    # 'develop' tip, HEAD^2). Retries absorb the short delay until 'Release Demo' tags
+    # the 'develop' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "local-apps" ]; then
             echo "::error::This workflow only releases from the 'local-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'develop' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/develop 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/develop" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'develop' tip -
+              # i.e. this is the promotion merge of 'develop', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Demo' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'local-apps' to the tagged 'develop' commit (git push origin origin/develop:local-apps) after 'Release Demo' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'develop' tip. Promote by merging the 'develop' -> 'local-apps' PR (or fast-forwarding: git push origin origin/develop:local-apps) after 'Release Demo' has created the tag; if 'develop' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-windows:
@@ -139,6 +174,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           # Demo electron releases go to the same repo

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -3,7 +3,8 @@ name: MCP Server Build Prod
 # The packaged desktop & server apps are built ONLY when 'master' is promoted to the 'apps' branch
 # (branch flow: develop -> stage -> master -> apps).
 # The build version is resolved at build time (.scripts/bump-version-electron.js) from the release
-# tag pointing at this commit, which 'Release Prod' creates on the merge to 'master' - so app releases
+# tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Prod' creates on the merge to 'master' - so app releases
 # always carry the same version as the corresponding platform release and publish to the
 # same targets (each app repo's GitHub Releases + DigitalOcean Spaces).
 on:
@@ -18,38 +19,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'apps' was fast-forwarded
-    # to a 'master' commit that 'Release Prod' has already tagged. Retries absorb the short
-    # merge -> tag delay when 'apps' is promoted right after the 'master' merge.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'apps' is promoted from 'master' either by
+    # fast-forwarding to the tagged 'master' commit (tag on HEAD) or by merging the
+    # 'master' -> 'apps' promotion PR (the tag then points at the merged
+    # 'master' tip, HEAD^2). Retries absorb the short delay until 'Release Prod' tags
+    # the 'master' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "apps" ]; then
             echo "::error::This workflow only releases from the 'apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'master' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/master 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/master" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'master' tip -
+              # i.e. this is the promotion merge of 'master', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Prod' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'apps' to the tagged 'master' commit (git push origin origin/master:apps) after 'Release Prod' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'master' tip. Promote by merging the 'master' -> 'apps' PR (or fast-forwarding: git push origin origin/master:apps) after 'Release Prod' has created the tag; if 'master' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -146,6 +181,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'
@@ -277,6 +313,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'
@@ -379,6 +416,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'
@@ -512,6 +550,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'
@@ -693,6 +732,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -3,7 +3,8 @@ name: MCP Server Build Stage
 # The packaged desktop & server stage apps are built ONLY when 'stage' is promoted to the 'stage-apps' branch
 # ('temp' is kept for ad-hoc testing). No new platform version is created here: the build
 # version is resolved at build time (.scripts/bump-version-electron.js) from the release tag
-# pointing at this commit, which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
+# of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
 # carry the same version as the corresponding platform stage release.
 on:
   push:
@@ -18,21 +19,30 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'stage-apps' was
-    # fast-forwarded to a 'stage' commit that 'Release Stage' has already tagged. Retries
-    # absorb the short merge -> tag delay. Ad-hoc pushes to 'temp' skip the check.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'stage-apps' is promoted from 'stage' either by
+    # fast-forwarding to the tagged 'stage' commit (tag on HEAD) or by merging the
+    # 'stage' -> 'stage-apps' promotion PR (the tag then points at the merged
+    # 'stage' tip, HEAD^2). Retries absorb the short delay until 'Release Stage' tags
+    # the 'stage' commit.
+    # Ad-hoc pushes to 'temp' skip the check.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" = "temp" ]; then
@@ -43,17 +53,43 @@ jobs:
             echo "::error::This workflow only releases from the 'stage-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'stage' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/stage 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/stage" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'stage' tip -
+              # i.e. this is the promotion merge of 'stage', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Stage' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'stage-apps' to the tagged 'stage' commit (git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'stage' tip. Promote by merging the 'stage' -> 'stage-apps' PR (or fast-forwarding: git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag; if 'stage' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -134,6 +170,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'
@@ -249,6 +286,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'
@@ -351,6 +389,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'
@@ -484,6 +523,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'
@@ -665,6 +705,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'
           DESKTOP_MCP_SERVER_REPO_NAME: 'ever-gauzy-mcp-server'

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -3,7 +3,8 @@ name: Server Build Prod
 # The packaged desktop & server apps are built ONLY when 'master' is promoted to the 'apps' branch
 # (branch flow: develop -> stage -> master -> apps).
 # The build version is resolved at build time (.scripts/bump-version-electron.js) from the release
-# tag pointing at this commit, which 'Release Prod' creates on the merge to 'master' - so app releases
+# tag of the promoted commit (on HEAD, or on the merge parent for PR-merge promotions), which
+# 'Release Prod' creates on the merge to 'master' - so app releases
 # always carry the same version as the corresponding platform release and publish to the
 # same targets (each app repo's GitHub Releases + DigitalOcean Spaces).
 on:
@@ -18,38 +19,72 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'apps' was fast-forwarded
-    # to a 'master' commit that 'Release Prod' has already tagged. Retries absorb the short
-    # merge -> tag delay when 'apps' is promoted right after the 'master' merge.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'apps' is promoted from 'master' either by
+    # fast-forwarding to the tagged 'master' commit (tag on HEAD) or by merging the
+    # 'master' -> 'apps' promotion PR (the tag then points at the merged
+    # 'master' tip, HEAD^2). Retries absorb the short delay until 'Release Prod' tags
+    # the 'master' commit.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" != "apps" ]; then
             echo "::error::This workflow only releases from the 'apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'master' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/master 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/master" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'master' tip -
+              # i.e. this is the promotion merge of 'master', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Prod' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'apps' to the tagged 'master' commit (git push origin origin/master:apps) after 'Release Prod' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'master' tip. Promote by merging the 'master' -> 'apps' PR (or fast-forwarding: git push origin origin/master:apps) after 'Release Prod' has created the tag; if 'master' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -155,6 +190,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'
@@ -331,6 +367,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'
@@ -471,6 +508,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'
@@ -640,6 +678,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'
@@ -861,6 +900,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(true))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -2,8 +2,8 @@ name: Server Build Stage
 
 # The packaged desktop & server stage apps are built ONLY when 'stage' is promoted to the 'stage-apps' branch
 # ('temp' is kept for ad-hoc testing). No new platform version is created here: the build
-# version is resolved at build time (.scripts/bump-version-electron.js) from the release tag
-# pointing at this commit, which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
+# version is resolved at build time (.scripts/bump-version-electron.js) from the release tag of the promoted
+# commit (on HEAD, or on the merge parent for PR-merge promotions), which 'Release Stage' creates on the merge to 'stage' - so the stage app prerelease builds
 # carry the same version as the corresponding platform stage release.
 on:
   push:
@@ -18,21 +18,30 @@ concurrency:
 
 jobs:
   check-release-tag:
-    # Only build when this exact commit carries a release tag (the version stamped into the
-    # packages - see header comment) - i.e. 'stage-apps' was
-    # fast-forwarded to a 'stage' commit that 'Release Stage' has already tagged. Retries
-    # absorb the short merge -> tag delay. Ad-hoc pushes to 'temp' skip the check.
+    # Only build when the promoted commit carries a release tag (the version stamped into the
+    # packages - see header comment). 'stage-apps' is promoted from 'stage' either by
+    # fast-forwarding to the tagged 'stage' commit (tag on HEAD) or by merging the
+    # 'stage' -> 'stage-apps' promotion PR (the tag then points at the merged
+    # 'stage' tip, HEAD^2). Retries absorb the short delay until 'Release Stage' tags
+    # the 'stage' commit.
+    # Ad-hoc pushes to 'temp' skip the check.
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      # The resolved vX.Y.Z release tag; the build jobs stamp exactly this version.
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          # Depth 2 so HEAD^2 resolves on merge-commit promotions
+          fetch-depth: 2
 
-      - name: Verify a release tag points at this commit
+      - name: Verify a release tag points at the promoted commit
+        id: resolve
         shell: bash
         run: |
           if [ "$GITHUB_REF_NAME" = "temp" ]; then
@@ -43,17 +52,43 @@ jobs:
             echo "::error::This workflow only releases from the 'stage-apps' branch (got '$GITHUB_REF_NAME')."
             exit 1
           fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Present only when the promotion PR was merged as a merge commit; the release tag
+          # then points at the merged 'stage' tip, not at the merge commit itself.
+          PARENT2_SHA=$(git rev-parse --verify --quiet 'HEAD^2' || true)
+          resolve_tag() {
+            # Highest vX.Y.Z tag pointing at $1 in the remote listing (peeled '^{}' entries
+            # carry the commit sha of annotated tags); empty when none match.
+            printf '%s\n' "$REMOTE_REFS" | awk -v sha="$1" '
+              $1 == sha && $2 ~ /^refs\/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\^\{\})?$/ {
+                t = $2
+                sub(/^refs\/tags\//, "", t)
+                sub(/\^\{\}$/, "", t)
+                print t
+              }' | sort -V | tail -n 1
+          }
           for i in $(seq 1 20); do
-            git fetch --quiet --depth=1 origin '+refs/tags/*:refs/tags/*' || echo "git fetch failed (attempt $i); will retry"
-            TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            if [ -n "$TAG" ]; then
-              echo "Release tag on this commit: $TAG"
-              exit 0
+            if REMOTE_REFS=$(git ls-remote origin refs/heads/stage 'refs/tags/*'); then
+              SRC_TIP=$(printf '%s\n' "$REMOTE_REFS" | awk -v ref="refs/heads/stage" '$2 == ref { print $1 }')
+              TAG=$(resolve_tag "$HEAD_SHA")
+              # Accept the merge-parent tag only when HEAD^2 is the current 'stage' tip -
+              # i.e. this is the promotion merge of 'stage', not an arbitrary tagged branch
+              # merged in, nor a fast-forward racing 'Release Stage' (whose tag lands on HEAD).
+              if [ -z "$TAG" ] && [ -n "$PARENT2_SHA" ] && [ "$PARENT2_SHA" = "$SRC_TIP" ]; then
+                TAG=$(resolve_tag "$PARENT2_SHA")
+              fi
+              if [ -n "$TAG" ]; then
+                echo "Release tag on the promoted commit: $TAG"
+                echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            else
+              echo "git ls-remote failed (attempt $i); will retry"
             fi
-            echo "No release tag points at this commit yet (attempt $i/20); retrying in 30s..."
+            echo "No release tag points at this commit or its merge parent yet (attempt $i/20); retrying in 30s..."
             sleep 30
           done
-          echo "::error::No release tag points at this commit. Promote by fast-forwarding 'stage-apps' to the tagged 'stage' commit (git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag."
+          echo "::error::No release tag points at this commit, and its merge parent does not match the tagged 'stage' tip. Promote by merging the 'stage' -> 'stage-apps' PR (or fast-forwarding: git push origin origin/stage:stage-apps) after 'Release Stage' has created the tag; if 'stage' has moved since the promotion PR was opened, re-promote."
           exit 1
 
   release-linux:
@@ -143,6 +178,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'
@@ -303,6 +339,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'
@@ -443,6 +480,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'
@@ -612,6 +650,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'
@@ -833,6 +872,7 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(false))
         env:
+          GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'
           DESKTOP_SERVER_REPO_NAME: 'ever-gauzy-server'

--- a/.scripts/bump-version-electron.js
+++ b/.scripts/bump-version-electron.js
@@ -62,6 +62,17 @@ async function getTagForCommit(repoURL, sha) {
 // exist (e.g. every develop merge creates one). Falls back to the latest tag for
 // builds of untagged commits (e.g. ad-hoc pushes to 'temp').
 async function getBuildTag(repoURL) {
+	// The check-release-tag gate resolves the release tag of the promoted commit - including
+	// merge-commit promotions, where the tag points at the merge parent (the promoted branch
+	// tip) rather than at GITHUB_SHA itself - and hands it down via GAUZY_RELEASE_TAG.
+	const gateTag = (process.env.GAUZY_RELEASE_TAG || '').trim();
+	if (gateTag) {
+		if (/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(gateTag)) {
+			console.log('Using release tag resolved by the check-release-tag gate:', gateTag);
+			return gateTag;
+		}
+		console.warn(`Ignoring GAUZY_RELEASE_TAG '${gateTag}' - not a vX.Y.Z release tag`);
+	}
 	try {
 		const sha = process.env.GITHUB_SHA || (await git.revparse(['HEAD'])).trim();
 		const tagAtCommit = await getTagForCommit(repoURL, sha);


### PR DESCRIPTION
## Why

Desktop/server app releases stopped building: see [run 29754352240](https://github.com/ever-co/ever-gauzy/actions/runs/29754352240). The `check-release-tag` gate (added during the #9780 review hardening) only accepts a `vX.Y.Z` release tag pointing at **HEAD**, assuming the apps branches are promoted by fast-forward. Real promotions are GitHub PR merges (e.g. #9813, `stage` -> `stage-apps`), which create a merge commit the tag can never point at - `v111.4.0` sits on the merge **parent** `4ca096f4`, not on HEAD `20622b82`.

Two compounding bugs made this hard to see:
1. The 20x30s poll loop refetched **all tag objects** every attempt (60-90s each on this repo''s tag count), blowing past the gate''s own `timeout-minutes: 15` - so the job died as cancelled without ever printing its `::error` diagnostic, and all `release-*` jobs were skipped.
2. Even if the gate had passed, `bump-version-electron.js` falls back to the **globally-latest** tag for untagged commits, which would stamp a newer develop version onto stage/prod artifacts - the exact mislabeling the gate exists to prevent.

## What

All 18 app workflows (6 apps x prod/stage/demo) + `.scripts/bump-version-electron.js`:

- **Gate accepts merge-commit promotions**: resolve the tag at HEAD, or at `HEAD^2` - but only when `HEAD^2` equals the current remote tip of the promoted-from branch (`master`/`stage`/`develop`). The source-tip equality check keeps the old guarantees: merging an arbitrary tagged branch into an apps branch still fails the gate, and a fast-forward promotion racing the Release workflow keeps polling for HEAD''s own tag instead of short-circuiting with the older `HEAD^2` (develop) version.
- **Cheap polling**: one `git ls-remote` ref listing per attempt (branch tip + tags in a single call) instead of refetching tag objects; `timeout-minutes` 15 -> 30 so the failure path surfaces the error message instead of a bare cancellation; checkout `fetch-depth: 2` so `HEAD^2` resolves.
- **Version stamping**: the gate exports the resolved tag as a job output; every build job passes it to `bump-version-electron.js` via `GAUZY_RELEASE_TAG`, which the script now prefers over re-resolving. Ad-hoc `temp` builds (gate skipped, no tag output) keep the existing fallback behavior.

## Verification

- `actionlint` clean on all 18 files (only pre-existing custom runner-label notices).
- Invariants checked: every `bump-version-electron.js` step (66 total) got exactly one `GAUZY_RELEASE_TAG` env line, all in jobs with `needs: check-release-tag`; `temp` skip present only in the 6 stage workflows.
- Gate shell logic replayed against the live repo under `bash -e -o pipefail`: the failed promotion (`20622b82`, `^2 = 4ca096f4` = current stage tip) resolves `v111.4.0`; an arbitrary tagged non-tip commit is rejected; annotated (peeled `^{}`) and lightweight tags both handled; untagged path survives the full retry loop.

After merge, the same fix will be landed on `stage` (cherry-pick PR) and `stage` re-promoted to `stage-apps` so the pending app release actually builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the app release gate to accept PR-merge promotions and restores app builds. Prevents version mislabeling by passing the resolved release tag through the pipeline and speeding up gate polling.

- **Bug Fixes**
  - Updated all 18 app workflows to resolve the release tag at HEAD, or at HEAD^2 only when it matches the source branch tip (`develop`/`stage`/`master`). This accepts merge-commit promotions while keeping safety checks.
  - Switched polling to a single `git ls-remote` per attempt, increased timeout to 30 minutes, and set checkout `fetch-depth: 2` so merge parents resolve reliably.
  - Exported the resolved tag as a job output and pass it as `GAUZY_RELEASE_TAG` to `.scripts/bump-version-electron.js`, which now prefers it. Prevents falling back to the globally latest tag on untagged merges; ad‑hoc `temp` builds keep the fallback.

<sup>Written for commit 51be07c1c0d562bad7369122016de53abfb2008c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

