### PR TITLE
ci: build-resilience for the Verdaccio registry path (concurrency + yarn network limits)

### DIFF
--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -109,8 +109,6 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
-    echo 'network-concurrency 4' >> .yarnrc && \
     if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
@@ -124,7 +122,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock && \
     sed -i 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock; \
     fi && \
-    yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts && \
+    yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts && \
     yarn postinstall.manual && \
     yarn cache clean && \
     rm -f .npmrc .yarnrc
@@ -209,8 +207,6 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
-    echo 'network-concurrency 4' >> .yarnrc && \
     if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
@@ -224,7 +220,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock && \
     sed -i 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock; \
     fi && \
-    yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts --production && \
+    yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts --production && \
     yarn postinstall.manual && \
     yarn cache clean && \
     rm -f .npmrc .yarnrc

--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -109,6 +109,8 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
+    { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
+    echo 'network-concurrency 4' >> .yarnrc && \
     if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
@@ -207,6 +209,8 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
+    { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
+    echo 'network-concurrency 4' >> .yarnrc && \
     if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \

--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -70,7 +70,9 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc \
+    && echo 'network-concurrency 4' >> .yarnrc \
+    && if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -158,7 +160,9 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc \
+    && echo 'network-concurrency 4' >> .yarnrc \
+    && if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \

--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -70,9 +70,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc \
-    && echo 'network-concurrency 4' >> .yarnrc \
-    && if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -90,7 +88,7 @@ RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-r
 # Without this, patch-package prints "No patch files found" and the typeorm v1 compat patch is
 # never applied. (typeorm is installed here because packages/core/package.json is copied above.)
 COPY --chown=node:node patches ./patches
-RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts \
+RUN yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts \
     && yarn postinstall.manual \
     && yarn cache clean
 
@@ -160,9 +158,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc \
-    && echo 'network-concurrency 4' >> .yarnrc \
-    && if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -179,7 +175,7 @@ RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-r
 # Copy patch-package patches so `yarn postinstall.manual` (patch-package) can apply them
 # (see note in the dependencies stage above).
 COPY --chown=node:node patches ./patches
-RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts --production \
+RUN yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts --production \
     && yarn postinstall.manual \
     && yarn cache clean
 

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -115,9 +115,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc \
-    && echo 'network-concurrency 4' >> .yarnrc \
-    && if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -131,7 +129,7 @@ RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-r
     sed -i 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock; \
     fi
 
-RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts \
+RUN yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts \
     && yarn postinstall.manual \
     && yarn cache clean
 
@@ -199,9 +197,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc \
-    && echo 'network-concurrency 4' >> .yarnrc \
-    && if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -215,7 +211,7 @@ RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-r
     sed -i 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock; \
     fi
 
-RUN yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts --production \
+RUN yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts --production \
     && yarn postinstall.manual \
     && yarn cache clean
 

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -115,7 +115,9 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc \
+    && echo 'network-concurrency 4' >> .yarnrc \
+    && if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -197,7 +199,9 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc \
+    && echo 'network-concurrency 4' >> .yarnrc \
+    && if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -126,6 +126,8 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
 	VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
+	{ echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
+	echo 'network-concurrency 4' >> .yarnrc && \
 	if [ -n "$VERDACCIO_REGISTRY" ]; then \
 	echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
 	echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -126,8 +126,6 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
 	VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-	{ echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
-	echo 'network-concurrency 4' >> .yarnrc && \
 	if [ -n "$VERDACCIO_REGISTRY" ]; then \
 	echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
 	echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
@@ -141,7 +139,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
 	sed -i 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock && \
 	sed -i 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock; \
 	fi && \
-	yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts && \
+	yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts && \
 	yarn postinstall.manual && \
 	yarn cache clean && \
 	rm -f .npmrc .yarnrc

--- a/.deploy/worker/Dockerfile
+++ b/.deploy/worker/Dockerfile
@@ -109,8 +109,6 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
-    echo 'network-concurrency 4' >> .yarnrc && \
     if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
@@ -124,7 +122,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock && \
     sed -i 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock; \
     fi && \
-    yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts && \
+    yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts && \
     yarn postinstall.manual && \
     yarn cache clean && \
     rm -f .npmrc .yarnrc
@@ -209,8 +207,6 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
-    echo 'network-concurrency 4' >> .yarnrc && \
     if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
@@ -224,7 +220,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock && \
     sed -i 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock; \
     fi && \
-    yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts --production && \
+    yarn install --network-timeout 1000000 --network-concurrency 4 --frozen-lockfile --ignore-scripts --production && \
     yarn postinstall.manual && \
     yarn cache clean && \
     rm -f .npmrc .yarnrc

--- a/.deploy/worker/Dockerfile
+++ b/.deploy/worker/Dockerfile
@@ -109,6 +109,8 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
+    { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
+    echo 'network-concurrency 4' >> .yarnrc && \
     if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
@@ -207,6 +209,8 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
+    { echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc && \
+    echo 'network-concurrency 4' >> .yarnrc && \
     if [ -n "$VERDACCIO_REGISTRY" ]; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \

--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -8,8 +8,13 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.event.workflow_run.head_branch }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
+  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
+  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
+  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
+  # build workflows are deliberately NOT in this group.
+  group: gauzy-docker-build
+  cancel-in-progress: false
 
 jobs:
   gauzy-api:

--- a/.github/workflows/docker-build-publish-mcp-auth-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-demo.yml
@@ -11,8 +11,13 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
+  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
+  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
+  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
+  # build workflows are deliberately NOT in this group.
+  group: gauzy-docker-build
+  cancel-in-progress: false
 
 jobs:
   gauzy-mcp-auth:

--- a/.github/workflows/docker-build-publish-mcp-auth-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-stage.yml
@@ -10,8 +10,13 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
+  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
+  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
+  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
+  # build workflows are deliberately NOT in this group.
+  group: gauzy-docker-build
+  cancel-in-progress: false
 
 jobs:
   gauzy-mcp-auth:

--- a/.github/workflows/docker-build-publish-mcp-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-demo.yml
@@ -11,8 +11,13 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
+  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
+  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
+  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
+  # build workflows are deliberately NOT in this group.
+  group: gauzy-docker-build
+  cancel-in-progress: false
 
 jobs:
   gauzy-mcp:

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -10,8 +10,13 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
+  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
+  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
+  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
+  # build workflows are deliberately NOT in this group.
+  group: gauzy-docker-build
+  cancel-in-progress: false
 
 jobs:
   gauzy-mcp:

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -6,8 +6,13 @@ on:
       - stage
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
+  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
+  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
+  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
+  # build workflows are deliberately NOT in this group.
+  group: gauzy-docker-build
+  cancel-in-progress: false
 
 jobs:
   gauzy-api:


### PR DESCRIPTION
## What

Two additive changes to make the CI image builds resilient to the Verdaccio registry path under **parallel build load**.

## Why

On **2026-07-23**, two "Build and Publish Docker Images" runs (demo + stage, 3 install-heavy jobs each) plus the MCP builds overlapped to **~6-8 concurrent `yarn install`s** against the single internal registry VIP (`192.168.1.183:4873`). That peak load saturated the registry path and the shared runner/dind, producing intermittent install slowness and build failures ("There appears to be trouble with your network connection. Retrying…", and buildx session-deadline drops).

## Changes

### 1. Dockerfiles — `.deploy/{api,worker,webapp,mcp,mcp-auth}` (9 install blocks)

In each install `RUN`, **before** the existing registry switch, add:

```sh
{ echo 'fetch-retries=5'; echo 'fetch-retry-mintimeout=20000'; echo 'fetch-retry-maxtimeout=120000'; echo 'fetch-retry-factor=10'; } >> .npmrc
echo 'network-concurrency 4' >> .yarnrc
```

- `network-concurrency 4` (down from yarn-classic's default 8) is the **effective lever** here: it halves the simultaneous sockets each build opens to the registry, cutting both peak VIP load and the window in which a transient reset can be caught.
- `fetch-retries*` harden any npm-path (the `npm i -g` steps / non-yarn fetches).
- Placed **before** the `if [ -n "$VERDACCIO_REGISTRY" ]` switch, so it applies to **all three paths** (internal VIP / `packages.ever.co` token / public npm) and to forks. **Nothing hardcoded** — registry selection is unchanged. The existing `rm -f .npmrc .yarnrc` still cleans up (no token/config persists in a layer).

### 2. Workflows — shared concurrency group on the six **non-prod** build workflows

`docker-build-publish-{demo,stage,mcp-demo,mcp-stage,mcp-auth-demo,mcp-auth-stage}.yml` now share:

```yaml
concurrency:
  group: gauzy-docker-build
  cancel-in-progress: false
```

Previously each workflow's group included `${{ github.workflow }}`, so it only serialized against *itself* — nothing stopped demo + stage + mcp from all running at once. The shared group makes them **queue instead of overlap**, capping peak install load to one workflow's job-set at a time.

## Deliberately NOT touched

- **The three prod (`master`) workflows** (`-prod`, `-mcp-prod`, `-mcp-auth-prod`) keep their existing per-workflow groups. A shared `cancel-in-progress: false` group can supersede an older *pending* run, which is fine for WIP images but must never silently drop a queued **prod** build.

## Trade-offs (for the reviewer)

- **`network-concurrency 4`** marginally slows every install (incl. prod, since the Dockerfiles are shared and this rides the normal `develop → stage → master` cascade). Tune to `6`/`8` if throughput matters more than headroom.
- **Shared queue semantics:** with `cancel-in-progress: false`, a newer queued run cancels an older *pending* run in the same group. For these WIP images that's acceptable (the next push rebuilds). If you'd rather let demo and stage run concurrently, split into two groups (`gauzy-docker-build-demo` / `-stage`) — higher peak load, no cross-env supersession.

## Scope / safety

- Everything is **additive** (no existing logic removed) and **fork-safe**.
- Targets `develop`; the Dockerfile change reaches prod only via the normal cascade.
- This is a **mitigation** for the parallel-load trigger. The underlying root cause of the flap (a BestEffort `metallb-speaker` crash-looping under build-node CPU load, which moves the registry VIP mid-connection) is a separate, cluster-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve CI image build resilience under Verdaccio load by capping Yarn network concurrency and queuing non-prod builds. This reduces peak registry traffic and lowers flaky installs.

- **Refactors**
  - Dockerfiles: pass `--network-concurrency 4` to all `yarn install` steps in `.deploy/{api,worker,webapp,mcp,mcp-auth}` (deps and prod stages); applies to all registry paths. Removed `.npmrc` retry config since Yarn Classic ignores it.
  - Workflows: share `concurrency.group: gauzy-docker-build` with `cancel-in-progress: false` across demo/stage/mcp builds so runs queue; prod workflows unchanged.

<sup>Written for commit 056bb0d518a5b149a612ddcd5d1fcad6a2d65912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

