### PR TITLE
ci: Linux VM runners + drop DO Spaces publisher (stage cherry-pick of #9827)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -254,6 +254,7 @@
 		"buildtools",
 		"buildx",
 		"Buildx",
+		"bwrap",
 		"Bykey",
 		"Bykey",
 		"bytea",

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -98,7 +98,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -99,7 +99,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -98,7 +98,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -99,7 +99,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -99,7 +99,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -94,7 +94,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -98,7 +98,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ["${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}"]
+        # Flatpak (bwrap) and Snapcraft (snapd) cannot run inside the k8s ARC container
+        # runners - this packaging job needs a VM-class runner. Override with the
+        # RUNNER_LINUX_APPS_X64 org/repo variable to use a self-hosted VM.
+        os: ["${{ vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest' }}"]
 
     steps:
       - name: Check out Git repository

--- a/.scripts/bump-version-electron.js
+++ b/.scripts/bump-version-electron.js
@@ -134,13 +134,6 @@ module.exports.serverapi = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -150,13 +143,6 @@ module.exports.serverapi = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -216,13 +202,6 @@ module.exports.server = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -232,13 +211,6 @@ module.exports.server = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -298,13 +270,6 @@ module.exports.servermcp = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -314,13 +279,6 @@ module.exports.servermcp = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -380,13 +338,6 @@ module.exports.desktop = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -396,13 +347,6 @@ module.exports.desktop = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -462,13 +406,6 @@ module.exports.desktopTimer = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${timerAppName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -478,13 +415,6 @@ module.exports.desktopTimer = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${timerAppName}`,
-					acl: 'public-read'
 				}
 			];
 		}
@@ -544,13 +474,6 @@ module.exports.agent = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'prerelease'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}-pre`,
-					acl: 'public-read'
 				}
 			];
 		} else {
@@ -560,13 +483,6 @@ module.exports.agent = async (isProd) => {
 					repo: appRepoName,
 					owner: appRepoOwner,
 					releaseType: 'release'
-				},
-				{
-					provider: 'spaces',
-					name: 'ever',
-					region: 'sfo3',
-					path: `/${appName}`,
-					acl: 'public-read'
 				}
 			];
 		}


### PR DESCRIPTION
Cherry-pick of #9827 (squash 9e006911a5, merged to `develop`) onto `stage`: release-linux app packaging moves off the ARC container runners onto VM-class runners (flatpak/snapcraft need bwrap/snapd), and the dead DigitalOcean Spaces publisher is removed from all electron-builder publish configs (NoSuchBucket aborted every Windows build after signing).

Merging fires Release Stage (new tag); the follow-up stage -> stage-apps promotion rebuilds all apps at that version, superseding the partial v111.5.3 wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Linux app packaging to VM runners and remove the dead DigitalOcean Spaces publisher to fix CI failures and unblock releases. This resolves flatpak/snapcraft errors on ARC container runners and stops post-signing build aborts.

- **Bug Fixes**
  - Route Linux packaging jobs to VM runners via `RUNNER_LINUX_APPS_X64` (fallback to `ubuntu-latest`); ARC containers cannot run `bwrap`/`snapd`.
  - Remove `spaces` publisher from all `electron-builder` configs; GitHub Releases is the only publish target.

- **Migration**
  - Set `RUNNER_LINUX_APPS_X64` to a self-hosted VM label if not using GitHub-hosted VMs.
  - Remove unused DO Spaces secrets (`DO_KEY_ID`, `DO_SECRET_KEY`) when convenient.

<sup>Written for commit 890da0b1b8f9b58fa39e243deaf267d959ba8cb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

