### PR TITLE
ci(e2e): npm -g installs need a user-writable prefix on the ARC container runners

### DIFF
--- a/.github/workflows/test_currents.yml
+++ b/.github/workflows/test_currents.yml
@@ -98,7 +98,13 @@ jobs:
         run: yarn build:package:all
 
       - name: Install forever package
-        run: npm install forever -g
+        shell: bash
+        # The k8s ARC container runners' system npm prefix (/usr/lib) is root-owned and there
+        # is no sudo - route npm -g installs to a user-writable prefix (harmless on VM runners).
+        run: |
+          npm config set prefix "$HOME/.npm-global"
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+          npm install forever -g
 
       - name: Run API in background
         run: yarn start:api:forever

--- a/.github/workflows/test_cypress.yml
+++ b/.github/workflows/test_cypress.yml
@@ -91,7 +91,13 @@ jobs:
         run: yarn build:package:all
 
       - name: Install forever package
-        run: npm install forever -g
+        shell: bash
+        # The k8s ARC container runners' system npm prefix (/usr/lib) is root-owned and there
+        # is no sudo - route npm -g installs to a user-writable prefix (harmless on VM runners).
+        run: |
+          npm config set prefix "$HOME/.npm-global"
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+          npm install forever -g
 
       - name: Run API in background
         run: yarn start:api:forever

--- a/.github/workflows/test_playwright.yml
+++ b/.github/workflows/test_playwright.yml
@@ -51,11 +51,16 @@ jobs:
         run: yarn config:dev
 
       - name: Install forever package
-        run: npm install forever -g
+        shell: bash
+        # The k8s ARC container runners' system npm prefix (/usr/lib) is root-owned and there
+        # is no sudo - route npm -g installs to a user-writable prefix (harmless on VM runners).
+        run: |
+          npm config set prefix "$HOME/.npm-global"
+          npm install forever -g
 
       - name: Add npm global bin to PATH
         shell: bash
-        run: echo "$(npm prefix -g)" >> "$GITHUB_PATH"
+        run: echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
       - name: Reset DB for a clean, deterministic seed
         shell: bash


### PR DESCRIPTION
Fixes the [Playwright Tests failure on develop](https://github.com/ever-co/ever-gauzy/actions/runs/30053247722/job/89359608667) reported after the runner migration: `npm install forever -g` dies with `EACCES: permission denied, mkdir /usr/lib/node_modules/forever` on the `ever-k8s-linux-x64-8` ARC container runners (root-owned system prefix, no sudo). It previously worked only because GitHub-hosted VMs have a user-writable `/usr/local`.

Fix: set the npm global prefix to `$HOME/.npm-global` before any `-g` install and put its `bin` on `GITHUB_PATH` - correct on both container and VM runners.

Also fixes a latent PATH bug in `test_playwright.yml`: the old step appended `$(npm prefix -g)` (the prefix root, not `bin/`), which only worked by accident. `test_cypress.yml` / `test_currents.yml` are trigger-disabled (`branches: [nope]`) but get the same treatment so re-enabling them cannot re-hit this.

Verification: actionlint clean; after merge I will `workflow_dispatch` Playwright Tests on develop and confirm the job gets past the install/PATH steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes e2e workflow failures on ARC container runners by routing global `npm` installs to a user-writable prefix and updating PATH. Ensures `forever` installs cleanly so Playwright/Cypress/Currents jobs can start services.

- **Bug Fixes**
  - Set `npm` global prefix to `$HOME/.npm-global` and add `$HOME/.npm-global/bin` to `GITHUB_PATH` before any `npm install -g` to avoid `EACCES` on ARC containers.
  - Correct PATH step in `test_playwright.yml` to append the `bin` dir (not the prefix root); applied the same change to `test_cypress.yml` and `test_currents.yml`.

<sup>Written for commit 96edbb881184cd6a0232ca506dc7b513e50c0df0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

