### PR TITLE
feat(ui): Tenant Settings page (Sidebar | Settings Menu | Content) + Quick Settings rework

### DIFF
--- a/apps/gauzy/src/app/pages/settings/settings-routing.module.ts
+++ b/apps/gauzy/src/app/pages/settings/settings-routing.module.ts
@@ -13,6 +13,11 @@ const routes: Routes = [
 		component: SettingsComponent,
 		children: [
 			{
+				path: '',
+				redirectTo: 'general',
+				pathMatch: 'full'
+			},
+			{
 				path: 'general',
 				loadChildren: () =>
 					import('./general-setting/general-setting.module').then((m) => m.GeneralSettingModule)

--- a/apps/gauzy/src/app/pages/settings/settings.component.html
+++ b/apps/gauzy/src/app/pages/settings/settings.component.html
@@ -1,1 +1,22 @@
-<router-outlet></router-outlet>
+<div class="settings-shell">
+	<!-- Settings menu (narrow column) -->
+	<nav class="settings-nav">
+		<span class="settings-nav-title">{{ 'MENU.SETTINGS' | translate }}</span>
+		<ul class="settings-nav-list">
+			@for (item of settingsMenuItems$ | async; track item.id) {
+			<li class="settings-nav-item">
+				<a class="settings-nav-link" [routerLink]="item.link" routerLinkActive="active">
+					@if (item.icon) {
+					<i [class]="item.icon"></i>
+					}
+					<span class="settings-nav-label">{{ item.title }}</span>
+				</a>
+			</li>
+			}
+		</ul>
+	</nav>
+	<!-- Selected settings page content -->
+	<div class="settings-content">
+		<router-outlet></router-outlet>
+	</div>
+</div>

--- a/apps/gauzy/src/app/pages/settings/settings.component.scss
+++ b/apps/gauzy/src/app/pages/settings/settings.component.scss
@@ -1,0 +1,105 @@
+@use 'themes' as *;
+@use 'var' as *;
+
+:host {
+	display: block;
+	height: 100%;
+}
+
+// Two-column settings shell: narrow settings menu | selected page content.
+.settings-shell {
+	display: flex;
+	align-items: flex-start;
+	gap: 1rem;
+	height: 100%;
+}
+
+.settings-nav {
+	flex: 0 0 auto;
+	width: 220px;
+	height: fit-content;
+	background-color: nb-theme(gauzy-card-2);
+	border-radius: nb-theme(border-radius);
+	padding: 0.75rem 0.5rem;
+}
+
+.settings-nav-title {
+	display: block;
+	padding: 0 0.5rem;
+	margin-bottom: 0.5rem;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: nb-theme(text-hint-color);
+}
+
+.settings-nav-list {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.settings-nav-link {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 5px 8px;
+	border-radius: calc(nb-theme(border-radius) / 2);
+	font-size: 13px;
+	line-height: 1.25;
+	color: nb-theme(text-basic-color);
+	text-decoration: none;
+	cursor: pointer;
+
+	i {
+		width: 1rem;
+		font-size: 12px;
+		text-align: center;
+		color: nb-theme(text-hint-color);
+	}
+
+	&:hover {
+		background-color: nb-theme(background-basic-color-3);
+		color: nb-theme(text-basic-color);
+	}
+
+	&.active {
+		background-color: nb-theme(background-basic-color-3);
+		color: nb-theme(text-primary-color);
+		font-weight: 600;
+
+		i {
+			color: nb-theme(text-primary-color);
+		}
+	}
+}
+
+.settings-nav-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.settings-content {
+	flex: 1 1 auto;
+	min-width: 0;
+	height: 100%;
+}
+
+@include respond(md) {
+	.settings-shell {
+		flex-direction: column;
+	}
+
+	.settings-nav {
+		width: 100%;
+	}
+
+	.settings-content {
+		width: 100%;
+	}
+}

--- a/apps/gauzy/src/app/pages/settings/settings.component.ts
+++ b/apps/gauzy/src/app/pages/settings/settings.component.ts
@@ -1,14 +1,37 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { BaseNavMenuComponent, NavMenuSectionItem } from '@gauzy/ui-core/core';
 
+@UntilDestroy()
 @Component({
-    selector: 'ngx-settings',
-    templateUrl: './settings.component.html',
-    standalone: false
+	selector: 'ngx-settings',
+	templateUrl: './settings.component.html',
+	styleUrls: ['./settings.component.scss'],
+	standalone: false
 })
-export class SettingsComponent implements OnInit, OnDestroy {
-	constructor() {}
+export class SettingsComponent extends BaseNavMenuComponent implements OnInit, OnDestroy {
+	/** Visible settings menu entries rendered in the left column of the settings shell. */
+	public settingsMenuItems$: Observable<NavMenuSectionItem[]>;
 
-	ngOnInit() {}
+	override ngOnInit(): void {
+		super.ngOnInit(); // Call the parent class's ngOnInit function
 
-	ngOnDestroy() {}
+		// Build the settings menu list from the shared nav menu configuration, so items
+		// registered dynamically (e.g. "AI Providers" added by plugins) are included too.
+		this.settingsMenuItems$ = this._navMenuBuilderService.menuConfig$.pipe(
+			map((sections: NavMenuSectionItem[]) =>
+				this.mapMenuSections(
+					(sections ?? []).filter((section: NavMenuSectionItem) => section.menuCategory === 'settings')
+				)
+					.flatMap((section: NavMenuSectionItem) => (section.children ?? []) as NavMenuSectionItem[])
+					.filter((item: NavMenuSectionItem) => !item.hidden)
+			),
+			untilDestroyed(this)
+		);
+	}
+
+	override ngOnDestroy(): void {
+		super.ngOnDestroy();
+	}
 }

--- a/packages/ui-core/core/src/lib/components/base-nav-menu/base-nav-menu.component.ts
+++ b/packages/ui-core/core/src/lib/components/base-nav-menu/base-nav-menu.component.ts
@@ -1030,6 +1030,7 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 				id: 'settings',
 				title: 'Settings',
 				icon: 'fas fa-cog',
+				link: '/pages/settings',
 				menuCategory: 'settings',
 				data: {
 					translationKey: 'MENU.SETTINGS'

--- a/packages/ui-core/core/src/lib/components/settings-nav-menu/settings-nav-menu.component.ts
+++ b/packages/ui-core/core/src/lib/components/settings-nav-menu/settings-nav-menu.component.ts
@@ -23,7 +23,11 @@ export class SettingsNavMenuComponent extends BaseNavMenuComponent implements On
 		// Subscribe to the menuConfig$ observable provided by _navMenuBuilderService
 		this.settingsMenuConfig$ = this._navMenuBuilderService.menuConfig$.pipe(
 			map((sections: NavMenuSectionItem[]) =>
-				this.mapMenuSections(sections ?? []).filter((section) => section.menuCategory === 'settings')
+				this.mapMenuSections(sections ?? [])
+					.filter((section) => section.menuCategory === 'settings')
+					// Render each settings section as a plain link (no inline accordion):
+					// the full settings menu now lives on the /pages/settings page itself.
+					.map((section) => ({ ...section, children: undefined }))
 			),
 			untilDestroyed(this)
 		);

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -1232,6 +1232,7 @@
 		"CARDS_GRID": "Cards Grid",
 		"SPRINT_VIEW": "Sprint View",
 		"QUICK_SETTINGS": "Quick Settings",
+		"SETTINGS": "Settings",
 		"NO_LAYOUT": "No data layout available"
 	},
 	"CHANGELOG_MENU": {

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/layout-selector/layout-selector.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/layout-selector/layout-selector.component.html
@@ -6,7 +6,7 @@
       icon="question-mark-circle-outline"
       ></nb-icon
     ></span>
-    <div>
+    <div class="layout-control">
       <nb-select
         [placeholder]="'SETTINGS_MENU.PREFERRED_LAYOUT' | translate"
         (selectedChange)="switchComponentLayout()"
@@ -24,16 +24,16 @@
             >
           }
         </nb-select>
+        <button
+          class="reset-layout"
+          [nbTooltip]="'SETTINGS_MENU.RESET_LAYOUT_TOOLTIP' | translate"
+          status="basic"
+          nbButton
+          outline
+          size="tiny"
+          (click)="resetLayoutForAllComponents()"
+          >
+          {{ 'SETTINGS_MENU.RESET_LAYOUT' | translate }}
+        </button>
       </div>
-    </div>
-    <div class="reset-button">
-      <button
-        [nbTooltip]="'SETTINGS_MENU.RESET_LAYOUT_TOOLTIP' | translate"
-        status="danger"
-        nbButton
-        size="small"
-        (click)="resetLayoutForAllComponents()"
-        >
-        {{ 'SETTINGS_MENU.RESET_LAYOUT' | translate }}
-      </button>
     </div>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/layout-selector/layout-selector.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/layout-selector/layout-selector.component.html
@@ -26,6 +26,7 @@
         </nb-select>
         <button
           class="reset-layout"
+          type="button"
           [nbTooltip]="'SETTINGS_MENU.RESET_LAYOUT_TOOLTIP' | translate"
           status="basic"
           nbButton

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/layout-selector/layout-selector.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/layout-selector/layout-selector.component.scss
@@ -7,9 +7,16 @@
   flex-wrap: wrap;
 }
 
-.reset-button{
-  margin-top: 1rem;
+// Dropdown with the tiny reset button tucked directly below it
+.layout-control{
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+}
+
+.reset-layout{
+  font-size: 11px;
 }
 
 :host ::ng-deep{

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
@@ -18,10 +18,15 @@
 }
 .card-container {
   background: nb-theme(gauzy-card-2);
-  margin-top: 10px;
+  margin-top: 8px;
   border-radius: nb-theme(border-radius);
+  // Compact option: small thumbnail on the left, theme name on the right
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  height: 48px;
+  overflow: hidden;
+  cursor: pointer;
   &.selected {
     .check {
       display: flex;
@@ -37,26 +42,30 @@
     }
   }
   .image-container {
-    object-fit: cover;
-    min-width: 200px;
-    width: 100%;
-    height: 100px;
+    order: -1; // thumbnail sits left of the name (markup keeps the name first)
+    flex: 0 0 auto;
+    width: 120px;
+    height: 100%;
     overflow: hidden;
     position: relative;
     img {
       position: absolute;
-      left: 1rem;
-      top: 1rem;
-      height: 150px;
-      border-radius: calc(nb-theme(border-radius) - 4px);
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: left top;
     }
   }
   span {
-    padding: 6px;
+    padding: 0 8px;
     font-size: 13px;
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
     display: flex;
     flex-direction: row;
+    align-items: center;
     justify-content: space-between;
   }
   .check {

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.html
@@ -18,5 +18,13 @@
 		<nb-list-item>
 			<gauzy-layout-selector class="theme"></gauzy-layout-selector>
 		</nb-list-item>
+		<nb-list-item>
+			<div class="settings-link theme">
+				<button nbButton fullWidth status="primary" size="small" (click)="navigateToSettings()">
+					<nb-icon icon="settings-2-outline"></nb-icon>
+					{{ 'SETTINGS_MENU.SETTINGS' | translate }}
+				</button>
+			</div>
+		</nb-list-item>
 	</nb-list>
 </div>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, AfterViewChecked } from '@angular/core';
+import { Router } from '@angular/router';
 import { NbSidebarService } from '@nebular/theme';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { tap } from 'rxjs/operators';
@@ -13,7 +14,7 @@ import { tap } from 'rxjs/operators';
 export class ThemeSettingsComponent implements AfterViewChecked, OnDestroy {
 	private state: boolean;
 
-	constructor(private readonly sidebarService: NbSidebarService) {}
+	constructor(private readonly sidebarService: NbSidebarService, private readonly router: Router) {}
 
 	ngAfterViewChecked(): void {
 		this.sidebarService
@@ -40,5 +41,13 @@ export class ThemeSettingsComponent implements AfterViewChecked, OnDestroy {
 	 */
 	public onClickOutside(event: boolean) {
 		if (!event && this.state) this.closeSidebar();
+	}
+
+	/**
+	 * Navigates to the settings page and closes the quick settings sidebar.
+	 */
+	public navigateToSettings() {
+		this.router.navigate(['/pages/settings']);
+		this.closeSidebar();
 	}
 }

--- a/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
@@ -32,34 +32,18 @@
     gap: 0.25rem;
   }
 
-  .setting.action ::ng-deep {
-    ga-main-nav-menu {
-      ga-sidebar-menu {
-        nb-accordion-item {
-          nb-accordion-item-header {
-            box-shadow: unset;
-            border-width: 0;
-            nb-icon {
-              display: none;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Settings is a plain link to /pages/settings (no inline accordion anymore),
-  // so hide the accordion expansion chevron the same way as the section above.
-  .setting ::ng-deep {
-    ga-settings-nav-menu {
-      ga-sidebar-menu {
-        nb-accordion-item {
-          nb-accordion-item-header {
-            box-shadow: unset;
-            border-width: 0;
-            nb-icon {
-              display: none;
-            }
+  // Flatten accordion headers in the popup for both nav menus. Settings is a
+  // plain link to /pages/settings (no inline accordion anymore), so its
+  // expansion chevron is hidden the same way as the main nav's.
+  .setting.action ::ng-deep ga-main-nav-menu,
+  .setting ::ng-deep ga-settings-nav-menu {
+    ga-sidebar-menu {
+      nb-accordion-item {
+        nb-accordion-item-header {
+          box-shadow: unset;
+          border-width: 0;
+          nb-icon {
+            display: none;
           }
         }
       }

--- a/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
@@ -48,6 +48,24 @@
     }
   }
 
+  // Settings is a plain link to /pages/settings (no inline accordion anymore),
+  // so hide the accordion expansion chevron the same way as the section above.
+  .setting ::ng-deep {
+    ga-settings-nav-menu {
+      ga-sidebar-menu {
+        nb-accordion-item {
+          nb-accordion-item-header {
+            box-shadow: unset;
+            border-width: 0;
+            nb-icon {
+              display: none;
+            }
+          }
+        }
+      }
+    }
+  }
+
   .item.footer {
     box-shadow: var(--gauzy-shadow);
     border-radius: 0 0 var(--border-radius) var(--border-radius);


### PR DESCRIPTION
## Tenant Settings shell
Clicking **Settings** (workspace popup) now navigates to `/pages/settings` instead of expanding a long inline submenu. The page renders a two-column shell inside the content area: a compact vertical settings menu (General, Features, Email History/Templates, Accounting Templates, File Storage, Monitoring, SMS Gateways, Custom SMTP, OAuth Clients, Roles & Permissions, Danger Zone, **AI Providers**, …) + the selected page on the right. The menu derives from the existing `NavMenuBuilderService` config, so it inherits all permission/feature gating and **plugin-registered items appear automatically**. Deep links unchanged (`/pages/settings/<child>`), `/pages/settings` redirects to General.

## Quick Settings panel
- **Reset Layout** → tiny outline button directly under the Layout dropdown
- A primary **⚙ Settings** button (navigates to the new settings page, closes the panel) where Reset Layout used to be
- Theme selector options compacted (small fixed-height thumbnails instead of oversized screenshots)

## Verified locally (screenshots on request; build green)
- `/pages/settings` renders the shell with all 13 items incl. dynamically-registered AI Providers; General active state highlighted
- Quick Settings shows Layout → tiny Reset Layout → Settings in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Tenant Settings page at `/pages/settings` with a compact sidebar and routed content. Cleans up the Quick Settings panel with a clear Settings button and tighter controls.

- **New Features**
  - Two-column settings shell; menu pulls from shared config, so permission-gated and plugin items appear automatically.
  - `/pages/settings` redirects to `/pages/settings/general`; existing deep links still work.
  - Workspace “Settings” is now a direct link to `/pages/settings` (accordion removed; chevron hidden).
  - Quick Settings: adds a primary “Settings” button that navigates to `/pages/settings` and closes the panel.
  - “Reset Layout” moved under the layout dropdown as a tiny outline button.
  - Theme selector options compacted with small thumbnails and fixed option height.
  - Adds i18n key `SETTINGS_MENU.SETTINGS`.

- **Bug Fixes**
  - Set `type="button"` on “Reset Layout” to avoid unintended form submissions.
  - Deduplicated popup styles that hide accordion chevrons for settings links.

<sup>Written for commit ebadc08052186bb82a869cb0298d1c866ca5cd82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

