### PR TITLE
feat(ui): breadcrumbs on every page, flat menu chrome, settings shell for plugin pages

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -899,6 +899,7 @@
 		"stefanzweifel",
 		"streamifier",
 		"stylelint",
+		"stylesheet",
 		"Sumanth",
 		"superfly",
 		"swapoff",

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.scss
@@ -85,39 +85,74 @@
 	color: var(--text-hint-color);
 }
 
+// ⋮ actions menu. The nb-popover host supplies the container chrome (1px
+// hairline + soft shadow + 8px radius) from
+// `packages/ui-core/static/styles/_overlays.scss`; everything below is the FLAT
+// item layer — no per-row border, shadow or resting fill.
 .dashboard-actions-popover {
 	display: flex;
 	flex-direction: column;
-	padding: 8px 0;
-	min-width: 200px;
+	// Just enough inset that a hovered row's 6px radius never touches the
+	// container edge.
+	padding: 4px;
+	min-width: 11rem;
 
 	.action {
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		padding: 8px 16px;
+		padding: 6px 10px;
+		border-radius: 6px;
 		font-size: 13px;
+		line-height: 1.25rem;
 		color: var(--text-basic-color);
 		cursor: pointer;
 		// native <button> resets (keyboard-accessible menu items)
 		background: none;
 		border: none;
 		width: 100%;
-		text-align: left;
+		// Logical keyword so the row flips on its own in RTL.
+		text-align: start;
 		font-family: inherit;
+		// Colour only: transitioning `all` would animate the radius and make the
+		// row look like it is inflating into a block.
+		transition: background-color 0.12s ease-in-out, color 0.12s ease-in-out;
 
 		nb-icon {
-			font-size: 16px;
-			height: 16px;
-			width: 16px;
+			flex-shrink: 0;
+			font-size: 14px;
+			height: 14px;
+			width: 14px;
+			// Muted glyph, brought up to full contrast on hover.
+			color: var(--text-hint-color);
+			transition: color 0.12s ease-in-out;
 		}
 
+		// Was `--background-basic-color-2`, which is the SAME colour as the
+		// popover surface in the dark themes — the hover state was invisible
+		// there. A neutral low-alpha tint reads on both backgrounds.
 		&:hover {
-			background-color: var(--background-basic-color-2);
+			background-color: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12));
+
+			nb-icon {
+				color: var(--text-basic-color);
+			}
 		}
 
 		&.danger {
 			color: var(--color-danger-default);
+
+			nb-icon {
+				color: var(--color-danger-default);
+			}
+
+			&:hover {
+				background-color: var(--color-danger-transparent-100);
+
+				nb-icon {
+					color: var(--color-danger-default);
+				}
+			}
 		}
 	}
 }

--- a/apps/gauzy/src/app/pages/settings/settings-routing.module.ts
+++ b/apps/gauzy/src/app/pages/settings/settings-routing.module.ts
@@ -1,147 +1,27 @@
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { DangerZoneComponent } from './danger-zone/danger-zone.component';
-import { SettingsComponent } from './settings.component';
-import { EmailHistoryComponent } from './email-history/email-history.component';
-import { PermissionsGuard } from '@gauzy/ui-core/core';
-import { PermissionsEnum } from '@gauzy/contracts';
-import { SmsGatewayComponent } from './sms-gateway/sms-gateway.component';
+import { ROUTES, RouterModule } from '@angular/router';
+import { PageRouteRegistryService } from '@gauzy/ui-core/core';
+import { createSettingsRoutes } from './settings.routes';
 
-const routes: Routes = [
-	{
-		path: '',
-		component: SettingsComponent,
-		children: [
-			{
-				path: '',
-				redirectTo: 'general',
-				pathMatch: 'full'
-			},
-			{
-				path: 'general',
-				loadChildren: () =>
-					import('./general-setting/general-setting.module').then((m) => m.GeneralSettingModule)
-			},
-			{
-				path: 'features',
-				loadChildren: () => import('./feature/feature.module').then((m) => m.FeatureModule)
-			},
-			{
-				path: 'email-history',
-				component: EmailHistoryComponent,
-				canActivate: [PermissionsGuard],
-				data: {
-					permissions: {
-						only: [PermissionsEnum.VIEW_ALL_EMAILS],
-						redirectTo: '/pages/settings'
-					},
-					selectors: {
-						project: false,
-						employee: false,
-						date: false,
-						organization: true
-					}
-				}
-			},
-			{
-				path: 'email-templates',
-				loadChildren: () =>
-					import('../email-templates/email-templates.module').then((m) => m.EmailTemplatesModule)
-			},
-			{
-				path: 'accounting-templates',
-				loadChildren: () =>
-					import('../accounting-templates/accounting-templates.module').then(
-						(m) => m.AccountingTemplatesModule
-					)
-			},
-			{
-				path: 'roles-permissions',
-				loadChildren: () =>
-					import('./roles-permissions/roles-permissions.module').then((m) => m.RolesPermissionsModule)
-			},
-			{
-				path: 'import-export',
-				loadChildren: () => import('../import-export/import-export.module').then((m) => m.ImportExportModule),
-				data: {
-					selectors: {
-						project: false,
-						employee: false,
-						date: false,
-						organization: false
-					}
-				}
-			},
-			{
-				path: 'sms-gateway',
-				component: SmsGatewayComponent,
-				canActivate: [PermissionsGuard],
-				data: {
-					permissions: {
-						only: [PermissionsEnum.SMS_GATEWAY_VIEW],
-						redirectTo: '/pages/settings'
-					},
-					selectors: {
-						project: false,
-						employee: false,
-						date: false,
-						organization: false
-					}
-				}
-			},
-			{
-				path: 'custom-smtp',
-				loadChildren: () => import('./custom-smtp/custom-smtp.module').then((m) => m.CustomSmtpModule)
-			},
-			{
-				path: 'oauth-clients',
-				loadChildren: () =>
-					import('./oauth-clients/oauth-clients.module').then((m) => m.OAuthClientsModule)
-			},
-			{
-				path: 'file-storage',
-				loadChildren: () => import('./file-storage/file-storage.module').then((m) => m.FileStorageModule)
-			},
-			{
-				path: 'monitoring',
-				loadChildren: () => import('./monitoring/monitoring.module').then((m) => m.MonitoringModule),
-				canActivate: [PermissionsGuard],
-				data: {
-					permissions: {
-						only: [PermissionsEnum.TENANT_SETTING],
-						redirectTo: '/pages/settings'
-					},
-					selectors: {
-						project: false,
-						employee: false,
-						date: false,
-						organization: false
-					}
-				}
-			},
-			{
-				path: 'danger-zone',
-				component: DangerZoneComponent,
-				canActivate: [PermissionsGuard],
-				data: {
-					permissions: {
-						only: [PermissionsEnum.ACCESS_DELETE_ACCOUNT, PermissionsEnum.ACCESS_DELETE_ALL_DATA],
-						redirectTo: '/pages/settings'
-					},
-					selectors: {
-						project: false,
-						employee: false,
-						organization: false,
-						date: false
-					}
-				}
-			}
-		]
-	}
-];
-
+/**
+ * Settings routing.
+ *
+ * Routes are built by a factory so plugin-contributed settings pages registered
+ * at the `settings-sections` location are spread into the settings shell's
+ * children (see {@link createSettingsRoutes}) and therefore render with the
+ * settings menu, exactly like the core settings pages.
+ */
 @NgModule({
-	imports: [RouterModule.forChild(routes)],
-	exports: [RouterModule]
+	imports: [RouterModule.forChild([])],
+	exports: [RouterModule],
+	providers: [
+		{
+			provide: ROUTES,
+			useFactory: (_pageRouteRegistryService: PageRouteRegistryService) =>
+				createSettingsRoutes(_pageRouteRegistryService),
+			deps: [PageRouteRegistryService],
+			multi: true
+		}
+	]
 })
 export class SettingsRoutingModule {}

--- a/apps/gauzy/src/app/pages/settings/settings.component.scss
+++ b/apps/gauzy/src/app/pages/settings/settings.component.scss
@@ -43,38 +43,56 @@
 	list-style: none;
 }
 
