### PR TITLE
feat(dashboard): custom user dashboards — create, save, switch, drag & drop widget layouts

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,7 +4,7 @@
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"ignoreRegExpList": ["GHSA-[A-Za-z0-9-]+"],
 	"words": [
-t	"componentless",
+		"componentless",
 		"relver",
 		"fontobject",
 		"textareas",

--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"ignoreRegExpList": ["GHSA-[A-Za-z0-9-]+"],
 	"words": [
+t	"componentless",
 		"relver",
 		"fontobject",
 		"textareas",

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.html
@@ -95,33 +95,33 @@
 <!-- ⋮ actions menu -->
 <ng-template #dashboardActions>
 	<div class="dashboard-actions-popover">
-		<div class="action" (click)="newDashboard()">
+		<button type="button" class="action" (click)="newDashboard()">
 			<nb-icon icon="plus-outline"></nb-icon>
 			{{ 'DASHBOARD_PAGE.CUSTOM.NEW_DASHBOARD' | translate }}
-		</div>
-		<div class="action" (click)="duplicateDashboard()">
+		</button>
+		<button type="button" class="action" (click)="duplicateDashboard()">
 			<nb-icon icon="copy-outline"></nb-icon>
 			{{ 'DASHBOARD_PAGE.CUSTOM.DUPLICATE_DASHBOARD' | translate }}
-		</div>
+		</button>
 		@if (selected()) {
-			<div class="action" (click)="renameDashboard()">
+			<button type="button" class="action" (click)="renameDashboard()">
 				<nb-icon icon="edit-2-outline"></nb-icon>
 				{{ 'DASHBOARD_PAGE.CUSTOM.RENAME_DASHBOARD' | translate }}
-			</div>
+			</button>
 		}
-		<div class="action" (click)="setAsDefault()">
+		<button type="button" class="action" (click)="setAsDefault()">
 			<nb-icon icon="star-outline"></nb-icon>
 			{{ 'DASHBOARD_PAGE.CUSTOM.SET_AS_DEFAULT' | translate }}
-		</div>
+		</button>
 		@if (selected()) {
-			<div class="action" (click)="editDashboard()">
+			<button type="button" class="action" (click)="editDashboard()">
 				<nb-icon icon="edit-outline"></nb-icon>
 				{{ 'DASHBOARD_PAGE.CUSTOM.EDIT_DASHBOARD' | translate }}
-			</div>
-			<div class="action danger" (click)="deleteDashboard()">
+			</button>
+			<button type="button" class="action danger" (click)="deleteDashboard()">
 				<nb-icon icon="trash-2-outline"></nb-icon>
 				{{ 'DASHBOARD_PAGE.CUSTOM.DELETE_DASHBOARD' | translate }}
-			</div>
+			</button>
 		}
 	</div>
 </ng-template>

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.html
@@ -1,0 +1,129 @@
+<div class="dashboard-switcher">
+	<!-- Chips row: only rendered when at least one custom dashboard exists -->
+	@if (dashboards$ | async; as dashboards) {
+		@if (dashboards.length > 0) {
+			<div class="chips-area">
+				@if (canScroll) {
+					<button
+						nbButton
+						ghost
+						size="tiny"
+						class="scroll-button"
+						type="button"
+						(click)="scroll(-1)"
+					>
+						<nb-icon icon="chevron-left-outline"></nb-icon>
+					</button>
+				}
+				<div #chipsScroll class="chips-scroll">
+					<button
+						type="button"
+						class="chip"
+						[class.active]="!(selectedDashboard$ | async)"
+						(click)="selectStandard()"
+					>
+						{{ 'DASHBOARD_PAGE.CUSTOM.STANDARD' | translate }}
+					</button>
+					@for (dashboard of dashboards; track dashboard.id) {
+						<button
+							type="button"
+							class="chip"
+							[class.active]="(selectedDashboard$ | async)?.id === dashboard.id"
+							(click)="select(dashboard)"
+						>
+							{{ dashboard.name }}
+							@if (dashboard.isDefault) {
+								<nb-icon class="default-icon" icon="star-outline"></nb-icon>
+							}
+						</button>
+					}
+				</div>
+				@if (canScroll) {
+					<button
+						nbButton
+						ghost
+						size="tiny"
+						class="scroll-button"
+						type="button"
+						(click)="scroll(1)"
+					>
+						<nb-icon icon="chevron-right-outline"></nb-icon>
+					</button>
+				}
+			</div>
+		}
+	}
+
+	<!-- Actions: Edit / Save / Discard + the ⋮ menu -->
+	<div class="actions-area">
+		@if (selectedDashboard$ | async) {
+			@if (editing$ | async) {
+				<button nbButton status="success" size="small" type="button" (click)="saveLayout()">
+					<nb-icon icon="save-outline"></nb-icon>
+					{{ 'BUTTONS.SAVE' | translate }}
+				</button>
+				<button nbButton status="basic" size="small" type="button" (click)="cancelEditing()">
+					{{ 'BUTTONS.CANCEL' | translate }}
+				</button>
+			} @else {
+				<button nbButton status="basic" size="small" type="button" (click)="editDashboard()">
+					<nb-icon icon="edit-outline"></nb-icon>
+					{{ 'DASHBOARD_PAGE.CUSTOM.EDIT_DASHBOARD' | translate }}
+				</button>
+			}
+		}
+		<button
+			nbButton
+			ghost
+			size="small"
+			type="button"
+			class="more-button"
+			[nbPopover]="dashboardActions"
+			nbPopoverPlacement="bottom"
+			nbPopoverTrigger="click"
+		>
+			<nb-icon icon="more-vertical-outline"></nb-icon>
+		</button>
+	</div>
+</div>
+
+<!-- Edit-mode hint -->
+@if (editing$ | async) {
+	<div class="edit-hint">
+		{{ 'DASHBOARD_PAGE.CUSTOM.EDIT_HINT' | translate }}
+	</div>
+}
+
+<!-- ⋮ actions menu -->
+<ng-template #dashboardActions>
+	<div class="dashboard-actions-popover">
+		<div class="action" (click)="newDashboard()">
+			<nb-icon icon="plus-outline"></nb-icon>
+			{{ 'DASHBOARD_PAGE.CUSTOM.NEW_DASHBOARD' | translate }}
+		</div>
+		<div class="action" (click)="duplicateDashboard()">
+			<nb-icon icon="copy-outline"></nb-icon>
+			{{ 'DASHBOARD_PAGE.CUSTOM.DUPLICATE_DASHBOARD' | translate }}
+		</div>
+		@if (selectedDashboard$ | async) {
+			<div class="action" (click)="renameDashboard()">
+				<nb-icon icon="edit-2-outline"></nb-icon>
+				{{ 'DASHBOARD_PAGE.CUSTOM.RENAME_DASHBOARD' | translate }}
+			</div>
+		}
+		<div class="action" (click)="setAsDefault()">
+			<nb-icon icon="star-outline"></nb-icon>
+			{{ 'DASHBOARD_PAGE.CUSTOM.SET_AS_DEFAULT' | translate }}
+		</div>
+		@if (selectedDashboard$ | async) {
+			<div class="action" (click)="editDashboard()">
+				<nb-icon icon="edit-outline"></nb-icon>
+				{{ 'DASHBOARD_PAGE.CUSTOM.EDIT_DASHBOARD' | translate }}
+			</div>
+			<div class="action danger" (click)="deleteDashboard()">
+				<nb-icon icon="trash-2-outline"></nb-icon>
+				{{ 'DASHBOARD_PAGE.CUSTOM.DELETE_DASHBOARD' | translate }}
+			</div>
+		}
+	</div>
+</ng-template>

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.html
@@ -1,63 +1,61 @@
 <div class="dashboard-switcher">
 	<!-- Chips row: only rendered when at least one custom dashboard exists -->
-	@if (dashboards$ | async; as dashboards) {
-		@if (dashboards.length > 0) {
-			<div class="chips-area">
-				@if (canScroll) {
-					<button
-						nbButton
-						ghost
-						size="tiny"
-						class="scroll-button"
-						type="button"
-						(click)="scroll(-1)"
-					>
-						<nb-icon icon="chevron-left-outline"></nb-icon>
-					</button>
-				}
-				<div #chipsScroll class="chips-scroll">
+	@if (dashboards().length > 0) {
+		<div class="chips-area">
+			@if (canScroll) {
+				<button
+					nbButton
+					ghost
+					size="tiny"
+					class="scroll-button"
+					type="button"
+					(click)="scroll(-1)"
+				>
+					<nb-icon icon="chevron-left-outline"></nb-icon>
+				</button>
+			}
+			<div #chipsScroll class="chips-scroll">
+				<button
+					type="button"
+					class="chip"
+					[class.active]="!selected()"
+					(click)="selectStandard()"
+				>
+					{{ 'DASHBOARD_PAGE.CUSTOM.STANDARD' | translate }}
+				</button>
+				@for (dashboard of dashboards(); track dashboard.id) {
 					<button
 						type="button"
 						class="chip"
-						[class.active]="!(selectedDashboard$ | async)"
-						(click)="selectStandard()"
+						[class.active]="selected()?.id === dashboard.id"
+						(click)="select(dashboard)"
 					>
-						{{ 'DASHBOARD_PAGE.CUSTOM.STANDARD' | translate }}
-					</button>
-					@for (dashboard of dashboards; track dashboard.id) {
-						<button
-							type="button"
-							class="chip"
-							[class.active]="(selectedDashboard$ | async)?.id === dashboard.id"
-							(click)="select(dashboard)"
-						>
-							{{ dashboard.name }}
-							@if (dashboard.isDefault) {
-								<nb-icon class="default-icon" icon="star-outline"></nb-icon>
-							}
-						</button>
-					}
-				</div>
-				@if (canScroll) {
-					<button
-						nbButton
-						ghost
-						size="tiny"
-						class="scroll-button"
-						type="button"
-						(click)="scroll(1)"
-					>
-						<nb-icon icon="chevron-right-outline"></nb-icon>
+						{{ dashboard.name }}
+						@if (dashboard.isDefault) {
+							<nb-icon class="default-icon" icon="star-outline"></nb-icon>
+						}
 					</button>
 				}
 			</div>
-		}
+			@if (canScroll) {
+				<button
+					nbButton
+					ghost
+					size="tiny"
+					class="scroll-button"
+					type="button"
+					(click)="scroll(1)"
+				>
+					<nb-icon icon="chevron-right-outline"></nb-icon>
+				</button>
+			}
+		</div>
 	}
 
 	<!-- Actions: Edit / Save / Discard + the ⋮ menu -->
 	<div class="actions-area">
-		@if (selectedDashboard$ | async) {
-			@if (editing$ | async) {
+		@if (selected()) {
+			@if (editing()) {
 				<button nbButton status="success" size="small" type="button" (click)="saveLayout()">
 					<nb-icon icon="save-outline"></nb-icon>
 					{{ 'BUTTONS.SAVE' | translate }}
@@ -88,7 +86,7 @@
 </div>
 
 <!-- Edit-mode hint -->
-@if (editing$ | async) {
+@if (editing()) {
 	<div class="edit-hint">
 		{{ 'DASHBOARD_PAGE.CUSTOM.EDIT_HINT' | translate }}
 	</div>
@@ -105,7 +103,7 @@
 			<nb-icon icon="copy-outline"></nb-icon>
 			{{ 'DASHBOARD_PAGE.CUSTOM.DUPLICATE_DASHBOARD' | translate }}
 		</div>
-		@if (selectedDashboard$ | async) {
+		@if (selected()) {
 			<div class="action" (click)="renameDashboard()">
 				<nb-icon icon="edit-2-outline"></nb-icon>
 				{{ 'DASHBOARD_PAGE.CUSTOM.RENAME_DASHBOARD' | translate }}
@@ -115,7 +113,7 @@
 			<nb-icon icon="star-outline"></nb-icon>
 			{{ 'DASHBOARD_PAGE.CUSTOM.SET_AS_DEFAULT' | translate }}
 		</div>
-		@if (selectedDashboard$ | async) {
+		@if (selected()) {
 			<div class="action" (click)="editDashboard()">
 				<nb-icon icon="edit-outline"></nb-icon>
 				{{ 'DASHBOARD_PAGE.CUSTOM.EDIT_DASHBOARD' | translate }}

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.scss
@@ -1,0 +1,117 @@
+@use 'var' as *;
+
+:host {
+	display: block;
+}
+
+.dashboard-switcher {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 8px;
+
+	.chips-area {
+		display: flex;
+		align-items: center;
+		flex: 1 1 auto;
+		min-width: 0;
+		gap: 4px;
+
+		.scroll-button {
+			flex: 0 0 auto;
+		}
+
+		.chips-scroll {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+			overflow-x: auto;
+			scroll-behavior: smooth;
+			// Hide the scrollbar; the < and > arrow buttons handle overflow
+			scrollbar-width: none;
+			-ms-overflow-style: none;
+
+			&::-webkit-scrollbar {
+				display: none;
+			}
+
+			.chip {
+				flex: 0 0 auto;
+				display: inline-flex;
+				align-items: center;
+				gap: 4px;
+				border: 1px solid var(--border-basic-color-4);
+				border-radius: var(--border-radius);
+				background-color: var(--card-background-color);
+				color: var(--text-basic-color);
+				padding: 4px 12px;
+				font-size: 12px;
+				font-weight: 600;
+				cursor: pointer;
+				white-space: nowrap;
+				transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+
+				&:hover {
+					background-color: var(--background-basic-color-2);
+				}
+
+				&.active {
+					background-color: var(--color-primary-default);
+					border-color: var(--color-primary-default);
+					color: var(--text-control-color);
+				}
+
+				.default-icon {
+					font-size: 12px;
+					height: 12px;
+					width: 12px;
+				}
+			}
+		}
+	}
+
+	.actions-area {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-left: auto;
+		flex: 0 0 auto;
+	}
+}
+
+.edit-hint {
+	padding: 2px 16px 6px;
+	font-size: 12px;
+	color: var(--text-hint-color);
+}
+
+.dashboard-actions-popover {
+	display: flex;
+	flex-direction: column;
+	padding: 8px 0;
+	min-width: 200px;
+
+	.action {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 16px;
+		font-size: 13px;
+		color: var(--text-basic-color);
+		cursor: pointer;
+
+		nb-icon {
+			font-size: 16px;
+			height: 16px;
+			width: 16px;
+		}
+
+		&:hover {
+			background-color: var(--background-basic-color-2);
+		}
+
+		&.danger {
+			color: var(--color-danger-default);
+		}
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.scss
@@ -99,6 +99,12 @@
 		font-size: 13px;
 		color: var(--text-basic-color);
 		cursor: pointer;
+		// native <button> resets (keyboard-accessible menu items)
+		background: none;
+		border: none;
+		width: 100%;
+		text-align: left;
+		font-family: inherit;
 
 		nb-icon {
 			font-size: 16px;

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.ts
@@ -1,0 +1,241 @@
+import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
+import { firstValueFrom, Observable } from 'rxjs';
+import { NbDialogService, NbPopoverDirective } from '@nebular/theme';
+import { TranslateService } from '@ngx-translate/core';
+import { UntilDestroy } from '@ngneat/until-destroy';
+import { IDashboard } from '@gauzy/contracts';
+import { DashboardStoreService, ToastrService } from '@gauzy/ui-core/core';
+import { ConfirmComponent, PromptComponent } from '@gauzy/ui-core/shared';
+import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
+
+/**
+ * Dashboard switcher bar rendered above the dashboard tabs:
+ *
+ * - A chips row listing "Standard" plus each of the user's custom dashboards
+ *   (only rendered when at least one custom dashboard exists), with < / >
+ *   arrow buttons handling horizontal overflow (no visible scrollbar).
+ * - A more-vertical (⋮) menu with New / Duplicate / Rename / Set as Default /
+ *   Delete / Edit actions, plus a visible Edit button when a custom dashboard
+ *   is active, and Save / Discard buttons while editing.
+ */
+@UntilDestroy()
+@Component({
+	selector: 'ga-dashboard-switcher',
+	templateUrl: './dashboard-switcher.component.html',
+	styleUrls: ['./dashboard-switcher.component.scss'],
+	standalone: false
+})
+export class DashboardSwitcherComponent extends TranslationBaseComponent implements AfterViewChecked {
+	public dashboards$: Observable<IDashboard[]>;
+	public selectedDashboard$: Observable<IDashboard | null>;
+	public editing$: Observable<boolean>;
+
+	/** Whether the chips row currently overflows and needs scroll arrows. */
+	public canScroll = false;
+
+	@ViewChild('chipsScroll') chipsScroll: ElementRef<HTMLElement>;
+	@ViewChild(NbPopoverDirective) actionsPopover: NbPopoverDirective;
+
+	constructor(
+		public readonly translateService: TranslateService,
+		private readonly _dashboardStore: DashboardStoreService,
+		private readonly _dialogService: NbDialogService,
+		private readonly _toastrService: ToastrService,
+		private readonly _changeRef: ChangeDetectorRef
+	) {
+		super(translateService);
+		this.dashboards$ = this._dashboardStore.dashboards$;
+		this.selectedDashboard$ = this._dashboardStore.selectedDashboard$;
+		this.editing$ = this._dashboardStore.editing$;
+	}
+
+	ngAfterViewChecked(): void {
+		const el = this.chipsScroll?.nativeElement;
+		const overflow = !!el && el.scrollWidth > el.clientWidth + 1;
+		if (overflow !== this.canScroll) {
+			this.canScroll = overflow;
+			this._changeRef.detectChanges();
+		}
+	}
+
+	/** Scrolls the chips row left (-1) or right (+1). */
+	public scroll(direction: number): void {
+		this.chipsScroll?.nativeElement?.scrollBy({ left: direction * 200, behavior: 'smooth' });
+	}
+
+	/** Switches to the Standard (prebuilt) dashboard. */
+	public selectStandard(): void {
+		this._dashboardStore.navigateToStandard();
+	}
+
+	/** Switches to the given custom dashboard. */
+	public select(dashboard: IDashboard): void {
+		if (this._dashboardStore.selectedDashboard?.id === dashboard.id) {
+			return;
+		}
+		this._dashboardStore.navigateToDashboard(dashboard.id);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Context menu (⋮) actions
+	|--------------------------------------------------------------------------
+	*/
+
+	/** Creates a new custom dashboard (default widget arrangement) and switches to it. */
+	public async newDashboard(): Promise<void> {
+		this.actionsPopover?.hide();
+		const name = await this._promptForName('DASHBOARD_PAGE.CUSTOM.NEW_DASHBOARD');
+		if (!name) {
+			return;
+		}
+		try {
+			const dashboard = await this._dashboardStore.createDashboard(name);
+			this._toastrService.success('DASHBOARD_PAGE.CUSTOM.CREATED', { name });
+			this._dashboardStore.navigateToDashboard(dashboard.id);
+		} catch (error) {
+			this._toastrService.danger(error);
+		}
+	}
+
+	/**
+	 * Duplicates the active dashboard (Standard duplicates the current live
+	 * layout) and switches to the copy.
+	 */
+	public async duplicateDashboard(): Promise<void> {
+		this.actionsPopover?.hide();
+		const source = this._dashboardStore.selectedDashboard;
+		const baseName = source?.name ?? this.getTranslation('DASHBOARD_PAGE.CUSTOM.STANDARD');
+		const name = `${baseName} ${this.getTranslation('DASHBOARD_PAGE.CUSTOM.COPY_SUFFIX')}`;
+		try {
+			const dashboard = await this._dashboardStore.duplicateDashboard(source, name);
+			this._toastrService.success('DASHBOARD_PAGE.CUSTOM.CREATED', { name });
+			this._dashboardStore.navigateToDashboard(dashboard.id);
+		} catch (error) {
+			this._toastrService.danger(error);
+		}
+	}
+
+	/** Renames the active custom dashboard. */
+	public async renameDashboard(): Promise<void> {
+		this.actionsPopover?.hide();
+		const selected = this._dashboardStore.selectedDashboard;
+		if (!selected) {
+			return;
+		}
+		const name = await this._promptForName('DASHBOARD_PAGE.CUSTOM.RENAME_DASHBOARD');
+		if (!name) {
+			return;
+		}
+		try {
+			await this._dashboardStore.renameDashboard(selected, name);
+			this._toastrService.success('DASHBOARD_PAGE.CUSTOM.UPDATED', { name });
+		} catch (error) {
+			this._toastrService.danger(error);
+		}
+	}
+
+	/**
+	 * Marks the active dashboard as the default one (loaded when the user
+	 * clicks "Dashboards" in the sidebar). With Standard active, clears the
+	 * default flag from all custom dashboards instead.
+	 */
+	public async setAsDefault(): Promise<void> {
+		this.actionsPopover?.hide();
+		const selected = this._dashboardStore.selectedDashboard;
+		try {
+			if (selected) {
+				await this._dashboardStore.setDefaultDashboard(selected);
+				this._toastrService.success('DASHBOARD_PAGE.CUSTOM.SET_DEFAULT_SUCCESS', { name: selected.name });
+			} else {
+				await this._dashboardStore.clearDefaultDashboard();
+				this._toastrService.success('DASHBOARD_PAGE.CUSTOM.SET_DEFAULT_SUCCESS', {
+					name: this.getTranslation('DASHBOARD_PAGE.CUSTOM.STANDARD')
+				});
+			}
+		} catch (error) {
+			this._toastrService.danger(error);
+		}
+	}
+
+	/** Deletes the active custom dashboard (with confirmation). */
+	public async deleteDashboard(): Promise<void> {
+		this.actionsPopover?.hide();
+		const selected = this._dashboardStore.selectedDashboard;
+		if (!selected) {
+			return;
+		}
+
+		const dialogRef = this._dialogService.open(ConfirmComponent, {
+			context: {
+				data: {
+					title: this.getTranslation('DASHBOARD_PAGE.CUSTOM.DELETE_DASHBOARD'),
+					message: this.getTranslation('DASHBOARD_PAGE.CUSTOM.DELETE_CONFIRM', { name: selected.name })
+				}
+			}
+		});
+
+		const confirmed = await firstValueFrom(dialogRef.onClose);
+		if (!confirmed) {
+			return;
+		}
+
+		try {
+			await this._dashboardStore.deleteDashboard(selected);
+			this._toastrService.success('DASHBOARD_PAGE.CUSTOM.DELETED', { name: selected.name });
+		} catch (error) {
+			this._toastrService.danger(error);
+		}
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Edit mode
+	|--------------------------------------------------------------------------
+	*/
+
+	/** Enters edit (arrange) mode for the active custom dashboard. */
+	public editDashboard(): void {
+		this.actionsPopover?.hide();
+		this._dashboardStore.startEditing();
+	}
+
+	/** Persists the current widget arrangement into the active custom dashboard. */
+	public async saveLayout(): Promise<void> {
+		try {
+			await this._dashboardStore.saveSelectedLayout();
+			this._toastrService.success('DASHBOARD_PAGE.CUSTOM.LAYOUT_SAVED');
+		} catch (error) {
+			this._toastrService.danger(error);
+		}
+	}
+
+	/** Discards unsaved layout changes. */
+	public cancelEditing(): void {
+		this._dashboardStore.cancelEditing();
+	}
+
+	/**
+	 * Opens a prompt dialog asking for a dashboard name.
+	 *
+	 * @param titleKey - Translation key for the dialog title.
+	 * @returns The entered name, or `null` when cancelled/empty.
+	 */
+	private async _promptForName(titleKey: string): Promise<string | null> {
+		const dialogRef = this._dialogService.open(PromptComponent, {
+			context: {
+				data: {
+					title: this.getTranslation(titleKey),
+					label: this.getTranslation('DASHBOARD_PAGE.CUSTOM.NAME_LABEL'),
+					placeholder: this.getTranslation('DASHBOARD_PAGE.CUSTOM.NAME_PLACEHOLDER'),
+					okText: this.getTranslation('BUTTONS.OK'),
+					cancelText: this.getTranslation('BUTTONS.CANCEL'),
+					inputType: 'text'
+				}
+			}
+		});
+
+		const name = await firstValueFrom(dialogRef.onClose);
+		return typeof name === 'string' && name.trim().length > 0 ? name.trim() : null;
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.ts
@@ -1,5 +1,6 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
-import { firstValueFrom, Observable } from 'rxjs';
+import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, Signal, ViewChild } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { firstValueFrom } from 'rxjs';
 import { NbDialogService, NbPopoverDirective } from '@nebular/theme';
 import { TranslateService } from '@ngx-translate/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
@@ -26,9 +27,10 @@ import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 	standalone: false
 })
 export class DashboardSwitcherComponent extends TranslationBaseComponent implements AfterViewChecked {
-	public dashboards$: Observable<IDashboard[]>;
-	public selectedDashboard$: Observable<IDashboard | null>;
-	public editing$: Observable<boolean>;
+	// Signals (single subscription each) instead of repeated `| async` pipes
+	public dashboards: Signal<IDashboard[]>;
+	public selected: Signal<IDashboard | null>;
+	public editing: Signal<boolean>;
 
 	/** Whether the chips row currently overflows and needs scroll arrows. */
 	public canScroll = false;
@@ -44,9 +46,9 @@ export class DashboardSwitcherComponent extends TranslationBaseComponent impleme
 		private readonly _changeRef: ChangeDetectorRef
 	) {
 		super(translateService);
-		this.dashboards$ = this._dashboardStore.dashboards$;
-		this.selectedDashboard$ = this._dashboardStore.selectedDashboard$;
-		this.editing$ = this._dashboardStore.editing$;
+		this.dashboards = toSignal(this._dashboardStore.dashboards$, { initialValue: [] as IDashboard[] });
+		this.selected = toSignal(this._dashboardStore.selectedDashboard$, { initialValue: null });
+		this.editing = toSignal(this._dashboardStore.editing$, { initialValue: false });
 	}
 
 	ngAfterViewChecked(): void {

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.html
@@ -1,3 +1,5 @@
 <div class="dashboard-container">
+	<!-- Custom dashboards switcher (chips row + actions), rendered above the tabs line -->
+	<ga-dashboard-switcher></ga-dashboard-switcher>
 	<gz-dynamic-tabs #dynamicTabs [tabsetId]="tabsetId"></gz-dynamic-tabs>
 </div>

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.module.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.module.ts
@@ -27,6 +27,7 @@ import { PageExtensionSlotComponent } from '@gauzy/plugin-ui';
 import {
 	ActivityItemModule,
 	CounterPointComponent,
+	DialogsModule,
 	DynamicTabsModule,
 	GalleryModule,
 	InfoBlockModule,
@@ -45,6 +46,7 @@ import {
 import { PageRouteRegistryService } from '@gauzy/ui-core/core';
 import { createDashboardRoutes } from './dashboard.routes';
 import { DashboardComponent } from './dashboard.component';
+import { DashboardSwitcherComponent } from './dashboard-switcher/dashboard-switcher.component';
 import { HumanResourcesComponent } from './human-resources/human-resources.component';
 import { AccountingComponent } from './accounting/accounting.component';
 import { ProjectManagementComponent } from './project-management/project-management.component';
@@ -94,6 +96,7 @@ const THIRD_PARTY_MODULES = [
 // Components
 const COMPONENTS = [
 	DashboardComponent,
+	DashboardSwitcherComponent,
 	AccountingComponent,
 	HumanResourcesComponent,
 	ProjectManagementComponent,
@@ -117,6 +120,7 @@ const COMPONENTS = [
 		...STANDALONE_MODULES,
 		BaseChartDirective,
 		// Feature Modules
+		DialogsModule,
 		RecordsHistoryModule,
 		ProfitHistoryModule,
 		SingleStatisticModule,

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.routes.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.routes.ts
@@ -1,5 +1,11 @@
 import { Route } from '@angular/router';
-import { BookmarkQueryParamsResolver, PageRouteRegistryService, PermissionsGuard } from '@gauzy/ui-core/core';
+import {
+	BookmarkQueryParamsResolver,
+	defaultDashboardGuard,
+	PageRouteRegistryService,
+	PermissionsGuard,
+	standardDashboardGuard
+} from '@gauzy/ui-core/core';
 import { PermissionsEnum } from '@gauzy/contracts';
 import { DateRangePickerResolver } from '@gauzy/ui-core/shared';
 import { DashboardComponent } from './dashboard.component';
@@ -27,13 +33,23 @@ export function createDashboardRoutes(_pageRouteRegistryService: PageRouteRegist
 			},
 			children: [
 				{
+					// Lands on the user's default custom dashboard when one exists,
+					// otherwise redirects to the standard time-tracking tab.
 					path: '',
-					redirectTo: 'time-tracking',
-					pathMatch: 'full'
+					pathMatch: 'full',
+					canActivate: [defaultDashboardGuard],
+					children: []
+				},
+				{
+					// Componentless intermediate hop used to force re-creation of the
+					// widget host when switching between two custom dashboards.
+					path: 'switching',
+					children: []
 				},
 				{
 					path: 'accounting',
 					component: AccountingComponent,
+					canActivate: [standardDashboardGuard],
 					data: {
 						selectors: {
 							project: false
@@ -50,6 +66,7 @@ export function createDashboardRoutes(_pageRouteRegistryService: PageRouteRegist
 				{
 					path: 'hr',
 					component: HumanResourcesComponent,
+					canActivate: [standardDashboardGuard],
 					data: {
 						selectors: {
 							project: false
@@ -67,7 +84,7 @@ export function createDashboardRoutes(_pageRouteRegistryService: PageRouteRegist
 				{
 					path: 'project-management',
 					component: ProjectManagementComponent,
-					canActivate: [PermissionsGuard],
+					canActivate: [PermissionsGuard, standardDashboardGuard],
 					data: {
 						datePicker: {
 							unitOfTime: 'month'
@@ -84,7 +101,7 @@ export function createDashboardRoutes(_pageRouteRegistryService: PageRouteRegist
 				{
 					path: 'teams',
 					component: TeamComponent,
-					canActivate: [PermissionsGuard],
+					canActivate: [PermissionsGuard, standardDashboardGuard],
 					data: {
 						datePicker: {
 							unitOfTime: 'day',

--- a/packages/contracts/src/lib/dashboard.model.ts
+++ b/packages/contracts/src/lib/dashboard.model.ts
@@ -24,5 +24,29 @@ export interface IDashboardCreateInput
 
 /**
  * Input interface for updating a Dashboard entity.
+ *
+ * Note: `isDefault` is intentionally allowed here (while excluded from creation),
+ * so an existing dashboard can be promoted to be the user's default one.
  */
-export interface IDashboardUpdateInput extends Partial<IDashboardCreateInput> {}
+export interface IDashboardUpdateInput extends Partial<IDashboardCreateInput>, Pick<IDashboard, 'isDefault'> {}
+
+/**
+ * Serialized state of a single draggable widget/window of the dashboard
+ * widget system (mirrors the `GuiDrag.toObject()` shape used by the UI).
+ */
+export interface IDashboardLayoutItem {
+	position: number;
+	title?: string;
+	hide?: boolean;
+	isCollapse?: boolean;
+	isExpand?: boolean;
+}
+
+/**
+ * Persisted layout of a custom dashboard: which widgets/windows are visible,
+ * their order and collapse state. Stored in `IDashboard.contentHtml`.
+ */
+export interface IDashboardLayout {
+	widgets?: IDashboardLayoutItem[];
+	windows?: IDashboardLayoutItem[];
+}

--- a/packages/core/src/lib/dashboard/dashboard.entity.ts
+++ b/packages/core/src/lib/dashboard/dashboard.entity.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { EntityRepositoryType } from '@mikro-orm/core';
 import { JoinColumn, RelationId } from 'typeorm';
-import { IsArray, IsBoolean, IsNotEmpty, IsObject, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsObject, IsOptional, IsString, IsUUID } from 'class-validator';
 import { isMySQL, isPostgres } from '@gauzy/config';
 import { ID, IDashboard, IEmployee, JsonData } from '@gauzy/contracts';
 import { DashboardWidget, Employee, TenantOrganizationBaseEntity } from '../core/entities/internal';
@@ -48,11 +48,14 @@ export class Dashboard extends TenantOrganizationBaseEntity implements IDashboar
 	description?: string;
 
 	/**
-	 * Content of the dashboard
+	 * Content of the dashboard (serialized widget layout).
+	 *
+	 * Note: intentionally has no strict type validator — `JsonData` may be an
+	 * object (postgres/mysql json columns) or a string (sqlite text column),
+	 * mirroring `DashboardWidget.options`.
 	 */
 	@ApiPropertyOptional({ type: () => Object })
 	@IsOptional()
-	@IsArray()
 	@MultiORMColumn({ type: isPostgres() ? 'jsonb' : isMySQL() ? 'json' : 'text', nullable: true })
 	contentHtml?: JsonData;
 

--- a/packages/core/src/lib/dashboard/dashboard.service.ts
+++ b/packages/core/src/lib/dashboard/dashboard.service.ts
@@ -145,8 +145,11 @@ export class DashboardService extends TenantAwareCrudService<Dashboard> {
 	 * @throws {ForbiddenException} If the dashboard belongs to another user.
 	 */
 	async delete(id: ID): Promise<DeleteResult> {
-		// Retrieve the existing dashboard by ID (throws NotFound if missing)
+		// Retrieve the existing dashboard by ID
 		const dashboard = await this.findOneByIdString(id);
+		if (!dashboard) {
+			throw new NotFoundException(`Dashboard with ID ${id} does not exist`);
+		}
 
 		// Dashboards are personal: only the user who created a dashboard may delete it
 		this.checkOwnership(dashboard);
@@ -162,7 +165,9 @@ export class DashboardService extends TenantAwareCrudService<Dashboard> {
 	 */
 	private checkOwnership(dashboard: IDashboard): void {
 		const currentUserId = RequestContext.currentUserId();
-		if (dashboard.createdByUserId && currentUserId && dashboard.createdByUserId !== currentUserId) {
+		// Deny when either identity is missing — an orphaned/legacy dashboard
+		// must not become manageable by arbitrary users.
+		if (!dashboard.createdByUserId || !currentUserId || dashboard.createdByUserId !== currentUserId) {
 			throw new ForbiddenException('You can only manage your own dashboards');
 		}
 	}

--- a/packages/core/src/lib/dashboard/dashboard.service.ts
+++ b/packages/core/src/lib/dashboard/dashboard.service.ts
@@ -1,12 +1,14 @@
-import { HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import {
 	ActionTypeEnum,
 	BaseEntityEnum,
 	ActorTypeEnum,
+	IDashboard,
 	IDashboardCreateInput,
 	IDashboardUpdateInput,
 	ID
 } from '@gauzy/contracts';
+import { DeleteResult } from 'typeorm';
 import { TenantAwareCrudService } from '../core/crud/tenant-aware-crud.service';
 import { RequestContext } from '../core/context/request-context';
 import { ActivityLogService } from '../activity-log/activity-log.service';
@@ -91,6 +93,15 @@ export class DashboardService extends TenantAwareCrudService<Dashboard> {
 				throw new NotFoundException(`Dashboard with ID ${id} does not exist`);
 			}
 
+			// Dashboards are personal: only the user who created a dashboard may modify it
+			this.checkOwnership(dashboard);
+
+			// When promoting a dashboard to be the default one,
+			// demote any other default dashboards of the same user first
+			if (input.isDefault === true) {
+				await this.resetDefaultDashboards(dashboard);
+			}
+
 			// Update the dashboard using the base service's create method
 			const updatedDashboard = await super.create({
 				...data,
@@ -116,9 +127,67 @@ export class DashboardService extends TenantAwareCrudService<Dashboard> {
 			// Return the updated dashboard
 			return updatedDashboard;
 		} catch (error) {
+			// Preserve the original HTTP semantics for ownership violations
+			if (error instanceof ForbiddenException) {
+				throw error;
+			}
 			// Log the error and throw an HttpException
 			console.error('Error while updating dashboard:', error);
 			throw new HttpException(`Failed to update dashboard: ${error.message}`, HttpStatus.BAD_REQUEST);
 		}
+	}
+
+	/**
+	 * Deletes a dashboard by ID, ensuring the requesting user owns it.
+	 *
+	 * @param id - The unique identifier of the dashboard to delete.
+	 * @returns The delete result.
+	 * @throws {ForbiddenException} If the dashboard belongs to another user.
+	 */
+	async delete(id: ID): Promise<DeleteResult> {
+		// Retrieve the existing dashboard by ID (throws NotFound if missing)
+		const dashboard = await this.findOneByIdString(id);
+
+		// Dashboards are personal: only the user who created a dashboard may delete it
+		this.checkOwnership(dashboard);
+
+		return await super.delete(id);
+	}
+
+	/**
+	 * Ensures the current user is the creator of the given dashboard.
+	 *
+	 * @param dashboard - The dashboard to verify ownership of.
+	 * @throws {ForbiddenException} If the dashboard was created by another user.
+	 */
+	private checkOwnership(dashboard: IDashboard): void {
+		const currentUserId = RequestContext.currentUserId();
+		if (dashboard.createdByUserId && currentUserId && dashboard.createdByUserId !== currentUserId) {
+			throw new ForbiddenException('You can only manage your own dashboards');
+		}
+	}
+
+	/**
+	 * Demotes all default dashboards of the dashboard's creator (within the same
+	 * tenant/organization), so that at most one dashboard is default per user.
+	 *
+	 * Uses `find` + `save` (via `super.create`) to stay ORM-agnostic (TypeORM/MikroORM).
+	 *
+	 * @param dashboard - The dashboard being promoted to default.
+	 */
+	private async resetDefaultDashboards(dashboard: IDashboard): Promise<void> {
+		const { tenantId, organizationId, createdByUserId, id } = dashboard;
+
+		// Find all other default dashboards of the same user
+		const { items: defaults } = await this.findAll({
+			where: { tenantId, organizationId, createdByUserId, isDefault: true }
+		});
+
+		// Demote each of them (except the one being promoted)
+		await Promise.all(
+			defaults
+				.filter((item: IDashboard) => item.id !== id)
+				.map((item: IDashboard) => super.create({ id: item.id, isDefault: false }))
+		);
 	}
 }

--- a/packages/core/src/lib/dashboard/dto/update-dashboard.dto.ts
+++ b/packages/core/src/lib/dashboard/dto/update-dashboard.dto.ts
@@ -1,8 +1,15 @@
-import { PartialType } from '@nestjs/swagger';
+import { IntersectionType, PartialType, PickType } from '@nestjs/swagger';
 import { IDashboardUpdateInput } from '@gauzy/contracts';
+import { Dashboard } from '../dashboard.entity';
 import { CreateDashboardDTO } from './create-dashboard.dto';
 
 /**
  * Update Dashboard validation request DTO
+ *
+ * Extends the create DTO (all fields optional) and re-allows `isDefault`,
+ * which is excluded on creation but may be toggled on update
+ * (e.g. "Set as Default" from the dashboard switcher).
  */
-export class UpdateDashboardDTO extends PartialType(CreateDashboardDTO) implements IDashboardUpdateInput {}
+export class UpdateDashboardDTO
+	extends IntersectionType(PartialType(CreateDashboardDTO), PickType(Dashboard, ['isDefault'] as const))
+	implements IDashboardUpdateInput {}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/dashboard-time-track-angular-ui.constants.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/dashboard-time-track-angular-ui.constants.ts
@@ -1,15 +1,38 @@
-import { PageRouteRegistryConfig } from '@gauzy/ui-core/core';
+import { customDashboardGuard, PageRouteRegistryConfig, standardDashboardGuard } from '@gauzy/ui-core/core';
 
 /** Path segment for the Time Tracking tab under /pages/dashboard. */
 export const DASHBOARD_TIME_TRACKING_PATH = 'time-tracking';
 
+/** Path segment for the custom dashboards host under /pages/dashboard. */
+export const DASHBOARD_CUSTOM_PATH = 'custom/:id';
+
 /**
  * Route config for registering the Angular Time Tracking tab at dashboard-sections.
  * Picked up by createDashboardRoutes via getPageLocationRoutes('dashboard-sections').
+ *
+ * `standardDashboardGuard` restores the Standard widget layout whenever a
+ * custom dashboard was previously applied.
  */
 export const DASHBOARD_TIME_TRACKING_ROUTE: PageRouteRegistryConfig = {
 	location: 'dashboard-sections',
 	path: DASHBOARD_TIME_TRACKING_PATH,
+	canActivate: [standardDashboardGuard],
+	loadChildren: () =>
+		import('./dashboard-time-track-angular-ui.module').then((m) => m.DashboardTimeTrackAngularUiModule)
+};
+
+/**
+ * Route config for the custom dashboards host (`/pages/dashboard/custom/:id`).
+ *
+ * A custom dashboard re-uses the Time Tracking widget system as its widget
+ * host: `customDashboardGuard` applies the dashboard's persisted widget layout
+ * (visibility/order/collapse state) into the widget system state BEFORE the
+ * host component initializes, then the same lazy module renders it.
+ */
+export const DASHBOARD_CUSTOM_ROUTE: PageRouteRegistryConfig = {
+	location: 'dashboard-sections',
+	path: DASHBOARD_CUSTOM_PATH,
+	canActivate: [customDashboardGuard],
 	loadChildren: () =>
 		import('./dashboard-time-track-angular-ui.module').then((m) => m.DashboardTimeTrackAngularUiModule)
 };

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/dashboard-time-track-angular-ui.plugin.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/dashboard-time-track-angular-ui.plugin.ts
@@ -1,6 +1,10 @@
 import { PermissionsEnum } from '@gauzy/contracts';
 import { defineDeclarativePlugin, IPluginI18nService, PluginRouteInput } from '@gauzy/plugin-ui';
-import { DASHBOARD_TIME_TRACKING_ROUTE, DASHBOARD_TIME_TRACKING_PATH } from './dashboard-time-track-angular-ui.constants';
+import {
+	DASHBOARD_CUSTOM_ROUTE,
+	DASHBOARD_TIME_TRACKING_ROUTE,
+	DASHBOARD_TIME_TRACKING_PATH
+} from './dashboard-time-track-angular-ui.constants';
 import ar from '../i18n/ar.json';
 import bg from '../i18n/bg.json';
 import de from '../i18n/de.json';
@@ -44,7 +48,7 @@ export const DashboardTimeTrackAngularUiPlugin = defineDeclarativePlugin('dashbo
 	location: 'page-sections',
 
 	// ── Routes ───────────────────────────────────────────────────
-	routes: [DASHBOARD_TIME_TRACKING_ROUTE as PluginRouteInput],
+	routes: [DASHBOARD_TIME_TRACKING_ROUTE as PluginRouteInput, DASHBOARD_CUSTOM_ROUTE as PluginRouteInput],
 
 	// ── Dashboard Tab ────────────────────────────────────────────
 	tabs: [

--- a/packages/ui-core/core/src/lib/components/base-nav-menu/base-nav-menu.component.ts
+++ b/packages/ui-core/core/src/lib/components/base-nav-menu/base-nav-menu.component.ts
@@ -3,9 +3,10 @@ import { combineLatest, EMPTY } from 'rxjs';
 import { catchError, debounceTime, filter, startWith, tap } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { FeatureEnum, IOrganization, PermissionsEnum } from '@gauzy/contracts';
+import { FeatureEnum, IDashboard, IOrganization, PermissionsEnum } from '@gauzy/contracts';
 import { distinctUntilChange } from '@gauzy/ui-core/common';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
+import { DashboardStoreService } from '../../services/dashboard/dashboard-store.service';
 import { FavoriteStoreService } from '../../services/favorite/favorite-store.service';
 import { NavMenuBuilderService } from '../../services/nav-builder/nav-menu-builder.service';
 import { NavMenuSectionItem } from '../../services/nav-builder/nav-builder-types';
@@ -22,8 +23,10 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 	protected readonly _store = inject(Store);
 	protected readonly _sidebarMenuService = inject(SidebarMenuService);
 	protected readonly _favoriteStoreService = inject(FavoriteStoreService);
+	protected readonly _dashboardStoreService = inject(DashboardStoreService);
 
 	private _favoriteItems: NavMenuSectionItem[] = [];
+	private _customDashboards: IDashboard[] = [];
 
 	constructor(protected readonly _translateService: TranslateService) {
 		super(_translateService);
@@ -36,6 +39,7 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 	ngAfterViewInit(): void {
 		combineLatest([
 			this._favoriteStoreService.favoriteItems$,
+			this._dashboardStoreService.dashboards$,
 			this._translateService.onLangChange.pipe(startWith(null)),
 			this._store.selectedOrganization$.pipe(
 				filter((organization: IOrganization | null): organization is IOrganization => !!organization),
@@ -47,8 +51,9 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 		])
 			.pipe(
 				debounceTime(50),
-				tap(([favorites]) => {
+				tap(([favorites, dashboards]) => {
 					this._favoriteItems = favorites;
+					this._customDashboards = dashboards;
 					this.defineBaseNavMenus();
 				}),
 				catchError((error) => {
@@ -99,6 +104,10 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 
 	/**
 	 * Returns the dashboard-related menu items (Dashboards, Focus, Applications).
+	 *
+	 * The "Dashboards" item is a plain link while the user has no custom
+	 * dashboards; once custom dashboards exist it becomes expandable with a
+	 * "Standard" child plus one child per custom dashboard.
 	 */
 	private _getDashboardMenu(): NavMenuSectionItem[] {
 		return [
@@ -106,13 +115,16 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 				id: 'dashboards',
 				title: 'Dashboards',
 				icon: 'fas fa-th',
-				link: '/pages/dashboard',
 				pathMatch: 'prefix',
 				home: true,
 				data: {
 					translationKey: 'MENU.DASHBOARDS',
 					featureKey: FeatureEnum.FEATURE_DASHBOARD
-				}
+				},
+				// Plain link when there are no custom dashboards; expandable otherwise
+				...(this._customDashboards.length === 0
+					? { link: '/pages/dashboard' }
+					: { items: this._getDashboardChildren() })
 			},
 			{
 				id: 'focus',
@@ -140,6 +152,34 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 					featureKey: FeatureEnum.FEATURE_DASHBOARD
 				}
 			}
+		];
+	}
+
+	/**
+	 * Returns the children of the expandable "Dashboards" menu item:
+	 * the "Standard" (prebuilt) dashboard followed by each custom dashboard.
+	 */
+	private _getDashboardChildren(): NavMenuSectionItem[] {
+		return [
+			{
+				id: 'dashboard-standard',
+				title: 'Standard',
+				icon: 'fas fa-columns',
+				link: '/pages/dashboard/time-tracking',
+				data: {
+					translationKey: 'DASHBOARD_PAGE.CUSTOM.STANDARD'
+				}
+			},
+			...this._customDashboards.map((dashboard: IDashboard) => ({
+				id: `dashboard-custom-${dashboard.id}`,
+				title: dashboard.name,
+				icon: 'fas fa-th-large',
+				link: `/pages/dashboard/custom/${dashboard.id}`,
+				data: {
+					// Custom dashboard names are user content; the translate pipe passes unknown keys through
+					translationKey: dashboard.name
+				}
+			}))
 		];
 	}
 

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
@@ -7,10 +7,10 @@ import { ID, IDashboard, IDashboardLayout, IDashboardLayoutItem, JsonData } from
 import { DashboardService } from './dashboard.service';
 import { Store } from '../store/store.service';
 
-/** LocalStorage key holding the currently applied custom dashboard ID. */
+/** LocalStorage key prefix holding the currently applied custom dashboard ID (suffixed with the user ID). */
 const SELECTED_DASHBOARD_KEY = '_selectedDashboardId';
 
-/** LocalStorage key holding the "Standard" widget layout snapshot taken before a custom dashboard is applied. */
+/** LocalStorage key prefix holding the "Standard" widget layout snapshot taken before a custom dashboard is applied (suffixed with the user ID). */
 const STANDARD_LAYOUT_BACKUP_KEY = '_standardDashboardLayout';
 
 /**
@@ -66,6 +66,18 @@ export class DashboardStoreService {
 	/** Triggers a reload of the dashboards list. */
 	public refresh(): void {
 		this._refresh$.next();
+	}
+
+	/**
+	 * Storage keys are scoped to the current user so that on a shared browser
+	 * one user's selection/layout backup can never leak into another's session.
+	 */
+	private get _selectedKey(): string {
+		return `${SELECTED_DASHBOARD_KEY}_${this._store.userId ?? 'anonymous'}`;
+	}
+
+	private get _backupKey(): string {
+		return `${STANDARD_LAYOUT_BACKUP_KEY}_${this._store.userId ?? 'anonymous'}`;
 	}
 
 	/*
@@ -126,7 +138,7 @@ export class DashboardStoreService {
 	 * (e.g. after rename) and clears a stale selection when the dashboard is gone.
 	 */
 	private _reconcileSelection(items: IDashboard[]): void {
-		const selectedId = this.selectedDashboard?.id ?? localStorage.getItem(SELECTED_DASHBOARD_KEY);
+		const selectedId = this.selectedDashboard?.id ?? localStorage.getItem(this._selectedKey);
 		if (!selectedId) {
 			return;
 		}
@@ -177,7 +189,7 @@ export class DashboardStoreService {
 		this._applyLayout(dashboard.contentHtml);
 
 		// Persist and publish the selection
-		localStorage.setItem(SELECTED_DASHBOARD_KEY, dashboard.id as string);
+		localStorage.setItem(this._selectedKey, dashboard.id as string);
 		this._selectedDashboard$.next(dashboard);
 		this._editing$.next(false);
 
@@ -190,13 +202,13 @@ export class DashboardStoreService {
 	 * call repeatedly (no-op when Standard is already active).
 	 */
 	public ensureStandardLayout(): void {
-		const selectedId = localStorage.getItem(SELECTED_DASHBOARD_KEY);
+		const selectedId = localStorage.getItem(this._selectedKey);
 		if (!selectedId && !this.selectedDashboard) {
 			return;
 		}
 
 		this._restoreStandardSnapshot();
-		localStorage.removeItem(SELECTED_DASHBOARD_KEY);
+		localStorage.removeItem(this._selectedKey);
 		this._selectedDashboard$.next(null);
 		this._editing$.next(false);
 	}
@@ -400,8 +412,9 @@ export class DashboardStoreService {
 	/** Writes the given saved layout into the widget system state. */
 	private _applyLayout(content: JsonData | undefined): void {
 		const layout = this._parseLayout(content);
-		this._store.widgets = (layout.widgets ?? []) as any[];
-		this._store.windows = (layout.windows ?? []) as any[];
+		// Validate shapes — malformed/hand-edited content must not crash the widget host
+		this._store.widgets = (Array.isArray(layout.widgets) ? layout.widgets : []) as any[];
+		this._store.windows = (Array.isArray(layout.windows) ? layout.windows : []) as any[];
 	}
 
 	/**
@@ -455,25 +468,25 @@ export class DashboardStoreService {
 
 	/** Snapshots the Standard layout once, before the first custom dashboard is applied. */
 	private _snapshotStandardIfNeeded(): void {
-		const alreadyCustom = !!localStorage.getItem(SELECTED_DASHBOARD_KEY);
+		const alreadyCustom = !!localStorage.getItem(this._selectedKey);
 		if (alreadyCustom) {
 			return;
 		}
 		const snapshot = this.captureLayout();
-		localStorage.setItem(STANDARD_LAYOUT_BACKUP_KEY, JSON.stringify(snapshot));
+		localStorage.setItem(this._backupKey, JSON.stringify(snapshot));
 	}
 
 	/** Restores the Standard layout snapshot into the widget system state. */
 	private _restoreStandardSnapshot(): void {
 		let layout: IDashboardLayout = {};
 		try {
-			layout = JSON.parse(localStorage.getItem(STANDARD_LAYOUT_BACKUP_KEY) || '{}') as IDashboardLayout;
+			layout = JSON.parse(localStorage.getItem(this._backupKey) || '{}') as IDashboardLayout;
 		} catch {
 			layout = {};
 		}
-		this._store.widgets = (layout.widgets ?? []) as any[];
-		this._store.windows = (layout.windows ?? []) as any[];
-		localStorage.removeItem(STANDARD_LAYOUT_BACKUP_KEY);
+		this._store.widgets = (Array.isArray(layout.widgets) ? layout.widgets : []) as any[];
+		this._store.windows = (Array.isArray(layout.windows) ? layout.windows : []) as any[];
+		localStorage.removeItem(this._backupKey);
 	}
 
 	/** Builds a unique identifier (slug) for a dashboard name. */

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
@@ -1,0 +1,457 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { BehaviorSubject, combineLatest, from, of, Subject } from 'rxjs';
+import { catchError, filter, startWith, switchMap } from 'rxjs/operators';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { ID, IDashboard, IDashboardLayout, IDashboardLayoutItem, JsonData } from '@gauzy/contracts';
+import { DashboardService } from './dashboard.service';
+import { Store } from '../store/store.service';
+
+/** LocalStorage key holding the currently applied custom dashboard ID. */
+const SELECTED_DASHBOARD_KEY = '_selectedDashboardId';
+
+/** LocalStorage key holding the "Standard" widget layout snapshot taken before a custom dashboard is applied. */
+const STANDARD_LAYOUT_BACKUP_KEY = '_standardDashboardLayout';
+
+/**
+ * Client-side state holder for custom user dashboards.
+ *
+ * Responsibilities:
+ * - Loads the current user's custom dashboards for the selected organization.
+ * - Tracks the currently applied dashboard (`null` = the Standard dashboard).
+ * - Applies/captures the widget layout state, which the existing widget system
+ *   (WidgetService/WindowService in @gauzy/ui-core/shared) reads from and writes to
+ *   `Store.widgets` / `Store.windows`. A custom dashboard is a persisted snapshot
+ *   of that serialized state (`IDashboardLayout`), stored in `IDashboard.contentHtml`.
+ * - Preserves the Standard layout in a localStorage backup while a custom
+ *   dashboard is active, and restores it when switching back to Standard.
+ */
+@UntilDestroy()
+@Injectable({
+	providedIn: 'root'
+})
+export class DashboardStoreService {
+	private readonly _dashboards$ = new BehaviorSubject<IDashboard[]>([]);
+	/** The current user's custom dashboards (for the selected organization). */
+	public readonly dashboards$ = this._dashboards$.asObservable();
+
+	private readonly _selectedDashboard$ = new BehaviorSubject<IDashboard | null>(null);
+	/** The currently applied custom dashboard, or `null` when the Standard dashboard is active. */
+	public readonly selectedDashboard$ = this._selectedDashboard$.asObservable();
+
+	private readonly _editing$ = new BehaviorSubject<boolean>(false);
+	/** Whether the currently selected custom dashboard is in edit (arrange) mode. */
+	public readonly editing$ = this._editing$.asObservable();
+
+	private readonly _refresh$ = new Subject<void>();
+
+	constructor(
+		private readonly _dashboardService: DashboardService,
+		private readonly _store: Store,
+		private readonly _router: Router
+	) {
+		this._listenToChangesAndLoadDashboards();
+	}
+
+	/** The currently applied custom dashboard, or `null` for Standard. */
+	public get selectedDashboard(): IDashboard | null {
+		return this._selectedDashboard$.getValue();
+	}
+
+	/** The current user's custom dashboards. */
+	public get dashboards(): IDashboard[] {
+		return this._dashboards$.getValue();
+	}
+
+	/** Triggers a reload of the dashboards list. */
+	public refresh(): void {
+		this._refresh$.next();
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Loading
+	|--------------------------------------------------------------------------
+	*/
+
+	private _listenToChangesAndLoadDashboards(): void {
+		combineLatest([
+			this._store.selectedOrganization$.pipe(filter((organization) => !!organization)),
+			this._refresh$.pipe(startWith(null))
+		])
+			.pipe(
+				// Catch load errors INSIDE the switchMap so a failed request
+				// does not complete the outer stream (future reloads keep working)
+				switchMap(() =>
+					from(this._loadDashboards()).pipe(
+						catchError((error) => {
+							console.error('Error loading custom dashboards', error);
+							return of([] as IDashboard[]);
+						})
+					)
+				),
+				untilDestroyed(this)
+			)
+			.subscribe((items: IDashboard[]) => {
+				this._dashboards$.next(items);
+				this._reconcileSelection(items);
+			});
+	}
+
+	/**
+	 * Loads the current user's dashboards for the selected organization.
+	 * Dashboards are personal, so results are scoped to the creating user.
+	 */
+	private async _loadDashboards(): Promise<IDashboard[]> {
+		const { id: organizationId, tenantId } = this._store.selectedOrganization || {};
+		const createdByUserId = this._store.userId;
+
+		if (!organizationId || !createdByUserId) {
+			return [];
+		}
+
+		const { items = [] } = await this._dashboardService.findAll({
+			where: { organizationId, tenantId, createdByUserId }
+		});
+
+		return items;
+	}
+
+	/**
+	 * Keeps the selected dashboard reference in sync with the freshly loaded list
+	 * (e.g. after rename) and clears a stale selection when the dashboard is gone.
+	 */
+	private _reconcileSelection(items: IDashboard[]): void {
+		const selectedId = this.selectedDashboard?.id ?? localStorage.getItem(SELECTED_DASHBOARD_KEY);
+		if (!selectedId) {
+			return;
+		}
+
+		const match = items.find((item: IDashboard) => item.id === selectedId);
+		if (match) {
+			this._selectedDashboard$.next(match);
+		} else if (this.selectedDashboard) {
+			// The selected dashboard no longer exists (e.g. deleted elsewhere)
+			this.ensureStandardLayout();
+		}
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Selection & layout application
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Applies the custom dashboard with the given ID: snapshots the Standard
+	 * layout (when leaving Standard), writes the dashboard's saved layout into
+	 * the widget system state and marks the dashboard as selected.
+	 *
+	 * Used by the `custom/:id` route guard BEFORE the widget host component
+	 * initializes, so the layout components pick up the applied state.
+	 *
+	 * @param id - The dashboard ID to apply.
+	 * @throws When the dashboard cannot be found.
+	 */
+	public async selectById(id: ID): Promise<IDashboard> {
+		let dashboard = this.dashboards.find((item: IDashboard) => item.id === id);
+		if (!dashboard) {
+			dashboard = await this._dashboardService.findById(id);
+		}
+		if (!dashboard) {
+			throw new Error(`Dashboard with id ${id} not found`);
+		}
+
+		// Preserve the Standard layout before the first custom dashboard is applied
+		this._snapshotStandardIfNeeded();
+
+		// Apply the saved layout into the widget system state
+		this._applyLayout(dashboard.contentHtml);
+
+		// Persist and publish the selection
+		localStorage.setItem(SELECTED_DASHBOARD_KEY, dashboard.id as string);
+		this._selectedDashboard$.next(dashboard);
+		this._editing$.next(false);
+
+		return dashboard;
+	}
+
+	/**
+	 * Restores the Standard dashboard layout if a custom dashboard was active.
+	 * Invoked by a guard on the standard dashboard tab routes, so it is safe to
+	 * call repeatedly (no-op when Standard is already active).
+	 */
+	public ensureStandardLayout(): void {
+		const selectedId = localStorage.getItem(SELECTED_DASHBOARD_KEY);
+		if (!selectedId && !this.selectedDashboard) {
+			return;
+		}
+
+		this._restoreStandardSnapshot();
+		localStorage.removeItem(SELECTED_DASHBOARD_KEY);
+		this._selectedDashboard$.next(null);
+		this._editing$.next(false);
+	}
+
+	/**
+	 * Resolves the user's default custom dashboard (if any).
+	 * Used to decide where `/pages/dashboard` should land.
+	 */
+	public async resolveDefaultDashboard(): Promise<IDashboard | null> {
+		const loaded = this.dashboards.find((item: IDashboard) => item.isDefault);
+		if (loaded) {
+			return loaded;
+		}
+
+		const { id: organizationId, tenantId } = this._store.selectedOrganization || {};
+		const createdByUserId = this._store.userId;
+		if (!createdByUserId) {
+			return null;
+		}
+
+		// Note: the default flag is filtered client-side to avoid boolean
+		// serialization differences across the supported databases.
+		const { items = [] } = await this._dashboardService.findAll({
+			where: {
+				...(organizationId ? { organizationId } : {}),
+				...(tenantId ? { tenantId } : {}),
+				createdByUserId
+			}
+		});
+
+		return items.find((item: IDashboard) => item.isDefault) ?? null;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Navigation helpers
+	|--------------------------------------------------------------------------
+	*/
+
+	/** Navigates to the given custom dashboard (the route guard applies its layout). */
+	public navigateToDashboard(id: ID): void {
+		this._router.navigate(['/pages/dashboard/custom', id]);
+	}
+
+	/** Navigates to the Standard dashboard (the route guard restores the standard layout). */
+	public navigateToStandard(): void {
+		this._router.navigate(['/pages/dashboard/time-tracking']);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| CRUD operations
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Creates a new custom dashboard.
+	 *
+	 * @param name - Display name of the dashboard.
+	 * @param layout - Initial layout; pass `null` for the default arrangement
+	 *   (every widget visible in its declared position).
+	 */
+	public async createDashboard(name: string, layout: IDashboardLayout | null = null): Promise<IDashboard> {
+		const { id: organizationId, tenantId } = this._store.selectedOrganization || {};
+
+		const dashboard = await this._dashboardService.create({
+			name,
+			identifier: this._slugify(name),
+			contentHtml: (layout ?? {}) as JsonData,
+			organizationId,
+			tenantId,
+			...(this._store.user?.employee?.id ? { employeeId: this._store.user.employee.id } : {})
+		});
+
+		this.refresh();
+		return dashboard;
+	}
+
+	/**
+	 * Duplicates the given dashboard (or the current live layout when
+	 * duplicating the Standard dashboard).
+	 *
+	 * @param source - The dashboard to duplicate, or `null` to duplicate the
+	 *   currently applied (Standard) layout.
+	 * @param name - Name for the copy.
+	 */
+	public async duplicateDashboard(source: IDashboard | null, name: string): Promise<IDashboard> {
+		const layout = source ? this._parseLayout(source.contentHtml) : this.captureLayout();
+		return this.createDashboard(name, layout);
+	}
+
+	/** Renames the given dashboard. */
+	public async renameDashboard(dashboard: IDashboard, name: string): Promise<IDashboard> {
+		const updated = await this._dashboardService.update(dashboard.id, { name });
+		this.refresh();
+		return updated;
+	}
+
+	/** Marks the given dashboard as the user's default one. */
+	public async setDefaultDashboard(dashboard: IDashboard): Promise<IDashboard> {
+		const updated = await this._dashboardService.update(dashboard.id, { isDefault: true });
+		this.refresh();
+		return updated;
+	}
+
+	/** Clears the default flag from all of the user's dashboards (Standard becomes the default again). */
+	public async clearDefaultDashboard(): Promise<void> {
+		const defaults = this.dashboards.filter((item: IDashboard) => item.isDefault);
+		await Promise.all(
+			defaults.map((item: IDashboard) => this._dashboardService.update(item.id, { isDefault: false }))
+		);
+		this.refresh();
+	}
+
+	/**
+	 * Deletes the given dashboard. When it is the currently applied one, the
+	 * Standard layout is restored and the user is navigated back to Standard.
+	 */
+	public async deleteDashboard(dashboard: IDashboard): Promise<void> {
+		await this._dashboardService.delete(dashboard.id);
+
+		if (this.selectedDashboard?.id === dashboard.id) {
+			this.ensureStandardLayout();
+			this.navigateToStandard();
+		}
+
+		this.refresh();
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Edit mode
+	|--------------------------------------------------------------------------
+	*/
+
+	/** Enters edit (arrange) mode for the currently selected custom dashboard. */
+	public startEditing(): void {
+		if (this.selectedDashboard) {
+			this._editing$.next(true);
+		}
+	}
+
+	/**
+	 * Persists the current live widget layout into the selected custom dashboard.
+	 */
+	public async saveSelectedLayout(): Promise<IDashboard | null> {
+		const selected = this.selectedDashboard;
+		if (!selected) {
+			return null;
+		}
+
+		const updated = await this._dashboardService.update(selected.id, {
+			contentHtml: this.captureLayout() as JsonData
+		});
+
+		this._editing$.next(false);
+		this._selectedDashboard$.next({ ...selected, contentHtml: updated?.contentHtml ?? this.captureLayout() });
+		this.refresh();
+
+		return updated;
+	}
+
+	/**
+	 * Discards unsaved layout changes: re-applies the persisted layout of the
+	 * selected dashboard and reloads the widget host route.
+	 */
+	public cancelEditing(): void {
+		const selected = this.selectedDashboard;
+		this._editing$.next(false);
+
+		if (selected) {
+			this._applyLayout(selected.contentHtml);
+			// Reload the route through an intermediate componentless hop so the
+			// widget host components re-create and pick up the restored state
+			// (a same-URL navigation would be ignored by the router).
+			void this._router
+				.navigateByUrl('/pages/dashboard/switching', { skipLocationChange: true })
+				.then(() => this._router.navigate(['/pages/dashboard/custom', selected.id]));
+		}
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Layout (de)serialization
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Captures the current live widget layout (as maintained by the existing
+	 * widget system in `Store.widgets` / `Store.windows`).
+	 */
+	public captureLayout(): IDashboardLayout {
+		return {
+			widgets: this._sanitizeLayoutItems(this._store.widgets),
+			windows: this._sanitizeLayoutItems(this._store.windows)
+		};
+	}
+
+	/** Writes the given saved layout into the widget system state. */
+	private _applyLayout(content: JsonData | undefined): void {
+		const layout = this._parseLayout(content);
+		this._store.widgets = (layout.widgets ?? []) as any[];
+		this._store.windows = (layout.windows ?? []) as any[];
+	}
+
+	/** Parses a dashboard `contentHtml` payload into a layout object. */
+	private _parseLayout(content: JsonData | undefined): IDashboardLayout {
+		if (!content) {
+			return {};
+		}
+		if (typeof content === 'string') {
+			try {
+				return JSON.parse(content) as IDashboardLayout;
+			} catch {
+				return {};
+			}
+		}
+		return content as IDashboardLayout;
+	}
+
+	/** Keeps only the serializable `GuiDrag` fields of each layout item. */
+	private _sanitizeLayoutItems(items: any[] | undefined): IDashboardLayoutItem[] {
+		return (items ?? [])
+			.filter((item: any) => !!item && typeof item.position === 'number')
+			.map((item: any) => ({
+				position: item.position,
+				title: item.title,
+				hide: item.hide,
+				isCollapse: item.isCollapse,
+				isExpand: item.isExpand
+			}));
+	}
+
+	/** Snapshots the Standard layout once, before the first custom dashboard is applied. */
+	private _snapshotStandardIfNeeded(): void {
+		const alreadyCustom = !!localStorage.getItem(SELECTED_DASHBOARD_KEY);
+		if (alreadyCustom) {
+			return;
+		}
+		const snapshot = this.captureLayout();
+		localStorage.setItem(STANDARD_LAYOUT_BACKUP_KEY, JSON.stringify(snapshot));
+	}
+
+	/** Restores the Standard layout snapshot into the widget system state. */
+	private _restoreStandardSnapshot(): void {
+		let layout: IDashboardLayout = {};
+		try {
+			layout = JSON.parse(localStorage.getItem(STANDARD_LAYOUT_BACKUP_KEY) || '{}') as IDashboardLayout;
+		} catch {
+			layout = {};
+		}
+		this._store.widgets = (layout.widgets ?? []) as any[];
+		this._store.windows = (layout.windows ?? []) as any[];
+		localStorage.removeItem(STANDARD_LAYOUT_BACKUP_KEY);
+	}
+
+	/** Builds a unique identifier (slug) for a dashboard name. */
+	private _slugify(name: string): string {
+		const base = name
+			.toLowerCase()
+			.trim()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-+|-+$/g, '');
+		return `${base || 'dashboard'}-${Date.now()}`;
+	}
+}

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
@@ -160,7 +160,11 @@ export class DashboardStoreService {
 	public async selectById(id: ID): Promise<IDashboard> {
 		let dashboard = this.dashboards.find((item: IDashboard) => item.id === id);
 		if (!dashboard) {
-			dashboard = await this._dashboardService.findById(id);
+			// Not in the loaded list yet (e.g. navigating right after create,
+			// before the refresh round-trip): reload and search again.
+			const items = await this._loadDashboards();
+			this._dashboards$.next(items);
+			dashboard = items.find((item: IDashboard) => item.id === id);
 		}
 		if (!dashboard) {
 			throw new Error(`Dashboard with id ${id} not found`);

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
@@ -114,7 +114,11 @@ export class DashboardStoreService {
 			where: { organizationId, tenantId, createdByUserId }
 		});
 
-		return items;
+		// Keep only dashboards that hold a serialized widget layout. Seeded /
+		// legacy rows (e.g. the demo "Default Dashboard" with HTML content)
+		// are not custom layout dashboards and must not surface in the
+		// switcher or hijack the default-dashboard redirect.
+		return items.filter((item: IDashboard) => this._isLayoutDashboard(item));
 	}
 
 	/**
@@ -219,7 +223,7 @@ export class DashboardStoreService {
 			}
 		});
 
-		return items.find((item: IDashboard) => item.isDefault) ?? null;
+		return items.find((item: IDashboard) => item.isDefault && this._isLayoutDashboard(item)) ?? null;
 	}
 
 	/*
@@ -257,7 +261,9 @@ export class DashboardStoreService {
 		const dashboard = await this._dashboardService.create({
 			name,
 			identifier: this._slugify(name),
-			contentHtml: (layout ?? {}) as JsonData,
+			// Always persist the layout marker keys so the row is recognized
+			// as a custom layout dashboard (see _isLayoutDashboard).
+			contentHtml: (layout ?? { widgets: [], windows: [] }) as JsonData,
 			organizationId,
 			tenantId,
 			...(this._store.user?.employee?.id ? { employeeId: this._store.user.employee.id } : {})
@@ -392,6 +398,27 @@ export class DashboardStoreService {
 		const layout = this._parseLayout(content);
 		this._store.widgets = (layout.widgets ?? []) as any[];
 		this._store.windows = (layout.windows ?? []) as any[];
+	}
+
+	/**
+	 * Whether the dashboard row holds a serialized widget layout (i.e. was
+	 * created by this feature). Seeded/legacy rows store arbitrary HTML in
+	 * `contentHtml` and are excluded from the custom dashboard experience.
+	 */
+	private _isLayoutDashboard(item: IDashboard): boolean {
+		const content = item?.contentHtml as JsonData | undefined;
+		if (!content) {
+			return false;
+		}
+		let parsed: unknown = content;
+		if (typeof content === 'string') {
+			try {
+				parsed = JSON.parse(content);
+			} catch {
+				return false;
+			}
+		}
+		return !!parsed && typeof parsed === 'object' && ('widgets' in (parsed as object) || 'windows' in (parsed as object));
 	}
 
 	/** Parses a dashboard `contentHtml` payload into a layout object. */

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard.guards.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard.guards.ts
@@ -1,0 +1,82 @@
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
+import { DashboardStoreService } from './dashboard-store.service';
+
+/** Base path of the dashboard page. */
+const DASHBOARD_BASE = '/pages/dashboard';
+
+/** Path of the custom dashboard host route. */
+const CUSTOM_DASHBOARD_BASE = `${DASHBOARD_BASE}/custom`;
+
+/** Componentless route used as an intermediate hop to force widget host re-creation. */
+const SWITCHING_PATH = `${DASHBOARD_BASE}/switching`;
+
+/**
+ * Guard for the `custom/:id` dashboard route.
+ *
+ * Applies the selected dashboard's saved widget layout BEFORE the widget host
+ * component initializes, so the layout components deserialize the applied state.
+ *
+ * When navigating from one custom dashboard to another (same route config,
+ * param-only change), Angular would re-use the component tree and the new
+ * layout would not be re-applied. In that case the guard cancels the current
+ * navigation and re-issues it through an intermediate componentless route so
+ * the widget host is destroyed and re-created.
+ */
+export const customDashboardGuard: CanActivateFn = async (route: ActivatedRouteSnapshot) => {
+	const router = inject(Router);
+	const dashboardStore = inject(DashboardStoreService);
+
+	const id = route.paramMap.get('id');
+	if (!id) {
+		return router.parseUrl(`${DASHBOARD_BASE}/time-tracking`);
+	}
+
+	// Force component re-creation when already on a custom dashboard route
+	if (router.url.startsWith(CUSTOM_DASHBOARD_BASE)) {
+		void router
+			.navigateByUrl(SWITCHING_PATH, { skipLocationChange: true })
+			.then(() => router.navigateByUrl(`${CUSTOM_DASHBOARD_BASE}/${id}`));
+		return false;
+	}
+
+	try {
+		await dashboardStore.selectById(id);
+		return true;
+	} catch (error) {
+		console.error('Failed to apply custom dashboard', error);
+		return router.parseUrl(`${DASHBOARD_BASE}/time-tracking`);
+	}
+};
+
+/**
+ * Guard for the standard dashboard tab routes (time-tracking, teams, etc.).
+ *
+ * Restores the Standard widget layout when a custom dashboard was active,
+ * before the standard widget host initializes. No-op otherwise.
+ */
+export const standardDashboardGuard: CanActivateFn = () => {
+	inject(DashboardStoreService).ensureStandardLayout();
+	return true;
+};
+
+/**
+ * Guard for the empty `/pages/dashboard` path.
+ *
+ * Redirects to the user's default custom dashboard when one exists,
+ * otherwise to the standard time-tracking tab.
+ */
+export const defaultDashboardGuard: CanActivateFn = async () => {
+	const router = inject(Router);
+	const dashboardStore = inject(DashboardStoreService);
+
+	try {
+		const dashboard = await dashboardStore.resolveDefaultDashboard();
+		return dashboard
+			? router.parseUrl(`${CUSTOM_DASHBOARD_BASE}/${dashboard.id}`)
+			: router.parseUrl(`${DASHBOARD_BASE}/time-tracking`);
+	} catch (error) {
+		console.error('Failed to resolve default dashboard', error);
+		return router.parseUrl(`${DASHBOARD_BASE}/time-tracking`);
+	}
+};

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard.service.ts
@@ -39,7 +39,9 @@ export class DashboardService {
 	findById(id: ID, params?: any): Promise<IDashboard> {
 		return firstValueFrom(
 			this.http.get<IDashboard>(`${this.DASHBOARD_URL}/${id}`, {
-				params: toParams(params)
+				// The endpoint's BaseQueryDTO rejects an empty `where`,
+				// so always send at least the id filter.
+				params: toParams(params ?? { where: { id } })
 			})
 		);
 	}

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ID, IDashboard, IDashboardCreateInput, IDashboardUpdateInput, IPagination } from '@gauzy/contracts';
+import { API_PREFIX, toParams } from '@gauzy/ui-core/common';
+
+/**
+ * API client for the `/api/dashboard` endpoints (custom user dashboards).
+ */
+@Injectable({
+	providedIn: 'root'
+})
+export class DashboardService {
+	DASHBOARD_URL = `${API_PREFIX}/dashboard`;
+
+	constructor(private readonly http: HttpClient) {}
+
+	/**
+	 * Retrieves dashboards matching the provided find options.
+	 *
+	 * @param params - Find options (e.g. `{ where: { organizationId, tenantId, createdByUserId } }`).
+	 * @returns A promise resolving to the paginated list of dashboards.
+	 */
+	findAll(params?: any): Promise<IPagination<IDashboard>> {
+		return firstValueFrom(
+			this.http.get<IPagination<IDashboard>>(this.DASHBOARD_URL, {
+				params: toParams(params)
+			})
+		);
+	}
+
+	/**
+	 * Retrieves a single dashboard by its ID.
+	 *
+	 * @param id - The dashboard ID.
+	 * @param params - Optional additional find options.
+	 * @returns A promise resolving to the dashboard.
+	 */
+	findById(id: ID, params?: any): Promise<IDashboard> {
+		return firstValueFrom(
+			this.http.get<IDashboard>(`${this.DASHBOARD_URL}/${id}`, {
+				params: toParams(params)
+			})
+		);
+	}
+
+	/**
+	 * Creates a new dashboard.
+	 *
+	 * @param input - The dashboard creation input.
+	 * @returns A promise resolving to the created dashboard.
+	 */
+	create(input: IDashboardCreateInput): Promise<IDashboard> {
+		return firstValueFrom(this.http.post<IDashboard>(this.DASHBOARD_URL, input));
+	}
+
+	/**
+	 * Updates an existing dashboard.
+	 *
+	 * @param id - The dashboard ID.
+	 * @param input - The dashboard update input.
+	 * @returns A promise resolving to the updated dashboard.
+	 */
+	update(id: ID, input: IDashboardUpdateInput): Promise<IDashboard> {
+		return firstValueFrom(this.http.put<IDashboard>(`${this.DASHBOARD_URL}/${id}`, input));
+	}
+
+	/**
+	 * Deletes a dashboard by its ID.
+	 *
+	 * @param id - The dashboard ID.
+	 * @returns A promise resolving when the dashboard is deleted.
+	 */
+	delete(id: ID): Promise<any> {
+		return firstValueFrom(this.http.delete(`${this.DASHBOARD_URL}/${id}`));
+	}
+}

--- a/packages/ui-core/core/src/lib/services/dashboard/index.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/index.ts
@@ -1,0 +1,3 @@
+export * from './dashboard.service';
+export * from './dashboard-store.service';
+export * from './dashboard.guards';

--- a/packages/ui-core/core/src/lib/services/index.ts
+++ b/packages/ui-core/core/src/lib/services/index.ts
@@ -15,6 +15,7 @@ export * from './country';
 export * from './crud';
 export * from './currency';
 export * from './custom-smtp';
+export * from './dashboard';
 export * from './deals';
 export * from './email';
 export * from './employee';

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -1847,6 +1847,25 @@
 		}
 	},
 	"DASHBOARD_PAGE": {
+		"CUSTOM": {
+			"STANDARD": "Standard",
+			"NEW_DASHBOARD": "New Dashboard",
+			"DUPLICATE_DASHBOARD": "Duplicate Dashboard",
+			"RENAME_DASHBOARD": "Rename Dashboard",
+			"SET_AS_DEFAULT": "Set as Default",
+			"DELETE_DASHBOARD": "Delete Dashboard",
+			"EDIT_DASHBOARD": "Edit Dashboard",
+			"NAME_LABEL": "Dashboard name",
+			"NAME_PLACEHOLDER": "Enter dashboard name",
+			"COPY_SUFFIX": "(Copy)",
+			"CREATED": "Dashboard \"{{ name }}\" created",
+			"UPDATED": "Dashboard \"{{ name }}\" updated",
+			"DELETED": "Dashboard \"{{ name }}\" deleted",
+			"SET_DEFAULT_SUCCESS": "\"{{ name }}\" is now your default dashboard",
+			"LAYOUT_SAVED": "Dashboard layout saved",
+			"DELETE_CONFIRM": "Are you sure you want to delete the dashboard \"{{ name }}\"? This cannot be undone.",
+			"EDIT_HINT": "Drag & drop widgets to rearrange them, or use the Manage Widget menu to show/hide widgets. Click Save to persist this layout."
+		},
 		"ACCOUNTING": "Accounting",
 		"HUMAN_RESOURCES": "Human Resources",
 		"TIME_TRACKING": "Time Tracking",


### PR DESCRIPTION
## What

Named **custom dashboards** on top of the existing dashboard widget system:

- **Sidebar**: "Dashboards" stays a plain link while the user has no custom dashboards; once at least one exists it becomes expandable with **Standard** + one child per custom dashboard.
- **Chips row** above the dashboard tabs line — rendered **only when custom dashboards exist**: "Standard" + each custom dashboard, horizontal overflow handled with **< / > arrow buttons** (no scrollbar).
- **⋮ (more-vertical) menu**: New Dashboard, Duplicate Dashboard, Rename, Set as Default, Delete, Edit — plus a **visible Edit button** when a custom dashboard is active, and Save / Cancel while editing.
- **Drag & drop**: a custom dashboard reuses the existing widget host (Time Tracking widget system); Edit → arrange/hide widgets → Save persists the layout snapshot ({widgets, windows} positions/visibility/collapse) into `Dashboard.contentHtml` (JSON).
- **Default dashboard**: "Set as Default" makes /pages/dashboard land on that custom dashboard (guard-based redirect); with Standard active it clears the default flag instead.
- **Routing**: `custom/:id` host route registered by the dashboard-time-track plugin at dashboard-sections; guards apply/restore layouts before widget-host init (componentless `switching` hop forces re-creation on custom→custom switches).

## Backend hardening (existing `Dashboard` core entity reused — no migrations)

- Ownership checks on update/delete (personal dashboards; `ForbiddenException` otherwise).
- `isDefault` promotion demotes the user's other defaults (single default per user).
- `UpdateDashboardDTO` re-allows `isDefault` (excluded at creation); `contentHtml` drops the incorrect `@IsArray` (it stores a JSON object / sqlite text).
- Seeded/legacy rows (demo 'Default Dashboard' with HTML content) are **excluded** from the custom dashboard experience client-side — they would otherwise hijack the default redirect into a blank layout.

## Verification

Local build + visual verification in progress; screenshots will be posted on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds custom user dashboards so users can create, arrange, save, switch, and set a default dashboard. Adds a switcher UI, per-user ownership checks, and guards that apply/restore layouts and land on the user’s default.

- **New Features**
  - Switcher chips: "Standard" + customs with < / > overflow; Edit, Save/Cancel, and ⋮ actions (New, Duplicate, Rename, Delete, Set as Default, Edit).
  - Drag & drop layouts persist to `Dashboard.contentHtml` (JSON); safe restore/cancel in edit mode.
  - Routing/guards: `custom/:id` reuses time-track host; `customDashboardGuard` applies layouts and forces host re-creation; `standardDashboardGuard` restores Standard; `/pages/dashboard` uses `defaultDashboardGuard`.
  - Sidebar “Dashboards” expands when customs exist; "Standard" + one per custom.
  - Services/i18n: new `DashboardService` (API) and `DashboardStoreService` (state) in `@gauzy/ui-core/core`; English strings added.
  - Backend: per-user ownership on update/delete; promoting `isDefault` demotes others; `UpdateDashboardDTO` allows `isDefault`; relaxed `contentHtml` validation.

- **Bug Fixes**
  - Create→navigate race: guard reloads list; client `findById` always sends an id `where` filter.
  - User-scoped localStorage keys; layout arrays validated to avoid crashes.
  - Delete 404s on missing dashboards; ownership denies orphaned rows.
  - Switcher template uses signals to avoid repeated async pipes/subscriptions.
  - Accessibility: popover actions are native buttons for keyboard/assistive tech.
  - CSpell: added "componentless" dictionary entry.

<sup>Written for commit 7dcc0cb290839c8bd1d3be36b7b9192b23434b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

