### PR TITLE
chore: cascade develop → stage (bot-audit follow-up fixes)

### DIFF
--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.ts
@@ -66,16 +66,43 @@ export class DashboardSwitcherComponent extends TranslationBaseComponent impleme
 	}
 
 	/** Switches to the Standard (prebuilt) dashboard. */
-	public selectStandard(): void {
+	public async selectStandard(): Promise<void> {
+		if (!(await this._confirmDiscardIfEditing())) {
+			return;
+		}
 		this._dashboardStore.navigateToStandard();
 	}
 
 	/** Switches to the given custom dashboard. */
-	public select(dashboard: IDashboard): void {
+	public async select(dashboard: IDashboard): Promise<void> {
 		if (this._dashboardStore.selectedDashboard?.id === dashboard.id) {
 			return;
 		}
+		if (!(await this._confirmDiscardIfEditing())) {
+			return;
+		}
 		this._dashboardStore.navigateToDashboard(dashboard.id);
+	}
+
+	/**
+	 * When edit mode is active, asks the user to confirm discarding the
+	 * unsaved widget arrangement before navigating away.
+	 *
+	 * @returns `true` to proceed with the navigation, `false` to stay.
+	 */
+	private async _confirmDiscardIfEditing(): Promise<boolean> {
+		if (!this.editing()) {
+			return true;
+		}
+		const dialogRef = this._dialogService.open(ConfirmComponent, {
+			context: {
+				data: {
+					title: this.getTranslation('DASHBOARD_PAGE.CUSTOM.DISCARD_CHANGES'),
+					message: this.getTranslation('DASHBOARD_PAGE.CUSTOM.DISCARD_CONFIRM')
+				}
+			}
+		});
+		return !!(await firstValueFrom(dialogRef.onClose));
 	}
 
 	/*

--- a/packages/core/src/lib/dashboard/commands/handlers/dashboard.update.handler.ts
+++ b/packages/core/src/lib/dashboard/commands/handlers/dashboard.update.handler.ts
@@ -22,6 +22,11 @@ export class DashboardUpdateHandler implements ICommandHandler<DashboardUpdateCo
 			return await this.dashboardService.update(id, input);
 		} catch (error) {
 			this.logger.error('Failed to update dashboard', error.stack);
+			// Preserve intentional HTTP semantics from the service
+			// (404 unknown id, 403 not owner) instead of flattening to 400.
+			if (error instanceof HttpException) {
+				throw error;
+			}
 			throw new HttpException(`Error while updating dashboard: ${error.message}`, HttpStatus.BAD_REQUEST);
 		}
 	}

--- a/packages/core/src/lib/dashboard/dashboard.service.ts
+++ b/packages/core/src/lib/dashboard/dashboard.service.ts
@@ -128,7 +128,8 @@ export class DashboardService extends TenantAwareCrudService<Dashboard> {
 			return updatedDashboard;
 		} catch (error) {
 			// Preserve the original HTTP semantics for ownership violations
-			if (error instanceof ForbiddenException) {
+			// and missing dashboards (403/404, not a generic 400)
+			if (error instanceof ForbiddenException || error instanceof NotFoundException) {
 				throw error;
 			}
 			// Log the error and throw an HttpException

--- a/packages/plugins/ai-chat-react-ui/src/i18n/en.json
+++ b/packages/plugins/ai-chat-react-ui/src/i18n/en.json
@@ -61,7 +61,8 @@
 			"DELETED": "{{provider}} credential deleted.",
 			"ERROR": "Something went wrong. Please try again.",
 			"CONNECTED": "{{ provider }} connected successfully.",
-			"CONNECT_WORKSPACE_MISMATCH": "This Connect flow was started in a different workspace. Switch back to that workspace and try again."
+			"CONNECT_WORKSPACE_MISMATCH": "This Connect flow was started in a different workspace. Switch back to that workspace and try again.",
+			"CONNECT_SESSION_EXPIRED": "The Connect session has expired or was started in another tab. Please click Connect again."
 		},
 		"LIST": {
 			"EMPTY": "No AI providers are configured yet. Add one to enable the AI chat.",

--- a/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.scss
+++ b/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.scss
@@ -112,9 +112,10 @@
 			letter-spacing: 0.04em;
 			padding: 0.125rem 0.5rem;
 			border-radius: 1rem;
-			background: rgba(0, 214, 143, 0.16);
-			// WCAG contrast: dark success shade on the light tint (not #00d68f)
-			color: #00875a;
+			// Theme tokens (not hardcoded hex) so every theme resolves an
+			// accessible pair; the dark override below lightens the foreground.
+			background: var(--color-success-transparent-200, rgba(0, 214, 143, 0.16));
+			color: var(--color-success-800, #007d6c);
 		}
 
 		.env-note {
@@ -168,8 +169,7 @@
 			align-items: center;
 			gap: 0.25rem;
 			font-size: 0.75rem;
-			// WCAG contrast: dark success shade (not #00d68f)
-			color: #00875a;
+			color: var(--color-success-800, #007d6c);
 
 			nb-icon {
 				font-size: 0.9375rem;
@@ -183,9 +183,24 @@
 			letter-spacing: 0.04em;
 			padding: 0.125rem 0.5rem;
 			border-radius: 1rem;
-			background: rgba(51, 102, 255, 0.14);
-			// WCAG contrast: darker primary shade on the light tint
-			color: #274bdb;
+			background: var(--color-primary-transparent-200, rgba(51, 102, 255, 0.14));
+			color: var(--color-primary-700, #274bdb);
+		}
+	}
+
+	// Dark themes: light foregrounds on the translucent tints (the light-theme
+	// shades would land well below the 4.5:1 WCAG minimum on dark cards).
+	@at-root :host-context(.nb-theme-gauzy-dark) &,
+		:host-context(.nb-theme-dark) &,
+		:host-context(.nb-theme-cosmic) &,
+		:host-context(.nb-theme-material-dark) & {
+		.default-chip,
+		.configured {
+			color: var(--color-success-300, #2ce69b);
+		}
+
+		.connect-chip {
+			color: var(--color-primary-300, #94b3ff);
 		}
 	}
 

--- a/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.ts
@@ -173,6 +173,16 @@ export class AiChatSettingsComponent implements OnInit {
 			} else {
 				this.completeConnect(pending.providerId, code, pending.verifier);
 			}
+		} else if (code) {
+			// ?code= arrived but the PKCE session is gone (page reloaded, other
+			// tab, or expired) — tell the user instead of failing silently, and
+			// strip the stale one-time code from the URL.
+			this.toastrService.warning(
+				this.translateService.instant('AI_CHAT_UI.SETTINGS.TOASTR.CONNECT_SESSION_EXPIRED'),
+				this.translateService.instant('AI_CHAT_UI.SETTINGS.TOASTR.ERROR_TITLE')
+			);
+			void this.router.navigate([], { relativeTo: this.route, queryParams: {} });
+			this.load();
 		} else {
 			this.load();
 		}

--- a/packages/plugins/ai-chat/src/lib/credentials/ai-provider-credential.service.ts
+++ b/packages/plugins/ai-chat/src/lib/credentials/ai-provider-credential.service.ts
@@ -105,15 +105,6 @@ export class AiProviderCredentialService extends TenantAwareCrudService<AiProvid
 	}
 
 	/**
-	 * Create or update the tenant's credential for a provider (one credential
-	 * per `(tenant, providerId)` pair). The API key is encrypted before storage;
-	 * when omitted on update, the previously stored key is kept. Setting
-	 * `isDefault: true` clears the flag on the tenant's other credentials.
-	 *
-	 * @param input - The credential payload (provider id required; API key required on first create).
-	 * @returns The persisted credential with a masked API key.
-	 */
-	/**
 	 * Complete a provider "Connect" flow: exchange the PKCE authorization
 	 * `code` + `codeVerifier` for an API key server-side and store it as the
 	 * tenant's BYOK credential for that provider. The key never touches the
@@ -175,6 +166,15 @@ export class AiProviderCredentialService extends TenantAwareCrudService<AiProvid
 		});
 	}
 
+	/**
+	 * Create or update the tenant's credential for a provider (one credential
+	 * per `(tenant, providerId)` pair). The API key is encrypted before storage;
+	 * when omitted on update, the previously stored key is kept. Setting
+	 * `isDefault: true` clears the flag on the tenant's other credentials.
+	 *
+	 * @param input - The credential payload (provider id required; API key required on first create).
+	 * @returns The persisted credential with a masked API key.
+	 */
 	async upsert(
 		input: IAiProviderCredentialCreateInput | IAiProviderCredentialUpdateInput
 	): Promise<IAiProviderCredential> {

--- a/packages/ui-core/core/src/lib/components/base-nav-menu/base-nav-menu.component.ts
+++ b/packages/ui-core/core/src/lib/components/base-nav-menu/base-nav-menu.component.ts
@@ -176,8 +176,10 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 				icon: 'fas fa-th-large',
 				link: `/pages/dashboard/custom/${dashboard.id}`,
 				data: {
-					// Custom dashboard names are user content; the translate pipe passes unknown keys through
-					translationKey: dashboard.name
+					// Custom dashboard names are user content — render literally so a
+					// name matching an existing i18n key isn't translated away.
+					translationKey: dashboard.name,
+					noTranslate: true
 				}
 			}))
 		];