+// Same flat chrome as the sidebar rows and the overlay menus: NOTHING is painted
+// at rest, hover is a low-contrast tint on a small radius, and "current" is a
+// slightly stronger tint plus weight — never a filled pill.
 .settings-nav-link {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	padding: 5px 8px;
-	border-radius: calc(nb-theme(border-radius) / 2);
+	// The shared row radius, not the CARD radius: a 10px pill on a 20px row is
+	// exactly what made these entries read as blocks.
+	border-radius: nb-theme(gauzy-radius-sm);
 	font-size: 13px;
 	line-height: 1.25;
-	color: nb-theme(text-basic-color);
+	// Muted at rest so the active row stands out on weight/colour alone.
+	color: nb-theme(text-hint-color);
 	text-decoration: none;
 	cursor: pointer;
+	transition-duration: 0.12s;
+	transition-property: background-color, color;
+	transition-timing-function: ease-in-out;
 
 	i {
 		width: 1rem;
 		font-size: 12px;
 		text-align: center;
-		color: nb-theme(text-hint-color);
+		color: inherit;
 	}
 
 	&:hover {
-		background-color: nb-theme(background-basic-color-3);
+		background-color: nb-theme(gauzy-hover-tint);
 		color: nb-theme(text-basic-color);
 	}
 
-	&.active {
-		background-color: nb-theme(background-basic-color-3);
-		color: nb-theme(text-primary-color);
-		font-weight: 600;
+	// Keyboard parity with hover, plus a non-colour indicator: the tint alone is
+	// a colour-only signal (WCAG 1.4.11 / 2.4.7). Inset so the row never grows.
+	&:focus-visible {
+		background-color: nb-theme(gauzy-hover-tint);
+		color: nb-theme(text-basic-color);
+		outline: 2px solid nb-theme(color-primary-default);
+		outline-offset: -2px;
+	}
 
-		i {
-			color: nb-theme(text-primary-color);
-		}
+	// Current page. Icon and label deliberately share `text-basic-color` instead
+	// of the brand accent: `text-primary-color` is color-primary-500 (#6e49e8),
+	// which measures ~2.5:1 against the tinted row on the dark themes. Tint +
+	// weight already say "current" without depending on a colour.
+	&.active {
+		background-color: nb-theme(gauzy-active-tint);
+		color: nb-theme(text-basic-color);
+		font-weight: 600;
 	}
 }
 

--- a/apps/gauzy/src/app/pages/settings/settings.routes.ts
+++ b/apps/gauzy/src/app/pages/settings/settings.routes.ts
@@ -77,7 +77,8 @@ export function createSettingsRoutes(_pageRouteRegistryService: PageRouteRegistr
 				},
 				{
 					path: 'import-export',
-					loadChildren: () => import('../import-export/import-export.module').then((m) => m.ImportExportModule),
+					loadChildren: () =>
+						import('../import-export/import-export.module').then((m) => m.ImportExportModule),
 					data: {
 						selectors: {
 							project: false,

--- a/apps/gauzy/src/app/pages/settings/settings.routes.ts
+++ b/apps/gauzy/src/app/pages/settings/settings.routes.ts
@@ -1,0 +1,151 @@
+import { Route } from '@angular/router';
+import { PermissionsEnum } from '@gauzy/contracts';
+import { PageRouteRegistryService, PermissionsGuard } from '@gauzy/ui-core/core';
+import { DangerZoneComponent } from './danger-zone/danger-zone.component';
+import { SettingsComponent } from './settings.component';
+import { EmailHistoryComponent } from './email-history/email-history.component';
+import { SmsGatewayComponent } from './sms-gateway/sms-gateway.component';
+
+/**
+ * Creates the settings child routes.
+ *
+ * Every settings page is a CHILD of {@link SettingsComponent}, which renders the
+ * `Sidebar | Settings menu | content` shell. Plugin-contributed settings pages
+ * are spread in from the `settings-sections` registry location so they inherit
+ * that shell too — registering a settings page at `page-sections` instead makes
+ * it render standalone, without the settings menu.
+ *
+ * @param _pageRouteRegistryService - Service for retrieving plugin-registered routes.
+ * @returns Angular Route array for the settings feature.
+ */
+export function createSettingsRoutes(_pageRouteRegistryService: PageRouteRegistryService): Route[] {
+	return [
+		{
+			path: '',
+			component: SettingsComponent,
+			children: [
+				{
+					path: 'general',
+					loadChildren: () =>
+						import('./general-setting/general-setting.module').then((m) => m.GeneralSettingModule)
+				},
+				{
+					path: 'features',
+					loadChildren: () => import('./feature/feature.module').then((m) => m.FeatureModule)
+				},
+				{
+					path: 'email-history',
+					component: EmailHistoryComponent,
+					canActivate: [PermissionsGuard],
+					data: {
+						permissions: {
+							only: [PermissionsEnum.VIEW_ALL_EMAILS],
+							redirectTo: '/pages/settings'
+						},
+						selectors: {
+							project: false,
+							employee: false,
+							date: false,
+							organization: true
+						}
+					}
+				},
+				{
+					path: 'email-templates',
+					loadChildren: () =>
+						import('../email-templates/email-templates.module').then((m) => m.EmailTemplatesModule)
+				},
+				{
+					path: 'accounting-templates',
+					loadChildren: () =>
+						import('../accounting-templates/accounting-templates.module').then(
+							(m) => m.AccountingTemplatesModule
+						)
+				},
+				{
+					path: 'roles-permissions',
+					loadChildren: () =>
+						import('./roles-permissions/roles-permissions.module').then((m) => m.RolesPermissionsModule)
+				},
+				{
+					path: 'import-export',
+					loadChildren: () => import('../import-export/import-export.module').then((m) => m.ImportExportModule),
+					data: {
+						selectors: {
+							project: false,
+							employee: false,
+							date: false,
+							organization: false
+						}
+					}
+				},
+				{
+					path: 'sms-gateway',
+					component: SmsGatewayComponent,
+					canActivate: [PermissionsGuard],
+					data: {
+						permissions: {
+							only: [PermissionsEnum.SMS_GATEWAY_VIEW],
+							redirectTo: '/pages/settings'
+						},
+						selectors: {
+							project: false,
+							employee: false,
+							date: false,
+							organization: false
+						}
+					}
+				},
+				{
+					path: 'custom-smtp',
+					loadChildren: () => import('./custom-smtp/custom-smtp.module').then((m) => m.CustomSmtpModule)
+				},
+				{
+					path: 'oauth-clients',
+					loadChildren: () => import('./oauth-clients/oauth-clients.module').then((m) => m.OAuthClientsModule)
+				},
+				{
+					path: 'file-storage',
+					loadChildren: () => import('./file-storage/file-storage.module').then((m) => m.FileStorageModule)
+				},
+				{
+					path: 'monitoring',
+					loadChildren: () => import('./monitoring/monitoring.module').then((m) => m.MonitoringModule),
+					canActivate: [PermissionsGuard],
+					data: {
+						permissions: {
+							only: [PermissionsEnum.TENANT_SETTING],
+							redirectTo: '/pages/settings'
+						},
+						selectors: {
+							project: false,
+							employee: false,
+							date: false,
+							organization: false
+						}
+					}
+				},
+				{
+					path: 'danger-zone',
+					component: DangerZoneComponent,
+					canActivate: [PermissionsGuard],
+					data: {
+						permissions: {
+							only: [PermissionsEnum.ACCESS_DELETE_ACCOUNT, PermissionsEnum.ACCESS_DELETE_ALL_DATA],
+							redirectTo: '/pages/settings'
+						},
+						selectors: {
+							project: false,
+							employee: false,
+							organization: false,
+							date: false
+						}
+					}
+				},
+				// Plugin-contributed settings pages (e.g. AI Providers) — rendered
+				// inside the settings shell like every core settings page.
+				..._pageRouteRegistryService.getPageLocationRoutes('settings-sections')
+			]
+		}
+	];
+}

--- a/apps/gauzy/src/app/pages/settings/settings.routes.ts
+++ b/apps/gauzy/src/app/pages/settings/settings.routes.ts
@@ -25,6 +25,14 @@ export function createSettingsRoutes(_pageRouteRegistryService: PageRouteRegistr
 			component: SettingsComponent,
 			children: [
 				{
+					// `/pages/settings` is a real navigation target (the sidebar entry and several
+					// permission guards redirect there), so the shell needs a default child or it
+					// renders an empty content pane next to the settings menu.
+					path: '',
+					redirectTo: 'general',
+					pathMatch: 'full'
+				},
+				{
 					path: 'general',
 					loadChildren: () =>
 						import('./general-setting/general-setting.module').then((m) => m.GeneralSettingModule)

--- a/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.routes.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.routes.ts
@@ -2,17 +2,25 @@ import { PermissionsEnum } from '@gauzy/contracts';
 import { PageRouteRegistryConfig, PermissionsGuard } from '@gauzy/ui-core/core';
 import { AiChatSettingsComponent } from './ai-chat-settings.component';
 
-/** Path segment for the AI Providers settings page under /pages. */
-export const AI_CHAT_SETTINGS_PATH = 'settings/ai';
+/**
+ * Path segment for the AI Providers settings page, RELATIVE to /pages/settings
+ * (the route is registered as a child of the settings shell).
+ */
+export const AI_CHAT_SETTINGS_PATH = 'ai';
 
 /**
  * Route config for the per-tenant "AI Providers" (BYOK) settings page.
- * Registered at `page-sections` so it appears as /pages/settings/ai,
- * guarded by the `AI_CHAT_SETTINGS` permission (same PermissionsGuard
- * pattern as the core settings routes).
+ *
+ * Registered at `settings-sections` — i.e. as a CHILD of the settings shell —
+ * so the page renders with the settings menu beside it, exactly like the core
+ * settings pages. (Registering at `page-sections` would still resolve
+ * /pages/settings/ai, but standalone, without the settings menu.)
+ *
+ * Guarded by the `AI_CHAT_SETTINGS` permission, matching the PermissionsGuard
+ * pattern used by the core settings routes.
  */
 export const AI_CHAT_SETTINGS_ROUTE: PageRouteRegistryConfig = {
-	location: 'page-sections',
+	location: 'settings-sections',
 	path: AI_CHAT_SETTINGS_PATH,
 	component: AiChatSettingsComponent,
 	canActivate: [PermissionsGuard],

--- a/packages/ui-core/core/src/lib/common/component-registry.types.ts
+++ b/packages/ui-core/core/src/lib/common/component-registry.types.ts
@@ -39,6 +39,10 @@ export type ComponentRegistryLocationId = 'table' | 'tab' | 'route';
  * - 'organization-sections': Children under /pages/organization.
  * - 'goals-sections': Children under /pages/goals.
  * - 'reports-sections': Children under /pages/reports.
+ * - 'settings-sections': Children under /pages/settings, rendered inside the
+ *   settings shell (Sidebar | Settings menu | content). Plugin settings pages
+ *   MUST use this rather than 'page-sections', or they render standalone
+ *   without the settings menu.
  * - 'page-sections': Top-level plugin section routes under /pages.
  */
 export type PageRouteLocationId =
@@ -57,6 +61,7 @@ export type PageRouteLocationId =
 	| 'organization-sections'
 	| 'goals-sections'
 	| 'reports-sections'
+	| 'settings-sections'
 	| 'page-sections';
 
 /**

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.html
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.html
@@ -1,7 +1,6 @@
 <ng-container *ngxPermissionsOnly="item?.data?.permissionKeys">
 	@if (!collapse) { @if (!item?.hidden) {
 	<div
-		[class.border-bottom]="!isLast()"
 		[gaTooltip]="item?.title"
 		[icon]="item?.icon"
 		[class]="(selected ? 'selected ' : '') + (!collapse ? 'custom ' : '') + 'sub-item'"
@@ -20,7 +19,6 @@
 	</div>
 	} } @else { @if (!item?.hidden) {
 	<div
-		[class.border-bottom]="!isLast()"
 		[nbTooltip]="item?.title"
 		nbTooltipPlacement="right"
 		[class]="(selected ? 'sub-item selected' : 'sub-item') + (!collapse ? ' custom' : '')"

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.scss
@@ -1,12 +1,34 @@
+// `themes` must be loaded HERE as well: Sass `@use ... as *` inside
+// menu-item.component.scss makes nb-theme() available to that file only, it is
+// not re-exported. Without this line the rules below compiled to a literal
+// `nb-theme(...)` in the output — an unknown CSS function the browser drops.
+@use 'themes' as *;
+
+// Row layout, hover/active overlays and the icon column all live in the parent
+// stylesheet so both components stay in sync; `:host` resolves to
+// <ga-children-menu-item> here.
 @use '../menu-item/menu-item.component';
 
+// Inline "add" affordance on a child row. It sits inside a flat menu row, so it
+// is a ghost icon button: no outline, no fill, it only brightens on hover.
 [nbButton].plus.appearance-outline.size-tiny {
-    padding: 2px 3px;
-    border: 2px solid nb-theme(gauzy-border-default-color);
-    color: nb-theme(gauzy-text-color-2);
+  padding: 0.125rem 0.25rem;
+  border: none;
+  background-color: transparent;
+  // `inherit`, not nb-theme(gauzy-text-color-2): that token is undefined in the
+  // material-* themes, and it would also freeze the button at the RESTING label
+  // colour while the row around it brightens on hover/selection. Inheriting from
+  // `.sub-item` tracks the row in every theme and every state.
+  color: inherit;
 
-    i.fa-plus {
-        margin: 0;
-        font-size: 14px;
-    }
+  &:hover,
+  &:focus {
+    background-color: transparent;
+    color: nb-theme(text-basic-color);
+  }
+
+  i.fa-plus {
+    margin: 0;
+    font-size: 0.75rem;
+  }
 }

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.scss
@@ -9,7 +9,7 @@
 // <ga-children-menu-item> here.
 @use '../menu-item/menu-item.component';
 
-// Inline "add" affordance on a child row. It sits inside a flat menu row, so it
+// Inline "add" control on a child row. It sits inside a flat menu row, so it
 // is a ghost icon button: no outline, no fill, it only brightens on hover.
 [nbButton].plus.appearance-outline.size-tiny {
   padding: 0.125rem 0.25rem;
@@ -21,10 +21,19 @@
   // `.sub-item` tracks the row in every theme and every state.
   color: inherit;
 
-  &:hover,
-  &:focus {
+  &:hover {
     background-color: transparent;
     color: nb-theme(text-basic-color);
+  }
+
+  // Keyboard focus needs a NON-colour indicator: the hover treatment is a
+  // brightness shift only, which on its own fails WCAG 1.4.11 / 2.4.7. The
+  // outline is inset so it never widens the row.
+  &:focus-visible {
+    background-color: transparent;
+    color: nb-theme(text-basic-color);
+    outline: 2px solid nb-theme(color-primary-default);
+    outline-offset: -2px;
   }
 
   i.fa-plus {

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.ts
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.ts
@@ -162,13 +162,4 @@ export class ChildrenMenuItemComponent implements OnInit {
 		this.focusItemChange.emit({ children: this.item, parent: this.parent });
 		this.router.navigateByUrl(this.item.data.add);
 	}
-
-	/**
-	 * Checks if the current item is the last item among its siblings.
-	 * @returns A boolean indicating whether the current item is the last among its siblings.
-	 */
-	public isLast(): boolean {
-		const last = this.parent.children.slice(-1)[0];
-		return this.item === last;
-	}
 }

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
@@ -1,87 +1,242 @@
 @use 'themes' as *;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Flat (shadcn-like) sidebar rows.
+//
+// WHY this file strips so much: Nebular renders every top level entry as its
+// own <nb-accordion>, and the framework defaults paint that accordion as a
+// CARD — an opaque `accordion-item-background-color` fill, the 0.625rem
+// `accordion-border-radius`, `accordion-shadow`, and a 1px divider under each
+// header. Stacked in a narrow sidebar those cards read as a "rounded block"
+// around every item, which is exactly the look we are removing.
+//
+// The rule from here on: a row paints NOTHING at rest. Only :hover and the
+// active entry get a low contrast overlay on a small radius — never a border,
+// never a per item shadow.
+//
+// The overlays are neutral rgba rather than solid colours on purpose: the same
+// value darkens the light sidebar (#f4f4f5 / #fbfbfb) and lightens the dark one
+// (#141416 / #1e1e22), so no per theme branch is needed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Hover overlay. `gauzy-sidebar-background-3` is rgba(126, 126, 143, 0.1) in
+// every theme that declares it; the literal fallback keeps hover visible in the
+// material-* themes, which never declared the token.
+// TODO(theme): replace with nb-theme(gauzy-menu-item-hover-background).
+$menu-row-hover-background: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+
+// Active overlay — exactly twice the hover alpha. Measured on both surfaces the
+// pair stays distinguishable (light #ededee vs #e2e2e5, dark #2b2b2f vs
+// #313138) while neither reads as a filled block.
+// TODO(theme): replace with nb-theme(gauzy-menu-item-active-background).
+$menu-row-active-background: rgba(126, 126, 143, 0.2);
+
+// 6px. Deliberately NOT nb-theme(border-radius) (0.625rem / 10px): that is the
+// CARD radius, and a 10px pill is a large part of why rows look like blocks.
+// TODO(theme): replace with nb-theme(gauzy-menu-item-radius).
+$menu-row-radius: 0.375rem;
+
+// Resting label colour, muted. Nested fallback because gauzy-text-color-2 is
+// undefined in the material-* themes.
+$menu-row-color: var(--gauzy-text-color-2, var(--text-hint-color));
+
+// Fixed icon column so labels line up whatever glyph an entry uses.
+$menu-icon-column: 1rem;
+
+// Room reserved on the trailing edge for the accordion chevron. Nebular pins
+// the indicator at `right: 1rem`, so the gutter has to clear 1rem + the icon.
+$menu-chevron-gutter: 2rem;
+
+// The inline half of `menu-item-padding` (0.5rem 0.75rem). Needed as a literal
+// wherever the chevron gutter is given back, because a CSS custom property
+// cannot be destructured into its longhands.
+// KEEP IN SYNC with `menu-item-padding` in packages/ui-core/static/styles/themes.scss.
+$menu-row-inline-padding: 0.75rem;
+
+// Child rows sit one step in from the parent row's icon column:
+// 0.75rem (row padding) + 0.75rem (step).
+$menu-child-indent: 1.5rem;
+
 :host {
   position: relative;
-  nb-accordion-item-body.item-collapsed ::ng-deep .item-body {
-    padding: 4px;
-  }
+  display: block;
+
+  // ── Container: no card fill, no card radius, no shadow ────────────────────
   nb-accordion {
-    box-shadow: unset;
-    margin-top: 2px;
-    nb-accordion-item.opened {
-      box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
-      nb-accordion-item-header {
-        background-color: nb-theme(gauzy-sidebar-background-3);
-        &.accordion-item-header-expanded {
-          border-radius: nb-theme(border-radius) nb-theme(border-radius) 0 0;
-        }
-      }
-      nb-accordion-item-body {
-        background-color: nb-theme(gauzy-sidebar-background-4);
-        border-radius: 0 0 nb-theme(border-radius) nb-theme(border-radius);
-      }
-    }
-    &.focus {
-      box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
-      nb-accordion-item-header,
-      i {
-        color: rgba(245, 109, 88, 1);
-      }
-    }
-    nb-accordion-item-header.accordion-item-header-collapsed {
-      border-radius: nb-theme(border-radius);
-    }
-    &.closed {
-      nb-accordion-item-header {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        i {
-          margin-right: unset;
-        }
-        ::ng-deep nb-icon {
-          display: none;
-        }
-      }
-    }
-    &.application {
-      nb-accordion-item {
-        nb-accordion-item-header {
-          border: 1px solid nb-theme(background-primary-color-1);
-          color: nb-theme(text-primary-color);
-          border-radius: nb-theme(border-radius);
-        }
-        i {
-          color: nb-theme(text-primary-color);
-        }
-        nb-accordion-item-header ::ng-deep nb-icon {
-          border: 1px solid nb-theme(background-primary-color-1);
-          border-radius: nb-theme(border-radius);
-          width: 1.75rem;
-          height: 1.75rem;
-          @include nb-ltr(margin-right, calc(-1.75rem / 4));
-          @include nb-rtl(margin-left, calc(-1.75rem / 4));
-        }
-      }
-    }
-  }
-  hr.custom-separator {
-    border: 0.5px solid nb-theme(gauzy-border-default-color);
-    border-top: none;
-    border-left: none;
-    border-right: none;
-  }
-  i {
-    color: nb-theme(gauzy-text-color-1);
+    // 2px breathing room between rows (shadcn stacks menu rows with a small gap
+    // instead of dividers).
+    margin-top: 0.125rem;
+    background-color: transparent;
+    border-radius: 0;
+    box-shadow: none;
   }
 
+  nb-accordion-item {
+    background-color: transparent;
+    border-radius: 0;
+  }
+
+  // ── The row ───────────────────────────────────────────────────────────────
   nb-accordion-item-header {
-    color: nb-theme(gauzy-text-color-2);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: nb-theme(menu-item-padding);
+    // Keep the label clear of the absolutely positioned chevron. Logical
+    // property rather than nb-ltr/nb-rtl: it flips with the inherited
+    // `direction` and does not depend on a [dir] attribute being present.
+    padding-inline-end: $menu-chevron-gutter;
+    border-radius: $menu-row-radius;
+    // Nebular draws a 1px divider above/below every header; flat rows have none.
+    border-width: 0;
+    color: $menu-row-color;
     font-size: nb-theme(menu-text-font-size);
     font-weight: nb-theme(menu-text-font-weight);
-    line-height: 16px;
-    letter-spacing: 0em;
-    gap: 0.5rem;
+    line-height: 1.25rem;
+    letter-spacing: 0;
+    transition:
+      background-color 0.12s ease-in-out,
+      color 0.12s ease-in-out;
+
+    // Icons inherit the row colour (muted at rest, brightening with the label)
+    // and sit in a fixed width column so every label starts at the same x.
+    > i {
+      flex: 0 0 auto;
+      width: $menu-icon-column;
+      font-size: 0.875rem;
+      text-align: center;
+      color: inherit;
+    }
+
+    // Label: never wraps, never pushes the chevron — it truncates.
+    > span {
+      flex: 1 1 auto;
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    // Collapsed and expanded headers look identical — the radius must not be
+    // squared off on expand, or the row turns back into the top half of a card.
+    &.accordion-item-header-collapsed,
+    &.accordion-item-header-expanded {
+      border-radius: $menu-row-radius;
+    }
+  }
+
+  // Hover: a tint only. No shadow, no border, no colour shift on the surface
+  // behind it.
+  nb-accordion-item-header:hover {
+    background-color: $menu-row-hover-background;
+    color: nb-theme(text-basic-color);
+  }
+
+  // Chevron: muted and sized to the row (nb-icon defaults to 1.25rem, which
+  // towers over a 0.8125rem label). Position stays Nebular's.
+  ::ng-deep nb-icon.expansion-indicator {
+    font-size: 1rem;
+    color: inherit;
+    opacity: 0.55;
+  }
+
+  // A leaf entry cannot expand, so it must not advertise a chevron. The body is
+  // only rendered when the entry has children, which is what :has() tests.
+  nb-accordion-item:not(:has(nb-accordion-item-body)) ::ng-deep nb-icon.expansion-indicator {
+    display: none;
+  }
+
+  // ...and with no chevron to clear, the trailing gutter is dead space that
+  // would truncate the label ~1.25rem early in a ~200px sidebar. Give it back.
+  // Same :has() test as above, so the two always agree: a browser without
+  // :has() keeps BOTH the chevron and its gutter.
+  nb-accordion-item:not(:has(nb-accordion-item-body)) > nb-accordion-item-header {
+    padding-inline-end: $menu-row-inline-padding;
+  }
+
+  // ── Active entry ──────────────────────────────────────────────────────────
+  // `.opened` is bound to `selected`, i.e. this entry owns the current route.
+  // Icon and label share `text-basic-color` on purpose: a single brand accent
+  // cannot clear 3:1 on BOTH the tinted light row (#e2e2e5) and the tinted dark
+  // one (#313138) — color-primary-default measures ~5.4:1 light but only ~2.5:1
+  // dark. Tint + weight already say "current" without a colour.
+  // TODO(theme): a per theme `gauzy-menu-item-active-foreground` would let the
+  // icon carry the accent safely (light: color-primary-600, dark: -300).
+  nb-accordion-item.opened > nb-accordion-item-header {
+    background-color: $menu-row-active-background;
+    color: nb-theme(text-basic-color);
+    font-weight: 600;
+  }
+
+  // ...but when the entry has children the fill belongs to the selected CHILD
+  // row. Filling the parent as well would stack two highlighted rows, which is
+  // the "block" look again — so the parent keeps the emphasis (weight/colour)
+  // and drops the fill. Browsers without :has() simply keep the fill above.
+  nb-accordion-item.opened:has(nb-accordion-item-body) > nb-accordion-item-header {
+    background-color: transparent;
+
+    &:hover {
+      background-color: $menu-row-hover-background;
+    }
+  }
+
+  // ── Sub-list ──────────────────────────────────────────────────────────────
+  nb-accordion-item-body {
+    background-color: transparent;
+    border-radius: 0;
+
+    ::ng-deep .item-body {
+      padding: 0.125rem 0 0.25rem;
+    }
+  }
+
+  // Icon rail (sidebar collapsed): the sub-list is a bare stack of glyphs, so
+  // it needs no horizontal gutter at all.
+  nb-accordion-item-body.item-collapsed ::ng-deep .item-body {
+    padding: 0.25rem 0;
+  }
+
+  // ── Icon rail ─────────────────────────────────────────────────────────────
+  // `.closed` mirrors the sidebar's collapsed state: one centred glyph per row,
+  // no label and no chevron (there is no width to spare for either).
+  nb-accordion.closed {
+    nb-accordion-item-header {
+      justify-content: center;
+      // The chevron is hidden here, so give its gutter back to the glyph.
+      padding-inline-end: $menu-row-inline-padding;
+
+      > i {
+        margin-right: unset;
+      }
+
+      // No room for the chevron in the rail.
+      ::ng-deep nb-icon {
+        display: none;
+      }
+    }
+  }
+
+  // ── Variants ──────────────────────────────────────────────────────────────
+  // "Focus" entry: keeps its accent label/icon colour (it reads on both the
+  // light and the dark sidebar), but no longer floats on its own drop shadow.
+  nb-accordion.focus {
+    nb-accordion-item-header,
+    i {
+      color: rgba(245, 109, 88, 1);
+    }
+  }
+
+  // "Applications" entry: same flat row as everything else; the boxed icon and
+  // outlined header it used to carry were pure block chrome.
+  nb-accordion.application {
+    nb-accordion-item-header {
+      color: nb-theme(text-basic-color);
+      border-width: 0;
+
+      i {
+        color: nb-theme(color-primary-default);
+      }
+    }
   }
 
   a {
@@ -90,34 +245,50 @@
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Child rows. NOTE: this block is consumed by children-menu-item.component.scss
+// via @use, so `:host` resolves to <ga-children-menu-item> there.
+// ─────────────────────────────────────────────────────────────────────────────
 :host .sub-item {
-  padding: 0px 9px;
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  color: nb-theme(gauzy-text-color-2);
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 16px;
-  letter-spacing: 0em;
+  border-radius: $menu-row-radius;
+  color: $menu-row-color;
+  font-size: nb-theme(menu-text-font-size);
+  font-weight: nb-theme(menu-text-font-weight);
+  line-height: 1.25rem;
+  letter-spacing: 0;
   cursor: pointer;
-  &:hover,
-  &.selected {
-    background-color: nb-theme(gauzy-sidebar-background-3);
-    border-radius: nb-theme(border-radius);
-    font-weight: 600;
-    color: nb-theme(gauzy-text-color-1);
-    border: unset;
+  transition:
+    background-color 0.12s ease-in-out,
+    color 0.12s ease-in-out;
+
+  // Hover: tint only — the old rule also fired a 10px drop shadow, which is
+  // what made child rows read as floating blocks.
+  &:hover {
+    background-color: $menu-row-hover-background;
+    color: nb-theme(text-basic-color);
   }
 
-  &:hover {
-    box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.15);
+  // Same treatment as an active top level row — see the contrast note there for
+  // why the icon stays neutral instead of taking the brand accent.
+  &.selected {
+    background-color: $menu-row-active-background;
+    color: nb-theme(text-basic-color);
+    font-weight: 600;
   }
+
+  // Icon rail: no indent, glyph centred, label hidden by the template.
   &.custom {
-    display: flex;
-    align-items: center;
     justify-content: center;
+
+    .info {
+      justify-content: center;
+      padding-inline: 0;
+    }
   }
+
   &.mouse-hover {
     display: flex;
     flex-direction: row;
@@ -129,9 +300,29 @@
   }
 }
 
-.info {
-  padding: 11px 0;
+// The clickable area of a child row. Padding lives here (not on .sub-item) so
+// the whole row height is a hit target, while the tint still spans full width.
+:host .info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: nb-theme(menu-item-padding);
+  padding-inline-start: $menu-child-indent;
+
+  i {
+    flex: 0 0 auto;
+    width: $menu-icon-column;
+    font-size: 0.875rem;
+    text-align: center;
+    color: inherit;
+  }
+
   span {
-    margin: 0 0.625rem;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 }

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
@@ -49,7 +49,7 @@ $menu-chevron-gutter: 2rem;
 
 // The inline half of `menu-item-padding` (0.5rem 0.75rem). Needed as a literal
 // wherever the chevron gutter is given back, because a CSS custom property
-// cannot be destructured into its longhands.
+// cannot be destructured into its longhand properties.
 // KEEP IN SYNC with `menu-item-padding` in packages/ui-core/static/styles/themes.scss.
 $menu-row-inline-padding: 0.75rem;
 
@@ -130,6 +130,16 @@ $menu-child-indent: 1.5rem;
   nb-accordion-item-header:hover {
     background-color: $menu-row-hover-background;
     color: nb-theme(text-basic-color);
+  }
+
+  // Nebular makes the header focusable (tabindex="0") but paints nothing on
+  // focus, so keyboard users had no row indicator at all. Same tint as hover
+  // plus an inset outline, because the tint alone is a colour-only signal.
+  nb-accordion-item-header:focus-visible {
+    background-color: $menu-row-hover-background;
+    color: nb-theme(text-basic-color);
+    outline: 2px solid nb-theme(color-primary-default);
+    outline-offset: -2px;
   }
 
   // Chevron: muted and sized to the row (nb-icon defaults to 1.25rem, which

--- a/packages/ui-core/shared/src/lib/components/header-title/header-title.component.ts
+++ b/packages/ui-core/shared/src/lib/components/header-title/header-title.component.ts
@@ -11,20 +11,29 @@ import { Store } from '@gauzy/ui-core/core';
     templateUrl: './header-title.component.html',
     styles: [
         `
-			.name,
-			.org-name {
-				font-size: 24px;
-				font-weight: 400;
-				line-height: 30px;
-				letter-spacing: 0em;
+			/*
+			 * Page title, NOT a breadcrumb trail — the real trail is rendered once
+			 * in the header (<ngx-breadcrumbs>). This used to be 24px/600, which
+			 * read as an oversized breadcrumb path; a page heading only needs to
+			 * out-rank body copy, so it now sits at the h5 step of the type scale.
+			 * The org/employee qualifier is deliberately lighter and muted so the
+			 * page name is what the eye lands on.
+			 */
+			:host {
+				font-size: 1.25rem;
+				font-weight: 600;
+				line-height: 1.75rem;
+				letter-spacing: -0.01em;
 				text-align: left;
 			}
-			:host {
-				font-size: 24px;
-				font-weight: 600;
-				line-height: 30px;
-				letter-spacing: 0em;
+			.name,
+			.org-name {
+				font-size: 1.25rem;
+				font-weight: 400;
+				line-height: 1.75rem;
+				letter-spacing: -0.01em;
 				text-align: left;
+				color: var(--text-hint-color);
 			}
 		`
     ],

--- a/packages/ui-core/static/styles/_overlays.scss
+++ b/packages/ui-core/static/styles/_overlays.scss
@@ -1,0 +1,319 @@
+// Forward so mixins/themes are available to importers
+@forward './themes';
+@use './themes' as *;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// shadcn-like overlay menus (context menu / dropdown / popover / option list)
+//
+// The whole point of this file is the CONTAINER / ITEM split:
+//
+//   CONTAINER  one soft 1px hairline + one soft shadow + 8px radius + 4px pad
+//   ITEMS      completely FLAT rows — no border, no shadow, no visible pill.
+//              6px/10px padding, 13px text, muted icon. Hover is nothing but a
+//              low-contrast background tint on a 6px radius; active/selected is
+//              a primary tint plus accent text.
+//
+// Why this lives in a global partial instead of the component styles: Nebular
+// renders every overlay into `.cdk-overlay-container` at the <body> level, so
+// component-scoped rules can only reach it through leaky `::ng-deep`. Several
+// components already do that (see `workspaces.component.scss`, whose top-level
+// `::ng-deep nb-context-menu {…}` compiles to a *global* `nb-context-menu` rule
+// and therefore restyles every context menu in the app). Prefixing everything
+// here with `.cdk-overlay-container` raises specificity by one class so these
+// rules win over those leaks regardless of stylesheet injection order.
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Colours go through CSS custom properties with alpha-neutral fallbacks so the
+// exact same declaration reads correctly on a white surface AND on a dark one.
+// The `--gauzy-overlay-*` properties are NOT registered in `themes.scss` yet —
+// that file is owned by the integrator — so the fallbacks below are the live
+// values until the tokens land, at which point they take over automatically.
+
+// 1px hairline: neutral grey at low alpha => light grey on white, soft light
+// line on dark. Never a raw hex that only works on one background.
+$overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+
+// Two-layer soft elevation (shadcn `shadow-md`), instead of Nebular's default
+// `rgba(0, 0, 0, 0.733) 0 4px 8px -2px` which is almost opaque in dark themes.
+// NOTE: a `var()` fallback keeps every comma after the first one, so the whole
+// two-shadow list below is the fallback value. It is written as an interpolated
+// literal so Sass emits it verbatim instead of re-parsing `12px -2px` as maths.
+$overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
+
+// Neutral hover tint (shadcn `accent`) — deliberately NOT the brand colour, so
+// hovering a row does not read as "selected".
+$overlay-item-hover-bg: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12));
+
+// Active / selected: brand tint (never a full-bleed solid fill).
+$overlay-item-active-bg: var(--gauzy-overlay-item-active-background, var(--color-primary-transparent-100));
+
+// Active / selected LABEL. Deliberately `text-basic-color` + weight 600 rather
+// than the brand colour: `--text-primary-color` is `color-primary-500`
+// (#6e49e8) in every gauzy theme, and on the dark themes that sits at ~2.7:1
+// against the tinted row — unreadable at 13px. Weight + tint carry the state
+// instead, which is also how shadcn marks a selected row (it uses a check mark,
+// not coloured text).
+// TODO(theme): once `--gauzy-overlay-item-active-text-color` exists per theme
+// (a light accent on dark, a dark accent on light) this can go back to accent
+// text automatically — the fallback is already wired below.
+$overlay-item-active-color: var(--gauzy-overlay-item-active-text-color, var(--text-basic-color));
+
+$overlay-radius: 8px;
+$overlay-padding: 4px;
+$overlay-item-radius: 6px;
+$overlay-item-padding-y: 0.375rem; // 6px
+$overlay-item-padding-x: 0.625rem; // 10px
+
+/**
+ * The soft container chrome shared by every overlay surface that hosts a list
+ * of menu rows.
+ */
+@mixin gauzy-overlay-surface() {
+  border: 1px solid #{$overlay-hairline};
+  border-radius: $overlay-radius;
+  box-shadow: #{$overlay-shadow};
+  background-color: nb-theme(background-basic-color-1);
+}
+
+/**
+ * A single flat menu row. No border, no shadow, no persistent background — the
+ * row only lights up on hover/active, which is what removes the "visible
+ * rounded blocks" the design review flagged.
+ */
+@mixin gauzy-overlay-item() {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: $overlay-item-padding-y $overlay-item-padding-x;
+  border: 0;
+  border-radius: $overlay-item-radius;
+  box-shadow: none;
+  background-color: transparent;
+  color: nb-theme(text-basic-color);
+  font-size: nb-theme(menu-text-font-size);
+  font-weight: nb-theme(menu-text-font-weight);
+  line-height: 1.25rem;
+  text-decoration: none;
+  // Nebular centres context-menu labels by default (`context-menu-text-align`);
+  // shadcn rows are start-aligned. `start` is the logical keyword, so it flips
+  // on its own in RTL without depending on a `dir` attribute being present.
+  text-align: start;
+  // Colour-only transition: transitioning `all` also animates the radius and
+  // makes the row look like it is inflating into a block.
+  transition:
+    background-color 0.12s ease-in-out,
+    color 0.12s ease-in-out;
+}
+
+@mixin gauzy-overlay-menus() {
+  // ── Context menus ───────────────────────────────────────────────────────
+  .cdk-overlay-container nb-context-menu {
+    @include gauzy-overlay-surface();
+    padding: $overlay-padding;
+    // Nebular ships 10rem/15rem; component-level leaks push it to 280/320px,
+    // which makes a two-item support menu absurdly wide.
+    min-width: 11rem;
+    max-width: 20rem;
+
+    nb-menu {
+      background-color: transparent;
+      border-radius: 0;
+      // The container already clips; keeping `overflow: hidden` here would
+      // crop the hover tint of the first/last row against the 4px padding.
+      overflow: visible;
+
+      .menu-items {
+        margin: 0;
+        padding: 0;
+      }
+
+      .menu-item {
+        // Kill any per-item divider inherited from the theme.
+        border: 0;
+        margin: 0;
+
+        > a {
+          @include gauzy-overlay-item();
+        }
+
+        > a:hover {
+          background-color: #{$overlay-item-hover-bg};
+          color: nb-theme(text-basic-color);
+        }
+
+        > a.active {
+          background-color: #{$overlay-item-active-bg};
+          color: #{$overlay-item-active-color};
+          font-weight: 600;
+        }
+
+        // Muted 16px glyph, flush with the label. The previous look wrapped
+        // it in a 32x32 filled rounded box — that box *was* the "rounded
+        // block" inside the popup.
+        > a .menu-icon {
+          flex-shrink: 0;
+          width: 1em;
+          height: 1em;
+          min-width: auto;
+          padding: 0;
+          border: 0;
+          border-radius: 0;
+          background-color: transparent;
+          font-size: 1rem;
+          color: nb-theme(text-hint-color);
+          margin: 0;
+
+          svg {
+            width: 100%;
+            height: 100%;
+          }
+        }
+
+        > a:hover .menu-icon {
+          color: nb-theme(text-basic-color);
+        }
+
+        > a.active .menu-icon {
+          color: #{$overlay-item-active-color};
+        }
+
+        > a .menu-title {
+          flex: 1 1 auto;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+
+        // Trailing chevron of a submenu row: same muted treatment, no box.
+        // `min-width` / `border-radius` / `svg` are reset explicitly because
+        // the leaked component rule targets `nb-icon` as a whole, so it hits
+        // the chevron as well as the leading glyph.
+        > a .expand-state {
+          flex-shrink: 0;
+          width: 0.875em;
+          height: 0.875em;
+          min-width: auto;
+          padding: 0;
+          border: 0;
+          border-radius: 0;
+          font-size: 0.875rem;
+          color: nb-theme(text-hint-color);
+          background-color: transparent;
+
+          svg {
+            width: 100%;
+            height: 100%;
+          }
+        }
+      }
+
+      // Section captions above a group of rows.
+      .menu-group {
+        padding: 0.375rem $overlay-item-padding-x 0.25rem;
+        color: nb-theme(text-hint-color);
+        font-size: nb-theme(text-caption-font-size);
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+    }
+  }
+
+  // ── Popovers ────────────────────────────────────────────────────────────
+  // Template-driven popovers render their content directly (no
+  // `.primitive-overlay` wrapper), so only the container chrome is set here
+  // and the content keeps its own padding.
+  .cdk-overlay-container nb-popover {
+    @include gauzy-overlay-surface();
+
+    // The arrow is two stacked triangles: the element itself is the outline,
+    // `::after` is the fill drawn 3px inside it. The theme paints the outline
+    // with `popover-border-color` (transparent), so it has to be re-pointed at
+    // the hairline or the arrow reads as detached from the bordered panel.
+    .arrow {
+      border-bottom-color: #{$overlay-hairline};
+
+      &::after {
+        border-bottom-color: nb-theme(background-basic-color-1);
+      }
+    }
+  }
+
+  // ── nb-select option lists ──────────────────────────────────────────────
+  .cdk-overlay-container nb-option-list {
+    @include gauzy-overlay-surface();
+
+    // Nebular draws a heavier "adjacent" edge on the side facing the trigger
+    // so the panel reads as glued to the select; a floating shadcn panel is
+    // a uniform hairline on all four sides.
+    &.position-top,
+    &.position-bottom {
+      border-top-color: #{$overlay-hairline};
+      border-bottom-color: #{$overlay-hairline};
+    }
+
+    .option-list {
+      padding: $overlay-padding;
+    }
+  }
+
+  // Nebular emits `nb-option-list.size-#{$size} nb-option` (0,1,2) for the
+  // option metrics; the selector below has the same specificity but is
+  // included later in this very stylesheet, so it wins the cascade.
+  .cdk-overlay-container nb-option-list nb-option {
+    @include gauzy-overlay-item();
+
+    &:hover,
+    &.active,
+    &:focus {
+      background-color: #{$overlay-item-hover-bg};
+      color: nb-theme(text-basic-color);
+    }
+
+    // shadcn marks the selected option with a tint + weight, never with a
+    // full-bleed solid primary fill (Nebular's default is the whole row
+    // painted `color-primary-default` with white text).
+    &.selected,
+    &.selected:hover,
+    &.selected:focus {
+      background-color: #{$overlay-item-active-bg};
+      color: #{$overlay-item-active-color};
+      font-weight: 600;
+    }
+  }
+
+  // The multi-select checkbox ships its own 0.5rem inline margin from a
+  // component-scoped rule; the flex `gap` above is the single source of
+  // spacing, so zero it. Anchoring on `.option-list` (rather than the
+  // `nb-option-list` element) is what buys the specificity to beat that
+  // component rule.
+  .cdk-overlay-container .option-list nb-option nb-checkbox {
+    margin: 0;
+  }
+
+  .cdk-overlay-container nb-option-list nb-option-group .option-group-title {
+    padding: 0.375rem $overlay-item-padding-x 0.25rem;
+    color: nb-theme(text-hint-color);
+    font-size: nb-theme(text-caption-font-size);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+
+  // ── Separators ──────────────────────────────────────────────────────────
+  // 1px hairlines at low alpha, never a thick divider. Bootstrap's reboot
+  // gives every `hr` a 1px `currentColor` border at 25% opacity, which reads
+  // as a hard grey bar inside a menu.
+  .cdk-overlay-container {
+    nb-context-menu hr,
+    nb-popover hr,
+    nb-option-list hr {
+      height: 0;
+      margin: $overlay-padding 0;
+      border: 0;
+      border-top: 1px solid #{$overlay-hairline};
+      opacity: 1;
+    }
+  }
+}

--- a/packages/ui-core/static/styles/_overlays.scss
+++ b/packages/ui-core/static/styles/_overlays.scss
@@ -25,9 +25,13 @@
 
 // Colours go through CSS custom properties with alpha-neutral fallbacks so the
 // exact same declaration reads correctly on a white surface AND on a dark one.
-// The `--gauzy-overlay-*` properties are NOT registered in `themes.scss` yet —
-// that file is owned by the integrator — so the fallbacks below are the live
-// values until the tokens land, at which point they take over automatically.
+// `--gauzy-overlay-border-color`, `--gauzy-hover-tint` and `--gauzy-radius-sm`
+// ARE registered in `themes.scss` (Nebular emits every theme map key as a custom
+// property), so those resolve from the theme; the fallbacks are kept only for
+// the material-* themes, which do not carry the gauzy token set. The remaining
+// `--gauzy-overlay-*` names below are not registered yet — a Sass map entry
+// cannot hold a comma-separated shadow list without changing how it is emitted —
+// so their fallbacks are still the live values.
 
 // 1px hairline: neutral grey at low alpha => light grey on white, soft light
 // line on dark. Never a raw hex that only works on one background.
@@ -41,8 +45,10 @@ $overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
 $overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
 
 // Neutral hover tint (shadcn `accent`) — deliberately NOT the brand colour, so
-// hovering a row does not read as "selected".
-$overlay-item-hover-bg: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12));
+// hovering a row does not read as "selected". This is the SAME concept as the
+// sidebar/breadcrumb/settings-menu hover, so it resolves the one registered
+// `gauzy-hover-tint` token instead of introducing a parallel overlay-only name.
+$overlay-item-hover-bg: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
 
 // Active / selected: brand tint (never a full-bleed solid fill).
 $overlay-item-active-bg: var(--gauzy-overlay-item-active-background, var(--color-primary-transparent-100));
@@ -58,9 +64,12 @@ $overlay-item-active-bg: var(--gauzy-overlay-item-active-background, var(--color
 // text automatically — the fallback is already wired below.
 $overlay-item-active-color: var(--gauzy-overlay-item-active-text-color, var(--text-basic-color));
 
+// CONTAINER radius. Its own value, not `gauzy-radius-sm`: the panel is a card-like
+// surface, the rows inside it are not.
 $overlay-radius: 8px;
 $overlay-padding: 4px;
-$overlay-item-radius: 6px;
+// ITEM radius — the shared flat-chrome row radius (0.375rem / 6px).
+$overlay-item-radius: var(--gauzy-radius-sm, 6px);
 $overlay-item-padding-y: 0.375rem; // 6px
 $overlay-item-padding-x: 0.625rem; // 10px
 

--- a/packages/ui-core/static/styles/_overrides.scss
+++ b/packages/ui-core/static/styles/_overrides.scss
@@ -255,7 +255,10 @@ body {
   }
 
   .ng-dropdown-panel {
-    background-color: var(--gauzy-card-5) !important;
+    // Was `--gauzy-card-5` (a faint lavender that is also undefined in the two
+    // material themes, leaving the panel transparent there). The overlay
+    // surface colour is the same one every other dropdown uses.
+    background-color: nb-theme(background-basic-color-1) !important;
 
     .scroll-host {
       scrollbar-width: thin;
@@ -345,28 +348,65 @@ body {
     @include f-window-mode(nb-theme(layout-window-mode-padding-top));
   }
 
+  // ng-select dropdown rows follow the same shadcn container/item split as the
+  // Nebular overlays (see `_overlays.scss`): the panel owns the border/shadow,
+  // the rows are flat until hovered.
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option {
-    background: nb-theme(background-basic-color-1);
-    color: var(--gauzy-text-color-1);
-    transition-duration: 0.15s;
-    transition-property: border, background-color, color, box-shadow;
-    transition-timing-function: ease-in;
+    background: transparent;
+    // `--gauzy-text-color-1` only exists in 6 of the 8 registered themes (the
+    // two material ones never define it), where the declaration would be
+    // invalid at computed-value time. `text-basic-color` is defined everywhere
+    // and is the same colour in the themes that do define the gauzy token.
+    color: nb-theme(text-basic-color);
+    transition-duration: 0.12s;
+    transition-property: background-color, color;
+    transition-timing-function: ease-in-out;
+    font-weight: nb-theme(menu-text-font-weight);
+    font-size: nb-theme(menu-text-font-size);
+    line-height: 1.25rem;
+    // Overrides ng-select's own `padding: 8px 10px` (its sheet is loaded after
+    // this one, so a tie would go to it).
+    padding: 0.375rem 0.625rem !important;
+    border-radius: 6px;
+  }
+
+  // Group captions get the same muted treatment as `nb-option-group`. ng-select
+  // hard-codes `color: rgba(0, 0, 0, 0.54)` and a pale blue fill on the
+  // marked/selected states — both illegible on the dark themes.
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-optgroup,
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-optgroup.ng-option-marked,
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-optgroup.ng-option-selected {
+    padding: 0.375rem 0.625rem !important;
+    color: var(--text-hint-color) !important;
+    background-color: transparent !important;
+    font-size: nb-theme(text-caption-font-size);
     font-weight: 600;
-    font-size: 0.8125rem;
-    line-height: 1.5rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
   }
 
+  // Neutral tint, not the brand colour — a hovered row must not read as
+  // "selected".
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option:hover {
-    background-color: var(--color-primary-transparent-default) !important;
+    background-color: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12)) !important;
   }
 
+  // `ng-option-marked` is keyboard focus; give it the same tint as hover so
+  // arrow-key navigation is visible (it used to be reset to nothing).
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option-marked {
-    background-color: unset !important;
+    background-color: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12)) !important;
   }
 
-  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option-selected {
-    color: var(--text-primary-color) !important;
-    background-color: var(--color-primary-transparent-default) !important;
+  // Selected keeps the accent tint even under the cursor, so the `:hover` rule
+  // above (same specificity, declared earlier) cannot grey it out. The label
+  // stays `text-basic-color` + weight 600 rather than the brand colour, which
+  // sits at ~2.7:1 on the tinted row in the dark themes — see the note on
+  // `$overlay-item-active-color` in `_overlays.scss`.
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option-selected,
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option-selected:hover {
+    color: var(--gauzy-overlay-item-active-text-color, var(--text-basic-color)) !important;
+    background-color: var(--gauzy-overlay-item-active-background, var(--color-primary-transparent-100)) !important;
+    font-weight: 600;
   }
 
   .ng-value-container .ng-input input {
@@ -374,17 +414,39 @@ body {
     color: nb-theme(text-basic-color);
   }
 
+  // NOTE ON `!important` IN THIS BLOCK: `@ng-select/ng-select/themes/default.theme.css`
+  // is listed AFTER `styles.scss` in the app's `styles` array, so its rules win
+  // every specificity tie. Each `!important` below overrides a specific
+  // declaration from that sheet — they are not blanket hammers.
   .ng-dropdown-panel {
-    transform: translateY(10px);
-    box-shadow: var(--gauzy-shadow);
-    border-width: 0 !important;
+    transform: translateY(6px);
+    // One soft 1px hairline + one soft shadow on the CONTAINER, mirroring
+    // `gauzy-overlay-surface()`. `--gauzy-overlay-*` are not registered in
+    // themes.scss yet, hence the inline fallbacks.
+    // Overrides `border: 1px solid #ccc`.
+    border: 1px solid var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)) !important;
+    // Overrides `box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06)`.
+    box-shadow: var(
+      --gauzy-overlay-shadow,
+      0 4px 12px -2px rgba(0, 0, 0, 0.14),
+      0 2px 6px -2px rgba(0, 0, 0, 0.08)
+    ) !important;
+    border-radius: 8px;
 
-    &.ng-select-bottom {
-      border-radius: nb-theme(border-radius);
+    // ng-select squares off the edge facing the trigger (`border-*-radius: 4px`
+    // on the other two corners) so the panel reads as glued to the input; a
+    // floating shadcn panel is uniformly rounded.
+    &.ng-select-bottom,
+    &.ng-select-top,
+    &.ng-select-left,
+    &.ng-select-right {
+      border-radius: 8px !important;
     }
 
     .ng-dropdown-panel-items {
-      border-radius: nb-theme(border-radius);
+      border-radius: 8px;
+      // Breathing room so the 6px item radius never touches the container edge.
+      padding: 4px;
 
       img {
         border-radius: 4px;
@@ -392,6 +454,22 @@ body {
         height: 24px;
         z-index: 10000001;
       }
+    }
+
+    // ng-select rounds the first/last row to the panel's old 4px corners. With
+    // the container padding above, every row is a free-floating 6px pill.
+    &.ng-select-bottom .ng-dropdown-panel-items .ng-option:last-child,
+    &.ng-select-top .ng-dropdown-panel-items .ng-option:first-child,
+    &.ng-select-left .ng-dropdown-panel-items .ng-option:first-child,
+    &.ng-select-right .ng-dropdown-panel-items .ng-option:first-child {
+      border-radius: 6px;
+    }
+
+    // Hairline, not the theme's hard `1px solid #ccc`.
+    .ng-dropdown-header,
+    .ng-dropdown-footer {
+      border-color: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+      padding: 0.375rem 0.625rem;
     }
   }
 
@@ -873,7 +951,13 @@ angular2-smart-table {
   }
 }
 
+// Rows are flat: the panel behind them supplies the surface colour, so an
+// opaque per-row background would paint a solid block inside the 4px container
+// padding and re-introduce the "rounded blocks" look.
 .ng-dropdown-panel .ng-dropdown-panel-items .ng-option {
-  background-color: var(--gauzy-card-1) !important;
-  color: var(--gauzy-text-color-1) !important;
+  background-color: transparent !important;
+  // `--text-basic-color` rather than `--gauzy-text-color-1`: the latter is
+  // undefined in the two material themes, so the row text fell back to
+  // whatever it inherited there.
+  color: var(--text-basic-color) !important;
 }

--- a/packages/ui-core/static/styles/_overrides.scss
+++ b/packages/ui-core/static/styles/_overrides.scss
@@ -352,12 +352,16 @@ body {
   // Nebular overlays (see `_overlays.scss`): the panel owns the border/shadow,
   // the rows are flat until hovered.
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option {
-    background: transparent;
+    // Rows are flat: the panel behind them supplies the surface colour, so an
+    // opaque per-row background would paint a solid block inside the 4px
+    // container padding and re-introduce the "rounded blocks" look.
+    // `!important` because ng-select's own sheet is loaded after this one.
+    background-color: transparent !important;
     // `--gauzy-text-color-1` only exists in 6 of the 8 registered themes (the
     // two material ones never define it), where the declaration would be
     // invalid at computed-value time. `text-basic-color` is defined everywhere
     // and is the same colour in the themes that do define the gauzy token.
-    color: nb-theme(text-basic-color);
+    color: nb-theme(text-basic-color) !important;
     transition-duration: 0.12s;
     transition-property: background-color, color;
     transition-timing-function: ease-in-out;
@@ -419,10 +423,9 @@ body {
   // every specificity tie. Each `!important` below overrides a specific
   // declaration from that sheet — they are not blanket hammers.
   .ng-dropdown-panel {
-    transform: translateY(6px);
     // One soft 1px hairline + one soft shadow on the CONTAINER, mirroring
-    // `gauzy-overlay-surface()`. `--gauzy-overlay-*` are not registered in
-    // themes.scss yet, hence the inline fallbacks.
+    // `gauzy-overlay-surface()`. `--gauzy-overlay-border-color` resolves from
+    // themes.scss; the fallback covers the material-* themes.
     // Overrides `border: 1px solid #ccc`.
     border: 1px solid var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)) !important;
     // Overrides `box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06)`.
@@ -441,6 +444,17 @@ body {
     &.ng-select-left,
     &.ng-select-right {
       border-radius: 8px !important;
+    }
+
+    // Detach the panel from the trigger by 6px. The offset has to follow the
+    // placement: a `.ng-select-top` panel sits ABOVE the input, so shifting it
+    // down would close the gap and push the panel over the trigger instead.
+    &.ng-select-bottom {
+      transform: translateY(6px);
+    }
+
+    &.ng-select-top {
+      transform: translateY(-6px);
     }
 
     .ng-dropdown-panel-items {
@@ -465,11 +479,14 @@ body {
       border-radius: 6px;
     }
 
-    // Hairline, not the theme's hard `1px solid #ccc`.
+    // Hairline, not the theme's hard `1px solid #ccc`. `!important` for the same
+    // reason as the rest of this block: ng-select's own sheet is loaded after
+    // this one, so it wins every specificity tie — and its `border-bottom`
+    // shorthand would otherwise reinstate both the colour and the width.
     .ng-dropdown-header,
     .ng-dropdown-footer {
-      border-color: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
-      padding: 0.375rem 0.625rem;
+      border-color: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)) !important;
+      padding: 0.375rem 0.625rem !important;
     }
   }
 
@@ -949,15 +966,4 @@ angular2-smart-table {
   angular2-st-tbody-create-cancel {
     display: flex;
   }
-}
-
-// Rows are flat: the panel behind them supplies the surface colour, so an
-// opaque per-row background would paint a solid block inside the 4px container
-// padding and re-introduce the "rounded blocks" look.
-.ng-dropdown-panel .ng-dropdown-panel-items .ng-option {
-  background-color: transparent !important;
-  // `--text-basic-color` rather than `--gauzy-text-color-1`: the latter is
-  // undefined in the two material themes, so the row text fell back to
-  // whatever it inherited there.
-  color: var(--text-basic-color) !important;
 }

--- a/packages/ui-core/static/styles/styles.scss
+++ b/packages/ui-core/static/styles/styles.scss
@@ -20,6 +20,7 @@
 
 // Files that DON'T need Bootstrap can use @use
 @use './overrides' as *;
+@use './overlays' as *;
 @use './material/material-overrides' as *;
 @use './gauzy/gauzy-overrides' as *;
 
@@ -60,4 +61,7 @@
   @include nb-overrides();
   @include material-overrides();
   @include gauzy-overrides();
+  // Last, so the shadcn container/item split wins over the older overlay rules
+  // above (and over the `::ng-deep` leaks coming from component stylesheets).
+  @include gauzy-overlay-menus();
 }

--- a/packages/ui-core/static/styles/themes.scss
+++ b/packages/ui-core/static/styles/themes.scss
@@ -29,6 +29,14 @@ $gauzy-density: (
 	menu-text-font-size: 0.8125rem,
 	menu-text-font-weight: 500,
 	menu-item-divider-width: 0,
+	// Flat-chrome tokens (shadcn-like): a small radius and a low-contrast
+	// hover fill shared by breadcrumb links, sidebar rows and overlay menu
+	// items, so "hover" reads identically everywhere in all 8 themes.
+	// NOTE: deliberately smaller than `border-radius` (0.625rem) — that is the
+	// CARD radius, and a 10px pill on a 20px row is what made menu items look
+	// like blocks.
+	gauzy-radius-sm: 0.375rem,
+	gauzy-hover-tint: background-basic-color-2,
 	menu-item-divider-style: none,
 	// Cards
 	card-padding: 1rem,

--- a/packages/ui-core/static/styles/themes.scss
+++ b/packages/ui-core/static/styles/themes.scss
@@ -30,13 +30,27 @@ $gauzy-density: (
 	menu-text-font-weight: 500,
 	menu-item-divider-width: 0,
 	// Flat-chrome tokens (shadcn-like): a small radius and a low-contrast
-	// hover fill shared by breadcrumb links, sidebar rows and overlay menu
-	// items, so "hover" reads identically everywhere in all 8 themes.
+	// hover fill shared by breadcrumb links, sidebar rows, settings menu rows
+	// and overlay menu items, so "hover" reads identically everywhere in all 8
+	// themes.
 	// NOTE: deliberately smaller than `border-radius` (0.625rem) — that is the
 	// CARD radius, and a 10px pill on a 20px row is what made menu items look
 	// like blocks.
 	gauzy-radius-sm: 0.375rem,
-	gauzy-hover-tint: background-basic-color-2,
+	// Translucent NEUTRAL rather than an alias of a background token: aliasing
+	// `background-basic-color-2` painted an invisible hover in `gauzy-dark`,
+	// where that token is rgba(32, 32, 35, 1) — the exact colour of the surfaces
+	// it sits on (`gauzy-card-1`, and the header/layout backgrounds aliased to
+	// it). A low-alpha grey darkens a light surface and lightens a dark one, so
+	// one value works in every theme without a per-theme branch.
+	gauzy-hover-tint: rgba(126, 126, 143, 0.12),
+	// Active / current row: exactly twice the hover alpha. The pair stays
+	// distinguishable on both surfaces while neither reads as a filled block.
+	gauzy-active-tint: rgba(126, 126, 143, 0.2),
+	// Overlay container hairline — shared by the global overlay rules and by the
+	// popups that are positioned by the layout instead of `.cdk-overlay-container`
+	// (user menu, workspace menu), so all of them resolve one value.
+	gauzy-overlay-border-color: rgba(126, 126, 143, 0.18),
 	menu-item-divider-style: none,
 	// Cards
 	card-padding: 1rem,

--- a/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.html
+++ b/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,40 @@
+@if (breadcrumbs().length) {
+	<nav class="breadcrumb" aria-label="Breadcrumb">
+		<ol class="breadcrumb-list">
+			@for (crumb of breadcrumbs(); track $index; let first = $first, last = $last) {
+				<li class="breadcrumb-item">
+					@if (!first) {
+						<span class="breadcrumb-separator" aria-hidden="true">
+							<nb-icon icon="chevron-right-outline"></nb-icon>
+						</span>
+					}
+
+					@if (crumb.link) {
+						<a class="breadcrumb-link" [routerLink]="crumb.link" [title]="crumb.label">
+							@if (crumb.icon) {
+								<nb-icon [icon]="crumb.icon" [attr.aria-label]="crumb.label"></nb-icon>
+							} @else {
+								{{ crumb.label }}
+							}
+						</a>
+					} @else {
+						<!-- Only the LAST crumb is the current page: intermediate levels without a
+						     route stay muted so they never read as "you are here". -->
+						<span
+							[class.breadcrumb-current]="last"
+							[class.breadcrumb-text]="!last"
+							[title]="crumb.label"
+							[attr.aria-current]="last ? 'page' : null"
+						>
+							@if (crumb.icon) {
+								<nb-icon [icon]="crumb.icon" [attr.aria-label]="crumb.label"></nb-icon>
+							} @else {
+								{{ crumb.label }}
+							}
+						</span>
+					}
+				</li>
+			}
+		</ol>
+	</nav>
+}

--- a/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.scss
+++ b/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.scss
@@ -6,7 +6,8 @@
 @include nb-install-component() {
   display: flex;
   align-items: center;
-  // Never push the header actions around — the trail shrinks and ellipsizes instead.
+  // Never push the header actions around — the trail shrinks and truncates with
+  // an ellipsis instead.
   min-width: 0;
   overflow: hidden;
 

--- a/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.scss
+++ b/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,112 @@
+@use '@nebular/theme/styles/global/breakpoints' as *;
+@use 'themes' as *;
+
+// shadcn-style trail: small muted text, thin chevrons, no title styling and no
+// background block. Every value is a theme token so light and dark stay in sync.
+@include nb-install-component() {
+  display: flex;
+  align-items: center;
+  // Never push the header actions around — the trail shrinks and ellipsizes instead.
+  min-width: 0;
+  overflow: hidden;
+
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .breadcrumb-list {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 0.125rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    min-width: 0;
+  }
+
+  .breadcrumb-item {
+    display: flex;
+    align-items: center;
+    gap: 0.125rem;
+    min-width: 0;
+    // 13px — same scale as the menu text from the density pass.
+    font-size: nb-theme(menu-text-font-size);
+    line-height: 1.25rem;
+  }
+
+  .breadcrumb-link,
+  .breadcrumb-text,
+  .breadcrumb-current {
+    display: inline-flex;
+    align-items: center;
+    // Long names (custom dashboards, projects) truncate rather than wrap the header.
+    max-width: 12rem;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    padding: 0.0625rem 0.25rem;
+    border-radius: 0.375rem;
+  }
+
+  .breadcrumb-link {
+    color: nb-theme(text-hint-color);
+    text-decoration: none;
+    transition:
+      color 0.15s ease-in-out,
+      background-color 0.15s ease-in-out;
+
+    &:hover {
+      // Low-contrast tint only — no border, no shadow, no pill.
+      color: nb-theme(text-basic-color);
+      background-color: nb-theme(background-basic-color-2);
+      text-decoration: none;
+    }
+
+    &:focus-visible {
+      color: nb-theme(text-basic-color);
+      background-color: nb-theme(background-basic-color-2);
+      outline: 1px solid nb-theme(color-primary-default);
+      outline-offset: 0;
+    }
+  }
+
+  // An intermediate level with no route of its own (a menu section such as
+  // "Organization"): muted like a link, but not interactive.
+  .breadcrumb-text {
+    color: nb-theme(text-hint-color);
+  }
+
+  .breadcrumb-current {
+    // The current page is the only crumb with full-strength text.
+    color: nb-theme(text-basic-color);
+    font-weight: 500;
+  }
+
+  .breadcrumb-separator {
+    display: inline-flex;
+    align-items: center;
+    color: nb-theme(text-hint-color);
+    opacity: 0.65;
+
+    nb-icon {
+      font-size: 0.875rem;
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+  }
+
+  nb-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  // The header band gets crowded on small screens, where the sidebar already
+  // answers "where am I" — drop the trail instead of squeezing the selectors.
+  @include media-breakpoint-down(lg) {
+    display: none;
+  }
+}

--- a/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.ts
+++ b/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,338 @@
+import { Component, Signal, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter, map, startWith } from 'rxjs/operators';
+import { TranslateService } from '@ngx-translate/core';
+import { NavMenuBuilderService, NavMenuSectionItem } from '@gauzy/ui-core/core';
+
+/**
+ * One rendered level of the breadcrumb trail.
+ */
+export interface IBreadcrumb {
+	/** Translated, human readable label. */
+	label: string;
+	/** Absolute router link, or `null` when this level has no navigable route. */
+	link: string | null;
+	/** Optional icon rendered instead of the label (the "home" crumb). */
+	icon?: string;
+}
+
+/**
+ * A navigation menu item paired with the sections it lives under.
+ */
+interface IMenuMatch {
+	item: NavMenuSectionItem;
+	ancestors: NavMenuSectionItem[];
+	/** The item's link, normalized to a bare path. */
+	link: string;
+}
+
+/**
+ * Breadcrumb trail for the current route.
+ *
+ * Labels are resolved from the navigation menu tree instead of the raw URL, so every
+ * crumb shows the same translated wording as the sidebar. Mounted once in the shared
+ * header, which gives every page under `/pages` a trail without touching page templates.
+ */
+@Component({
+	selector: 'ngx-breadcrumbs',
+	templateUrl: './breadcrumb.component.html',
+	styleUrls: ['./breadcrumb.component.scss'],
+	standalone: false
+})
+export class BreadcrumbComponent {
+	/** Application home — `/pages` redirects here. */
+	private static readonly HOME_LINK = '/pages/dashboard';
+
+	/** Segments that are record identifiers (uuid / numeric): they carry no readable meaning. */
+	private static readonly ID_SEGMENT = /^\d+$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+	/**
+	 * Menu sections skipped while matching. "Favorites" mirrors links that already live
+	 * elsewhere in the tree, so a favorited page would otherwise win the match and render
+	 * as "Favorites / …" instead of its real place in the hierarchy.
+	 */
+	private static readonly IGNORED_SECTION_IDS = new Set<string>(['favorites']);
+
+	/** Namespaces probed (in order) when a URL segment has no navigation menu entry. */
+	private static readonly SEGMENT_TRANSLATION_NAMESPACES = ['MENU', 'BUTTONS'];
+
+	private readonly _router = inject(Router);
+	private readonly _navMenuBuilderService = inject(NavMenuBuilderService);
+	private readonly _translateService = inject(TranslateService);
+
+	/** Current URL, tracked across navigations. */
+	private readonly _url = toSignal(
+		this._router.events.pipe(
+			filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+			map((event: NavigationEnd) => event.urlAfterRedirects),
+			startWith(this._router.url)
+		),
+		{ initialValue: this._router.url }
+	);
+
+	/** Navigation menu tree — the source of translated, hierarchy-aware labels. */
+	private readonly _menu = toSignal(this._navMenuBuilderService.menuConfig$, {
+		initialValue: [] as NavMenuSectionItem[]
+	});
+
+	/** Emits on language change so the trail can be re-translated in place. */
+	private readonly _language = toSignal(this._translateService.onLangChange.pipe(startWith(null)), {
+		initialValue: null
+	});
+
+	/** The trail for the current route, outermost level first. */
+	public readonly breadcrumbs: Signal<IBreadcrumb[]> = computed(() => {
+		// Read the language signal so switching language rebuilds (and re-translates) the trail.
+		this._language();
+		return this.buildTrail(this._url(), this._menu());
+	});
+
+	/**
+	 * Builds the breadcrumb trail for a URL.
+	 *
+	 * @param url Current router URL — may carry a query string, fragment or matrix params.
+	 * @param sections Navigation menu sections as defined by the menu builder.
+	 * @returns The ordered trail; empty outside the `/pages` shell.
+	 */
+	private buildTrail(url: string, sections: NavMenuSectionItem[]): IBreadcrumb[] {
+		const path = this.toPath(url);
+
+		// Breadcrumbs describe the in-app page hierarchy only (auth / public routes have none).
+		if (!path.startsWith('/pages')) {
+			return [];
+		}
+
+		const match = this.findDeepestMatch(path, sections);
+		const crumbs: IBreadcrumb[] = [this.homeCrumb()];
+
+		if (match) {
+			for (const ancestor of match.ancestors) {
+				crumbs.push(this.toCrumb(ancestor));
+			}
+			crumbs.push(this.toCrumb(match.item));
+			crumbs.push(...this.segmentCrumbs(path, match.link));
+		} else {
+			crumbs.push(...this.segmentCrumbs(path, '/pages'));
+		}
+
+		return this.finalize(crumbs);
+	}
+
+	/**
+	 * Finds the deepest navigation menu item whose link is an ancestor of (or equal to) the path.
+	 *
+	 * @param path Normalized URL path.
+	 * @param sections Navigation menu sections to search.
+	 * @returns The matched item together with its ancestor sections, or `null` when nothing matches.
+	 */
+	private findDeepestMatch(path: string, sections: NavMenuSectionItem[]): IMenuMatch | null {
+		const matches = this.collectMatches(path, sections, []);
+
+		return matches.reduce((best: IMenuMatch | null, candidate: IMenuMatch) => {
+			// Deepest link wins; on a tie a visible item beats a hidden twin
+			// (several hidden items point at /pages/dashboard, for instance).
+			if (!best) {
+				return candidate;
+			}
+			return this.matchScore(candidate) > this.matchScore(best) ? candidate : best;
+		}, null);
+	}
+
+	/**
+	 * Walks the menu tree and collects every item whose link covers the path.
+	 *
+	 * @param path Normalized URL path.
+	 * @param items Menu items at the current level.
+	 * @param ancestors Sections walked through to reach `items`.
+	 * @returns All matching items, in tree order.
+	 */
+	private collectMatches(path: string, items: NavMenuSectionItem[], ancestors: NavMenuSectionItem[]): IMenuMatch[] {
+		const matches: IMenuMatch[] = [];
+
+		for (const item of items ?? []) {
+			if (BreadcrumbComponent.IGNORED_SECTION_IDS.has(item.id)) {
+				continue;
+			}
+
+			const link = typeof item.link === 'string' ? this.toPath(item.link) : null;
+
+			if (link && this.isAncestorPath(link, path)) {
+				matches.push({ item, ancestors: [...ancestors], link });
+			}
+
+			if (item.items?.length) {
+				matches.push(...this.collectMatches(path, item.items, [...ancestors, item]));
+			}
+		}
+
+		return matches;
+	}
+
+	/**
+	 * Ranks a match: deeper links score higher, and visible items outrank hidden ones.
+	 *
+	 * @param match Candidate match.
+	 * @returns The comparable score.
+	 */
+	private matchScore(match: IMenuMatch): number {
+		return match.link.split('/').length * 2 + (match.item.hidden ? 0 : 1);
+	}
+
+	/**
+	 * Builds crumbs for the URL segments left over after the matched menu link.
+	 *
+	 * These levels are deliberately not links: nothing guarantees an intermediate URL
+	 * resolves to a route (`/pages/employees/edit` on its own is a 404), and a dead
+	 * crumb is worse than a plain one.
+	 *
+	 * @param path Normalized URL path.
+	 * @param basePath The already-covered prefix of the path.
+	 * @returns Crumbs for the remaining, meaningful segments.
+	 */
+	private segmentCrumbs(path: string, basePath: string): IBreadcrumb[] {
+		return path
+			.slice(basePath.length)
+			.split('/')
+			.filter((segment: string) => !!segment && !BreadcrumbComponent.ID_SEGMENT.test(segment))
+			.map((segment: string) => ({ label: this.labelForSegment(segment), link: null }));
+	}
+
+	/**
+	 * Removes empty and repeated levels and marks the last crumb as the current page.
+	 *
+	 * @param crumbs Raw trail.
+	 * @returns The trail ready for rendering.
+	 */
+	private finalize(crumbs: IBreadcrumb[]): IBreadcrumb[] {
+		const trail: IBreadcrumb[] = [];
+
+		for (const crumb of crumbs) {
+			if (!crumb.label && !crumb.icon) {
+				continue;
+			}
+
+			// Collapse repeats — home and the "Dashboards" menu item point at the same route.
+			const previous = trail[trail.length - 1];
+			const duplicate =
+				previous && ((!!crumb.link && previous.link === crumb.link) || previous.label === crumb.label);
+			if (duplicate) {
+				continue;
+			}
+
+			trail.push({ ...crumb });
+		}
+
+		if (trail.length > 0) {
+			// The current page is never a link — it is announced with aria-current instead.
+			trail[trail.length - 1].link = null;
+		}
+
+		// A lone home crumb reads better as a word than as a bare icon.
+		if (trail.length === 1) {
+			trail[0] = { ...trail[0], icon: undefined };
+		}
+
+		return trail;
+	}
+
+	/**
+	 * Maps a navigation menu item to a crumb.
+	 *
+	 * @param item Navigation menu item.
+	 * @returns The crumb, linked only when the menu item itself defines a route.
+	 */
+	private toCrumb(item: NavMenuSectionItem): IBreadcrumb {
+		const key = item.data?.translationKey;
+		// `noTranslate` items hold user content (custom dashboard names) — render literally so a
+		// name that happens to match an i18n key is not translated away.
+		const label = key
+			? item.data?.noTranslate
+				? key
+				: (this.translateOrNull(key) ?? item.title ?? '')
+			: (item.title ?? '');
+
+		return { label, link: typeof item.link === 'string' ? this.toPath(item.link) : null };
+	}
+
+	/**
+	 * The root crumb, pointing at the application home.
+	 *
+	 * @returns The home crumb.
+	 */
+	private homeCrumb(): IBreadcrumb {
+		return {
+			label: this.translateOrNull('MENU.DASHBOARDS') ?? 'Dashboards',
+			link: BreadcrumbComponent.HOME_LINK,
+			icon: 'home-outline'
+		};
+	}
+
+	/**
+	 * Resolves a readable label for a URL segment that has no navigation menu entry.
+	 *
+	 * @param segment Raw URL segment (e.g. `edit`, `expense-recurring`).
+	 * @returns A translated label when a matching i18n key exists, a humanized segment otherwise.
+	 */
+	private labelForSegment(segment: string): string {
+		const key = segment.replace(/[^a-z\d]+/gi, '_').toUpperCase();
+
+		for (const namespace of BreadcrumbComponent.SEGMENT_TRANSLATION_NAMESPACES) {
+			const translated = this.translateOrNull(`${namespace}.${key}`);
+			if (translated) {
+				return translated;
+			}
+		}
+
+		return this.humanize(segment);
+	}
+
+	/**
+	 * Translates a key, treating "missing" as absent.
+	 *
+	 * @param key i18n key.
+	 * @returns The translation, or `null` when the key is unknown (ngx-translate echoes the key back)
+	 *          or resolves to a namespace object rather than a string.
+	 */
+	private translateOrNull(key: string): string | null {
+		const translated = this._translateService.instant(key);
+		return typeof translated === 'string' && translated !== key && translated.trim().length > 0 ? translated : null;
+	}
+
+	/**
+	 * Turns a URL segment into title case words.
+	 *
+	 * @param segment Raw URL segment.
+	 * @returns The humanized text (`expense-recurring` → `Expense Recurring`).
+	 */
+	private humanize(segment: string): string {
+		return segment
+			.replace(/[-_]+/g, ' ')
+			.replace(/([a-z\d])([A-Z])/g, '$1 $2')
+			.replace(/\b\w/g, (char: string) => char.toUpperCase())
+			.trim();
+	}
+
+	/**
+	 * Strips the query string, fragment, matrix params and any trailing slash from a URL.
+	 *
+	 * @param url Router URL or menu link.
+	 * @returns The bare path.
+	 */
+	private toPath(url: string): string {
+		const [path = ''] = String(url ?? '').split(/[?#;]/);
+		return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+	}
+
+	/**
+	 * Checks whether a link addresses the path itself or one of its ancestors, comparing
+	 * whole segments so `/pages/tag` never matches `/pages/tags`.
+	 *
+	 * @param link Candidate ancestor path.
+	 * @param path Current path.
+	 * @returns True when `link` is `path` or a segment-aligned prefix of it.
+	 */
+	private isAncestorPath(link: string, path: string): boolean {
+		return path === link || path.startsWith(`${link}/`);
+	}
+}

--- a/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.ts
+++ b/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.ts
@@ -49,7 +49,7 @@ export class BreadcrumbComponent {
 
 	/**
 	 * Menu sections skipped while matching. "Favorites" mirrors links that already live
-	 * elsewhere in the tree, so a favorited page would otherwise win the match and render
+	 * elsewhere in the tree, so a page marked as favorite would otherwise win the match and render
 	 * as "Favorites / …" instead of its real place in the hierarchy.
 	 */
 	private static readonly IGNORED_SECTION_IDS = new Set<string>(['favorites']);
@@ -104,17 +104,14 @@ export class BreadcrumbComponent {
 		}
 
 		const match = this.findDeepestMatch(path, sections);
-		const crumbs: IBreadcrumb[] = [this.homeCrumb()];
-
-		if (match) {
-			for (const ancestor of match.ancestors) {
-				crumbs.push(this.toCrumb(ancestor));
-			}
-			crumbs.push(this.toCrumb(match.item));
-			crumbs.push(...this.segmentCrumbs(path, match.link));
-		} else {
-			crumbs.push(...this.segmentCrumbs(path, '/pages'));
-		}
+		const crumbs: IBreadcrumb[] = match
+			? [
+					this.homeCrumb(),
+					...match.ancestors.map((ancestor: NavMenuSectionItem) => this.toCrumb(ancestor)),
+					this.toCrumb(match.item),
+					...this.segmentCrumbs(path, match.link)
+				]
+			: [this.homeCrumb(), ...this.segmentCrumbs(path, '/pages')];
 
 		return this.finalize(crumbs);
 	}
@@ -213,7 +210,7 @@ export class BreadcrumbComponent {
 			}
 
 			// Collapse repeats — home and the "Dashboards" menu item point at the same route.
-			const previous = trail[trail.length - 1];
+			const previous = trail.at(-1);
 			const duplicate =
 				previous && ((!!crumb.link && previous.link === crumb.link) || previous.label === crumb.label);
 			if (duplicate) {
@@ -223,9 +220,10 @@ export class BreadcrumbComponent {
 			trail.push({ ...crumb });
 		}
 
-		if (trail.length > 0) {
-			// The current page is never a link — it is announced with aria-current instead.
-			trail[trail.length - 1].link = null;
+		// The current page is never a link — it is announced with aria-current instead.
+		const current = trail.at(-1);
+		if (current) {
+			current.link = null;
 		}
 
 		// A lone home crumb reads better as a word than as a bare icon.
@@ -244,15 +242,19 @@ export class BreadcrumbComponent {
 	 */
 	private toCrumb(item: NavMenuSectionItem): IBreadcrumb {
 		const key = item.data?.translationKey;
+		const link = typeof item.link === 'string' ? this.toPath(item.link) : null;
+
+		if (!key) {
+			return { label: item.title ?? '', link };
+		}
+
 		// `noTranslate` items hold user content (custom dashboard names) — render literally so a
 		// name that happens to match an i18n key is not translated away.
-		const label = key
-			? item.data?.noTranslate
-				? key
-				: (this.translateOrNull(key) ?? item.title ?? '')
-			: (item.title ?? '');
+		if (item.data?.noTranslate) {
+			return { label: key, link };
+		}
 
-		return { label, link: typeof item.link === 'string' ? this.toPath(item.link) : null };
+		return { label: this.translateOrNull(key) ?? item.title ?? '', link };
 	}
 
 	/**
@@ -320,7 +322,15 @@ export class BreadcrumbComponent {
 	 * @returns The bare path.
 	 */
 	private toPath(url: string): string {
-		const [path = ''] = String(url ?? '').split(/[?#;]/);
+		const [withoutQuery = ''] = String(url ?? '').split(/[?#]/);
+		// Matrix params attach to a SINGLE segment (`/pages/settings;tab=1/ai`), so they have to
+		// be stripped segment by segment. Splitting the whole URL on the first `;` instead would
+		// discard every later segment and leave the trail pointing at the wrong page.
+		const path = withoutQuery
+			.split('/')
+			.map((segment: string) => segment.split(';')[0])
+			.join('/');
+
 		return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
 	}
 

--- a/packages/ui-core/theme/src/lib/components/header/header.component.html
+++ b/packages/ui-core/theme/src/lib/components/header/header.component.html
@@ -5,10 +5,16 @@
   </div>
 }
 <div class="main-header">
-  <div class="header-container"
+  <!-- Breadcrumbs live in the header band, which is the single host every page
+       under /pages already renders: page templates stay untouched and the trail
+       costs the page zero vertical space. -->
+  <div class="header-container breadcrumb-container"
     [class.left]="position === 'normal'"
     [class.right]="position === 'inverse'"
-  ></div>
+    [class.compacted]="!expanded"
+  >
+    <ngx-breadcrumbs></ngx-breadcrumbs>
+  </div>
 
   <div class="header-container">
     @if (createQuickActionsMenu?.length > 0) {

--- a/packages/ui-core/theme/src/lib/components/header/header.component.scss
+++ b/packages/ui-core/theme/src/lib/components/header/header.component.scss
@@ -94,6 +94,40 @@ $orange: #f56d58;
       padding: 0 !important;
     }
 
+    // The nav sidebar's container is fixed at top: 0 with z-index 1041 (see the
+    // one-column layout), so it paints OVER the left of the header band and the
+    // trail has to start exactly where the sidebar ends — and follow it when the
+    // sidebar is compacted.
+    //
+    // The offset is the bare sidebar width: `nb-layout-header nav` has its
+    // `header-padding` zeroed globally (_overrides.scss), so there is no padding
+    // to subtract — doing so would tuck the first crumb under the sidebar.
+    .breadcrumb-container {
+      flex: 1 1 auto;
+      min-width: 0;
+      @include nb-ltr(margin-left, nb-theme(sidebar-width));
+      @include nb-rtl(margin-right, nb-theme(sidebar-width));
+
+      &.compacted {
+        @include nb-ltr(margin-left, nb-theme(sidebar-width-compact));
+        @include nb-rtl(margin-right, nb-theme(sidebar-width-compact));
+      }
+
+      // Below `lg` the trail itself is hidden (breadcrumb.component.scss). Drop the
+      // offset with it: an empty spacer carrying a 16rem margin would push the
+      // header actions off a narrow viewport. The element stays in the flow so
+      // `justify-content: space-between` still parks the actions on the right.
+      @include media-breakpoint-down(lg) {
+        @include nb-ltr(margin-left, 0);
+        @include nb-rtl(margin-right, 0);
+
+        &.compacted {
+          @include nb-ltr(margin-left, 0);
+          @include nb-rtl(margin-right, 0);
+        }
+      }
+    }
+
     .header-container {
       display: flex;
       align-items: center;

--- a/packages/ui-core/theme/src/lib/components/index.ts
+++ b/packages/ui-core/theme/src/lib/components/index.ts
@@ -1,3 +1,4 @@
+export * from './breadcrumb/breadcrumb.component';
 export * from './header/header.component';
 export * from './footer/footer.component';
 export * from './gauzy-logo/gauzy-logo.component';

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
@@ -1,18 +1,29 @@
 @use 'themes' as *;
 
+// The account dropdown is a popup, so it follows the same shadcn rules as the
+// overlay menus in `packages/ui-core/static/styles/_overlays.scss`: ONE soft
+// container wrapping FLAT rows. Like the workspace switcher it is absolutely
+// positioned by the layout rather than rendered into `.cdk-overlay-container`,
+// so the container chrome is repeated here. `--gauzy-overlay-*` are not
+// registered in themes.scss yet (the integrator owns that file), hence the
+// alpha-neutral fallbacks — they read correctly on light AND dark surfaces.
+$overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+$overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
+$overlay-item-hover-bg: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12));
+
 :host {
   .main-menu {
     width: 36rem;
     //height: 30.5625rem; // After implement features revert to this height
     height: 18rem;
-    box-shadow: 0rem 0.25rem 1rem rgba(0, 0, 0, 0.25);
-    border-radius: nb-theme(border-radius) nb-theme(border-radius)
-      nb-theme(border-radius) 0rem;
+    border: 1px solid #{$overlay-hairline};
+    box-shadow: #{$overlay-shadow};
+    border-radius: 8px;
     background: nb-theme(background-basic-color-1);
     display: flex;
     .right-menu {
       background: nb-theme(color-primary-transparent-default);
-      border-radius: 0px nb-theme(border-radius) nb-theme(border-radius) 0px;
+      border-radius: 0 8px 8px 0;
       width: 50%;
       padding: 13.5px 15.5px 13.5px 26px;
       span {
@@ -32,12 +43,14 @@
     }
     .left-menu {
       width: 50%;
-      border-radius: 0px nb-theme(border-radius) nb-theme(border-radius) 0px;
+      border-radius: 8px 0 0 8px;
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      @include nb-ltr(padding, 19px 47px 10px 11px);
-      @include nb-rtl(padding, 19px 11px 10px 47px);
+      // Trimmed from 11px/47px: each row now carries its own 10px inline
+      // padding (see `p.link` below), so the column only needs a small inset.
+      @include nb-ltr(padding, 14px 16px 10px 6px);
+      @include nb-rtl(padding, 14px 6px 10px 16px);
       .sub-menu {
         background: rgba(126, 126, 143, 0.05);
         padding: 10px;
@@ -74,10 +87,36 @@
     text-decoration: none;
     color: nb-theme(text-basic-color);
   }
+
   .links {
-    align-items: flex-start;
+    // `stretch` (was `flex-start`) so a hovered row's tint spans the column
+    // instead of hugging the label.
+    align-items: stretch;
     display: flex;
     flex-direction: column;
+    gap: 0.125rem;
+
+    // Flat menu rows: no border, no shadow, no resting fill — only a subtle
+    // background tint on a 6px radius when hovered. Scoped to `.links` so the
+    // right-hand column (whose `p`s wrap full-width selector widgets, not menu
+    // entries) keeps its own alignment.
+    p.link {
+      margin: 0;
+      padding: 0.375rem 0.625rem;
+      border-radius: 6px;
+      font-size: nb-theme(menu-text-font-size);
+      font-weight: nb-theme(menu-text-font-weight);
+      line-height: 1.25rem;
+      // Colour only: transitioning `all` would animate the radius and make the
+      // row look like it is inflating into a block.
+      transition:
+        background-color 0.12s ease-in-out,
+        color 0.12s ease-in-out;
+
+      &:hover {
+        background-color: #{$overlay-item-hover-bg};
+      }
+    }
   }
 
   .right-menu {
@@ -94,7 +133,9 @@
       margin-bottom: 1rem;
 
       .download-apps-label {
-        color: #7e7e8f;
+        // Token, not a raw hex: `#7e7e8f` was a fixed grey that does not lift
+        // on the dark themes.
+        color: nb-theme(text-hint-color);
       }
 
       .download-apps-icons {
@@ -108,7 +149,7 @@
           i {
             padding: 0;
             margin: 0;
-            color: #7e7e8f;
+            color: nb-theme(text-hint-color);
           }
 
           &:hover {
@@ -122,7 +163,7 @@
     }
   }
   .disabled-table {
-	pointer-events: none;
-	opacity: 0.5;
+    pointer-events: none;
+    opacity: 0.5;
   }
 }

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
@@ -4,12 +4,12 @@
 // overlay menus in `packages/ui-core/static/styles/_overlays.scss`: ONE soft
 // container wrapping FLAT rows. Like the workspace switcher it is absolutely
 // positioned by the layout rather than rendered into `.cdk-overlay-container`,
-// so the container chrome is repeated here. `--gauzy-overlay-*` are not
-// registered in themes.scss yet (the integrator owns that file), hence the
-// alpha-neutral fallbacks — they read correctly on light AND dark surfaces.
+// so the container chrome is repeated here. `--gauzy-overlay-border-color` and
+// `--gauzy-hover-tint` resolve from themes.scss; the alpha-neutral fallbacks
+// cover the material-* themes and read correctly on light AND dark surfaces.
 $overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
 $overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
-$overlay-item-hover-bg: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12));
+$overlay-item-hover-bg: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
 
 :host {
   .main-menu {
@@ -23,7 +23,11 @@ $overlay-item-hover-bg: var(--gauzy-overlay-item-hover-background, rgba(126, 126
     display: flex;
     .right-menu {
       background: nb-theme(color-primary-transparent-default);
-      border-radius: 0 8px 8px 0;
+      // `direction: rtl` reverses the flex row, so this column moves to the
+      // LEFT edge under RTL while physical corner radii stay put — mirror them
+      // or the panel ends up with two squared outer corners.
+      @include nb-ltr(border-radius, 0 8px 8px 0);
+      @include nb-rtl(border-radius, 8px 0 0 8px);
       width: 50%;
       padding: 13.5px 15.5px 13.5px 26px;
       span {
@@ -43,7 +47,9 @@ $overlay-item-hover-bg: var(--gauzy-overlay-item-hover-background, rgba(126, 126
     }
     .left-menu {
       width: 50%;
-      border-radius: 8px 0 0 8px;
+      // Mirrored for the same reason as `.right-menu` above.
+      @include nb-ltr(border-radius, 8px 0 0 8px);
+      @include nb-rtl(border-radius, 0 8px 8px 0);
       display: flex;
       flex-direction: column;
       justify-content: space-between;

--- a/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
@@ -7,11 +7,12 @@
 //
 // It is NOT rendered into `.cdk-overlay-container` — the layout absolutely
 // positions it — so the global overlay rules never reach it and the container
-// chrome has to be repeated here. The `--gauzy-overlay-*` custom properties are
-// not registered in themes.scss yet (the integrator owns that file), so each one
-// carries the same alpha-neutral fallback the global partial uses: a neutral
-// grey at low alpha darkens a light surface and lightens a dark one, so no
-// per-theme branch is needed.
+// chrome has to be repeated here. `--gauzy-overlay-border-color` resolves from
+// themes.scss; `--gauzy-overlay-shadow` is not registered (a Sass map entry
+// cannot hold a comma-separated shadow list as-is), so each one keeps the same
+// alpha-neutral fallback the global partial uses: a neutral grey at low alpha
+// darkens a light surface and lightens a dark one, so no per-theme branch is
+// needed.
 $overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
 $overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
 

--- a/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
@@ -1,25 +1,43 @@
 @use 'themes' as *;
 
+// The workspace switcher is a popup, so it follows the same shadcn rules as the
+// overlay menus in `packages/ui-core/static/styles/_overlays.scss`: ONE soft
+// container (1px hairline + soft shadow + 8px radius + small padding) wrapping
+// completely FLAT rows.
+//
+// It is NOT rendered into `.cdk-overlay-container` — the layout absolutely
+// positions it — so the global overlay rules never reach it and the container
+// chrome has to be repeated here. The `--gauzy-overlay-*` custom properties are
+// not registered in themes.scss yet (the integrator owns that file), so each one
+// carries the same alpha-neutral fallback the global partial uses: a neutral
+// grey at low alpha darkens a light surface and lightens a dark one, so no
+// per-theme branch is needed.
+$overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+$overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
+
 :host {
   .workspace-dropdown {
     height: fit-content;
     max-height: 80vh;
-    box-shadow: 0px 6px 30px 0px rgba(0, 0, 0, 0.2);
-    border-radius: var(--border-radius);
-    background: nb-theme(background-basic-color-2);
-    padding: 0.75rem;
+    border: 1px solid #{$overlay-hairline};
+    border-radius: 8px;
+    box-shadow: #{$overlay-shadow};
+    background: nb-theme(background-basic-color-1);
+    // Just enough inset that a hovered row's radius never touches the edge.
+    padding: 0.375rem;
   }
 
   .workspace-content {
     display: flex;
     width: 100%;
-    gap: 0.75rem;
+    gap: 0.5rem;
   }
 
   .workspace-left-section {
     overflow-y: auto;
-    border-right: 1px solid nb-theme(border-basic-color-4);
-    padding-right: 0.75rem;
+    // 1px hairline at low alpha, not a solid theme divider.
+    border-right: 1px solid #{$overlay-hairline};
+    padding-right: 0.5rem;
     min-width: 180px;
   }
 
@@ -28,31 +46,36 @@
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-    padding-left: 0.75rem;
-    gap: 0.25rem;
+    padding-left: 0.5rem;
+    gap: 0.125rem;
   }
 
-  // Flatten accordion headers in the popup for both nav menus. Settings is a
-  // plain link to /pages/settings (no inline accordion anymore), so its
-  // expansion chevron is hidden the same way as the main nav's.
+  // The two nav menus embedded here are the sidebar's `ga-sidebar-menu`, which
+  // already renders flat rows (see `menu-item.component.scss`). The only thing
+  // that differs in the popup is the accordion chevron: Settings is a plain
+  // link to /pages/settings and the main nav routes straight through, so
+  // nothing ever expands inline and the indicator would be a lie.
   .setting.action ::ng-deep ga-main-nav-menu,
   .setting ::ng-deep ga-settings-nav-menu {
     ga-sidebar-menu {
-      nb-accordion-item {
-        nb-accordion-item-header {
-          box-shadow: unset;
-          border-width: 0;
-          nb-icon {
-            display: none;
-          }
+      nb-accordion-item nb-accordion-item-header {
+        nb-icon {
+          display: none;
         }
+
+        // With no chevron to clear, reclaim the gutter the sidebar rows
+        // reserve for it so the label is not floating in dead space.
+        @include nb-ltr(padding-right, 0.625rem);
+        @include nb-rtl(padding-left, 0.625rem);
       }
     }
   }
 
+  // Spacer under the two menu columns. It used to carry `--gauzy-shadow`,
+  // which drew a stray line across the bottom of an otherwise empty element.
   .item.footer {
-    box-shadow: var(--gauzy-shadow);
-    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    box-shadow: none;
+
     ::ng-deep {
       .item-body {
         padding: 5px;

--- a/packages/ui-core/theme/src/lib/theme.module.ts
+++ b/packages/ui-core/theme/src/lib/theme.module.ts
@@ -57,6 +57,7 @@ import {
 	MATERIAL_LIGHT_THEME
 } from './themes';
 import { WindowModeBlockScrollService } from './services/window-mode-block-scroll.service';
+import { BreadcrumbComponent } from './components/breadcrumb/breadcrumb.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { HeaderComponent } from './components/header/header.component';
 import { ThemeSidebarModule } from './components/theme-sidebar/theme-sidebar.module';
@@ -103,6 +104,7 @@ const MODULES = [
 ];
 
 const COMPONENTS = [
+	BreadcrumbComponent,
 	HeaderComponent,
 	FooterComponent,
 	OneColumnLayoutComponent,


### PR DESCRIPTION
Addresses two pieces of feedback from the demo environment.

## (a) AI Providers rendered without the Settings menu

Not styling — **structural**. The settings shell's child routes were a static array with **no extension point**, so the AI Providers page registered at `page-sections`: a *top-level* route that merely resolved to `/pages/settings/ai` while living outside the shell. The menu item pointed at it, so it looked wired up.

- new **`settings-sections`** registry location (documented, so future plugin settings pages can't repeat this)
- `settings-routing.module` builds routes through a `ROUTES` factory (same pattern the dashboard already uses) and spreads `getPageLocationRoutes('settings-sections')` into the shell's children
- the AI plugin re-registers there with path `ai`

Any plugin settings page now inherits the shell automatically.

## (b) shadcn-like chrome

**There were no breadcrumbs in the codebase at all.** What reads as an oversized breadcrumb path (`Settings/ Roles & Permissions`) is `ngx-header-title` — the *page title*, hardcoded at `24px/600` across ~82 pages.

- **NEW `ngx-breadcrumbs`**, mounted **once** in the shared header, so every `/pages/*` route gets a trail with zero page-template edits. Labels resolve from the translated **nav-menu tree** (not raw URL segments), uuid/numeric ids are dropped, every crumb but the last is a `routerLink`, last carries `aria-current="page"`, separators `aria-hidden`. Mounted in the header band rather than above `<router-outlet>` because dozens of pages use `.h-100` full-height rows — a bar there would add a scrollbar to all of them.
- **Page title** `24px/600` → `1.25rem` with a muted org qualifier, so it stops competing with the trail.
- **Sidebar rows flattened** — nothing painted at rest (Nebular renders each entry as an `nb-accordion` **card**: opaque fill + 10px radius + shadow + divider, which is the "rounded blocks" look), subtle tint on hover, restrained active state.
- **Overlay menus** — container keeps one soft border + shadow; items inside are flat rows.
- New shared tokens **`gauzy-radius-sm`** (6px — deliberately not the 10px *card* radius) and **`gauzy-hover-tint`**, so hover reads identically across all 8 themes.

## Verification

Built and checked live in **both** gauzy-light and gauzy-dark: AI Providers renders with the Settings menu; trails read `🏠 / Settings / AI Providers` and `🏠 / Organization / Projects`; sidebar rows are flat. Screenshots in the thread.

Known follow-up: the **settings menu's own active item** still renders as a filled block — it sits outside the files this change owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real breadcrumbs to all `/pages` views, flattens menu and overlay chrome, and mounts plugin settings pages inside the Settings shell. Also keeps the `'' -> general` settings redirect and ensures breadcrumbs handle matrix params correctly.

- **New Features**
  - Breadcrumbs in the shared header for all `/pages/*`; clickable trail, labels from the translated nav menu, IDs skipped, proper aria-current; supports matrix params.
  - New `settings-sections` registry + `ROUTES` factory; plugin settings pages now render inside the Settings shell and inherit its menu; `'' -> general` redirect retained.
  - Flat chrome across sidebar, Settings menu and overlays (`nb-popover`, `nb-select`/`ng-select`, user/workspace menus): no resting fill/shadow; subtle hover/active tints via `gauzy-radius-sm`, `gauzy-hover-tint`, `gauzy-active-tint`, and `gauzy-overlay-border-color`. Page title reduced to 1.25rem.

- **Migration**
  - Plugin settings pages should register under `settings-sections` (child paths relative to `/pages/settings`) instead of `page-sections`.

<sup>Written for commit b0aef0196e5c0a56795192771e63b68c18ca1d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

