### PR TITLE
feat(core): add dependency-free GET /api/health/live liveness endpoint

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -558,6 +558,7 @@
 		"kube",
 		"kubeconfig",
 		"kubectl",
+		"kubelet",
 		"Kubernetes",
 		"kurkle",
 		"Kyoster",

--- a/packages/core/src/lib/bootstrap/redis-store.ts
+++ b/packages/core/src/lib/bootstrap/redis-store.ts
@@ -30,6 +30,25 @@ function createRedisClient(options: any) {
 }
 
 /**
+ * Wraps the session middleware so it is skipped for health probe routes.
+ *
+ * Probe requests carry no cookies, so with `saveUninitialized: true` every probe
+ * would create a brand-new session, and — with the Redis store — express-session
+ * defers the response until the session write settles. That would silently couple
+ * the dependency-free liveness endpoint (`GET /api/health/live`) to Redis
+ * availability (a Redis outage would hang the response past the probe timeout and
+ * get healthy pods killed) and grows garbage session keys on every readiness probe.
+ * Health routes never use sessions, so skipping is safe.
+ *
+ * @param middleware - The configured express-session middleware.
+ * @returns A middleware that bypasses session handling for `/api/health*` routes.
+ */
+function skipSessionForHealthRoutes(middleware: any) {
+	return (req: any, res: any, next: any) =>
+		req.path === '/api/health' || req.path.startsWith('/api/health/') ? next() : middleware(req, res, next);
+}
+
+/**
  * Configures session store with Redis or falls back to in-memory session management.
  *
  * @param app - The Express application instance.
@@ -102,15 +121,17 @@ export async function configureRedisSession(app: any): Promise<void> {
 			});
 
 			app.use(
-				expressSession({
-					store: redisStore,
-					secret: environment.EXPRESS_SESSION_SECRET,
-					resave: false, // Required for lightweight session keep alive (touch)
-					saveUninitialized: true,
-					// 'auto' sets the Secure flag only over HTTPS: on (prod/stage/demo run behind the proxy with
-					// `trust proxy` enabled in bootstrap) and off on plain-HTTP local dev so sessions keep working there.
-					cookie: { secure: 'auto' }
-				})
+				skipSessionForHealthRoutes(
+					expressSession({
+						store: redisStore,
+						secret: environment.EXPRESS_SESSION_SECRET,
+						resave: false, // Required for lightweight session keep alive (touch)
+						saveUninitialized: true,
+						// 'auto' sets the Secure flag only over HTTPS: on (prod/stage/demo run behind the proxy with
+						// `trust proxy` enabled in bootstrap) and off on plain-HTTP local dev so sessions keep working there.
+						cookie: { secure: 'auto' }
+					})
+				)
 			);
 
 			redisWorked = true;
@@ -121,14 +142,16 @@ export async function configureRedisSession(app: any): Promise<void> {
 
 	if (!redisWorked) {
 		app.use(
-			expressSession({
-				secret: environment.EXPRESS_SESSION_SECRET,
-				resave: true, // Required as MemoryStore doesn't support `touch` method
-				saveUninitialized: true,
-				// 'auto' sets the Secure flag only over HTTPS: on (prod/stage/demo run behind the proxy with
-				// `trust proxy` enabled in bootstrap) and off on plain-HTTP local dev so sessions keep working there.
-				cookie: { secure: 'auto' }
-			})
+			skipSessionForHealthRoutes(
+				expressSession({
+					secret: environment.EXPRESS_SESSION_SECRET,
+					resave: true, // Required as MemoryStore doesn't support `touch` method
+					saveUninitialized: true,
+					// 'auto' sets the Secure flag only over HTTPS: on (prod/stage/demo run behind the proxy with
+					// `trust proxy` enabled in bootstrap) and off on plain-HTTP local dev so sessions keep working there.
+					cookie: { secure: 'auto' }
+				})
+			)
 		);
 	}
 }

--- a/packages/core/src/lib/health/health.controller.ts
+++ b/packages/core/src/lib/health/health.controller.ts
@@ -11,4 +11,23 @@ export class HealthController {
 	async getHealthStatus() {
 		return this.healthService.getHealthStatus();
 	}
+
+	/**
+	 * Liveness probe endpoint: reports only that the Node.js process and event
+	 * loop are responsive. It MUST stay free of any dependency checks (database,
+	 * storage, cache, redis) — a slow or down dependency should fail readiness
+	 * (`GET /health`), never liveness, otherwise the kubelet kills healthy pods
+	 * that are merely waiting on a dependency.
+	 *
+	 * @returns {{ status: string; uptime: number; timestamp: string }} - Process liveness info.
+	 */
+	@Public()
+	@Get('/live')
+	getLiveness() {
+		return {
+			status: 'ok',
+			uptime: process.uptime(),
+			timestamp: new Date().toISOString()
+		};
+	}
 }

--- a/packages/core/src/lib/health/health.controller.ts
+++ b/packages/core/src/lib/health/health.controller.ts
@@ -16,8 +16,10 @@ export class HealthController {
 	 * Liveness probe endpoint: reports only that the Node.js process and event
 	 * loop are responsive. It MUST stay free of any dependency checks (database,
 	 * storage, cache, redis) — a slow or down dependency should fail readiness
-	 * (`GET /health`), never liveness, otherwise the kubelet kills healthy pods
-	 * that are merely waiting on a dependency.
+	 * (`GET /api/health`), never liveness, otherwise the kubelet kills healthy
+	 * pods that are merely waiting on a dependency. The session middleware is
+	 * bypassed for health routes (see bootstrap/redis-store.ts), so this response
+	 * never waits on a session-store write either.
 	 *
 	 * @returns {{ status: string; uptime: number; timestamp: string }} - Process liveness info.
 	 */


### PR DESCRIPTION
## Why

`GET /api/health` runs real dependency checks (database user count, storage, cache, redis) — correct for **readiness**, dangerous for **liveness**: a slow database made the kubelet SIGKILL healthy API pods (prod incidents 2026-07-19/20/23). Prod liveness is currently a `tcpSocket` workaround, which cannot catch a hung event loop.

## What

New `GET /api/health/live` that touches **no dependencies at all** — it only proves the process + event loop are responsive (returns `status`/`uptime`/`timestamp`). This is the same three-tier shape Ever Works already uses (`/live` = process, `/health` = dependencies).

- `GET /api/health` — **unchanged**; readiness keeps using it
- `@Public()` like the existing route, so kubelet can probe unauthenticated

## Rollout

Once this ships in the `:dev`/`:stage`/`:prod` images via the normal develop → stage → master cascade, the k8s `livenessProbe` in `ever-co/k8s-gitops` will be pointed at `/api/health/live` per env (tracked in infra TODO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /api/health/live`, a dependency-free, `@Public()` liveness endpoint for process responsiveness. Health routes now bypass `express-session` so probes never wait on Redis or create sessions; `GET /api/health` readiness is unchanged.

- **Bug Fixes**
  - Bypass `express-session` on `/api/health*` (Redis and in-memory paths) to avoid Redis coupling and junk session keys.

- **Migration**
  - Point the Kubernetes livenessProbe to GET /api/health/live.

<sup>Written for commit 0605eeabe57bd85fdd5c90ccb69f8dbd16eb81ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

