### PR TITLE
ci: run Linux app packaging on VM runners + drop dead DO Spaces publisher

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -254,6 +254,7 @@
 		"buildtools",
 		"buildx",
 		"Buildx",
+		"bwrap",
 		"Bykey",
 		"Bykey",
 		"bytea",

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -98,7 +98,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -99,7 +99,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -98,7 +98,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -99,7 +99,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -99,7 +99,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -98,7 +98,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.scripts/bump-version-electron.js
+++ b/.scripts/bump-version-electron.js
@@ -134,13 +134,6 @@ module.exports.serverapi = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -150,13 +143,6 @@ module.exports.serverapi = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -216,13 +202,6 @@ module.exports.server = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -232,13 +211,6 @@ module.exports.server = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -298,13 +270,6 @@ module.exports.servermcp = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -314,13 +279,6 @@ module.exports.servermcp = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -380,13 +338,6 @@ module.exports.desktop = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -396,13 +347,6 @@ module.exports.desktop = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -462,13 +406,6 @@ module.exports.desktopTimer = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${timerAppName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -478,13 +415,6 @@ module.exports.desktopTimer = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${timerAppName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -544,13 +474,6 @@ module.exports.agent = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -560,13 +483,6 @@ module.exports.agent = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}


### PR DESCRIPTION
Follow-up to #9818: the first real app-build wave (v111.5.3, promoted in #9826) got past the fixed release-tag gates and exposed two deterministic failures unrelated to app code:

1. **`release-linux` cannot run on the k8s ARC container runners.** Flatpak needs bwrap mount namespaces (`bwrap: Failed to make / slave: Permission denied`) and Snapcraft needs snapd - neither works in an unprivileged container. These packaging jobs ran on VM-class runners until the `RUNNER_LINUX_X64_8` conversion. This PR routes them to a dedicated `RUNNER_LINUX_APPS_X64` variable falling back to GitHub-hosted `ubuntu-latest` VMs (free for public repos). 12 files (6 apps x prod/stage; demo builds are Windows-only).

2. **electron-builder still published to the dead DigitalOcean Spaces bucket `ever`** - every upload 404s (`NoSuchBucket`) and aborts the build *after* signing (observed on the MCP Server Windows build). Removed the `spaces` publisher from all 12 publish configs; GitHub Releases remains the publish target. The now-unused `DO_KEY_ID`/`DO_SECRET_KEY` envs in workflows can be cleaned separately.

Also observed in the wave, not addressed here: `windows-11-arm` hosted jobs fail instantly with no runner (GitHub-side; retrying with the next wave), `linux-arm64` jobs sit queued because the Ubicloud integration appears inactive, one transient npm-registry failure on macOS, and one self-hosted Windows runner communication loss.

Verification: `actionlint` clean on the 12 workflows; `node -e require(...)` loads the modified bump script; the removed blocks were pattern-asserted (exactly 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Linux app packaging on VM runners to unblock `flatpak`/`snapcraft`, and remove the dead DigitalOcean Spaces publisher to stop post-signing build failures. Uses `RUNNER_LINUX_APPS_X64` with an `ubuntu-latest` fallback; GitHub Releases remains the only publish target.

- **Bug Fixes**
  - Route `release-linux` packaging jobs to VM-class runners via `RUNNER_LINUX_APPS_X64` (fallback `ubuntu-latest`); `flatpak` (`bwrap`) and `snapcraft` (`snapd`) require VMs; add "bwrap" to .cspell.json.
  - Remove `electron-builder` `spaces` publisher (bucket `ever`) to prevent 404s and aborted builds; publish only to GitHub Releases.

- **Migration**
  - Set `RUNNER_LINUX_APPS_X64` at the org/repo level if using self-hosted VM runners; otherwise GitHub-hosted VMs are used.
  - `DO_KEY_ID` and `DO_SECRET_KEY` workflow envs are now unused and can be removed.

<sup>Written for commit 3cccd9f4c405a2104806e138873b7d9a95ebcae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

