### PR TITLE
fix(core): parse legacy relations in employee and candidate pagination

### DIFF
--- a/packages/core/src/lib/candidate/candidate.service.ts
+++ b/packages/core/src/lib/candidate/candidate.service.ts
@@ -4,7 +4,7 @@ import { ICandidateCreateInput, BaseEntityEnum } from '@gauzy/contracts';
 import { isNotEmpty } from '@gauzy/utils';
 import { Candidate } from './candidate.entity';
 import { TenantAwareCrudService } from './../core/crud';
-import { MultiORMEnum } from './../core/utils';
+import { MultiORMEnum, parseFindOptionsRelations } from './../core/utils';
 import { RequestContext } from './../core/context';
 import { prepareSQLQuery as p } from './../database/database.helper';
 import { TypeOrmCandidateRepository } from './repository/type-orm-candidate.repository';
@@ -94,7 +94,7 @@ export class CandidateService extends TenantAwareCrudService<Candidate> {
 						take: options && options.take ? options.take : 10,
 						...(options && options.relations
 							? {
-									relations: options.relations
+									relations: parseFindOptionsRelations(options.relations)
 							  }
 							: {}),
 						...(options && options.join

--- a/packages/core/src/lib/candidate/candidate.service.ts
+++ b/packages/core/src/lib/candidate/candidate.service.ts
@@ -4,7 +4,7 @@ import { ICandidateCreateInput, BaseEntityEnum } from '@gauzy/contracts';
 import { isNotEmpty } from '@gauzy/utils';
 import { Candidate } from './candidate.entity';
 import { TenantAwareCrudService } from './../core/crud';
-import { MultiORMEnum, parseFindOptionsRelations } from './../core/utils';
+import { flatten, MultiORMEnum, parseFindOptionsRelations } from './../core/utils';
 import { RequestContext } from './../core/context';
 import { prepareSQLQuery as p } from './../database/database.helper';
 import { TypeOrmCandidateRepository } from './repository/type-orm-candidate.repository';
@@ -80,7 +80,7 @@ export class CandidateService extends TenantAwareCrudService<Candidate> {
 					}
 
 					const [items, total] = await this.mikroOrmRepository.findAndCount(mikroWhere, {
-						...(options?.relations ? { populate: Object.keys(options.relations) as any[] } : {}),
+						...(options?.relations ? { populate: flatten(options.relations) as any[] } : {}),
 						offset: options?.skip ? (options.take || 10) * (options.skip - 1) : 0,
 						limit: options?.take || 10
 					});

--- a/packages/core/src/lib/employee/employee.service.ts
+++ b/packages/core/src/lib/employee/employee.service.ts
@@ -14,7 +14,7 @@ import {
 import { isNotEmpty } from '@gauzy/utils';
 import { RequestContext } from '../core/context';
 import { BaseQueryDTO, TenantAwareCrudService } from './../core/crud';
-import { getDateRangeFormat, MultiORMEnum, parseFindOptionsRelations } from './../core/utils';
+import { flatten, getDateRangeFormat, MultiORMEnum, parseFindOptionsRelations } from './../core/utils';
 import { prepareSQLQuery as p } from './../database/database.helper';
 import { MikroOrmEmployeeRepository } from './repository/mikro-orm-employee.repository';
 import { TypeOrmEmployeeRepository } from './repository/type-orm-employee.repository';
@@ -564,7 +564,7 @@ export class EmployeeService extends TenantAwareCrudService<Employee> {
 					}
 
 					const [mItems, mTotal] = await this.mikroOrmRepository.findAndCount(mFilter, {
-						...(options?.relations ? { populate: Object.keys(options.relations) as any[] } : {}),
+						...(options?.relations ? { populate: flatten(options.relations) as any[] } : {}),
 						offset: options?.skip ? options.take * (options.skip - 1) : 0,
 						limit: options?.take || 10
 					});

--- a/packages/core/src/lib/employee/employee.service.ts
+++ b/packages/core/src/lib/employee/employee.service.ts
@@ -14,7 +14,7 @@ import {
 import { isNotEmpty } from '@gauzy/utils';
 import { RequestContext } from '../core/context';
 import { BaseQueryDTO, TenantAwareCrudService } from './../core/crud';
-import { getDateRangeFormat, MultiORMEnum } from './../core/utils';
+import { getDateRangeFormat, MultiORMEnum, parseFindOptionsRelations } from './../core/utils';
 import { prepareSQLQuery as p } from './../database/database.helper';
 import { MikroOrmEmployeeRepository } from './repository/mikro-orm-employee.repository';
 import { TypeOrmEmployeeRepository } from './repository/type-orm-employee.repository';
@@ -607,7 +607,9 @@ export class EmployeeService extends TenantAwareCrudService<Employee> {
 							isAway: true,
 							isOnline: true
 						},
-						...(options && options.relations ? { relations: options.relations } : {}),
+						...(options && options.relations
+							? { relations: parseFindOptionsRelations(options.relations) }
+							: {}),
 						...(options && 'withDeleted' in options ? { withDeleted: options.withDeleted } : {}) // Include soft-deleted parent entities
 					});
 


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

---

Fixes #9836

The TypeORM 0.3 to 1.0 migration (523700555b) removed the legacy string array form of `relations`. That migration added the `parseFindOptionsRelations` helper and applied it in the generic CRUD pagination and in the `organization-team`, `time-off-request` and `task` services, but the `employee` and `candidate` services still pass the raw array into `setFindOptions`. TypeORM now throws, the API answers 400 with an empty body, and the Employees > Manage and Candidates pages fail to load.

Reproduced on the demo environment: on exactly these two pagination endpoints, `relations[0]=user` fails with 400 while `relations[user]=true` succeeds, and the other pagination endpoints accept both forms.

This PR applies the same normalization helper at the two remaining call sites, matching what the migration already did everywhere else. Both the legacy array form and the object form are accepted again, so older clients keep working.

Local verification done on the SQLite dev setup with seeded data: both endpoints now return 200 for the legacy array form (`relations[0]=user`) and for the object form (`relations[user]=true`), and the employee list hydrates the `user` relation for the array form the UI sends. Before the fix, the array form returned 400 on exactly these two endpoints, as reproduced on the demo environment.