@@ -1229,7 +1231,10 @@ export class BaseNavMenuComponent extends TranslationBaseComponent implements On
 	public mapMenuSection(item: NavMenuSectionItem): NavMenuSectionItem {
 		const section: NavMenuSectionItem = {
 			...item,
-			title: this.getTranslation(item.data.translationKey),
+			// noTranslate items carry user content (e.g. a custom dashboard name)
+			// that must render literally — a name that happens to match an i18n
+			// key must not come out as that key's translation.
+			title: item.data.noTranslate ? item.data.translationKey : this.getTranslation(item.data.translationKey),
 			hidden: item.hidden || this.isSectionHidden(item)
 		};
 

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
@@ -68,16 +68,28 @@ export class DashboardStoreService {
 		this._refresh$.next();
 	}
 
+	/** The organization the in-memory dashboard state currently belongs to. */
+	private _activeOrganizationId: string | null = null;
+
 	/**
-	 * Storage keys are scoped to the current user so that on a shared browser
-	 * one user's selection/layout backup can never leak into another's session.
+	 * Storage keys are scoped to the current user AND organization so that on a
+	 * shared browser (or after an organization switch) one context's selection
+	 * or layout backup can never leak into another's session.
 	 */
+	private _selectedKeyFor(organizationId: string | null | undefined): string {
+		return `${SELECTED_DASHBOARD_KEY}_${this._store.userId ?? 'anonymous'}_${organizationId ?? 'no-org'}`;
+	}
+
+	private _backupKeyFor(organizationId: string | null | undefined): string {
+		return `${STANDARD_LAYOUT_BACKUP_KEY}_${this._store.userId ?? 'anonymous'}_${organizationId ?? 'no-org'}`;
+	}
+
 	private get _selectedKey(): string {
-		return `${SELECTED_DASHBOARD_KEY}_${this._store.userId ?? 'anonymous'}`;
+		return this._selectedKeyFor(this._store.selectedOrganization?.id);
 	}
 
 	private get _backupKey(): string {
-		return `${STANDARD_LAYOUT_BACKUP_KEY}_${this._store.userId ?? 'anonymous'}`;
+		return this._backupKeyFor(this._store.selectedOrganization?.id);
 	}
 
 	/*
@@ -93,21 +105,64 @@ export class DashboardStoreService {
 		])
 			.pipe(
 				// Catch load errors INSIDE the switchMap so a failed request
-				// does not complete the outer stream (future reloads keep working)
-				switchMap(() =>
-					from(this._loadDashboards()).pipe(
+				// does not complete the outer stream (future reloads keep working).
+				// A failure emits `null` (NOT []) so it can't be mistaken for
+				// "the user has no dashboards" downstream.
+				switchMap(([organization]) => {
+					// Organization switch: restore the OUTGOING organization's
+					// Standard snapshot (its keys, not the new org's) and clear
+					// all in-memory dashboard state BEFORE loading, so stale
+					// cross-organization chips/selection are never usable —
+					// even if the load below fails.
+					const organizationId = organization.id as string;
+					if (this._activeOrganizationId && this._activeOrganizationId !== organizationId) {
+						this._leaveOrganization(this._activeOrganizationId);
+					}
+					this._activeOrganizationId = organizationId;
+					return from(this._loadDashboards()).pipe(
 						catchError((error) => {
 							console.error('Error loading custom dashboards', error);
-							return of([] as IDashboard[]);
+							return of(null as IDashboard[] | null);
 						})
-					)
-				),
+					);
+				}),
 				untilDestroyed(this)
 			)
-			.subscribe((items: IDashboard[]) => {
+			.subscribe((items: IDashboard[] | null) => {
+				if (items === null) {
+					// Transient load failure: keep the current list and selection —
+					// reconciling against [] would wrongly treat the active custom
+					// dashboard as deleted and silently kick the user to Standard.
+					return;
+				}
 				this._dashboards$.next(items);
 				this._reconcileSelection(items);
 			});
+	}
+
+	/**
+	 * Leaves the given organization's dashboard context: restores its Standard
+	 * layout snapshot (when a custom dashboard was active there), removes its
+	 * persisted keys and resets the in-memory list/selection.
+	 */
+	private _leaveOrganization(organizationId: string): void {
+		const selectedKey = this._selectedKeyFor(organizationId);
+		const backupKey = this._backupKeyFor(organizationId);
+		if (this.selectedDashboard || localStorage.getItem(selectedKey)) {
+			let layout: IDashboardLayout = {};
+			try {
+				layout = JSON.parse(localStorage.getItem(backupKey) || '{}') as IDashboardLayout;
+			} catch {
+				layout = {};
+			}
+			this._store.widgets = (Array.isArray(layout.widgets) ? layout.widgets : []) as any[];
+			this._store.windows = (Array.isArray(layout.windows) ? layout.windows : []) as any[];
+		}
+		localStorage.removeItem(selectedKey);
+		localStorage.removeItem(backupKey);
+		this._selectedDashboard$.next(null);
+		this._editing$.next(false);
+		this._dashboards$.next([]);
 	}
 
 	/**
@@ -149,6 +204,11 @@ export class DashboardStoreService {
 		} else if (this.selectedDashboard) {
 			// The selected dashboard no longer exists (e.g. deleted elsewhere)
 			this.ensureStandardLayout();
+		} else {
+			// Stale persisted selection with no in-memory counterpart (e.g. the
+			// dashboard was deleted in another session) — drop it so it can't
+			// resurface later.
+			localStorage.removeItem(this._selectedKey);
 		}
 	}
 
@@ -218,22 +278,29 @@ export class DashboardStoreService {
 	 * Used to decide where `/pages/dashboard` should land.
 	 */
 	public async resolveDefaultDashboard(): Promise<IDashboard | null> {
-		const loaded = this.dashboards.find((item: IDashboard) => item.isDefault);
-		if (loaded) {
-			return loaded;
-		}
-
 		const { id: organizationId, tenantId } = this._store.selectedOrganization || {};
 		const createdByUserId = this._store.userId;
-		if (!createdByUserId) {
+		// The custom dashboard experience is organization-scoped: without a
+		// selected organization the query could surface a default dashboard
+		// from ANOTHER organization — land on Standard instead. Guard BEFORE
+		// the cached-list fast path so a stale cross-organization cache can't
+		// short-circuit the check during an organization switch.
+		if (!createdByUserId || !organizationId) {
 			return null;
+		}
+
+		const loaded = this.dashboards.find(
+			(item: IDashboard) => item.isDefault && item.organizationId === organizationId
+		);
+		if (loaded) {
+			return loaded;
 		}
 
 		// Note: the default flag is filtered client-side to avoid boolean
 		// serialization differences across the supported databases.
 		const { items = [] } = await this._dashboardService.findAll({
 			where: {
-				...(organizationId ? { organizationId } : {}),
+				organizationId,
 				...(tenantId ? { tenantId } : {}),
 				createdByUserId
 			}
@@ -443,14 +510,20 @@ export class DashboardStoreService {
 		if (!content) {
 			return {};
 		}
+		let parsed: unknown = content;
 		if (typeof content === 'string') {
 			try {
-				return JSON.parse(content) as IDashboardLayout;
+				parsed = JSON.parse(content);
 			} catch {
 				return {};
 			}
 		}
-		return content as IDashboardLayout;
+		// Normalize: a null/array/primitive root (e.g. the string "null") must
+		// not reach _applyLayout, which reads `.widgets` off the result.
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			return {};
+		}
+		return parsed as IDashboardLayout;
 	}
 
 	/** Keeps only the serializable `GuiDrag` fields of each layout item. */

--- a/packages/ui-core/core/src/lib/services/nav-builder/nav-builder-types.ts
+++ b/packages/ui-core/core/src/lib/services/nav-builder/nav-builder-types.ts
@@ -25,6 +25,7 @@ export interface NavMenuSectionItem extends NbMenuItem {
  */
 export interface NavMenuItemData {
 	translationKey: string; // Translation key for the title, mandatory for all items
+	noTranslate?: boolean; // When true, translationKey holds user content and is rendered literally (e.g. custom dashboard names)
 	permissionKeys?: PermissionsEnum[]; // Permissions required to display the item (optional)
 	featureKey?: FeatureEnum; // Feature key required to display the item (optional)
 	hide?: () => boolean | boolean; // Function to determine if the item should be hidden (optional)

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -1865,7 +1865,9 @@
 			"SET_DEFAULT_SUCCESS": "\"{{ name }}\" is now your default dashboard",
 			"LAYOUT_SAVED": "Dashboard layout saved",
 			"DELETE_CONFIRM": "Are you sure you want to delete the dashboard \"{{ name }}\"? This cannot be undone.",
-			"EDIT_HINT": "Drag & drop widgets to rearrange them, or use the Manage Widget menu to show/hide widgets. Click Save to persist this layout."
+			"EDIT_HINT": "Drag & drop widgets to rearrange them, or use the Manage Widget menu to show/hide widgets. Click Save to persist this layout.",
+			"DISCARD_CHANGES": "Discard unsaved changes?",
+			"DISCARD_CONFIRM": "You have unsaved layout changes. Switching dashboards will discard them. Continue?"
 		},
 		"ACCOUNTING": "Accounting",
 		"HUMAN_RESOURCES": "Human Resources",


### PR DESCRIPTION
Promotes the post-merge AI-bot audit follow-ups (#9846) to stage, on top of the feature cascade #9845 (whose image builds are still blocked by the runner-fleet DNS outage — this keeps stage's code current so a single build round covers everything once the fleet recovers).

⚠️ Merge with a MERGE COMMIT (not squash) per promotion policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens custom dashboards and `ai-chat` settings with org-scoped state, correct error semantics, accessible theming, and clearer Connect/edit flows. Prevents cross-organization leakage, unintended navigation, and silent failures.

- **Bug Fixes**
  - Dashboard: scope selection/layout `localStorage` by organization; on org switch, restore the previous org’s Standard layout, clear persisted keys, and reset in-memory state.
  - Dashboard: treat load errors as transient (keep current list/selection); require a selected org to resolve default and validate cached hits against the current org.
  - Dashboard: confirm before discarding unsaved layout changes when switching; parse layout defensively to avoid crashes on invalid data.
  - Dashboard: preserve `403/404` from the service/handler on update instead of flattening to `400`.
  - Navigation: render custom dashboard names literally via `noTranslate` so user-provided names aren’t translated.
  - `ai-chat-react-ui`: use theme tokens for status chips with dark-theme overrides for WCAG contrast.
  - `ai-chat-react-ui`: when `?code=` arrives without a PKCE session, show a warning toast, strip the stale code, and reload; added `CONNECT_SESSION_EXPIRED` i18n.
  - `ai-chat`: restored `upsert()` JSDoc in `ai-provider-credential.service`.

<sup>Written for commit c809b9951a6ea1fcc4e8bb339842448e3d4cc00f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

