### PR TITLE
chore: cascade develop → stage (dashboard builder + breadcrumbs/flat menus/settings shell)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -737,6 +737,7 @@
 		"Pdfmaker",
 		"PERFLOG",
 		"PERFLOG",
+		"persistance",
 		"PGBIN",
 		"PGBIN",
 		"pgcrypto",

--- a/.cspell.json
+++ b/.cspell.json
@@ -900,6 +900,7 @@
 		"stefanzweifel",
 		"streamifier",
 		"stylelint",
+		"stylesheet",
 		"Sumanth",
 		"superfly",
 		"swapoff",

--- a/apps/gauzy/src/app/bootstrap.module.ts
+++ b/apps/gauzy/src/app/bootstrap.module.ts
@@ -11,7 +11,13 @@ import {
 	PluginUiRegistryService,
 	TranslateAdapterService
 } from '@gauzy/plugin-ui';
-import { NavMenuBuilderService, PageRouteRegistryService, PageTabRegistryService, Store } from '@gauzy/ui-core/core';
+import {
+	NavMenuBuilderService,
+	PageRouteRegistryService,
+	PageTabRegistryService,
+	Store,
+	WidgetRegistryService
+} from '@gauzy/ui-core/core';
 import { provideEffectsManager } from '@ngneat/effects-ng';
 import { TranslateService, TranslateStore } from '@ngx-translate/core';
 import { AppComponent } from './app.component';
@@ -38,6 +44,7 @@ import { AppModule } from './app.module';
 			navBuilder: NavMenuBuilderService,
 			routeRegistry: PageRouteRegistryService,
 			tabRegistry: PageTabRegistryService,
+			widgetRegistry: WidgetRegistryService,
 			translateService: TranslateAdapterService,
 			permissionChecker: PermissionAdapterService,
 			featureChecker: FeatureAdapterService

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/custom-dashboard.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/custom-dashboard.component.html
@@ -1,0 +1,40 @@
+<div class="custom-dashboard">
+	<!-- Builder hint bar: only while arranging. Save / Discard live in the switcher. -->
+	@if (editing) {
+		<div class="builder-toolbar">
+			<span class="builder-toolbar__hint">
+				{{ 'DASHBOARD_PAGE.BUILDER.EDIT_HINT' | translate }}
+			</span>
+			@if (dirty) {
+				<span class="builder-toolbar__dirty">
+					<nb-icon icon="alert-circle-outline"></nb-icon>
+					{{ 'DASHBOARD_PAGE.BUILDER.UNSAVED_CHANGES' | translate }}
+				</span>
+			}
+		</div>
+	}
+
+	<ga-dashboard-tab-strip
+		[tabs]="layout.tabs"
+		[activeTabId]="activeTabId"
+		[editing]="editing"
+		(tabSelect)="onSelectTab($event)"
+		(addRequested)="onAddTab($event)"
+		(renameRequested)="onRenameTab($event)"
+		(duplicateRequested)="onDuplicateTab($event)"
+		(deleteRequested)="onDeleteTab($event)"
+		(reordered)="onReorderTabs($event)"
+	></ga-dashboard-tab-strip>
+
+	<div class="custom-dashboard__body">
+		<ga-dashboard-canvas
+			[tab]="activeTab"
+			[editing]="editing"
+			(layoutChange)="onLayoutChange($event)"
+		></ga-dashboard-canvas>
+
+		@if (editing) {
+			<ga-widget-palette (addRequested)="onAddWidget($event)"></ga-widget-palette>
+		}
+	</div>
+</div>

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/custom-dashboard.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/custom-dashboard.component.scss
@@ -1,0 +1,74 @@
+@use 'var' as *;
+
+:host {
+	display: block;
+	height: 100%;
+	min-height: 0;
+}
+
+.custom-dashboard {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	height: 100%;
+	min-height: 0;
+	padding: 0.5rem 0.25rem 0;
+}
+
+.builder-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+	padding: 0.375rem 0.5rem;
+	border: 1px solid nb-theme(border-basic-color-3);
+	border-radius: nb-theme(border-radius);
+	background-color: nb-theme(background-basic-color-2);
+
+	&__hint {
+		flex: 1 1 auto;
+		min-width: 0;
+		font-size: 0.75rem;
+		line-height: 1.35;
+		color: nb-theme(text-hint-color);
+	}
+
+	&__dirty {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		flex: 0 0 auto;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: nb-theme(color-warning-default);
+
+		nb-icon {
+			font-size: 14px;
+			height: 14px;
+			width: 14px;
+		}
+	}
+}
+
+.custom-dashboard__body {
+	display: flex;
+	align-items: stretch;
+	gap: 1rem;
+	flex: 1 1 auto;
+	min-height: 0;
+	// The canvas scrolls; the palette stays put next to it
+	overflow: auto;
+	padding-bottom: 1rem;
+}
+
+// Stack the palette under the canvas on narrow viewports
+@include respond(lg) {
+	.custom-dashboard__body {
+		flex-direction: column;
+
+		ga-widget-palette {
+			width: 100%;
+			max-height: 320px;
+		}
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/custom-dashboard.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/custom-dashboard.component.ts
@@ -1,0 +1,293 @@
+import { ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { TranslateService } from '@ngx-translate/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { IDashboard, IDashboardLayoutV2, IDashboardTab, IDashboardWidgetPlacement } from '@gauzy/contracts';
+import { createId, DashboardStoreService, normalizeLayout, parseLayout } from '@gauzy/ui-core/core';
+import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
+import { DashboardCanvasComponent } from './dashboard-canvas.component';
+
+/**
+ * Host page of a custom dashboard (route `custom/:id`).
+ *
+ * Reads the applied dashboard from {@link DashboardStoreService} (the route guard
+ * selects it before activation), normalizes its persisted `contentHtml` into a v2
+ * builder document, and renders the tab strip, the active tab's canvas and — in
+ * edit mode — the widget palette.
+ *
+ * The active tab lives in the `?tab=<tabId>` query parameter, so a tab is
+ * deep-linkable and survives a reload.
+ *
+ * Saving is NOT done here: every change is staged on the dashboard store, which
+ * is what the switcher's Save / Discard buttons act on. Keeping a single pair of
+ * buttons avoids two competing "save" controls on the same screen.
+ */
+@UntilDestroy()
+@Component({
+	selector: 'ga-custom-dashboard',
+	templateUrl: './custom-dashboard.component.html',
+	styleUrls: ['./custom-dashboard.component.scss'],
+	standalone: false
+})
+export class CustomDashboardComponent extends TranslationBaseComponent implements OnInit {
+	/** The dashboard currently applied by the route guard. */
+	public dashboard: IDashboard | null = null;
+
+	/** The normalized (v2) builder document being displayed/edited. */
+	public layout: IDashboardLayoutV2 = normalizeLayout(null);
+
+	/** Id of the tab currently rendered. */
+	public activeTabId: string | null = null;
+
+	/** Edit (arrange) mode, owned by the dashboard store. */
+	public editing = false;
+
+	/** Whether the document has changes that have not been saved yet. */
+	public dirty = false;
+
+	/** Tab id requested through the URL, applied as soon as the layout is known. */
+	private _requestedTabId: string | null = null;
+
+	@ViewChild(DashboardCanvasComponent) private readonly _canvas?: DashboardCanvasComponent;
+
+	constructor(
+		public readonly translateService: TranslateService,
+		private readonly _route: ActivatedRoute,
+		private readonly _router: Router,
+		private readonly _dashboardStore: DashboardStoreService,
+		private readonly _changeRef: ChangeDetectorRef
+	) {
+		super(translateService);
+	}
+
+	ngOnInit(): void {
+		combineLatest([this._route.paramMap, this._dashboardStore.selectedDashboard$])
+			.pipe(
+				map(([params, selected]) => ({ id: params.get('id'), selected })),
+				untilDestroyed(this)
+			)
+			.subscribe(({ id, selected }) => {
+				// Ignore selections for another dashboard: while navigating between
+				// two custom dashboards the route param and the store selection are
+				// momentarily out of sync.
+				if (!selected || (id && selected.id !== id)) {
+					return;
+				}
+				this._hydrate(selected);
+			});
+
+		this._route.queryParamMap
+			.pipe(
+				map((params) => params.get('tab')),
+				untilDestroyed(this)
+			)
+			.subscribe((tabId: string | null) => {
+				this._requestedTabId = tabId;
+				this._applyActiveTab();
+			});
+
+		this._dashboardStore.editing$.pipe(untilDestroyed(this)).subscribe((editing: boolean) => {
+			// Leaving edit mode means the switcher has either saved the staged
+			// document or discarded it — either way nothing of ours is pending any
+			// more. Without clearing the flag here it would stay set forever, and
+			// `_hydrate()` (which skips hydration while dirty, to protect an
+			// in-progress arrangement) would never read the freshly saved layout
+			// back in.
+			if (this.editing && !editing) {
+				this.dirty = false;
+			}
+			this.editing = editing;
+			this._changeRef.markForCheck();
+		});
+	}
+
+	/** The tab currently rendered on the canvas. */
+	public get activeTab(): IDashboardTab | null {
+		return this.layout.tabs.find((tab: IDashboardTab) => tab.id === this.activeTabId) ?? null;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Tab strip
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Switches to a tab and mirrors it into the `?tab=` query parameter.
+	 *
+	 * @param tabId - Id of the tab to display.
+	 */
+	public onSelectTab(tabId: string): void {
+		this.activeTabId = tabId;
+		void this._router.navigate([], {
+			relativeTo: this._route,
+			queryParams: { tab: tabId },
+			queryParamsHandling: 'merge',
+			// A tab switch is not a history entry — Back should leave the dashboard
+			replaceUrl: true
+		});
+	}
+
+	/**
+	 * Appends a new empty tab and switches to it.
+	 *
+	 * @param name - Name entered by the user.
+	 */
+	public onAddTab(name: string): void {
+		const tab: IDashboardTab = { id: createId(), name, order: this.layout.tabs.length, widgets: [] };
+		this._updateTabs([...this.layout.tabs, tab]);
+		this.onSelectTab(tab.id);
+	}
+
+	/**
+	 * Renames a tab.
+	 *
+	 * @param payload - The tab and its new name.
+	 */
+	public onRenameTab(payload: { tab: IDashboardTab; name: string }): void {
+		this._updateTabs(
+			this.layout.tabs.map((tab: IDashboardTab) =>
+				tab.id === payload.tab.id ? { ...tab, name: payload.name } : tab
+			)
+		);
+	}
+
+	/**
+	 * Duplicates a tab, including its widgets, and switches to the copy.
+	 *
+	 * Every copied placement gets a fresh `instanceId`, otherwise the two tabs
+	 * would share widget identities and their configuration would collide.
+	 *
+	 * @param tab - The tab to duplicate.
+	 */
+	public onDuplicateTab(tab: IDashboardTab): void {
+		const copy: IDashboardTab = {
+			...tab,
+			id: createId(),
+			name: `${tab.name} ${this.getTranslation('DASHBOARD_PAGE.BUILDER.TABS.COPY_SUFFIX')}`,
+			order: this.layout.tabs.length,
+			widgets: (tab.widgets ?? []).map((placement: IDashboardWidgetPlacement) => ({
+				...placement,
+				instanceId: createId(),
+				config: placement.config ? { ...placement.config } : undefined
+			}))
+		};
+		this._updateTabs([...this.layout.tabs, copy]);
+		this.onSelectTab(copy.id);
+	}
+
+	/**
+	 * Deletes a tab (the strip already confirmed with the user) and activates a
+	 * neighboring tab when the deleted one was displayed.
+	 *
+	 * @param tab - The tab to delete.
+	 */
+	public onDeleteTab(tab: IDashboardTab): void {
+		// A dashboard always keeps at least one canvas
+		if (this.layout.tabs.length <= 1) {
+			return;
+		}
+		const index = this.layout.tabs.findIndex((item: IDashboardTab) => item.id === tab.id);
+		const tabs = this.layout.tabs
+			.filter((item: IDashboardTab) => item.id !== tab.id)
+			.map((item: IDashboardTab, order: number) => ({ ...item, order }));
+
+		this._updateTabs(tabs);
+
+		if (this.activeTabId === tab.id) {
+			this.onSelectTab(tabs[Math.min(Math.max(index, 0), tabs.length - 1)].id);
+		}
+	}
+
+	/**
+	 * Applies a drag-reordered tab list.
+	 *
+	 * @param tabs - The tabs in their new order (already re-numbered).
+	 */
+	public onReorderTabs(tabs: IDashboardTab[]): void {
+		this._updateTabs(tabs);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Canvas & palette
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Stores the new arrangement of the active tab.
+	 *
+	 * @param placements - The tab's placements after the change.
+	 */
+	public onLayoutChange(placements: IDashboardWidgetPlacement[]): void {
+		const activeId = this.activeTabId;
+		if (!activeId) {
+			return;
+		}
+		this._updateTabs(
+			this.layout.tabs.map((tab: IDashboardTab) =>
+				tab.id === activeId ? { ...tab, widgets: placements } : tab
+			)
+		);
+	}
+
+	/**
+	 * Adds a widget clicked in the palette — the keyboard-accessible counterpart
+	 * of dragging it onto the canvas.
+	 *
+	 * @param widgetId - Registry key of the widget to add.
+	 */
+	public onAddWidget(widgetId: string): void {
+		this._canvas?.addWidget(widgetId);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Internals
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Reads the persisted layout of the given dashboard into the page.
+	 *
+	 * A background reload (e.g. after a rename elsewhere) must not throw away an
+	 * in-progress arrangement, so hydration is skipped while the same dashboard
+	 * still has unsaved changes.
+	 */
+	private _hydrate(dashboard: IDashboard): void {
+		if (this.dashboard?.id === dashboard.id && this.dirty) {
+			this.dashboard = dashboard;
+			return;
+		}
+		this.dashboard = dashboard;
+		this.layout = normalizeLayout(
+			parseLayout(dashboard.contentHtml),
+			this.getTranslation('DASHBOARD_PAGE.BUILDER.TABS.DEFAULT_NAME')
+		);
+		this.dirty = false;
+		// The persisted document is now on screen: nothing is staged any more.
+		this._dashboardStore.stagePendingLayout(null);
+		this._applyActiveTab();
+	}
+
+	/** Resolves the active tab from the URL, falling back to the first tab. */
+	private _applyActiveTab(): void {
+		const tabs = this.layout?.tabs ?? [];
+		const requested = tabs.find((tab: IDashboardTab) => tab.id === this._requestedTabId);
+		this.activeTabId = (requested ?? tabs[0])?.id ?? null;
+		this._changeRef.markForCheck();
+	}
+
+	/**
+	 * Replaces the tab list and stages the working document on the dashboard
+	 * store, which is what the switcher's Save button persists.
+	 */
+	private _updateTabs(tabs: IDashboardTab[]): void {
+		this.layout = { ...this.layout, tabs };
+		this.dirty = true;
+		this._dashboardStore.stagePendingLayout(this.layout);
+		this._changeRef.markForCheck();
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-canvas.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-canvas.component.html
@@ -1,0 +1,81 @@
+<div
+	class="dashboard-canvas"
+	[class.editing]="editing"
+	cdkDropList
+	cdkDropListOrientation="mixed"
+	[id]="dropListId"
+	[cdkDropListData]="placements"
+	[cdkDropListConnectedTo]="connectedTo"
+	[cdkDropListDisabled]="!editing"
+	(cdkDropListDropped)="onDrop($event)"
+>
+	@for (placement of placements; track placement.instanceId) {
+		<div
+			class="canvas-cell"
+			[class.hidden-widget]="placement.hidden"
+			[style.grid-column]="placement.x + 1 + ' / span ' + placement.w"
+			[style.grid-row]="placement.y + 1 + ' / span ' + placement.h"
+			cdkDrag
+			[cdkDragData]="placement"
+			[cdkDragDisabled]="!editing"
+		>
+			<!--
+				Placeholder left behind while the cell is dragged. CDK swaps it in
+				for the cell itself, so it must carry the same grid position or the
+				surrounding widgets jump.
+			-->
+			<div
+				class="canvas-drop-placeholder"
+				*cdkDragPlaceholder
+				[style.grid-column]="placement.x + 1 + ' / span ' + placement.w"
+				[style.grid-row]="placement.y + 1 + ' / span ' + placement.h"
+			></div>
+
+			@if (editing) {
+				<!--
+					Pointer drag AND keyboard move: CDK drag is pointer-only, so the
+					handle also answers the arrow keys to move the widget one slot in
+					reading order. Without that, reordering is unreachable by keyboard.
+				-->
+				<button
+					type="button"
+					class="drag-handle"
+					cdkDragHandle
+					[attr.aria-label]="'DASHBOARD_PAGE.BUILDER.CANVAS.DRAG_HANDLE' | translate"
+					[nbTooltip]="'DASHBOARD_PAGE.BUILDER.CANVAS.DRAG_HANDLE' | translate"
+					(keydown.arrowLeft)="moveBy(placement, -1, $event)"
+					(keydown.arrowUp)="moveBy(placement, -1, $event)"
+					(keydown.arrowRight)="moveBy(placement, 1, $event)"
+					(keydown.arrowDown)="moveBy(placement, 1, $event)"
+				>
+					<nb-icon icon="move-outline"></nb-icon>
+				</button>
+			}
+
+			<ga-dashboard-widget-host
+				[placement]="placement"
+				[editing]="editing"
+				(removed)="onRemove(placement)"
+				(configureRequested)="onConfigure(placement)"
+				(resized)="onResize(placement, $event)"
+			></ga-dashboard-widget-host>
+		</div>
+	}
+
+	<!-- Empty state: the key call to action of the builder -->
+	@if (!placements.length) {
+		<div class="canvas-empty">
+			<nb-icon class="canvas-empty__icon" icon="grid-outline"></nb-icon>
+			<h4 class="canvas-empty__title">
+				{{ 'DASHBOARD_PAGE.BUILDER.CANVAS.EMPTY_TITLE' | translate }}
+			</h4>
+			<p class="canvas-empty__hint">
+				@if (editing) {
+					{{ 'DASHBOARD_PAGE.BUILDER.CANVAS.EMPTY_HINT' | translate }}
+				} @else {
+					{{ 'DASHBOARD_PAGE.BUILDER.CANVAS.EMPTY_HINT_READONLY' | translate }}
+				}
+			</p>
+		</div>
+	}
+</div>

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-canvas.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-canvas.component.scss
@@ -1,0 +1,153 @@
+@use 'var' as *;
+
+:host {
+	display: block;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.dashboard-canvas {
+	display: grid;
+	grid-template-columns: repeat(12, minmax(0, 1fr));
+	grid-auto-rows: 80px;
+	gap: 1rem;
+	// Keeps the drop target usable while the canvas is (nearly) empty
+	min-height: 320px;
+	padding: 0.25rem;
+	border-radius: nb-theme(border-radius);
+	transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+	&.editing {
+		// Tint the arrangeable area so the drop target is obvious while editing
+		background-color: nb-theme(background-basic-color-2);
+		box-shadow: inset 0 0 0 1px nb-theme(border-basic-color-3);
+	}
+}
+
+.canvas-cell {
+	position: relative;
+	min-width: 0;
+	min-height: 0;
+	border-radius: nb-theme(border-radius);
+
+	// The widget fills its grid cell
+	> ga-dashboard-widget-host {
+		display: block;
+		height: 100%;
+		width: 100%;
+		overflow: hidden;
+	}
+
+	&.hidden-widget {
+		opacity: 0.5;
+	}
+
+	/*
+	 * A grab rail down the left edge rather than a floating button: the widget
+	 * host owns the card header (title on the left, kebab menu on the right), so
+	 * an overlay button would sit on top of one of them.
+	 */
+	.drag-handle {
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		z-index: 3;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 14px;
+		padding: 0;
+		border: none;
+		border-radius: nb-theme(border-radius) 0 0 nb-theme(border-radius);
+		background-color: nb-theme(color-primary-transparent-200);
+		color: nb-theme(color-primary-default);
+		cursor: grab;
+		opacity: 0;
+		transition: opacity 0.15s ease-in-out;
+
+		nb-icon {
+			font-size: 14px;
+			height: 14px;
+			width: 14px;
+		}
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+
+	// Reveal the grip on hover, and always for keyboard users
+	&:hover .drag-handle,
+	.drag-handle:focus-visible {
+		opacity: 1;
+	}
+}
+
+// Slot left behind in the grid while a cell is dragged
+.canvas-drop-placeholder {
+	height: 100%;
+	width: 100%;
+	border: 2px dashed nb-theme(color-primary-default);
+	border-radius: nb-theme(border-radius);
+	background-color: nb-theme(color-primary-transparent-100);
+}
+
+.canvas-empty {
+	grid-column: 1 / -1;
+	grid-row: 1 / span 4;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
+	padding: 2rem 1rem;
+	text-align: center;
+	border: 2px dashed nb-theme(border-basic-color-4);
+	border-radius: nb-theme(border-radius);
+	background-color: nb-theme(background-basic-color-2);
+	color: nb-theme(text-hint-color);
+
+	&__icon {
+		font-size: 32px;
+		height: 32px;
+		width: 32px;
+		color: nb-theme(text-hint-color);
+	}
+
+	&__title {
+		margin: 0;
+		font-size: 1rem;
+		font-weight: 600;
+		color: nb-theme(text-basic-color);
+	}
+
+	&__hint {
+		margin: 0;
+		max-width: 34rem;
+		font-size: 0.8125rem;
+		line-height: 1.4;
+	}
+}
+
+/*
+ * CDK drag artifacts. The preview is teleported to the <body>, but it is a clone
+ * of the cell and therefore keeps this component's style attribute, so these
+ * scoped rules still match it.
+ */
+.cdk-drag-preview {
+	border-radius: nb-theme(border-radius);
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+	opacity: 0.9;
+}
+
+.cdk-drag-animating,
+.dashboard-canvas.cdk-drop-list-dragging .canvas-cell:not(.cdk-drag-placeholder) {
+	transition: transform 200ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+// Highlight the canvas while a palette item hovers over it
+.dashboard-canvas.cdk-drop-list-receiving,
+.dashboard-canvas.cdk-drop-list-dragging {
+	box-shadow: inset 0 0 0 2px nb-theme(color-primary-default);
+}

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-canvas.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-canvas.component.ts
@@ -1,0 +1,276 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { TranslateService } from '@ngx-translate/core';
+import { IDashboardTab, IDashboardWidgetPlacement } from '@gauzy/contracts';
+import {
+	addPlacement,
+	createId,
+	DASHBOARD_GRID_COLUMNS,
+	DEFAULT_WIDGET_SIZE,
+	movePlacement,
+	packLayout,
+	removePlacement,
+	resizePlacement,
+	WidgetRegistryService
+} from '@gauzy/ui-core/core';
+import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
+
+/** Default id of the canvas CDK drop list — the palette connects to it by name. */
+export const DASHBOARD_CANVAS_DROP_LIST_ID = 'ga-dashboard-canvas-list';
+
+/**
+ * The canvas of a single dashboard tab.
+ *
+ * Renders the tab's widget placements on a 12 column CSS grid, each cell hosting
+ * a `<ga-dashboard-widget-host>`. In edit mode the cells can be reordered by
+ * drag & drop and new widgets can be dropped in from the widget palette.
+ *
+ * All geometry (clamping, packing, insert/move/resize) is delegated to the
+ * shared, unit-tested helpers in `dashboard-layout.utils` — this component only
+ * translates CDK drop events into calls on those helpers and re-emits the
+ * resulting placement list.
+ */
+@Component({
+	selector: 'ga-dashboard-canvas',
+	templateUrl: './dashboard-canvas.component.html',
+	styleUrls: ['./dashboard-canvas.component.scss'],
+	standalone: false
+})
+export class DashboardCanvasComponent extends TranslationBaseComponent {
+	/** Placements of the active tab, always kept in reading order (top-to-bottom, then left-to-right). */
+	public placements: IDashboardWidgetPlacement[] = [];
+
+	private _tab: IDashboardTab | null = null;
+
+	/** The tab being rendered. */
+	@Input()
+	public set tab(value: IDashboardTab | null) {
+		this._tab = value ?? null;
+		this.placements = this._readingOrder(value?.widgets ?? []);
+	}
+	public get tab(): IDashboardTab | null {
+		return this._tab;
+	}
+
+	/** Whether the dashboard is in edit (arrange) mode. */
+	@Input() public editing = false;
+
+	/**
+	 * CDK drop list id of this canvas. The palette connects to this id, so it is
+	 * an input purely to allow more than one canvas on screen later.
+	 */
+	@Input() public dropListId: string = DASHBOARD_CANVAS_DROP_LIST_ID;
+
+	/** Drop lists this canvas may hand items to. Empty by default (the palette rejects drops). */
+	@Input() public connectedTo: string[] = [];
+
+	/** Emits the full placement list of the tab whenever the arrangement changes. */
+	@Output() public readonly layoutChange = new EventEmitter<IDashboardWidgetPlacement[]>();
+
+	/**
+	 * Re-emits a widget's "configure" request so the page can open the settings dialog.
+	 *
+	 * Named `configureRequested` for symmetry with the widget host: outputs here
+	 * must never collide with a native DOM event name.
+	 */
+	@Output() public readonly configureRequested = new EventEmitter<IDashboardWidgetPlacement>();
+
+	constructor(
+		public readonly translateService: TranslateService,
+		private readonly _widgetRegistry: WidgetRegistryService
+	) {
+		super(translateService);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Drag & drop
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Handles a CDK drop on the canvas.
+	 *
+	 * A drop coming from the canvas itself is a reorder; a drop coming from any
+	 * other list is a palette drop and creates a brand new placement.
+	 *
+	 * @param event - The CDK drop event.
+	 */
+	public onDrop(event: CdkDragDrop<IDashboardWidgetPlacement[]>): void {
+		if (!this.editing) {
+			return;
+		}
+
+		if (event.previousContainer === event.container) {
+			if (event.previousIndex === event.currentIndex) {
+				return;
+			}
+			// `movePlacement` performs the move AND repacks, so the array must not
+			// be mutated with `moveItemInArray` first (that would move it twice).
+			this._emit(movePlacement(this.placements, event.previousIndex, event.currentIndex));
+			return;
+		}
+
+		const widgetId = (event.item?.data as { widgetId?: string } | undefined)?.widgetId;
+		if (widgetId) {
+			this.addWidget(widgetId, event.currentIndex);
+		}
+	}
+
+	/**
+	 * Adds a new instance of the given widget to this canvas.
+	 *
+	 * Also the keyboard-accessible path: the palette calls this (through the page)
+	 * when a widget entry is clicked, since dragging is pointer-only.
+	 *
+	 * @param widgetId - Registry key of the widget to add.
+	 * @param index - Optional reading-order index to insert at (from a drop).
+	 */
+	public addWidget(widgetId: string, index?: number): void {
+		const config = this._widgetRegistry.getWidget(widgetId);
+		const size = config?.defaultSize ?? DEFAULT_WIDGET_SIZE;
+		const w = Math.min(Math.max(Math.round(size.w) || DEFAULT_WIDGET_SIZE.w, 1), DASHBOARD_GRID_COLUMNS);
+		const h = Math.max(Math.round(size.h) || DEFAULT_WIDGET_SIZE.h, 1);
+
+		// Pick the first free slot so widgets flow across the 12 columns instead
+		// of stacking in column 0 (`packLayout` only ever adjusts `y`).
+		const { x, y } = this._firstFreeOrigin(w, h);
+		const placement: IDashboardWidgetPlacement = { instanceId: createId(), widgetId, x, y, w, h };
+
+		let next = addPlacement(this.placements, placement);
+		if (typeof index === 'number' && index >= 0 && index < next.length) {
+			const from = next.findIndex((item) => item.instanceId === placement.instanceId);
+			if (from >= 0 && from !== index) {
+				next = movePlacement(next, from, index);
+			}
+		}
+		this._emit(next);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Widget host events
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Removes a widget instance from the canvas.
+	 *
+	 * @param placement - The placement to remove.
+	 */
+	public onRemove(placement: IDashboardWidgetPlacement): void {
+		this._emit(removePlacement(this.placements, placement.instanceId));
+	}
+
+	/**
+	 * Resizes a widget instance.
+	 *
+	 * @param placement - The placement being resized.
+	 * @param size - The requested footprint; missing dimensions are kept as-is.
+	 */
+	public onResize(placement: IDashboardWidgetPlacement, size: { w?: number; h?: number } | null | undefined): void {
+		if (!size || (size.w === undefined && size.h === undefined)) {
+			return;
+		}
+		this._emit(resizePlacement(this.placements, placement.instanceId, size));
+	}
+
+	/**
+	 * Re-emits a widget's configuration request.
+	 *
+	 * `DashboardWidgetHostComponent.configure` is deliberately payload-less — it
+	 * does not own the settings dialog — so the canvas only forwards WHICH
+	 * placement the user wants to configure; the resulting configuration comes
+	 * back through {@link applyConfig}.
+	 *
+	 * @param placement - The placement being configured.
+	 */
+	public onConfigure(placement: IDashboardWidgetPlacement): void {
+		this.configureRequested.emit(placement);
+	}
+
+	/**
+	 * Moves a widget one slot forwards/backwards in reading order.
+	 *
+	 * The keyboard counterpart of dragging the handle: CDK drag & drop is
+	 * pointer-only, so without this the canvas cannot be rearranged at all
+	 * without a mouse.
+	 *
+	 * @param placement - The placement to move.
+	 * @param delta - `-1` to move it earlier, `+1` to move it later.
+	 * @param event - The originating key event, whose default scroll is suppressed.
+	 */
+	public moveBy(placement: IDashboardWidgetPlacement, delta: number, event?: Event): void {
+		event?.preventDefault();
+		if (!this.editing) {
+			return;
+		}
+		const from = this.placements.findIndex((item) => item.instanceId === placement.instanceId);
+		const to = from + delta;
+		if (from < 0 || to < 0 || to >= this.placements.length) {
+			return;
+		}
+		this._emit(movePlacement(this.placements, from, to));
+	}
+
+	/**
+	 * Writes a new per-instance configuration onto a placement.
+	 *
+	 * @param instanceId - The placement to configure.
+	 * @param config - The settings produced by the configuration dialog.
+	 */
+	public applyConfig(instanceId: string, config: Record<string, unknown>): void {
+		this._emit(
+			this.placements.map((item) =>
+				item.instanceId === instanceId ? { ...item, config: { ...config } } : item
+			)
+		);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Internals
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Publishes a new arrangement: keeps the local list in reading order (so CDK
+	 * indices line up with the rendered order) and notifies the page.
+	 */
+	private _emit(placements: IDashboardWidgetPlacement[]): void {
+		this.placements = this._readingOrder(packLayout(placements));
+		this.layoutChange.emit(this.placements);
+	}
+
+	/** Sorts placements top-to-bottom, then left-to-right. */
+	private _readingOrder(placements: IDashboardWidgetPlacement[]): IDashboardWidgetPlacement[] {
+		return [...placements].sort((a, b) => (a.y === b.y ? a.x - b.x : a.y - b.y));
+	}
+
+	/**
+	 * First-fit search for a free `w`x`h` slot, scanning row by row.
+	 *
+	 * Bounded by the current content height, so it always terminates; when no
+	 * gap is large enough the widget starts on a fresh row below everything.
+	 */
+	private _firstFreeOrigin(w: number, h: number): { x: number; y: number } {
+		const bottom = this.placements.reduce((max, item) => Math.max(max, item.y + item.h), 0);
+		for (let y = 0; y <= bottom; y++) {
+			for (let x = 0; x <= DASHBOARD_GRID_COLUMNS - w; x++) {
+				const candidate = { x, y, w, h };
+				if (!this.placements.some((item) => this._collides(candidate, item))) {
+					return { x, y };
+				}
+			}
+		}
+		return { x: 0, y: bottom };
+	}
+
+	/** Do two grid rectangles overlap? */
+	private _collides(
+		a: { x: number; y: number; w: number; h: number },
+		b: { x: number; y: number; w: number; h: number }
+	): boolean {
+		return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-tab-strip.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-tab-strip.component.html
@@ -1,0 +1,81 @@
+<!--
+	A labelled navigation landmark rather than an ARIA tablist: every chip is a
+	wrapper that also carries a kebab button, so the chips cannot be the direct
+	tab children a tablist requires. Switching tabs is a navigation (it updates
+	the tab query parameter), and the active chip is marked with aria-current.
+-->
+<nav class="tab-strip" [attr.aria-label]="'DASHBOARD_PAGE.BUILDER.TABS.TITLE' | translate">
+	<div
+		class="tab-strip__list"
+		cdkDropList
+		cdkDropListOrientation="horizontal"
+		[cdkDropListDisabled]="!editing"
+		(cdkDropListDropped)="onDrop($event)"
+	>
+		@for (tab of tabs; track tab.id) {
+			<div class="tab-chip" [class.active]="tab.id === activeTabId" cdkDrag [cdkDragDisabled]="!editing">
+				<div class="tab-chip__placeholder" *cdkDragPlaceholder></div>
+
+				<button
+					type="button"
+					class="tab-chip__label"
+					[attr.aria-current]="tab.id === activeTabId ? 'true' : null"
+					(click)="onSelect(tab)"
+				>
+					@if (tab.icon) {
+						<nb-icon class="tab-chip__icon" [icon]="tab.icon"></nb-icon>
+					}
+					{{ tab.name }}
+				</button>
+
+				@if (editing) {
+					<button
+						type="button"
+						class="tab-chip__menu"
+						[nbPopover]="tabActions"
+						nbPopoverPlacement="bottom"
+						nbPopoverTrigger="click"
+						[attr.aria-label]="'DASHBOARD_PAGE.BUILDER.TABS.TAB_ACTIONS' | translate: { name: tab.name }"
+						(click)="openMenu(tab)"
+					>
+						<nb-icon icon="more-vertical-outline"></nb-icon>
+					</button>
+				}
+			</div>
+		}
+
+		@if (editing) {
+			<button
+				type="button"
+				class="tab-add"
+				[attr.aria-label]="'DASHBOARD_PAGE.BUILDER.TABS.ADD_TAB' | translate"
+				[nbTooltip]="'DASHBOARD_PAGE.BUILDER.TABS.ADD_TAB' | translate"
+				(click)="promptAdd()"
+			>
+				<nb-icon icon="plus-outline"></nb-icon>
+			</button>
+		}
+	</div>
+</nav>
+
+<!-- Shared kebab menu; menuTab is set by the button that opened it -->
+<ng-template #tabActions>
+	@if (menuTab) {
+		<div class="tab-actions-popover">
+			<button type="button" class="action" (click)="promptRename(menuTab)">
+				<nb-icon icon="edit-2-outline"></nb-icon>
+				{{ 'DASHBOARD_PAGE.BUILDER.TABS.RENAME_TAB' | translate }}
+			</button>
+			<button type="button" class="action" (click)="onDuplicate(menuTab)">
+				<nb-icon icon="copy-outline"></nb-icon>
+				{{ 'DASHBOARD_PAGE.BUILDER.TABS.DUPLICATE_TAB' | translate }}
+			</button>
+			@if (canDelete) {
+				<button type="button" class="action danger" (click)="confirmDelete(menuTab)">
+					<nb-icon icon="trash-2-outline"></nb-icon>
+					{{ 'DASHBOARD_PAGE.BUILDER.TABS.DELETE_TAB' | translate }}
+				</button>
+			}
+		</div>
+	}
+</ng-template>

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-tab-strip.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-tab-strip.component.scss
@@ -1,0 +1,190 @@
+@use 'var' as *;
+
+:host {
+	display: block;
+}
+
+// Single keyboard-focus treatment for every control in the strip, so tabbing
+// through chips, kebab menus and popover actions looks the same everywhere.
+@mixin tab-strip-focus-ring {
+	outline: 2px solid nb-theme(color-primary-default);
+	outline-offset: -2px;
+}
+
+.tab-strip {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+
+	&__list {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		flex: 1 1 auto;
+		min-width: 0;
+		padding: 0.25rem 0;
+		overflow-x: auto;
+		// The strip scrolls horizontally without showing a scrollbar
+		scrollbar-width: none;
+		-ms-overflow-style: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
+	}
+}
+
+.tab-chip {
+	display: inline-flex;
+	align-items: center;
+	flex: 0 0 auto;
+	border: 1px solid nb-theme(border-basic-color-4);
+	border-radius: nb-theme(border-radius);
+	background-color: nb-theme(card-background-color);
+	color: nb-theme(text-basic-color);
+	overflow: hidden;
+	transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, color 0.15s ease-in-out;
+
+	&:hover {
+		background-color: nb-theme(background-basic-color-2);
+	}
+
+	&.active {
+		border-color: nb-theme(color-primary-default);
+		background-color: nb-theme(color-primary-default);
+		color: nb-theme(text-control-color);
+
+		.tab-chip__menu {
+			color: nb-theme(text-control-color);
+		}
+	}
+
+	&.cdk-drag-preview {
+		border-radius: nb-theme(border-radius);
+		box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+	}
+
+	&__label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.3125rem 0.75rem;
+		border: none;
+		background: none;
+		font-family: inherit;
+		font-size: 0.75rem;
+		font-weight: 600;
+		white-space: nowrap;
+		color: inherit;
+		cursor: pointer;
+
+		&:focus-visible {
+			@include tab-strip-focus-ring;
+		}
+	}
+
+	&__icon {
+		font-size: 14px;
+		height: 14px;
+		width: 14px;
+	}
+
+	&__menu {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		padding: 0.3125rem 0.375rem 0.3125rem 0;
+		border: none;
+		background: none;
+		color: nb-theme(text-hint-color);
+		cursor: pointer;
+
+		nb-icon {
+			font-size: 14px;
+			height: 14px;
+			width: 14px;
+		}
+
+		&:focus-visible {
+			@include tab-strip-focus-ring;
+		}
+	}
+
+	// CDK swaps this in for the whole chip, so it needs its own footprint
+	&__placeholder {
+		height: 28px;
+		width: 80px;
+		border: 1px dashed nb-theme(color-primary-default);
+		border-radius: nb-theme(border-radius);
+		background-color: nb-theme(color-primary-transparent-100);
+	}
+}
+
+.tab-add {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	height: 26px;
+	width: 26px;
+	padding: 0;
+	border: 1px dashed nb-theme(border-basic-color-4);
+	border-radius: nb-theme(border-radius);
+	background: none;
+	color: nb-theme(text-hint-color);
+	cursor: pointer;
+	transition: border-color 0.15s ease-in-out, color 0.15s ease-in-out;
+
+	nb-icon {
+		font-size: 14px;
+		height: 14px;
+		width: 14px;
+	}
+
+	&:hover,
+	&:focus-visible {
+		border-color: nb-theme(color-primary-default);
+		color: nb-theme(color-primary-default);
+	}
+}
+
+.tab-actions-popover {
+	display: flex;
+	flex-direction: column;
+	padding: 0.5rem 0;
+	min-width: 180px;
+
+	.action {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		padding: 0.5rem 1rem;
+		border: none;
+		background: none;
+		font-family: inherit;
+		font-size: 0.8125rem;
+		text-align: left;
+		color: nb-theme(text-basic-color);
+		cursor: pointer;
+
+		nb-icon {
+			font-size: 16px;
+			height: 16px;
+			width: 16px;
+		}
+
+		&:hover {
+			background-color: nb-theme(background-basic-color-2);
+		}
+
+		&:focus-visible {
+			@include tab-strip-focus-ring;
+		}
+
+		&.danger {
+			color: nb-theme(color-danger-default);
+		}
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-tab-strip.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/dashboard-tab-strip.component.ts
@@ -1,0 +1,218 @@
+import { Component, EventEmitter, Input, Output, QueryList, ViewChildren } from '@angular/core';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { firstValueFrom } from 'rxjs';
+import { NbDialogService, NbPopoverDirective } from '@nebular/theme';
+import { TranslateService } from '@ngx-translate/core';
+import { IDashboardTab } from '@gauzy/contracts';
+import { ConfirmComponent, PromptComponent } from '@gauzy/ui-core/shared';
+import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
+
+/**
+ * Horizontal tab strip of a custom dashboard.
+ *
+ * Read-only mode is a plain chip row. Edit mode adds a `+` button, a per-tab
+ * kebab menu (Rename / Duplicate / Delete) and horizontal drag reordering.
+ *
+ * The component owns the Prompt/Confirm dialogs and emits the RESULT of the
+ * interaction (a name, a confirmed tab, the reordered list), so the page stays
+ * free of dialog plumbing.
+ */
+@Component({
+	selector: 'ga-dashboard-tab-strip',
+	templateUrl: './dashboard-tab-strip.component.html',
+	styleUrls: ['./dashboard-tab-strip.component.scss'],
+	standalone: false
+})
+export class DashboardTabStripComponent extends TranslationBaseComponent {
+	/** Tabs of the dashboard, in display order. */
+	@Input() public tabs: IDashboardTab[] = [];
+
+	/** Id of the currently displayed tab. */
+	@Input() public activeTabId: string | null = null;
+
+	/** Whether the dashboard is in edit (arrange) mode. */
+	@Input() public editing = false;
+
+	/*
+	|--------------------------------------------------------------------------
+	| Outputs
+	|--------------------------------------------------------------------------
+	| None of these may be named after a native DOM event (`select`, `add`,
+	| `delete`, ...): such an output shadows the real event on the host element,
+	| so a parent binding can fire twice or bind the wrong thing entirely.
+	*/
+
+	/** Emits the id of the tab the user switched to. */
+	@Output() public readonly tabSelect = new EventEmitter<string>();
+
+	/** Emits the name entered for a new tab. */
+	@Output() public readonly addRequested = new EventEmitter<string>();
+
+	/** Emits the tab together with its new name. */
+	@Output() public readonly renameRequested = new EventEmitter<{ tab: IDashboardTab; name: string }>();
+
+	/** Emits the tab to duplicate. */
+	@Output() public readonly duplicateRequested = new EventEmitter<IDashboardTab>();
+
+	/** Emits the tab to delete (already confirmed by the user). */
+	@Output() public readonly deleteRequested = new EventEmitter<IDashboardTab>();
+
+	/** Emits the full tab list in its new order, with `order` re-numbered. */
+	@Output() public readonly reordered = new EventEmitter<IDashboardTab[]>();
+
+	/** Tab whose kebab menu is currently open (the menu template reads it). */
+	public menuTab: IDashboardTab | null = null;
+
+	@ViewChildren(NbPopoverDirective) private readonly _popovers: QueryList<NbPopoverDirective>;
+
+	constructor(
+		public readonly translateService: TranslateService,
+		private readonly _dialogService: NbDialogService
+	) {
+		super(translateService);
+	}
+
+	/** The last tab may not be deleted — a dashboard always has one canvas. */
+	public get canDelete(): boolean {
+		return this.tabs.length > 1;
+	}
+
+	/**
+	 * Switches to the given tab.
+	 *
+	 * @param tab - The tab to display.
+	 */
+	public onSelect(tab: IDashboardTab): void {
+		if (tab.id !== this.activeTabId) {
+			this.tabSelect.emit(tab.id);
+		}
+	}
+
+	/**
+	 * Opens the kebab menu of a tab.
+	 *
+	 * Runs before Nebular renders the popover (Angular host listeners fire first),
+	 * so the shared menu template already knows which tab it belongs to.
+	 *
+	 * @param tab - The tab whose menu is opening.
+	 */
+	public openMenu(tab: IDashboardTab): void {
+		this.menuTab = tab;
+	}
+
+	/**
+	 * Reorders the tabs after a horizontal drag.
+	 *
+	 * @param event - The CDK drop event.
+	 */
+	public onDrop(event: CdkDragDrop<IDashboardTab[]>): void {
+		if (!this.editing || event.previousIndex === event.currentIndex) {
+			return;
+		}
+		const tabs = [...this.tabs];
+		moveItemInArray(tabs, event.previousIndex, event.currentIndex);
+		this.reordered.emit(tabs.map((tab, index) => ({ ...tab, order: index })));
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Edit-mode actions
+	|--------------------------------------------------------------------------
+	*/
+
+	/** Prompts for a name and emits it as a new tab request. */
+	public async promptAdd(): Promise<void> {
+		const name = await this._promptForName('DASHBOARD_PAGE.BUILDER.TABS.ADD_TAB');
+		if (name) {
+			this.addRequested.emit(name);
+		}
+	}
+
+	/**
+	 * Prompts for a new name for the given tab.
+	 *
+	 * The prompt opens pre-filled with the current name: renaming is usually a
+	 * small edit, and an empty box would force the user to retype it in full.
+	 *
+	 * @param tab - The tab to rename.
+	 */
+	public async promptRename(tab: IDashboardTab): Promise<void> {
+		this._closeMenus();
+		const name = await this._promptForName('DASHBOARD_PAGE.BUILDER.TABS.RENAME_TAB', tab.name);
+		if (name) {
+			this.renameRequested.emit({ tab, name });
+		}
+	}
+
+	/**
+	 * Requests a duplicate of the given tab.
+	 *
+	 * @param tab - The tab to duplicate.
+	 */
+	public onDuplicate(tab: IDashboardTab): void {
+		this._closeMenus();
+		this.duplicateRequested.emit(tab);
+	}
+
+	/**
+	 * Asks for confirmation, then requests deletion of the given tab.
+	 *
+	 * @param tab - The tab to delete.
+	 */
+	public async confirmDelete(tab: IDashboardTab): Promise<void> {
+		this._closeMenus();
+		if (!this.canDelete) {
+			return;
+		}
+
+		const dialogRef = this._dialogService.open(ConfirmComponent, {
+			context: {
+				data: {
+					title: this.getTranslation('DASHBOARD_PAGE.BUILDER.TABS.DELETE_TAB'),
+					message: this.getTranslation('DASHBOARD_PAGE.BUILDER.TABS.DELETE_CONFIRM', { name: tab.name })
+				}
+			}
+		});
+
+		if (await firstValueFrom(dialogRef.onClose)) {
+			this.deleteRequested.emit(tab);
+		}
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Internals
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Opens a prompt dialog asking for a tab name.
+	 *
+	 * @param titleKey - Translation key for the dialog title.
+	 * @param value - Initial value of the input (used when renaming).
+	 * @returns The trimmed name, or `null` when cancelled/empty.
+	 */
+	private async _promptForName(titleKey: string, value = ''): Promise<string | null> {
+		const dialogRef = this._dialogService.open(PromptComponent, {
+			context: {
+				data: {
+					title: this.getTranslation(titleKey),
+					label: this.getTranslation('DASHBOARD_PAGE.BUILDER.TABS.NAME_LABEL'),
+					placeholder: this.getTranslation('DASHBOARD_PAGE.BUILDER.TABS.NAME_PLACEHOLDER'),
+					okText: this.getTranslation('BUTTONS.OK'),
+					cancelText: this.getTranslation('BUTTONS.CANCEL'),
+					inputType: 'text',
+					value
+				}
+			}
+		});
+
+		const name = await firstValueFrom(dialogRef.onClose);
+		return typeof name === 'string' && name.trim().length > 0 ? name.trim() : null;
+	}
+
+	/** Hides every kebab popover (only one can be open at a time). */
+	private _closeMenus(): void {
+		this._popovers?.forEach((popover: NbPopoverDirective) => popover.hide());
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/widget-palette.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/widget-palette.component.html
@@ -1,0 +1,100 @@
+<aside class="widget-palette" [attr.aria-label]="'DASHBOARD_PAGE.BUILDER.PALETTE.TITLE' | translate">
+	<header class="palette-header">
+		<h5 class="palette-header__title">{{ 'DASHBOARD_PAGE.BUILDER.PALETTE.TITLE' | translate }}</h5>
+		<p class="palette-header__hint">{{ 'DASHBOARD_PAGE.BUILDER.PALETTE.HINT' | translate }}</p>
+	</header>
+
+	<div class="palette-search">
+		<input
+			#searchInput
+			nbInput
+			fullWidth
+			fieldSize="small"
+			type="text"
+			autocomplete="off"
+			[placeholder]="'DASHBOARD_PAGE.BUILDER.PALETTE.SEARCH_PLACEHOLDER' | translate"
+			[attr.aria-label]="'DASHBOARD_PAGE.BUILDER.PALETTE.SEARCH_PLACEHOLDER' | translate"
+			(input)="onSearch($event)"
+		/>
+		@if (term) {
+			<button
+				type="button"
+				class="palette-search__clear"
+				[attr.aria-label]="'DASHBOARD_PAGE.BUILDER.PALETTE.CLEAR_SEARCH' | translate"
+				(click)="clearSearch(searchInput)"
+			>
+				<nb-icon icon="close-outline"></nb-icon>
+			</button>
+		}
+	</div>
+
+	<div
+		class="palette-list"
+		cdkDropList
+		cdkDropListSortingDisabled
+		[id]="dropListId"
+		[cdkDropListConnectedTo]="connectedTo"
+		[cdkDropListEnterPredicate]="rejectDrops"
+	>
+		@for (group of groups(); track group.category) {
+			<section class="palette-group">
+				<button
+					type="button"
+					class="palette-group__header"
+					[attr.aria-expanded]="isExpanded(group.category)"
+					(click)="toggleCategory(group.category)"
+				>
+					<nb-icon
+						class="palette-group__chevron"
+						[icon]="isExpanded(group.category) ? 'chevron-down-outline' : 'chevron-right-outline'"
+					></nb-icon>
+					<span class="palette-group__label">{{ group.labelKey | translate }}</span>
+					<span class="palette-group__count">{{ group.items.length }}</span>
+				</button>
+
+				@if (isExpanded(group.category)) {
+					@for (item of group.items; track item.widgetId) {
+						<button
+							type="button"
+							class="palette-item"
+							cdkDrag
+							[cdkDragData]="{ widgetId: item.widgetId }"
+							[attr.aria-label]="
+								'DASHBOARD_PAGE.BUILDER.PALETTE.ADD_WIDGET' | translate: { name: item.title }
+							"
+							[nbTooltip]="'DASHBOARD_PAGE.BUILDER.PALETTE.ADD_WIDGET' | translate: { name: item.title }"
+							(cdkDragStarted)="onDragStarted()"
+							(cdkDragEnded)="onDragEnded()"
+							(click)="onPick(item.widgetId)"
+						>
+							<nb-icon class="palette-item__icon" [icon]="item.icon"></nb-icon>
+							<span class="palette-item__text">
+								<span class="palette-item__title">{{ item.title }}</span>
+								@if (item.description) {
+									<span class="palette-item__description">{{ item.description }}</span>
+								}
+							</span>
+							<nb-icon class="palette-item__add" icon="plus-outline"></nb-icon>
+
+							<!-- Compact drag preview instead of a clone of the whole row -->
+							<div class="palette-drag-preview" *cdkDragPreview>
+								<nb-icon [icon]="item.icon"></nb-icon>
+								<span>{{ item.title }}</span>
+							</div>
+						</button>
+					}
+				}
+			</section>
+		}
+
+		@if (!total()) {
+			<p class="palette-empty">
+				@if (term) {
+					{{ 'DASHBOARD_PAGE.BUILDER.PALETTE.NO_RESULTS' | translate: { term: term } }}
+				} @else {
+					{{ 'DASHBOARD_PAGE.BUILDER.PALETTE.NO_WIDGETS' | translate }}
+				}
+			</p>
+		}
+	</div>
+</aside>

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/widget-palette.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/widget-palette.component.scss
@@ -1,0 +1,231 @@
+@use 'var' as *;
+
+:host {
+	display: block;
+	flex: 0 0 auto;
+	width: 300px;
+	max-width: 100%;
+	min-width: 0;
+}
+
+.widget-palette {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	max-height: 100%;
+	border: 1px solid nb-theme(border-basic-color-3);
+	border-radius: nb-theme(border-radius);
+	background-color: nb-theme(card-background-color);
+	overflow: hidden;
+}
+
+.palette-header {
+	padding: 0.75rem 0.75rem 0.5rem;
+	border-bottom: 1px solid nb-theme(border-basic-color-3);
+
+	&__title {
+		margin: 0;
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: nb-theme(text-basic-color);
+	}
+
+	&__hint {
+		margin: 0.25rem 0 0;
+		font-size: 0.75rem;
+		line-height: 1.35;
+		color: nb-theme(text-hint-color);
+	}
+}
+
+.palette-search {
+	position: relative;
+	padding: 0.5rem 0.75rem;
+
+	&__clear {
+		position: absolute;
+		top: 50%;
+		right: 1.125rem;
+		transform: translateY(-50%);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		height: 20px;
+		width: 20px;
+		padding: 0;
+		border: none;
+		background: none;
+		color: nb-theme(text-hint-color);
+		cursor: pointer;
+
+		nb-icon {
+			font-size: 14px;
+			height: 14px;
+			width: 14px;
+		}
+
+		&:hover {
+			color: nb-theme(text-basic-color);
+		}
+	}
+}
+
+.palette-list {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 0 0.5rem 0.75rem;
+}
+
+.palette-group {
+	display: block;
+
+	&__header {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		width: 100%;
+		padding: 0.5rem 0.25rem;
+		border: none;
+		background: none;
+		font-family: inherit;
+		font-size: 0.6875rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		text-align: left;
+		color: nb-theme(text-hint-color);
+		cursor: pointer;
+
+		&:hover {
+			color: nb-theme(text-basic-color);
+		}
+	}
+
+	&__chevron {
+		font-size: 14px;
+		height: 14px;
+		width: 14px;
+		flex: 0 0 auto;
+	}
+
+	&__label {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	&__count {
+		flex: 0 0 auto;
+		font-weight: 600;
+		color: nb-theme(text-hint-color);
+	}
+}
+
+.palette-item {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	width: 100%;
+	margin-bottom: 0.25rem;
+	padding: 0.5rem;
+	border: 1px solid nb-theme(border-basic-color-3);
+	border-radius: nb-theme(border-radius);
+	background-color: nb-theme(background-basic-color-1);
+	font-family: inherit;
+	text-align: left;
+	color: nb-theme(text-basic-color);
+	cursor: grab;
+	transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
+
+	&:hover,
+	&:focus-visible {
+		border-color: nb-theme(color-primary-default);
+		background-color: nb-theme(background-basic-color-2);
+
+		.palette-item__add {
+			opacity: 1;
+		}
+	}
+
+	&:active {
+		cursor: grabbing;
+	}
+
+	&__icon {
+		flex: 0 0 auto;
+		font-size: 18px;
+		height: 18px;
+		width: 18px;
+		color: nb-theme(text-hint-color);
+	}
+
+	&__text {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	&__title {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		line-height: 1.2;
+		// Long widget names must not blow the panel width out
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__description {
+		font-size: 0.6875rem;
+		line-height: 1.3;
+		color: nb-theme(text-hint-color);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__add {
+		flex: 0 0 auto;
+		font-size: 16px;
+		height: 16px;
+		width: 16px;
+		color: nb-theme(color-primary-default);
+		opacity: 0;
+		transition: opacity 0.15s ease-in-out;
+	}
+}
+
+.palette-empty {
+	margin: 1rem 0.5rem;
+	font-size: 0.75rem;
+	line-height: 1.4;
+	text-align: center;
+	color: nb-theme(text-hint-color);
+}
+
+/*
+ * Custom drag preview (a compact chip). It is teleported to the <body> but keeps
+ * this component's style attribute, so the scoped rule still matches it.
+ */
+.palette-drag-preview {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.375rem 0.625rem;
+	border: 1px solid nb-theme(color-primary-default);
+	border-radius: nb-theme(border-radius);
+	background-color: nb-theme(card-background-color);
+	color: nb-theme(text-basic-color);
+	font-size: 0.8125rem;
+	font-weight: 600;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+
+	nb-icon {
+		font-size: 16px;
+		height: 16px;
+		width: 16px;
+		color: nb-theme(color-primary-default);
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/custom-dashboard/widget-palette.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/custom-dashboard/widget-palette.component.ts
@@ -1,0 +1,304 @@
+import { Component, EventEmitter, Injector, Input, Output, Signal, runInInjectionContext } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ResolveFn } from '@angular/router';
+import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { map, shareReplay, startWith } from 'rxjs/operators';
+import { TranslateService } from '@ngx-translate/core';
+import { PermissionsEnum } from '@gauzy/contracts';
+import { Store, WidgetCategory, WidgetRegistryConfig, WidgetRegistryService } from '@gauzy/ui-core/core';
+import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
+import { DASHBOARD_CANVAS_DROP_LIST_ID } from './dashboard-canvas.component';
+
+/** A single palette entry (a registered widget the user may add). */
+export interface IWidgetPaletteItem {
+	widgetId: string;
+	title: string;
+	description?: string;
+	icon: string;
+	category: WidgetCategory;
+}
+
+/** Palette entries of one category. */
+export interface IWidgetPaletteGroup {
+	category: WidgetCategory;
+	/** Translation key of the category heading. */
+	labelKey: string;
+	items: IWidgetPaletteItem[];
+}
+
+/** Display order of the palette categories (anything unknown falls to the end). */
+const CATEGORY_ORDER: WidgetCategory[] = [
+	'time-tracking',
+	'accounting',
+	'hr',
+	'teams',
+	'project-management',
+	'plugin',
+	'other'
+];
+
+/** Category -> translation key suffix under `DASHBOARD_PAGE.BUILDER.CATEGORIES`. */
+const CATEGORY_LABELS: Record<WidgetCategory, string> = {
+	'time-tracking': 'TIME_TRACKING',
+	accounting: 'ACCOUNTING',
+	hr: 'HR',
+	teams: 'TEAMS',
+	'project-management': 'PROJECT_MANAGEMENT',
+	plugin: 'PLUGIN',
+	other: 'OTHER'
+};
+
+/**
+ * Right-hand panel listing every widget the current user may place on a canvas.
+ *
+ * Entries can be dragged onto the canvas, and — because dragging is pointer-only
+ * and therefore not keyboard accessible — clicking (or pressing Enter on) an
+ * entry adds it too, which is the accessible path.
+ */
+@Component({
+	selector: 'ga-widget-palette',
+	templateUrl: './widget-palette.component.html',
+	styleUrls: ['./widget-palette.component.scss'],
+	standalone: false
+})
+export class WidgetPaletteComponent extends TranslationBaseComponent {
+	/** CDK drop list id of the palette itself (nothing may be dropped into it). */
+	@Input() public dropListId = 'ga-widget-palette-list';
+
+	/** Drop lists palette entries may be dragged into. */
+	@Input() public connectedTo: string[] = [DASHBOARD_CANVAS_DROP_LIST_ID];
+
+	/**
+	 * Emits the registry key of the widget to add (click / keyboard path).
+	 *
+	 * Named `addRequested` rather than `add`: an output that shadows a native DOM
+	 * event name makes a parent binding ambiguous.
+	 */
+	@Output() public readonly addRequested = new EventEmitter<string>();
+
+	/** Categories with their (permission- and search-filtered) widgets. */
+	public readonly groups: Signal<IWidgetPaletteGroup[]>;
+
+	/** Total number of visible entries, used for the "no results" state. */
+	public readonly total: Signal<number>;
+
+	/** Current search term (mirrored as a field so the template needs no async pipe). */
+	public term = '';
+
+	/** Current search term. */
+	public readonly search$ = new BehaviorSubject<string>('');
+
+	/** Categories the user collapsed (all expanded by default). */
+	private readonly _collapsed = new Set<WidgetCategory>();
+
+	/**
+	 * True between `cdkDragStarted` and `cdkDragEnded`.
+	 *
+	 * Palette entries are `<button>`s so they can be activated from the keyboard,
+	 * which means a pointer drag can be followed by a `click` on the same element
+	 * — that would add the widget twice (once on drop, once on click).
+	 */
+	private _dragging = false;
+
+	constructor(
+		public readonly translateService: TranslateService,
+		private readonly _widgetRegistry: WidgetRegistryService,
+		private readonly _store: Store,
+		private readonly _injector: Injector
+	) {
+		super(translateService);
+
+		// `shareReplay` so the two signals below share ONE registry subscription.
+		const groups$: Observable<IWidgetPaletteGroup[]> = combineLatest([
+			this._widgetRegistry.getWidgets$(),
+			// Re-filter when the permission set changes (role switch / reload)
+			this._store.userRolePermissions$.pipe(startWith(this._store.userRolePermissions ?? [])),
+			this.search$,
+			// `_buildGroups` resolves titles/descriptions EAGERLY, so a language
+			// switch has to rebuild them — otherwise the palette keeps the old
+			// labels (and searches against them) until something else changes.
+			this.translateService.onLangChange.pipe(startWith(null))
+		]).pipe(
+			map(([widgets, , term]) => this._buildGroups(widgets, term)),
+			shareReplay({ bufferSize: 1, refCount: true })
+		);
+
+		this.groups = toSignal(groups$, { initialValue: [] as IWidgetPaletteGroup[] });
+		this.total = toSignal(
+			groups$.pipe(map((groups) => groups.reduce((sum, group) => sum + group.items.length, 0))),
+			{ initialValue: 0 }
+		);
+	}
+
+	/**
+	 * Nothing may be dropped back into the palette — it is a source list only.
+	 * CDK still needs it to be a drop list so its items can be dragged out.
+	 */
+	public readonly rejectDrops = (): boolean => false;
+
+	/**
+	 * Updates the search term.
+	 *
+	 * @param event - The input event of the search box.
+	 */
+	public onSearch(event: Event): void {
+		this.term = (event.target as HTMLInputElement)?.value ?? '';
+		this.search$.next(this.term);
+	}
+
+	/**
+	 * Clears the search term.
+	 *
+	 * @param input - The search box, reset alongside the stream.
+	 */
+	public clearSearch(input: HTMLInputElement): void {
+		input.value = '';
+		this.term = '';
+		this.search$.next('');
+	}
+
+	/** Remembers that a pointer drag is in progress. */
+	public onDragStarted(): void {
+		this._dragging = true;
+	}
+
+	/**
+	 * Clears the drag flag one task later, so the synthetic `click` some browsers
+	 * fire on the source element right after a drop still sees it set.
+	 */
+	public onDragEnded(): void {
+		setTimeout(() => (this._dragging = false));
+	}
+
+	/**
+	 * Adds a widget from a click / keyboard activation.
+	 *
+	 * Ignored right after a drag: the drop already added the widget.
+	 *
+	 * @param widgetId - Registry key of the widget to add.
+	 */
+	public onPick(widgetId: string): void {
+		if (this._dragging) {
+			return;
+		}
+		this.addRequested.emit(widgetId);
+	}
+
+	/**
+	 * Toggles a category open/closed.
+	 *
+	 * @param category - The category to toggle.
+	 */
+	public toggleCategory(category: WidgetCategory): void {
+		if (this._collapsed.has(category)) {
+			this._collapsed.delete(category);
+		} else {
+			this._collapsed.add(category);
+		}
+	}
+
+	/**
+	 * Is the given category expanded?
+	 *
+	 * @param category - The category to check.
+	 */
+	public isExpanded(category: WidgetCategory): boolean {
+		return !this._collapsed.has(category);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Internals
+	|--------------------------------------------------------------------------
+	*/
+
+	/** Builds the permission- and search-filtered category groups. */
+	private _buildGroups(widgets: WidgetRegistryConfig[], term: string): IWidgetPaletteGroup[] {
+		const needle = (term ?? '').trim().toLowerCase();
+
+		const items = (widgets ?? [])
+			.filter((widget) => this._isPermitted(widget))
+			.map((widget) => this._toItem(widget))
+			.filter((item) => !needle || this._matches(item, needle))
+			.sort((a, b) => a.title.localeCompare(b.title));
+
+		const byCategory = new Map<WidgetCategory, IWidgetPaletteItem[]>();
+		for (const item of items) {
+			const bucket = byCategory.get(item.category) ?? [];
+			bucket.push(item);
+			byCategory.set(item.category, bucket);
+		}
+
+		return [...byCategory.keys()]
+			.sort((a, b) => this._categoryRank(a) - this._categoryRank(b))
+			.map((category) => ({
+				category,
+				labelKey: `DASHBOARD_PAGE.BUILDER.CATEGORIES.${CATEGORY_LABELS[category] ?? 'OTHER'}`,
+				items: byCategory.get(category) ?? []
+			}));
+	}
+
+	/**
+	 * A widget with no declared permissions is available to everyone; otherwise
+	 * the user needs at least one of them (mirrors the widget page gating).
+	 */
+	private _isPermitted(widget: WidgetRegistryConfig): boolean {
+		const permissions = (widget?.permissions ?? []) as PermissionsEnum[];
+		return permissions.length === 0 || this._store.hasAnyPermission(...permissions);
+	}
+
+	/** Maps a registry entry to its palette view model. */
+	private _toItem(widget: WidgetRegistryConfig): IWidgetPaletteItem {
+		return {
+			widgetId: widget.widgetId,
+			title: this._resolveText(widget.title) || widget.widgetId,
+			description: this._resolveText(widget.description),
+			icon: widget.icon || 'cube-outline',
+			category: widget.category ?? 'other'
+		};
+	}
+
+	/** Does the entry match the search term (title, description or id)? */
+	private _matches(item: IWidgetPaletteItem, needle: string): boolean {
+		return [item.title, item.description, item.widgetId]
+			.filter((value): value is string => !!value)
+			.some((value) => value.toLowerCase().includes(needle));
+	}
+
+	/**
+	 * Resolves a registry title/description, which may be a literal, a
+	 * translation key, or a resolver function.
+	 *
+	 * Registry resolvers are typed as `ResolveFn` but never read their route
+	 * arguments; they commonly call `inject()`, so they are run in an injection
+	 * context — exactly like `<ga-dashboard-widget-host>` does — otherwise every
+	 * resolver-titled widget would fall back to showing its raw id. Only
+	 * synchronous string results are used: the palette renders a plain list and
+	 * has nowhere to await a promise.
+	 */
+	private _resolveText(value: unknown): string | undefined {
+		if (typeof value === 'string') {
+			// A translation key resolves; a plain label falls through unchanged.
+			return this.getTranslation(value) || value;
+		}
+		if (typeof value === 'function') {
+			try {
+				const resolved = runInInjectionContext(this._injector, () =>
+					(value as ResolveFn<string>)(null as never, null as never)
+				);
+				return typeof resolved === 'string' ? this.getTranslation(resolved) || resolved : undefined;
+			} catch {
+				// A resolver that needs a real route activation must not take the
+				// whole palette down — the entry simply shows no extra text.
+				return undefined;
+			}
+		}
+		return undefined;
+	}
+
+	/** Sort rank of a category (unknown categories go last). */
+	private _categoryRank(category: WidgetCategory): number {
+		const index = CATEGORY_ORDER.indexOf(category);
+		return index === -1 ? CATEGORY_ORDER.length : index;
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard-switcher/dashboard-switcher.component.scss
@@ -85,39 +85,74 @@
 	color: var(--text-hint-color);
 }
 
+// ⋮ actions menu. The nb-popover host supplies the container chrome (1px
+// hairline + soft shadow + 8px radius) from
+// `packages/ui-core/static/styles/_overlays.scss`; everything below is the FLAT
+// item layer — no per-row border, shadow or resting fill.
 .dashboard-actions-popover {
 	display: flex;
 	flex-direction: column;
-	padding: 8px 0;
-	min-width: 200px;
+	// Just enough inset that a hovered row's 6px radius never touches the
+	// container edge.
+	padding: 4px;
+	min-width: 11rem;
 
 	.action {
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		padding: 8px 16px;
+		padding: 6px 10px;
+		border-radius: 6px;
 		font-size: 13px;
+		line-height: 1.25rem;
 		color: var(--text-basic-color);
 		cursor: pointer;
 		// native <button> resets (keyboard-accessible menu items)
 		background: none;
 		border: none;
 		width: 100%;
-		text-align: left;
+		// Logical keyword so the row flips on its own in RTL.
+		text-align: start;
 		font-family: inherit;
+		// Colour only: transitioning `all` would animate the radius and make the
+		// row look like it is inflating into a block.
+		transition: background-color 0.12s ease-in-out, color 0.12s ease-in-out;
 
 		nb-icon {
-			font-size: 16px;
-			height: 16px;
-			width: 16px;
+			flex-shrink: 0;
+			font-size: 14px;
+			height: 14px;
+			width: 14px;
+			// Muted glyph, brought up to full contrast on hover.
+			color: var(--text-hint-color);
+			transition: color 0.12s ease-in-out;
 		}
 
+		// Was `--background-basic-color-2`, which is the SAME colour as the
+		// popover surface in the dark themes — the hover state was invisible
+		// there. A neutral low-alpha tint reads on both backgrounds.
 		&:hover {
-			background-color: var(--background-basic-color-2);
+			background-color: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12));
+
+			nb-icon {
+				color: var(--text-basic-color);
+			}
 		}
 
 		&.danger {
 			color: var(--color-danger-default);
+
+			nb-icon {
+				color: var(--color-danger-default);
+			}
+
+			&:hover {
+				background-color: var(--color-danger-transparent-100);
+
+				nb-icon {
+					color: var(--color-danger-default);
+				}
+			}
 		}
 	}
 }

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.module.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.module.ts
@@ -1,5 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { RouterModule, ROUTES } from '@angular/router';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import {
 	NbAlertModule,
 	NbBadgeModule,
@@ -27,6 +28,7 @@ import { PageExtensionSlotComponent } from '@gauzy/plugin-ui';
 import {
 	ActivityItemModule,
 	CounterPointComponent,
+	DashboardWidgetHostComponent,
 	DialogsModule,
 	DynamicTabsModule,
 	GalleryModule,
@@ -47,6 +49,10 @@ import { PageRouteRegistryService } from '@gauzy/ui-core/core';
 import { createDashboardRoutes } from './dashboard.routes';
 import { DashboardComponent } from './dashboard.component';
 import { DashboardSwitcherComponent } from './dashboard-switcher/dashboard-switcher.component';
+import { CustomDashboardComponent } from './custom-dashboard/custom-dashboard.component';
+import { DashboardCanvasComponent } from './custom-dashboard/dashboard-canvas.component';
+import { WidgetPaletteComponent } from './custom-dashboard/widget-palette.component';
+import { DashboardTabStripComponent } from './custom-dashboard/dashboard-tab-strip.component';
 import { HumanResourcesComponent } from './human-resources/human-resources.component';
 import { AccountingComponent } from './accounting/accounting.component';
 import { ProjectManagementComponent } from './project-management/project-management.component';
@@ -97,6 +103,11 @@ const THIRD_PARTY_MODULES = [
 const COMPONENTS = [
 	DashboardComponent,
 	DashboardSwitcherComponent,
+	// Dashboard builder: canvas page, grid canvas, widget palette, tab strip
+	CustomDashboardComponent,
+	DashboardCanvasComponent,
+	WidgetPaletteComponent,
+	DashboardTabStripComponent,
 	AccountingComponent,
 	HumanResourcesComponent,
 	ProjectManagementComponent,
@@ -119,6 +130,10 @@ const COMPONENTS = [
 		...THIRD_PARTY_MODULES,
 		...STANDALONE_MODULES,
 		BaseChartDirective,
+		// Dashboard builder: CDK drag & drop (canvas + palette + tab strip)
+		// and the standalone widget host that instantiates palette widgets.
+		DragDropModule,
+		DashboardWidgetHostComponent,
 		// Feature Modules
 		DialogsModule,
 		RecordsHistoryModule,

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.routes.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.routes.ts
@@ -1,6 +1,7 @@
 import { Route } from '@angular/router';
 import {
 	BookmarkQueryParamsResolver,
+	customDashboardGuard,
 	defaultDashboardGuard,
 	PageRouteRegistryService,
 	PermissionsGuard,
@@ -9,6 +10,7 @@ import {
 import { PermissionsEnum } from '@gauzy/contracts';
 import { DateRangePickerResolver } from '@gauzy/ui-core/shared';
 import { DashboardComponent } from './dashboard.component';
+import { CustomDashboardComponent } from './custom-dashboard/custom-dashboard.component';
 import { HumanResourcesComponent } from './human-resources/human-resources.component';
 import { AccountingComponent } from './accounting/accounting.component';
 import { ProjectManagementComponent } from './project-management/project-management.component';
@@ -45,6 +47,27 @@ export function createDashboardRoutes(_pageRouteRegistryService: PageRouteRegist
 					// widget host when switching between two custom dashboards.
 					path: 'switching',
 					children: []
+				},
+				{
+					// A user-built custom dashboard: a canvas of freely placed widgets
+					// across user-created tabs. Owned by the core dashboard feature
+					// (it used to be registered by the time-track plugin, which made a
+					// custom dashboard a permutation of that plugin's page).
+					path: 'custom/:id',
+					component: CustomDashboardComponent,
+					canActivate: [customDashboardGuard],
+					data: {
+						selectors: {
+							project: false
+						},
+						datePicker: {
+							unitOfTime: 'week'
+						}
+					},
+					resolve: {
+						dates: DateRangePickerResolver,
+						bookmarkParams: BookmarkQueryParamsResolver
+					}
 				},
 				{
 					path: 'accounting',

--- a/apps/gauzy/src/app/pages/settings/settings-routing.module.ts
+++ b/apps/gauzy/src/app/pages/settings/settings-routing.module.ts
@@ -1,147 +1,27 @@
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { DangerZoneComponent } from './danger-zone/danger-zone.component';
-import { SettingsComponent } from './settings.component';
-import { EmailHistoryComponent } from './email-history/email-history.component';
-import { PermissionsGuard } from '@gauzy/ui-core/core';
-import { PermissionsEnum } from '@gauzy/contracts';
-import { SmsGatewayComponent } from './sms-gateway/sms-gateway.component';
+import { ROUTES, RouterModule } from '@angular/router';
+import { PageRouteRegistryService } from '@gauzy/ui-core/core';
+import { createSettingsRoutes } from './settings.routes';
 
-const routes: Routes = [
-	{
-		path: '',
-		component: SettingsComponent,
-		children: [
-			{
-				path: '',
-				redirectTo: 'general',
-				pathMatch: 'full'
-			},
-			{
-				path: 'general',
-				loadChildren: () =>
-					import('./general-setting/general-setting.module').then((m) => m.GeneralSettingModule)
-			},
-			{
-				path: 'features',
-				loadChildren: () => import('./feature/feature.module').then((m) => m.FeatureModule)
-			},
-			{
-				path: 'email-history',
-				component: EmailHistoryComponent,
-				canActivate: [PermissionsGuard],
-				data: {
-					permissions: {
-						only: [PermissionsEnum.VIEW_ALL_EMAILS],
-						redirectTo: '/pages/settings'
-					},
-					selectors: {
-						project: false,
-						employee: false,
-						date: false,
-						organization: true
-					}
-				}
-			},
-			{
-				path: 'email-templates',
-				loadChildren: () =>
-					import('../email-templates/email-templates.module').then((m) => m.EmailTemplatesModule)
-			},
-			{
-				path: 'accounting-templates',
-				loadChildren: () =>
-					import('../accounting-templates/accounting-templates.module').then(
-						(m) => m.AccountingTemplatesModule
-					)
-			},
-			{
-				path: 'roles-permissions',
-				loadChildren: () =>
-					import('./roles-permissions/roles-permissions.module').then((m) => m.RolesPermissionsModule)
-			},
-			{
-				path: 'import-export',
-				loadChildren: () => import('../import-export/import-export.module').then((m) => m.ImportExportModule),
-				data: {
-					selectors: {
-						project: false,
-						employee: false,
-						date: false,
-						organization: false
-					}
-				}
-			},
-			{
-				path: 'sms-gateway',
-				component: SmsGatewayComponent,
-				canActivate: [PermissionsGuard],
-				data: {
-					permissions: {
-						only: [PermissionsEnum.SMS_GATEWAY_VIEW],
-						redirectTo: '/pages/settings'
-					},
-					selectors: {
-						project: false,
-						employee: false,
-						date: false,
-						organization: false
-					}
-				}
-			},
-			{
-				path: 'custom-smtp',
-				loadChildren: () => import('./custom-smtp/custom-smtp.module').then((m) => m.CustomSmtpModule)
-			},
-			{
-				path: 'oauth-clients',
-				loadChildren: () =>
-					import('./oauth-clients/oauth-clients.module').then((m) => m.OAuthClientsModule)
-			},
-			{
-				path: 'file-storage',
-				loadChildren: () => import('./file-storage/file-storage.module').then((m) => m.FileStorageModule)
-			},
-			{
-				path: 'monitoring',
-				loadChildren: () => import('./monitoring/monitoring.module').then((m) => m.MonitoringModule),
-				canActivate: [PermissionsGuard],
-				data: {
-					permissions: {
-						only: [PermissionsEnum.TENANT_SETTING],
-						redirectTo: '/pages/settings'
-					},
-					selectors: {
-						project: false,
-						employee: false,
-						date: false,
-						organization: false
-					}
-				}
-			},
-			{
-				path: 'danger-zone',
-				component: DangerZoneComponent,
-				canActivate: [PermissionsGuard],
-				data: {
-					permissions: {
-						only: [PermissionsEnum.ACCESS_DELETE_ACCOUNT, PermissionsEnum.ACCESS_DELETE_ALL_DATA],
-						redirectTo: '/pages/settings'
-					},
-					selectors: {
-						project: false,
-						employee: false,
-						organization: false,
-						date: false
-					}
-				}
-			}
-		]
-	}
-];
-
+/**
+ * Settings routing.
+ *
+ * Routes are built by a factory so plugin-contributed settings pages registered
+ * at the `settings-sections` location are spread into the settings shell's
+ * children (see {@link createSettingsRoutes}) and therefore render with the
+ * settings menu, exactly like the core settings pages.
+ */
 @NgModule({
-	imports: [RouterModule.forChild(routes)],
-	exports: [RouterModule]
+	imports: [RouterModule.forChild([])],
+	exports: [RouterModule],
+	providers: [
+		{
+			provide: ROUTES,
+			useFactory: (_pageRouteRegistryService: PageRouteRegistryService) =>
+				createSettingsRoutes(_pageRouteRegistryService),
+			deps: [PageRouteRegistryService],
+			multi: true
+		}
+	]
 })
 export class SettingsRoutingModule {}

--- a/apps/gauzy/src/app/pages/settings/settings.component.scss
+++ b/apps/gauzy/src/app/pages/settings/settings.component.scss
@@ -43,38 +43,56 @@
 	list-style: none;
 }
 
+// Same flat chrome as the sidebar rows and the overlay menus: NOTHING is painted
+// at rest, hover is a low-contrast tint on a small radius, and "current" is a
+// slightly stronger tint plus weight — never a filled pill.
 .settings-nav-link {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
 	padding: 5px 8px;
-	border-radius: calc(nb-theme(border-radius) / 2);
+	// The shared row radius, not the CARD radius: a 10px pill on a 20px row is
+	// exactly what made these entries read as blocks.
+	border-radius: nb-theme(gauzy-radius-sm);
 	font-size: 13px;
 	line-height: 1.25;
-	color: nb-theme(text-basic-color);
+	// Muted at rest so the active row stands out on weight/colour alone.
+	color: nb-theme(text-hint-color);
 	text-decoration: none;
 	cursor: pointer;
+	transition-duration: 0.12s;
+	transition-property: background-color, color;
+	transition-timing-function: ease-in-out;
 
 	i {
 		width: 1rem;
 		font-size: 12px;
 		text-align: center;
-		color: nb-theme(text-hint-color);
+		color: inherit;
 	}
 
 	&:hover {
-		background-color: nb-theme(background-basic-color-3);
+		background-color: nb-theme(gauzy-hover-tint);
 		color: nb-theme(text-basic-color);
 	}
 
-	&.active {
-		background-color: nb-theme(background-basic-color-3);
-		color: nb-theme(text-primary-color);
-		font-weight: 600;
+	// Keyboard parity with hover, plus a non-colour indicator: the tint alone is
+	// a colour-only signal (WCAG 1.4.11 / 2.4.7). Inset so the row never grows.
+	&:focus-visible {
+		background-color: nb-theme(gauzy-hover-tint);
+		color: nb-theme(text-basic-color);
+		outline: 2px solid nb-theme(color-primary-default);
+		outline-offset: -2px;
+	}
 
-		i {
-			color: nb-theme(text-primary-color);
-		}
+	// Current page. Icon and label deliberately share `text-basic-color` instead
+	// of the brand accent: `text-primary-color` is color-primary-500 (#6e49e8),
+	// which measures ~2.5:1 against the tinted row on the dark themes. Tint +
+	// weight already say "current" without depending on a colour.
+	&.active {
+		background-color: nb-theme(gauzy-active-tint);
+		color: nb-theme(text-basic-color);
+		font-weight: 600;
 	}
 }
 

--- a/apps/gauzy/src/app/pages/settings/settings.routes.ts
+++ b/apps/gauzy/src/app/pages/settings/settings.routes.ts
@@ -1,0 +1,160 @@
+import { Route } from '@angular/router';
+import { PermissionsEnum } from '@gauzy/contracts';
+import { PageRouteRegistryService, PermissionsGuard } from '@gauzy/ui-core/core';
+import { DangerZoneComponent } from './danger-zone/danger-zone.component';
+import { SettingsComponent } from './settings.component';
+import { EmailHistoryComponent } from './email-history/email-history.component';
+import { SmsGatewayComponent } from './sms-gateway/sms-gateway.component';
+
+/**
+ * Creates the settings child routes.
+ *
+ * Every settings page is a CHILD of {@link SettingsComponent}, which renders the
+ * `Sidebar | Settings menu | content` shell. Plugin-contributed settings pages
+ * are spread in from the `settings-sections` registry location so they inherit
+ * that shell too — registering a settings page at `page-sections` instead makes
+ * it render standalone, without the settings menu.
+ *
+ * @param _pageRouteRegistryService - Service for retrieving plugin-registered routes.
+ * @returns Angular Route array for the settings feature.
+ */
+export function createSettingsRoutes(_pageRouteRegistryService: PageRouteRegistryService): Route[] {
+	return [
+		{
+			path: '',
+			component: SettingsComponent,
+			children: [
+				{
+					// `/pages/settings` is a real navigation target (the sidebar entry and several
+					// permission guards redirect there), so the shell needs a default child or it
+					// renders an empty content pane next to the settings menu.
+					path: '',
+					redirectTo: 'general',
+					pathMatch: 'full'
+				},
+				{
+					path: 'general',
+					loadChildren: () =>
+						import('./general-setting/general-setting.module').then((m) => m.GeneralSettingModule)
+				},
+				{
+					path: 'features',
+					loadChildren: () => import('./feature/feature.module').then((m) => m.FeatureModule)
+				},
+				{
+					path: 'email-history',
+					component: EmailHistoryComponent,
+					canActivate: [PermissionsGuard],
+					data: {
+						permissions: {
+							only: [PermissionsEnum.VIEW_ALL_EMAILS],
+							redirectTo: '/pages/settings'
+						},
+						selectors: {
+							project: false,
+							employee: false,
+							date: false,
+							organization: true
+						}
+					}
+				},
+				{
+					path: 'email-templates',
+					loadChildren: () =>
+						import('../email-templates/email-templates.module').then((m) => m.EmailTemplatesModule)
+				},
+				{
+					path: 'accounting-templates',
+					loadChildren: () =>
+						import('../accounting-templates/accounting-templates.module').then(
+							(m) => m.AccountingTemplatesModule
+						)
+				},
+				{
+					path: 'roles-permissions',
+					loadChildren: () =>
+						import('./roles-permissions/roles-permissions.module').then((m) => m.RolesPermissionsModule)
+				},
+				{
+					path: 'import-export',
+					loadChildren: () =>
+						import('../import-export/import-export.module').then((m) => m.ImportExportModule),
+					data: {
+						selectors: {
+							project: false,
+							employee: false,
+							date: false,
+							organization: false
+						}
+					}
+				},
+				{
+					path: 'sms-gateway',
+					component: SmsGatewayComponent,
+					canActivate: [PermissionsGuard],
+					data: {
+						permissions: {
+							only: [PermissionsEnum.SMS_GATEWAY_VIEW],
+							redirectTo: '/pages/settings'
+						},
+						selectors: {
+							project: false,
+							employee: false,
+							date: false,
+							organization: false
+						}
+					}
+				},
+				{
+					path: 'custom-smtp',
+					loadChildren: () => import('./custom-smtp/custom-smtp.module').then((m) => m.CustomSmtpModule)
+				},
+				{
+					path: 'oauth-clients',
+					loadChildren: () => import('./oauth-clients/oauth-clients.module').then((m) => m.OAuthClientsModule)
+				},
+				{
+					path: 'file-storage',
+					loadChildren: () => import('./file-storage/file-storage.module').then((m) => m.FileStorageModule)
+				},
+				{
+					path: 'monitoring',
+					loadChildren: () => import('./monitoring/monitoring.module').then((m) => m.MonitoringModule),
+					canActivate: [PermissionsGuard],
+					data: {
+						permissions: {
+							only: [PermissionsEnum.TENANT_SETTING],
+							redirectTo: '/pages/settings'
+						},
+						selectors: {
+							project: false,
+							employee: false,
+							date: false,
+							organization: false
+						}
+					}
+				},
+				{
+					path: 'danger-zone',
+					component: DangerZoneComponent,
+					canActivate: [PermissionsGuard],
+					data: {
+						permissions: {
+							only: [PermissionsEnum.ACCESS_DELETE_ACCOUNT, PermissionsEnum.ACCESS_DELETE_ALL_DATA],
+							redirectTo: '/pages/settings'
+						},
+						selectors: {
+							project: false,
+							employee: false,
+							organization: false,
+							date: false
+						}
+					}
+				},
+				// Plugin-contributed settings pages (e.g. AI Providers) — rendered
+				// inside the settings shell like every core settings page.
+				..._pageRouteRegistryService.getPageLocationRoutes('settings-sections')
+			]
+		}
+	];
+}

--- a/packages/contracts/src/lib/dashboard.model.ts
+++ b/packages/contracts/src/lib/dashboard.model.ts
@@ -43,10 +43,73 @@ export interface IDashboardLayoutItem {
 }
 
 /**
- * Persisted layout of a custom dashboard: which widgets/windows are visible,
- * their order and collapse state. Stored in `IDashboard.contentHtml`.
+ * Persisted layout of a custom dashboard (v1): which widgets/windows are
+ * visible, their order and collapse state. Stored in `IDashboard.contentHtml`.
+ *
+ * v1 documents are snapshots of the legacy `GuiDrag` widget system — widgets
+ * are identified by POSITION only, so they can be reordered but never placed
+ * freely. Superseded by {@link IDashboardLayoutV2}; still read for dashboards
+ * created before the builder shipped.
  */
 export interface IDashboardLayout {
 	widgets?: IDashboardLayoutItem[];
 	windows?: IDashboardLayoutItem[];
 }
+
+/**
+ * A single widget instance placed on a dashboard canvas.
+ *
+ * Unlike {@link IDashboardLayoutItem} (positional identity), a placement has a
+ * stable `instanceId` and names the widget it renders via `widgetId`, so the
+ * same widget can appear multiple times with different configuration.
+ */
+export interface IDashboardWidgetPlacement {
+	/** Stable identity of this placement (uuid). */
+	instanceId: string;
+	/** Registry key of the widget to render, e.g. `time-tracking.members-worked`. */
+	widgetId: string;
+	/** Grid origin, 0-based, in a 12 column grid. */
+	x: number;
+	y: number;
+	/** Span, in grid columns / row units. */
+	w: number;
+	h: number;
+	/** User override of the widget's registry title. */
+	title?: string;
+	/** Per-instance settings (e.g. a project/team/employee scope). */
+	config?: Record<string, unknown>;
+	/** Temporarily hidden without being removed from the canvas. */
+	hidden?: boolean;
+}
+
+/**
+ * A user-created tab inside a custom dashboard. Each tab owns its own canvas.
+ */
+export interface IDashboardTab {
+	/** Stable identity of the tab (uuid). */
+	id: string;
+	name: string;
+	icon?: string;
+	/** Ascending display order in the tab strip. */
+	order: number;
+	widgets: IDashboardWidgetPlacement[];
+}
+
+/**
+ * Persisted layout of a custom dashboard (v2 — the dashboard builder).
+ *
+ * A v2 document is a set of named tabs, each holding freely placed widget
+ * instances. It intentionally extends {@link IDashboardLayout} so a v2
+ * document can still carry a v1 snapshot for backward compatibility while a
+ * dashboard is migrated.
+ */
+export interface IDashboardLayoutV2 extends IDashboardLayout {
+	/** Schema version. Absent/`1` = legacy snapshot, `2` = builder document. */
+	version: 2;
+	tabs: IDashboardTab[];
+}
+
+/**
+ * Either persisted layout shape, as read from `IDashboard.contentHtml`.
+ */
+export type DashboardLayout = IDashboardLayout | IDashboardLayoutV2;

--- a/packages/plugin-ui/src/lib/plugin-ui.helper.ts
+++ b/packages/plugin-ui/src/lib/plugin-ui.helper.ts
@@ -37,6 +37,13 @@ export const PLUGIN_ROUTE_REGISTRY = new InjectionToken<IDeclarativePageRouteReg
 export const PLUGIN_TAB_REGISTRY = new InjectionToken<IDeclarativePageTabRegistry>('PLUGIN_TAB_REGISTRY');
 
 /**
+ * Token for the dashboard widget registry.
+ * Used internally by `defineDeclarativePlugin` to publish plugin widgets to the
+ * dashboard builder's palette.
+ */
+export const PLUGIN_WIDGET_REGISTRY = new InjectionToken<IDeclarativeWidgetRegistry>('PLUGIN_WIDGET_REGISTRY');
+
+/**
  * Minimal interface for applying nav sections/items.
  * Implemented by NavMenuBuilderService from @gauzy/ui-core.
  */
@@ -77,6 +84,17 @@ export interface IDeclarativeExtensionRegistry {
 export interface IDeclarativePageTabRegistry {
 	registerPageTab(config: unknown): void;
 	registerPageTabs(configs: unknown[]): void;
+}
+
+/**
+ * Minimal interface for registering dashboard-builder widgets.
+ * Implemented by WidgetRegistryService from @gauzy/ui-core.
+ *
+ * `registerOrReplaceWidget` is used (not `registerWidget`) so re-registering a
+ * plugin — e.g. after it is toggled off and on — never throws on duplicate ids.
+ */
+export interface IDeclarativeWidgetRegistry {
+	registerOrReplaceWidget(config: unknown): void;
 }
 
 /**
@@ -501,9 +519,10 @@ export function applyDeclarativeRegistrations(
 		pageRouteRegistry?: IDeclarativePageRouteRegistry;
 		pageTabRegistry?: IDeclarativePageTabRegistry;
 		pageExtensionRegistry?: IDeclarativeExtensionRegistry;
+		widgetRegistry?: IDeclarativeWidgetRegistry;
 	}
 ): void {
-	const { navBuilder, pageRouteRegistry, pageTabRegistry, pageExtensionRegistry } = services;
+	const { navBuilder, pageRouteRegistry, pageTabRegistry, pageExtensionRegistry, widgetRegistry } = services;
 
 	if (pageRouteRegistry && definition.routes?.length) {
 		for (const r of definition.routes) {
@@ -530,6 +549,24 @@ export function applyDeclarativeRegistrations(
 
 	if (pageExtensionRegistry && definition.extensions?.length) {
 		pageExtensionRegistry.registerAll(definition.extensions, { pluginId: definition.id });
+	}
+
+	// Dashboard-builder widgets contributed by this plugin. Registered here —
+	// alongside routes/tabs/nav — rather than through plugin `providers`,
+	// because declarative providers live in a child EnvironmentInjector whose
+	// app initializers never run (APP_INITIALIZER fires only for the root).
+	if (widgetRegistry && definition.widgets?.length) {
+		for (const widget of definition.widgets) {
+			// Isolated per widget: `registerOrReplaceWidget` throws on a malformed
+			// entry, and letting that escape would abort the rest of
+			// `defineDeclarativePlugin` — translations and settings included — over
+			// one bad widget.
+			try {
+				widgetRegistry.registerOrReplaceWidget(widget);
+			} catch (error) {
+				console.error(`[${definition.id}] failed to register a dashboard widget`, error);
+			}
+		}
 	}
 }
 
@@ -590,7 +627,8 @@ export function defineDeclarativePlugin(
 			navBuilder: injector.get(PLUGIN_NAV_BUILDER, null) ?? undefined,
 			pageRouteRegistry: injector.get(PLUGIN_ROUTE_REGISTRY, null) ?? undefined,
 			pageTabRegistry: injector.get(PLUGIN_TAB_REGISTRY, null) ?? undefined,
-			pageExtensionRegistry: injector.get(PageExtensionRegistryService, null) ?? undefined
+			pageExtensionRegistry: injector.get(PageExtensionRegistryService, null) ?? undefined,
+			widgetRegistry: injector.get(PLUGIN_WIDGET_REGISTRY, null) ?? undefined
 		});
 
 		// Merge plugin translations into the global @ngx-translate namespace.

--- a/packages/plugin-ui/src/lib/plugin-ui.module.ts
+++ b/packages/plugin-ui/src/lib/plugin-ui.module.ts
@@ -27,12 +27,14 @@ import {
 	IDeclarativeNavBuilder,
 	IDeclarativePageRouteRegistry,
 	IDeclarativePageTabRegistry,
+	IDeclarativeWidgetRegistry,
 	IPluginTranslateService,
 	IPluginPermissionChecker,
 	IPluginFeatureChecker,
 	PLUGIN_NAV_BUILDER,
 	PLUGIN_ROUTE_REGISTRY,
 	PLUGIN_TAB_REGISTRY,
+	PLUGIN_WIDGET_REGISTRY,
 	PLUGIN_TRANSLATE_SERVICE,
 	PLUGIN_PERMISSION_CHECKER,
 	PLUGIN_FEATURE_CHECKER
@@ -57,6 +59,8 @@ export interface PluginUiServices {
 	routeRegistry?: Type<IDeclarativePageRouteRegistry>;
 	/** Page-tab registry (bound to PLUGIN_TAB_REGISTRY). */
 	tabRegistry?: Type<IDeclarativePageTabRegistry>;
+	/** Dashboard widget registry (bound to PLUGIN_WIDGET_REGISTRY). */
+	widgetRegistry?: Type<IDeclarativeWidgetRegistry>;
 	/** Translate service for plugin translations (bound to PLUGIN_TRANSLATE_SERVICE). */
 	translateService?: Type<IPluginTranslateService>;
 	/** Permission checker for extension visibility (bound to PLUGIN_PERMISSION_CHECKER). */
@@ -70,6 +74,7 @@ const SERVICE_TOKEN_MAP: Record<keyof PluginUiServices, InjectionToken<any>> = {
 	navBuilder: PLUGIN_NAV_BUILDER,
 	routeRegistry: PLUGIN_ROUTE_REGISTRY,
 	tabRegistry: PLUGIN_TAB_REGISTRY,
+	widgetRegistry: PLUGIN_WIDGET_REGISTRY,
 	translateService: PLUGIN_TRANSLATE_SERVICE,
 	permissionChecker: PLUGIN_PERMISSION_CHECKER,
 	featureChecker: PLUGIN_FEATURE_CHECKER

--- a/packages/plugin-ui/src/lib/plugin-ui.types.ts
+++ b/packages/plugin-ui/src/lib/plugin-ui.types.ts
@@ -124,6 +124,25 @@ export interface PluginTabInput {
 }
 
 /**
+ * A dashboard-builder widget contributed by a plugin.
+ *
+ * Structurally compatible with `WidgetRegistryConfig` from @gauzy/ui-core/core,
+ * declaring only the fields `WidgetRegistryService.registerOrReplaceWidget()`
+ * validates at runtime. Every other `WidgetRegistryConfig` field (title, icon,
+ * loadComponent, ...) rides along structurally. This keeps @gauzy/plugin-ui
+ * dependency-free while still failing at COMPILE time on the mistakes the
+ * registry would otherwise only catch at bootstrap.
+ */
+export interface PluginWidgetInput {
+	/** Page location the widget is registered at (e.g. 'dashboard'). */
+	location: string;
+	/** Globally unique id; persisted on every dashboard placement. */
+	widgetId: string;
+	/** Permissions required to see the widget (empty = everyone). */
+	permissions: string[];
+}
+
+/**
  * Defines a UI plugin for the Gauzy application.
  *
  * Each plugin encapsulates an Angular module, its metadata, and a
@@ -245,6 +264,21 @@ export interface PluginUiDefinition {
 	 * Use applyDeclarativeRegistrations() with pageTabRegistry to apply.
 	 */
 	tabs?: PluginTabInput[];
+
+	/**
+	 * Dashboard-builder widgets contributed by this plugin.
+	 *
+	 * Each entry is a `WidgetRegistryConfig` (from @gauzy/ui-core/core) and is
+	 * published to the widget palette, so users can drop it onto any custom
+	 * dashboard canvas. Applied by `applyDeclarativeRegistrations()` when a
+	 * `widgetRegistry` service is available.
+	 *
+	 * Structurally typed (rather than importing `WidgetRegistryConfig`) to keep
+	 * @gauzy/plugin-ui free of a build-time dependency on the widget registry,
+	 * while still catching at compile time the three fields the registry
+	 * validates at runtime.
+	 */
+	widgets?: PluginWidgetInput[];
 
 	/**
 	 * Plugin-specific translations keyed by language code.

--- a/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.routes.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.routes.ts
@@ -2,17 +2,25 @@ import { PermissionsEnum } from '@gauzy/contracts';
 import { PageRouteRegistryConfig, PermissionsGuard } from '@gauzy/ui-core/core';
 import { AiChatSettingsComponent } from './ai-chat-settings.component';
 
-/** Path segment for the AI Providers settings page under /pages. */
-export const AI_CHAT_SETTINGS_PATH = 'settings/ai';
+/**
+ * Path segment for the AI Providers settings page, RELATIVE to /pages/settings
+ * (the route is registered as a child of the settings shell).
+ */
+export const AI_CHAT_SETTINGS_PATH = 'ai';
 
 /**
  * Route config for the per-tenant "AI Providers" (BYOK) settings page.
- * Registered at `page-sections` so it appears as /pages/settings/ai,
- * guarded by the `AI_CHAT_SETTINGS` permission (same PermissionsGuard
- * pattern as the core settings routes).
+ *
+ * Registered at `settings-sections` — i.e. as a CHILD of the settings shell —
+ * so the page renders with the settings menu beside it, exactly like the core
+ * settings pages. (Registering at `page-sections` would still resolve
+ * /pages/settings/ai, but standalone, without the settings menu.)
+ *
+ * Guarded by the `AI_CHAT_SETTINGS` permission, matching the PermissionsGuard
+ * pattern used by the core settings routes.
  */
 export const AI_CHAT_SETTINGS_ROUTE: PageRouteRegistryConfig = {
-	location: 'page-sections',
+	location: 'settings-sections',
 	path: AI_CHAT_SETTINGS_PATH,
 	component: AiChatSettingsComponent,
 	canActivate: [PermissionsGuard],

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/dashboard-time-track-angular-ui.constants.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/dashboard-time-track-angular-ui.constants.ts
@@ -1,10 +1,7 @@
-import { customDashboardGuard, PageRouteRegistryConfig, standardDashboardGuard } from '@gauzy/ui-core/core';
+import { PageRouteRegistryConfig, standardDashboardGuard } from '@gauzy/ui-core/core';
 
 /** Path segment for the Time Tracking tab under /pages/dashboard. */
 export const DASHBOARD_TIME_TRACKING_PATH = 'time-tracking';
-
-/** Path segment for the custom dashboards host under /pages/dashboard. */
-export const DASHBOARD_CUSTOM_PATH = 'custom/:id';
 
 /**
  * Route config for registering the Angular Time Tracking tab at dashboard-sections.
@@ -12,27 +9,17 @@ export const DASHBOARD_CUSTOM_PATH = 'custom/:id';
  *
  * `standardDashboardGuard` restores the Standard widget layout whenever a
  * custom dashboard was previously applied.
+ *
+ * NOTE: the custom dashboard host (`custom/:id`) used to be registered here and
+ * lazy-loaded THIS module — i.e. a custom dashboard was the Time Tracking page
+ * with a different saved permutation. It now lives in the core dashboard
+ * feature as its own canvas page (see `createDashboardRoutes`), and this plugin
+ * instead contributes its counters to the builder palette as registered widgets.
  */
 export const DASHBOARD_TIME_TRACKING_ROUTE: PageRouteRegistryConfig = {
 	location: 'dashboard-sections',
 	path: DASHBOARD_TIME_TRACKING_PATH,
 	canActivate: [standardDashboardGuard],
-	loadChildren: () =>
-		import('./dashboard-time-track-angular-ui.module').then((m) => m.DashboardTimeTrackAngularUiModule)
-};
-
-/**
- * Route config for the custom dashboards host (`/pages/dashboard/custom/:id`).
- *
- * A custom dashboard re-uses the Time Tracking widget system as its widget
- * host: `customDashboardGuard` applies the dashboard's persisted widget layout
- * (visibility/order/collapse state) into the widget system state BEFORE the
- * host component initializes, then the same lazy module renders it.
- */
-export const DASHBOARD_CUSTOM_ROUTE: PageRouteRegistryConfig = {
-	location: 'dashboard-sections',
-	path: DASHBOARD_CUSTOM_PATH,
-	canActivate: [customDashboardGuard],
 	loadChildren: () =>
 		import('./dashboard-time-track-angular-ui.module').then((m) => m.DashboardTimeTrackAngularUiModule)
 };

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/dashboard-time-track-angular-ui.plugin.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/dashboard-time-track-angular-ui.plugin.ts
@@ -1,10 +1,7 @@
 import { PermissionsEnum } from '@gauzy/contracts';
 import { defineDeclarativePlugin, IPluginI18nService, PluginRouteInput } from '@gauzy/plugin-ui';
-import {
-	DASHBOARD_CUSTOM_ROUTE,
-	DASHBOARD_TIME_TRACKING_ROUTE,
-	DASHBOARD_TIME_TRACKING_PATH
-} from './dashboard-time-track-angular-ui.constants';
+import { DASHBOARD_TIME_TRACKING_ROUTE, DASHBOARD_TIME_TRACKING_PATH } from './dashboard-time-track-angular-ui.constants';
+import { DASHBOARD_TIME_TRACK_WIDGETS } from './widgets/dashboard-time-track.widgets';
 import ar from '../i18n/ar.json';
 import bg from '../i18n/bg.json';
 import de from '../i18n/de.json';
@@ -48,7 +45,15 @@ export const DashboardTimeTrackAngularUiPlugin = defineDeclarativePlugin('dashbo
 	location: 'page-sections',
 
 	// ── Routes ───────────────────────────────────────────────────
-	routes: [DASHBOARD_TIME_TRACKING_ROUTE as PluginRouteInput, DASHBOARD_CUSTOM_ROUTE as PluginRouteInput],
+	// NOTE: the custom dashboard host (`custom/:id`) is NO LONGER registered
+	// here. A custom dashboard is its own canvas page owned by the core
+	// dashboard feature, not a saved permutation of this plugin's page.
+	routes: [DASHBOARD_TIME_TRACKING_ROUTE as PluginRouteInput],
+
+	// ── Dashboard builder widgets ────────────────────────────────
+	// Published to the widget palette so users can drop these counters onto
+	// any custom dashboard canvas.
+	widgets: DASHBOARD_TIME_TRACK_WIDGETS,
 
 	// ── Dashboard Tab ────────────────────────────────────────────
 	tabs: [

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/base-time-track-counter-widget.component.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/base-time-track-counter-widget.component.ts
@@ -1,0 +1,134 @@
+import { computed, Directive, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { combineLatest, of, Subject } from 'rxjs';
+import { catchError, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
+import { ICountsStatistics } from '@gauzy/contracts';
+import { IDashboardWidgetContext, TimesheetStatisticsCacheService } from '@gauzy/ui-core/core';
+import { BaseDashboardWidgetComponent } from '@gauzy/ui-core/shared';
+import {
+	isCurrentWeekRange,
+	RangePeriod,
+	resolvePeriodSeconds,
+	resolveRangePeriod,
+	toErrorMessage
+} from './time-track-widget.utils';
+
+/**
+ * Shared data layer for every Time Tracking counter widget.
+ *
+ * All six counters are projections of the very same
+ * `/timesheet/statistics/counts` payload, so they all subscribe to the ambient
+ * dashboard context here and fetch through {@link TimesheetStatisticsCacheService}.
+ * The cache collapses the six identical in-flight requests into one — which is
+ * the whole reason a counter is cheap enough to be dropped on a canvas six times.
+ *
+ * Subclasses only decide *which* number of the payload they show and how it is
+ * formatted; they never fetch.
+ */
+@Directive()
+export abstract class BaseTimeTrackCounterWidgetComponent extends BaseDashboardWidgetComponent implements OnInit {
+	private readonly _statisticsCache = inject(TimesheetStatisticsCacheService);
+
+	/** Manual re-fetch trigger, fed by {@link refresh}. */
+	private readonly _reload$ = new Subject<void>();
+
+	/** Latest counts payload; `null` until the first successful fetch. */
+	protected readonly counts = signal<ICountsStatistics | null>(null);
+
+	/** Context the current payload was fetched for; powers the period-aware titles. */
+	protected readonly widgetContext = signal<IDashboardWidgetContext | null>(null);
+
+	/** Day / week / arbitrary-period classification of the selected range. */
+	protected readonly rangePeriod = computed<RangePeriod>(() => resolveRangePeriod(this.widgetContext()));
+
+	/** True when the selected range is exactly the current calendar week. */
+	protected readonly isCurrentWeek = computed<boolean>(() => isCurrentWeekRange(this.widgetContext()));
+
+	/** Workable seconds in the range across all members — the duration counters' denominator. */
+	protected readonly periodSeconds = computed<number>(() =>
+		resolvePeriodSeconds(this.widgetContext(), this.counts()?.employeesCount ?? 0)
+	);
+
+	/** Displayable form of the base class' `error` signal. */
+	protected readonly errorMessage = computed<string | null>(() => toErrorMessage(this.error()));
+
+	/**
+	 * Starts the counts subscription.
+	 *
+	 * Deliberately does NOT call `super.ngOnInit()`: the base class' default is to
+	 * call {@link refresh} on every context emission, which here would push an
+	 * extra value through `_reload$` and fetch the same payload twice. This class
+	 * subscribes to `context$` itself instead.
+	 *
+	 * Subclasses that need extra data (total members, total projects) override
+	 * this and must call `super.ngOnInit()`.
+	 */
+	public override ngOnInit(): void {
+		// Show the skeleton from the very first paint: the canvas may take a moment
+		// to resolve an organization, and a hard "0" would read as real data.
+		this.loading.set(true);
+		this.observeCounts();
+	}
+
+	/**
+	 * Re-fetches the counts payload, clearing any previous error first.
+	 *
+	 * Invoked by the widget host's refresh control and by the card's retry button.
+	 */
+	public override refresh(): void {
+		this.error.set(null);
+
+		// Without dropping the cached payload a manual refresh inside the cache TTL
+		// would silently replay the stale numbers. `invalidate()` coalesces per
+		// scope, so all six counters refreshing at once still cause one request.
+		const context = this.widgetContext();
+		if (context) {
+			this._statisticsCache.invalidate(context);
+		}
+
+		this._reload$.next();
+	}
+
+	/**
+	 * Wires `context$` (plus manual reloads) to the cached counts endpoint and
+	 * mirrors the request lifecycle into the `loading` / `error` signals.
+	 */
+	private observeCounts(): void {
+		combineLatest([this.context$, this._reload$.pipe(startWith(undefined))])
+			.pipe(
+				map(([context]) => context),
+				// A context without an organization cannot produce a meaningful
+				// request; the canvas shows the "select an organization" state.
+				filter((context): context is IDashboardWidgetContext => !!context?.organizationId),
+				tap((context: IDashboardWidgetContext) => {
+					this.widgetContext.set(context);
+					this.loading.set(true);
+					this.error.set(null);
+				}),
+				// switchMap, not mergeMap: a fast date-range change must abandon
+				// the previous request instead of racing it to the signal.
+				switchMap((context: IDashboardWidgetContext) =>
+					// The cache service takes the context itself and does the
+					// request shaping (`buildStatisticsRequest`) — reproducing it
+					// here is what makes a widget disagree with the standard
+					// dashboard about the UTC offset.
+					this._statisticsCache.getCounts(context).pipe(
+						catchError((error: unknown) => {
+							this.error.set(toErrorMessage(error));
+							return of(null);
+						})
+					)
+				),
+				tap((counts: ICountsStatistics | null) => {
+					// Keep the last good payload on screen when a refresh fails,
+					// rather than blanking a working widget.
+					if (counts) {
+						this.counts.set(counts);
+					}
+					this.loading.set(false);
+				}),
+				takeUntilDestroyed(this.destroyRef)
+			)
+			.subscribe();
+	}
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/dashboard-time-track.widgets.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/dashboard-time-track.widgets.ts
@@ -1,0 +1,140 @@
+import { PermissionsEnum } from '@gauzy/contracts';
+import { WidgetRegistryConfig } from '@gauzy/ui-core/core';
+
+/**
+ * Namespaced widget ids for the Time Tracking counters.
+ *
+ * These strings are persisted inside every saved dashboard layout
+ * (`IDashboardWidgetPlacement.widgetId`), so treat them as a public data
+ * contract: renaming one orphans every placement that references it.
+ */
+export const TIME_TRACKING_WIDGET_IDS = {
+	MEMBERS_WORKED: 'time-tracking.members-worked',
+	PROJECTS_WORKED: 'time-tracking.projects-worked',
+	TODAY_ACTIVITY: 'time-tracking.today-activity',
+	WORKED_TODAY: 'time-tracking.worked-today',
+	WORKED_THIS_WEEK: 'time-tracking.worked-this-week',
+	WEEKLY_ACTIVITY: 'time-tracking.weekly-activity'
+} as const;
+
+/**
+ * Every counter is a quarter-row tile by default (12-column grid → four per row),
+ * matching the legacy Time Tracking widget strip.
+ */
+const COUNTER_DEFAULT_SIZE = { w: 3, h: 2 };
+const COUNTER_MIN_SIZE = { w: 3, h: 2 };
+const COUNTER_MAX_SIZE = { w: 12, h: 4 };
+
+/** Widths a counter still reads well at. */
+const COUNTER_SUPPORTED_WIDTHS: WidgetRegistryConfig['supportedWidths'] = [3, 4, 6, 12];
+
+/**
+ * All counters need an organization and a date range; none of them need a
+ * specific employee, project or team (those merely narrow the numbers).
+ */
+const COUNTER_CONTEXT: WidgetRegistryConfig['contextRequirements'] = ['organization', 'dateRange'];
+
+/**
+ * Registry entries for the six Time Tracking counter widgets.
+ *
+ * Registered by the plugin (the integrator wires the
+ * `WidgetRegistryService.registerWidgets` call) so they show up in the dashboard
+ * builder's palette under the "Time tracking" category.
+ *
+ * Permissions mirror the legacy dashboard exactly: only "Members worked" was
+ * gated (`*ngxPermissionsOnly="CHANGE_SELECTED_EMPLOYEE"`), because a user who
+ * cannot switch employees only ever sees their own numbers, for which a member
+ * head count is meaningless.
+ */
+export const DASHBOARD_TIME_TRACK_WIDGETS: WidgetRegistryConfig[] = [
+	{
+		location: 'dashboard',
+		category: 'time-tracking',
+		widgetId: TIME_TRACKING_WIDGET_IDS.MEMBERS_WORKED,
+		title: 'DASHBOARD_PAGE.BUILDER.WIDGETS.MEMBERS_WORKED.TITLE',
+		description: 'DASHBOARD_PAGE.BUILDER.WIDGETS.MEMBERS_WORKED.DESCRIPTION',
+		icon: 'people-outline',
+		defaultSize: COUNTER_DEFAULT_SIZE,
+		minSize: COUNTER_MIN_SIZE,
+		maxSize: COUNTER_MAX_SIZE,
+		supportedWidths: COUNTER_SUPPORTED_WIDTHS,
+		contextRequirements: COUNTER_CONTEXT,
+		permissions: [PermissionsEnum.CHANGE_SELECTED_EMPLOYEE],
+		loadComponent: () => import('./members-worked-widget.component').then((m) => m.MembersWorkedWidgetComponent)
+	},
+	{
+		location: 'dashboard',
+		category: 'time-tracking',
+		widgetId: TIME_TRACKING_WIDGET_IDS.PROJECTS_WORKED,
+		title: 'DASHBOARD_PAGE.BUILDER.WIDGETS.PROJECTS_WORKED.TITLE',
+		description: 'DASHBOARD_PAGE.BUILDER.WIDGETS.PROJECTS_WORKED.DESCRIPTION',
+		icon: 'briefcase-outline',
+		defaultSize: COUNTER_DEFAULT_SIZE,
+		minSize: COUNTER_MIN_SIZE,
+		maxSize: COUNTER_MAX_SIZE,
+		supportedWidths: COUNTER_SUPPORTED_WIDTHS,
+		contextRequirements: COUNTER_CONTEXT,
+		permissions: [],
+		loadComponent: () => import('./projects-worked-widget.component').then((m) => m.ProjectsWorkedWidgetComponent)
+	},
+	{
+		location: 'dashboard',
+		category: 'time-tracking',
+		widgetId: TIME_TRACKING_WIDGET_IDS.TODAY_ACTIVITY,
+		title: 'DASHBOARD_PAGE.BUILDER.WIDGETS.TODAY_ACTIVITY.TITLE',
+		description: 'DASHBOARD_PAGE.BUILDER.WIDGETS.TODAY_ACTIVITY.DESCRIPTION',
+		icon: 'activity-outline',
+		defaultSize: COUNTER_DEFAULT_SIZE,
+		minSize: COUNTER_MIN_SIZE,
+		maxSize: COUNTER_MAX_SIZE,
+		supportedWidths: COUNTER_SUPPORTED_WIDTHS,
+		contextRequirements: COUNTER_CONTEXT,
+		permissions: [],
+		loadComponent: () => import('./today-activity-widget.component').then((m) => m.TodayActivityWidgetComponent)
+	},
+	{
+		location: 'dashboard',
+		category: 'time-tracking',
+		widgetId: TIME_TRACKING_WIDGET_IDS.WORKED_TODAY,
+		title: 'DASHBOARD_PAGE.BUILDER.WIDGETS.WORKED_TODAY.TITLE',
+		description: 'DASHBOARD_PAGE.BUILDER.WIDGETS.WORKED_TODAY.DESCRIPTION',
+		icon: 'clock-outline',
+		defaultSize: COUNTER_DEFAULT_SIZE,
+		minSize: COUNTER_MIN_SIZE,
+		maxSize: COUNTER_MAX_SIZE,
+		supportedWidths: COUNTER_SUPPORTED_WIDTHS,
+		contextRequirements: COUNTER_CONTEXT,
+		permissions: [],
+		loadComponent: () => import('./worked-today-widget.component').then((m) => m.WorkedTodayWidgetComponent)
+	},
+	{
+		location: 'dashboard',
+		category: 'time-tracking',
+		widgetId: TIME_TRACKING_WIDGET_IDS.WORKED_THIS_WEEK,
+		title: 'DASHBOARD_PAGE.BUILDER.WIDGETS.WORKED_THIS_WEEK.TITLE',
+		description: 'DASHBOARD_PAGE.BUILDER.WIDGETS.WORKED_THIS_WEEK.DESCRIPTION',
+		icon: 'calendar-outline',
+		defaultSize: COUNTER_DEFAULT_SIZE,
+		minSize: COUNTER_MIN_SIZE,
+		maxSize: COUNTER_MAX_SIZE,
+		supportedWidths: COUNTER_SUPPORTED_WIDTHS,
+		contextRequirements: COUNTER_CONTEXT,
+		permissions: [],
+		loadComponent: () => import('./worked-this-week-widget.component').then((m) => m.WorkedThisWeekWidgetComponent)
+	},
+	{
+		location: 'dashboard',
+		category: 'time-tracking',
+		widgetId: TIME_TRACKING_WIDGET_IDS.WEEKLY_ACTIVITY,
+		title: 'DASHBOARD_PAGE.BUILDER.WIDGETS.WEEKLY_ACTIVITY.TITLE',
+		description: 'DASHBOARD_PAGE.BUILDER.WIDGETS.WEEKLY_ACTIVITY.DESCRIPTION',
+		icon: 'trending-up-outline',
+		defaultSize: COUNTER_DEFAULT_SIZE,
+		minSize: COUNTER_MIN_SIZE,
+		maxSize: COUNTER_MAX_SIZE,
+		supportedWidths: COUNTER_SUPPORTED_WIDTHS,
+		contextRequirements: COUNTER_CONTEXT,
+		permissions: [],
+		loadComponent: () => import('./weekly-activity-widget.component').then((m) => m.WeeklyActivityWidgetComponent)
+	}
+];

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/index.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Time Tracking dashboard widgets.
+ *
+ * NOTE: this barrel is for direct/eager consumers (tests, future modules). The
+ * widget registry in `dashboard-time-track.widgets.ts` deliberately imports each
+ * component through its own `loadComponent` dynamic import so a canvas only pays
+ * for the widgets it actually renders.
+ */
+export * from './time-track-widget.utils';
+export * from './time-track-counter-card.component';
+export * from './base-time-track-counter-widget.component';
+export * from './members-worked-widget.component';
+export * from './projects-worked-widget.component';
+export * from './today-activity-widget.component';
+export * from './worked-today-widget.component';
+export * from './worked-this-week-widget.component';
+export * from './weekly-activity-widget.component';
+export * from './dashboard-time-track.widgets';

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/members-worked-widget.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/members-worked-widget.component.html
@@ -1,0 +1,9 @@
+<gz-time-track-counter-card
+	color="info"
+	[value]="membersWorked().toString()"
+	[counterValue]="membersWorked()"
+	[total]="totalEmployees()"
+	[loading]="loading()"
+	[error]="errorMessage()"
+	(retry)="refresh()"
+></gz-time-track-counter-card>

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/members-worked-widget.component.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/members-worked-widget.component.ts
@@ -1,0 +1,78 @@
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { of } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, retry, switchMap, tap } from 'rxjs/operators';
+import { IDashboardWidgetContext, EmployeesService } from '@gauzy/ui-core/core';
+import { BaseTimeTrackCounterWidgetComponent } from './base-time-track-counter-widget.component';
+import { TimeTrackCounterCardComponent } from './time-track-counter-card.component';
+
+/**
+ * Counter widget: how many members logged time in the selected range.
+ *
+ * The counter-point strip compares that number against the organization's total
+ * head count, so an "8" reads very differently in a team of 9 than in a team of 90.
+ */
+@Component({
+	selector: 'gz-members-worked-widget',
+	templateUrl: './members-worked-widget.component.html',
+	standalone: true,
+	imports: [TimeTrackCounterCardComponent],
+	// `EmployeesService` is a plain `@Injectable()` (NOT `providedIn: 'root'`) that
+	// today is only provided by a handful of feature modules. A canvas widget is
+	// created through the host's own injector and may be dropped on any page, so
+	// it provides the service itself instead of gambling on a NullInjectorError.
+	providers: [EmployeesService],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MembersWorkedWidgetComponent extends BaseTimeTrackCounterWidgetComponent implements OnInit {
+	private readonly _employeesService = inject(EmployeesService);
+
+	/** Total members in the organization — the counter-point denominator. */
+	protected readonly totalEmployees = signal<number>(0);
+
+	/** Members that logged time in the selected range. */
+	protected readonly membersWorked = computed<number>(() => this.counts()?.employeesCount ?? 0);
+
+	/**
+	 * Starts the shared counts subscription and the organization head-count lookup.
+	 */
+	public override ngOnInit(): void {
+		super.ngOnInit();
+		this.observeEmployeesCount();
+	}
+
+	/**
+	 * Keeps the total head count in sync with the active organization.
+	 *
+	 * A failure here only degrades the strip's scale, never the headline figure,
+	 * so it is swallowed instead of surfacing an error state on the whole widget.
+	 */
+	private observeEmployeesCount(): void {
+		this.context$
+			.pipe(
+				filter((context): context is IDashboardWidgetContext => !!context?.organizationId),
+				// The head count depends on the organization ALONE. Without this,
+				// every date-range tweak would fire another `/employee/count` per
+				// widget on the canvas, for an answer that cannot have changed.
+				distinctUntilChanged(
+					(previous: IDashboardWidgetContext, current: IDashboardWidgetContext) =>
+						previous.organizationId === current.organizationId && previous.tenantId === current.tenantId
+				),
+				switchMap((context: IDashboardWidgetContext) =>
+					this._employeesService
+						.getCount({ organizationId: context.organizationId, tenantId: context.tenantId })
+						// One retry before giving up: because the request is now
+						// deduplicated per organization, a transient failure would
+						// otherwise pin the denominator to 0 until the user switches
+						// organizations.
+						.pipe(
+							retry({ count: 1, delay: 1_000 }),
+							catchError(() => of(0))
+						)
+				),
+				tap((count: number) => this.totalEmployees.set(count || 0)),
+				takeUntilDestroyed(this.destroyRef)
+			)
+			.subscribe();
+	}
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/projects-worked-widget.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/projects-worked-widget.component.html
@@ -1,0 +1,9 @@
+<gz-time-track-counter-card
+	color="success"
+	[value]="projectsWorked().toString()"
+	[counterValue]="projectsWorked()"
+	[total]="totalProjects()"
+	[loading]="loading()"
+	[error]="errorMessage()"
+	(retry)="refresh()"
+></gz-time-track-counter-card>

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/projects-worked-widget.component.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/projects-worked-widget.component.ts
@@ -1,0 +1,73 @@
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { defer, from, of } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, retry, switchMap, tap } from 'rxjs/operators';
+import { IDashboardWidgetContext, OrganizationProjectsService } from '@gauzy/ui-core/core';
+import { BaseTimeTrackCounterWidgetComponent } from './base-time-track-counter-widget.component';
+import { TimeTrackCounterCardComponent } from './time-track-counter-card.component';
+
+/**
+ * Counter widget: how many projects were worked on in the selected range,
+ * scaled against the organization's total project count.
+ */
+@Component({
+	selector: 'gz-projects-worked-widget',
+	templateUrl: './projects-worked-widget.component.html',
+	standalone: true,
+	imports: [TimeTrackCounterCardComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ProjectsWorkedWidgetComponent extends BaseTimeTrackCounterWidgetComponent implements OnInit {
+	private readonly _projectsService = inject(OrganizationProjectsService);
+
+	/** Total projects in the organization — the counter-point denominator. */
+	protected readonly totalProjects = signal<number>(0);
+
+	/** Projects that received logged time in the selected range. */
+	protected readonly projectsWorked = computed<number>(() => this.counts()?.projectsCount ?? 0);
+
+	/**
+	 * Starts the shared counts subscription and the organization project-count lookup.
+	 */
+	public override ngOnInit(): void {
+		super.ngOnInit();
+		this.observeProjectsCount();
+	}
+
+	/**
+	 * Keeps the total project count in sync with the active organization.
+	 *
+	 * Wrapped in `defer` + `from` because `OrganizationProjectsService.getCount`
+	 * returns a Promise — `defer` re-invokes it on retry, where a bare `from`
+	 * would just replay the SAME settled promise. Failures only affect the
+	 * strip's scale, so they are swallowed.
+	 */
+	private observeProjectsCount(): void {
+		this.context$
+			.pipe(
+				filter((context): context is IDashboardWidgetContext => !!context?.organizationId),
+				// The project count depends on the organization ALONE, so a date-range
+				// change must not re-issue it (see the Members Worked widget).
+				distinctUntilChanged(
+					(previous: IDashboardWidgetContext, current: IDashboardWidgetContext) =>
+						previous.organizationId === current.organizationId && previous.tenantId === current.tenantId
+				),
+				switchMap((context: IDashboardWidgetContext) =>
+					defer(() =>
+						from(
+							this._projectsService.getCount({
+								organizationId: context.organizationId,
+								tenantId: context.tenantId
+							})
+						)
+					).pipe(
+						retry({ count: 1, delay: 1_000 }),
+						catchError(() => of(0))
+					)
+				),
+				tap((count: number) => this.totalProjects.set(count || 0)),
+				takeUntilDestroyed(this.destroyRef)
+			)
+			.subscribe();
+	}
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-counter-card.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-counter-card.component.html
@@ -1,0 +1,37 @@
+@if (error()) {
+	<div class="counter-error" role="alert">
+		<div class="counter-error-text">
+			<nb-icon icon="alert-triangle-outline" status="danger"></nb-icon>
+			<span class="counter-error-label" [title]="error()">
+				{{ 'DASHBOARD_PAGE.BUILDER.WIDGETS.ERROR' | translate }}
+			</span>
+		</div>
+		<button nbButton ghost size="tiny" status="basic" type="button" (click)="retry.emit()">
+			{{ 'DASHBOARD_PAGE.BUILDER.WIDGETS.RETRY' | translate }}
+		</button>
+	</div>
+} @else if (loading()) {
+	<!-- <output> carries an implicit `status` live region, so no explicit role. -->
+	<output
+		class="counter-skeleton"
+		aria-busy="true"
+		[attr.aria-label]="'DASHBOARD_PAGE.BUILDER.WIDGETS.LOADING' | translate"
+	>
+		<div class="skeleton-line skeleton-value"></div>
+		<div class="skeleton-line skeleton-strip"></div>
+	</output>
+} @else {
+	<div class="h1 counter-value">{{ value() }}</div>
+	<div class="counter-container">
+		<gauzy-counter-point
+			[total]="total()"
+			[value]="counterValue()"
+			[color]="color()"
+			[progress]="progress()"
+		></gauzy-counter-point>
+	</div>
+
+	@if (captionKey(); as caption) {
+		<div class="counter-caption">{{ caption | translate }}</div>
+	}
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-counter-card.component.scss
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-counter-card.component.scss
@@ -1,0 +1,104 @@
+@use 'themes' as *;
+
+// No card chrome here on purpose: `ga-dashboard-widget-host` already renders the
+// `nb-card`, its header and the body padding. This component only fills that body,
+// centred the same way the legacy Time Tracking counter centres its content.
+:host {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 100%;
+	width: 100%;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.counter-value {
+	margin-bottom: 0.5rem;
+}
+
+.counter-container {
+	width: 71%;
+}
+
+.counter-caption {
+	margin-top: 0.375rem;
+	color: nb-theme(text-hint-color);
+	font-size: nb-theme(text-caption-font-size);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+// Loading state — two shimmering bars standing in for the value and the
+// counter-point strip, so the card does not change height while fetching.
+.counter-skeleton {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+
+	.skeleton-line {
+		border-radius: nb-theme(border-radius);
+		background: linear-gradient(
+			90deg,
+			nb-theme(background-basic-color-2) 25%,
+			nb-theme(background-basic-color-3) 37%,
+			nb-theme(background-basic-color-2) 63%
+		);
+		background-size: 400% 100%;
+		animation: counter-skeleton-shimmer 1.4s ease infinite;
+	}
+
+	.skeleton-value {
+		height: 30px;
+		width: 45%;
+	}
+
+	.skeleton-strip {
+		height: 10px;
+		width: 71%;
+	}
+}
+
+// Respect users who asked the OS to reduce motion.
+@media (prefers-reduced-motion: reduce) {
+	.counter-skeleton .skeleton-line {
+		animation: none;
+	}
+}
+
+@keyframes counter-skeleton-shimmer {
+	0% {
+		background-position: 100% 50%;
+	}
+	100% {
+		background-position: 0 50%;
+	}
+}
+
+.counter-error {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.25rem;
+
+	.counter-error-text {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		color: nb-theme(text-hint-color);
+		font-size: 12px;
+		line-height: 15px;
+	}
+
+	.counter-error-label {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	nb-icon {
+		height: 14px;
+		width: 14px;
+	}
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-counter-card.component.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-counter-card.component.ts
@@ -1,0 +1,71 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { NbButtonModule, NbIconModule } from '@nebular/theme';
+import { TranslateModule } from '@ngx-translate/core';
+import { CounterPointComponent } from '@gauzy/ui-core/shared';
+
+/**
+ * Presentational body shared by the six Time Tracking counter widgets.
+ *
+ * It renders the inside of the legacy dashboard counter (large value plus the
+ * `gauzy-counter-point` strip) and adds the two states a canvas-hosted widget
+ * needs but the legacy page never had: a loading skeleton and a recoverable
+ * error state.
+ *
+ * It deliberately renders NO card and NO title: on a canvas every widget is
+ * already wrapped by `<ga-dashboard-widget-host>`, which owns the `nb-card`, the
+ * header title and the edit-mode menu. Rendering our own would nest a card in a
+ * card and print the title twice.
+ *
+ * Purely presentational on purpose — all fetching lives in
+ * `BaseTimeTrackCounterWidgetComponent`, so this component stays trivially
+ * reusable by any future counter.
+ */
+@Component({
+	selector: 'gz-time-track-counter-card',
+	templateUrl: './time-track-counter-card.component.html',
+	styleUrls: ['./time-track-counter-card.component.scss'],
+	standalone: true,
+	imports: [NbButtonModule, NbIconModule, TranslateModule, CounterPointComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TimeTrackCounterCardComponent {
+	/**
+	 * Optional translation key for a muted line under the counter.
+	 *
+	 * Used by the range-aware counters to say what the number actually covers
+	 * ("Worked over the period") when the selected range is not the one the host
+	 * header implies. `null` — the default — renders nothing, because repeating
+	 * the host's title inside the card is pure noise.
+	 */
+	readonly captionKey = input<string | null>(null);
+
+	/** Already formatted value shown as the headline figure (`"12"`, `"08:15:00"`, `"64%"`). */
+	readonly value = input<string>('');
+
+	/** Raw numeric value driving the counter-point strip. */
+	readonly counterValue = input<number>(0);
+
+	/** Denominator for the counter-point strip. `0` falls back to a full day. */
+	readonly total = input<number>(0);
+
+	/**
+	 * Nebular status name used to colour filled points (`info`, `success`, …).
+	 *
+	 * A status — not a hex — because `CounterPointComponent` interpolates this
+	 * into `var(--color-<value>-default)`, which is what keeps the strip correct
+	 * in every theme.
+	 */
+	readonly color = input<string>('');
+
+	/** Renders a progress bar instead of the point strip (percentage counters). */
+	readonly progress = input<boolean>(false);
+
+	/** Shows the skeleton instead of the value. */
+	readonly loading = input<boolean>(false);
+
+	/** Non-null switches the card into its error state. */
+	readonly error = input<string | null>(null);
+
+	/** Emitted when the user asks for a re-fetch from the error state. */
+	readonly retry = output<void>();
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-widget.utils.spec.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-widget.utils.spec.ts
@@ -1,0 +1,121 @@
+import * as moment from 'moment';
+import type { IOrganization } from '@gauzy/contracts';
+import type { IDashboardWidgetContext } from '@gauzy/ui-core/core';
+import {
+	isCurrentWeekRange,
+	RangePeriod,
+	resolvePeriodSeconds,
+	resolveRangePeriod,
+	toErrorMessage
+} from './time-track-widget.utils';
+
+/**
+ * Builds a minimal widget context for the pure helpers under test.
+ */
+function createContext(overrides: Partial<IDashboardWidgetContext> = {}): IDashboardWidgetContext {
+	return {
+		tenantId: 'tenant-1',
+		organizationId: 'org-1',
+		startDate: new Date('2026-07-20T00:00:00Z'),
+		endDate: new Date('2026-07-26T23:59:59Z'),
+		todayStart: new Date('2026-07-26T00:00:00Z'),
+		todayEnd: new Date('2026-07-26T23:59:59Z'),
+		timeZone: 'UTC',
+		...overrides
+	} as IDashboardWidgetContext;
+}
+
+describe('time-track widget utils', () => {
+	describe('resolveRangePeriod', () => {
+		it('classifies a single day', () => {
+			const day = new Date('2026-07-26T00:00:00Z');
+			expect(resolveRangePeriod(createContext({ startDate: day, endDate: day }))).toBe(RangePeriod.DAY);
+		});
+
+		it('classifies a seven day span as a week', () => {
+			expect(resolveRangePeriod(createContext())).toBe(RangePeriod.WEEK);
+		});
+
+		it('classifies anything else as a period', () => {
+			const context = createContext({ endDate: new Date('2026-08-19T23:59:59Z') });
+			expect(resolveRangePeriod(context)).toBe(RangePeriod.PERIOD);
+		});
+
+		it('defaults to week without a range', () => {
+			expect(resolveRangePeriod(null)).toBe(RangePeriod.WEEK);
+		});
+	});
+
+	describe('isCurrentWeekRange', () => {
+		it('detects the current calendar week', () => {
+			const context = createContext({
+				startDate: moment().startOf('week').toDate(),
+				endDate: moment().endOf('week').toDate()
+			});
+			expect(isCurrentWeekRange(context)).toBe(true);
+		});
+
+		it('rejects a past week', () => {
+			const context = createContext({
+				startDate: moment().subtract(3, 'weeks').startOf('week').toDate(),
+				endDate: moment().subtract(3, 'weeks').endOf('week').toDate()
+			});
+			expect(isCurrentWeekRange(context)).toBe(false);
+		});
+	});
+
+	describe('resolvePeriodSeconds', () => {
+		it('uses the organization working hours', () => {
+			const context = createContext({
+				organization: { defaultStartTime: '09:00', defaultEndTime: '17:00' } as unknown as IOrganization
+			});
+			// 7 days * 8h * 3 members
+			expect(resolvePeriodSeconds(context, 3)).toBe(7 * 28800 * 3);
+		});
+
+		it('falls back to a full day when working hours are not configured', () => {
+			expect(resolvePeriodSeconds(createContext(), 2)).toBe(7 * 86400 * 2);
+		});
+
+		it('falls back to a full day when only one end of the working day is set', () => {
+			const context = createContext({
+				organization: { defaultStartTime: '09:00' } as unknown as IOrganization
+			});
+			expect(resolvePeriodSeconds(context, 2)).toBe(7 * 86400 * 2);
+		});
+
+		it('falls back to a full day when the working hours do not parse', () => {
+			const context = createContext({
+				organization: { defaultStartTime: 'nonsense', defaultEndTime: '17:00' } as unknown as IOrganization
+			});
+			expect(resolvePeriodSeconds(context, 1)).toBe(7 * 86400);
+		});
+
+		it('is zero without a range', () => {
+			expect(resolvePeriodSeconds(null, 5)).toBe(0);
+		});
+	});
+
+	describe('toErrorMessage', () => {
+		it('returns null when there is no error', () => {
+			expect(toErrorMessage(null)).toBeNull();
+		});
+
+		it('passes strings through', () => {
+			expect(toErrorMessage('boom')).toBe('boom');
+		});
+
+		it('unwraps an error message', () => {
+			expect(toErrorMessage(new Error('request failed'))).toBe('request failed');
+		});
+
+		it('prefers the nested API message of an HttpErrorResponse', () => {
+			const response = { message: 'Http failure response', error: { message: 'Organization not found' } };
+			expect(toErrorMessage(response)).toBe('Organization not found');
+		});
+
+		it('never renders a bare object as [object Object]', () => {
+			expect(toErrorMessage({ status: 500 })).toBe('Something went wrong');
+		});
+	});
+});

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-widget.utils.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/time-track-widget.utils.ts
@@ -1,0 +1,152 @@
+import * as moment from 'moment';
+// Type-only import keeps this module free of cross-package runtime dependencies,
+// so it stays trivially unit-testable.
+import type { IDashboardWidgetContext } from '@gauzy/ui-core/core';
+
+/**
+ * Granularity of the selected reporting window.
+ *
+ * Mirrors the `RangePeriod` enum declared on the legacy `TimeTrackingComponent`.
+ * It is re-declared here on purpose: importing it from the component file would
+ * drag the whole (eagerly-styled, Swiper-registering) dashboard component into
+ * every lazily loaded widget chunk.
+ */
+export enum RangePeriod {
+	DAY = 'DAY',
+	WEEK = 'WEEK',
+	PERIOD = 'PERIOD'
+}
+
+/** Seconds in a full day, used when the organization has no working hours configured. */
+const SECONDS_IN_DAY = 86400;
+
+// NOTE: request shaping for `/timesheet/statistics/*` deliberately lives in
+// `TimesheetStatisticsCacheService.buildStatisticsRequest` (@gauzy/ui-core/core)
+// and must NOT be duplicated here — it applies the organization's UTC offset,
+// and a second, offset-free implementation is exactly what makes a canvas widget
+// disagree with the standard Time Tracking page about the same numbers.
+
+/**
+ * Classifies the selected date range as a single day, a week, or an arbitrary period.
+ *
+ * @param context The ambient dashboard widget context.
+ * @returns The matching {@link RangePeriod}; defaults to `WEEK` when unknown.
+ */
+export function resolveRangePeriod(context: IDashboardWidgetContext | null): RangePeriod {
+	if (!context?.startDate || !context?.endDate) {
+		return RangePeriod.WEEK;
+	}
+
+	const days = moment(context.endDate).diff(moment(context.startDate), 'days');
+
+	if (days === 0) {
+		return RangePeriod.DAY;
+	}
+	if (days === 6) {
+		return RangePeriod.WEEK;
+	}
+	return RangePeriod.PERIOD;
+}
+
+/**
+ * Whether the selected range is exactly the current calendar week.
+ *
+ * Drives the "Worked this week" vs "Worked for the week" title, matching the
+ * legacy dashboard wording.
+ *
+ * @param context The ambient dashboard widget context.
+ * @returns True when the range spans the current week.
+ */
+export function isCurrentWeekRange(context: IDashboardWidgetContext | null): boolean {
+	if (!context?.startDate || !context?.endDate) {
+		return false;
+	}
+
+	return (
+		moment(context.startDate).format('YYYY-MM-DD') === moment().startOf('week').format('YYYY-MM-DD') &&
+		moment(context.endDate).format('YYYY-MM-DD') === moment().endOf('week').format('YYYY-MM-DD')
+	);
+}
+
+/**
+ * Total number of workable seconds in the selected range across all members.
+ *
+ * Used as the denominator ("total") of the duration counters so the coloured
+ * points represent progress against capacity rather than against a fixed day.
+ * Replicates `TimeTrackingComponent.period`.
+ *
+ * @param context The ambient dashboard widget context.
+ * @param employeesCount Number of members that logged time in the range.
+ * @returns The capacity in seconds; `0` when it cannot be derived.
+ */
+export function resolvePeriodSeconds(context: IDashboardWidgetContext | null, employeesCount: number): number {
+	if (!context?.startDate || !context?.endDate) {
+		return 0;
+	}
+
+	const dayCount = moment(context.endDate).diff(moment(context.startDate), 'days') + 1;
+
+	return dayCount * resolveWorkingSeconds(context) * (employeesCount || 0);
+}
+
+/**
+ * Working seconds in one day for the context's organization.
+ *
+ * Both ends have to be present AND parse: `moment(undefined, 'HH:mm')` yields
+ * the CURRENT time rather than an invalid date, so an organization with no
+ * configured hours would produce a near-zero capacity instead of reaching the
+ * documented full-day fallback.
+ *
+ * @param context The ambient dashboard widget context.
+ * @returns Seconds of capacity per day, falling back to a full day.
+ */
+function resolveWorkingSeconds(context: IDashboardWidgetContext): number {
+	const { defaultStartTime, defaultEndTime } = context.organization ?? {};
+	if (!defaultStartTime || !defaultEndTime) {
+		return SECONDS_IN_DAY;
+	}
+
+	const startWork = moment(defaultStartTime, 'HH:mm', true);
+	const endWork = moment(defaultEndTime, 'HH:mm', true);
+	if (!startWork.isValid() || !endWork.isValid()) {
+		return SECONDS_IN_DAY;
+	}
+
+	const workingSeconds = endWork.diff(startWork) / 1000;
+	return Number.isNaN(workingSeconds) || workingSeconds <= 0 ? SECONDS_IN_DAY : workingSeconds;
+}
+
+/** Shown when an error carries no readable message of its own. */
+const GENERIC_ERROR_MESSAGE = 'Something went wrong';
+
+/**
+ * Normalizes anything thrown by an HTTP call (or held in the base widget's
+ * `error` signal) into a displayable message.
+ *
+ * An `HttpErrorResponse` nests the server's text under `error.message`, so that
+ * is unwrapped too. A bare object is NEVER stringified: `String({})` renders the
+ * useless `[object Object]` straight into the widget's error state.
+ *
+ * @param error The caught value.
+ * @returns A human readable message, or `null` when there is no error.
+ */
+export function toErrorMessage(error: unknown): string | null {
+	if (!error) {
+		return null;
+	}
+	if (typeof error === 'string') {
+		return error;
+	}
+	if (typeof error !== 'object') {
+		return String(error);
+	}
+
+	const candidate = error as { message?: unknown; error?: { message?: unknown } };
+	// The API payload's own message wins: it is the one written for a human.
+	const nested = candidate.error?.message;
+	if (typeof nested === 'string' && nested.length > 0) {
+		return nested;
+	}
+	const message = candidate.message;
+	return typeof message === 'string' && message.length > 0 ? message : GENERIC_ERROR_MESSAGE;
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/today-activity-widget.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/today-activity-widget.component.html
@@ -1,0 +1,8 @@
+<gz-time-track-counter-card
+	[progress]="true"
+	[value]="todayActivity() + '%'"
+	[counterValue]="todayActivity()"
+	[loading]="loading()"
+	[error]="errorMessage()"
+	(retry)="refresh()"
+></gz-time-track-counter-card>

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/today-activity-widget.component.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/today-activity-widget.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { BaseTimeTrackCounterWidgetComponent } from './base-time-track-counter-widget.component';
+import { TimeTrackCounterCardComponent } from './time-track-counter-card.component';
+
+/**
+ * Counter widget: today's overall activity percentage (keyboard/mouse activity
+ * recorded by the desktop tracker), rendered as a progress bar.
+ */
+@Component({
+	selector: 'gz-today-activity-widget',
+	templateUrl: './today-activity-widget.component.html',
+	standalone: true,
+	imports: [TimeTrackCounterCardComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TodayActivityWidgetComponent extends BaseTimeTrackCounterWidgetComponent {
+	/** Today's activity percentage. */
+	protected readonly todayActivity = computed<number>(() => this.counts()?.todayActivities ?? 0);
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/weekly-activity-widget.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/weekly-activity-widget.component.html
@@ -1,0 +1,9 @@
+<gz-time-track-counter-card
+	[captionKey]="captionKey()"
+	[progress]="true"
+	[value]="weekActivity() + '%'"
+	[counterValue]="weekActivity()"
+	[loading]="loading()"
+	[error]="errorMessage()"
+	(retry)="refresh()"
+></gz-time-track-counter-card>

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/weekly-activity-widget.component.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/weekly-activity-widget.component.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { BaseTimeTrackCounterWidgetComponent } from './base-time-track-counter-widget.component';
+import { TimeTrackCounterCardComponent } from './time-track-counter-card.component';
+import { RangePeriod } from './time-track-widget.utils';
+
+/**
+ * Counter widget: overall activity percentage for the selected period,
+ * rendered as a progress bar.
+ *
+ * Like its duration sibling, it captions the number with the selected range so a
+ * month-long selection does not silently read as "Weekly Activity".
+ */
+@Component({
+	selector: 'gz-weekly-activity-widget',
+	templateUrl: './weekly-activity-widget.component.html',
+	standalone: true,
+	imports: [TimeTrackCounterCardComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WeeklyActivityWidgetComponent extends BaseTimeTrackCounterWidgetComponent {
+	/** Activity percentage over the selected range. */
+	protected readonly weekActivity = computed<number>(() => this.counts()?.weekActivities ?? 0);
+
+	/** Range-aware caption; `null` when the host title already says it. */
+	protected readonly captionKey = computed<string | null>(() => {
+		switch (this.rangePeriod()) {
+			case RangePeriod.PERIOD:
+				return 'TIMESHEET.ACTIVITY_OVER_PERIOD';
+			case RangePeriod.DAY:
+				return 'TIMESHEET.ACTIVITY_FOR_DAY';
+			default:
+				// The host header already reads "Weekly Activity".
+				return null;
+		}
+	});
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/worked-this-week-widget.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/worked-this-week-widget.component.html
@@ -1,0 +1,10 @@
+<gz-time-track-counter-card
+	color="success"
+	[captionKey]="captionKey()"
+	[value]="weekDuration() | durationFormat"
+	[counterValue]="weekDuration()"
+	[total]="periodSeconds()"
+	[loading]="loading()"
+	[error]="errorMessage()"
+	(retry)="refresh()"
+></gz-time-track-counter-card>

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/worked-this-week-widget.component.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/worked-this-week-widget.component.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { DurationFormatPipe } from '@gauzy/ui-core/shared';
+import { BaseTimeTrackCounterWidgetComponent } from './base-time-track-counter-widget.component';
+import { TimeTrackCounterCardComponent } from './time-track-counter-card.component';
+import { RangePeriod } from './time-track-widget.utils';
+
+/**
+ * Counter widget: total duration worked over the selected period.
+ *
+ * The host header always reads "Worked This Week" (the registry title), so the
+ * widget adds a caption whenever the selected range is something else — the
+ * legacy dashboard conveyed the same thing by rewriting its card title, which a
+ * canvas widget cannot do.
+ */
+@Component({
+	selector: 'gz-worked-this-week-widget',
+	templateUrl: './worked-this-week-widget.component.html',
+	standalone: true,
+	imports: [DurationFormatPipe, TimeTrackCounterCardComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WorkedThisWeekWidgetComponent extends BaseTimeTrackCounterWidgetComponent {
+	/** Seconds worked over the selected range. */
+	protected readonly weekDuration = computed<number>(() => this.counts()?.weekDuration ?? 0);
+
+	/** Range-aware caption; `null` when the host title already says it. */
+	protected readonly captionKey = computed<string | null>(() => {
+		switch (this.rangePeriod()) {
+			case RangePeriod.PERIOD:
+				return 'TIMESHEET.WORKED_OVER_PERIOD';
+			case RangePeriod.DAY:
+				return 'TIMESHEET.WORKED_FOR_DAY';
+			default:
+				return this.isCurrentWeek() ? null : 'TIMESHEET.WORKED_FOR_WEEK';
+		}
+	});
+}

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/worked-today-widget.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/worked-today-widget.component.html
@@ -1,0 +1,9 @@
+<gz-time-track-counter-card
+	color="success"
+	[value]="todayDuration() | durationFormat"
+	[counterValue]="todayDuration()"
+	[total]="periodSeconds()"
+	[loading]="loading()"
+	[error]="errorMessage()"
+	(retry)="refresh()"
+></gz-time-track-counter-card>

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/worked-today-widget.component.ts
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/widgets/worked-today-widget.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { DurationFormatPipe } from '@gauzy/ui-core/shared';
+import { BaseTimeTrackCounterWidgetComponent } from './base-time-track-counter-widget.component';
+import { TimeTrackCounterCardComponent } from './time-track-counter-card.component';
+
+/**
+ * Counter widget: total duration worked today across the current scope,
+ * rendered as `HH:mm:ss` against the range's workable capacity.
+ */
+@Component({
+	selector: 'gz-worked-today-widget',
+	templateUrl: './worked-today-widget.component.html',
+	standalone: true,
+	imports: [DurationFormatPipe, TimeTrackCounterCardComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WorkedTodayWidgetComponent extends BaseTimeTrackCounterWidgetComponent {
+	/** Seconds worked today. */
+	protected readonly todayDuration = computed<number>(() => this.counts()?.todayDuration ?? 0);
+}

--- a/packages/ui-core/core/src/lib/common/component-registry.types.ts
+++ b/packages/ui-core/core/src/lib/common/component-registry.types.ts
@@ -39,6 +39,10 @@ export type ComponentRegistryLocationId = 'table' | 'tab' | 'route';
  * - 'organization-sections': Children under /pages/organization.
  * - 'goals-sections': Children under /pages/goals.
  * - 'reports-sections': Children under /pages/reports.
+ * - 'settings-sections': Children under /pages/settings, rendered inside the
+ *   settings shell (Sidebar | Settings menu | content). Plugin settings pages
+ *   MUST use this rather than 'page-sections', or they render standalone
+ *   without the settings menu.
  * - 'page-sections': Top-level plugin section routes under /pages.
  */
 export type PageRouteLocationId =
@@ -57,6 +61,7 @@ export type PageRouteLocationId =
 	| 'organization-sections'
 	| 'goals-sections'
 	| 'reports-sections'
+	| 'settings-sections'
 	| 'page-sections';
 
 /**

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.html
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.html
@@ -1,7 +1,6 @@
 <ng-container *ngxPermissionsOnly="item?.data?.permissionKeys">
 	@if (!collapse) { @if (!item?.hidden) {
 	<div
-		[class.border-bottom]="!isLast()"
 		[gaTooltip]="item?.title"
 		[icon]="item?.icon"
 		[class]="(selected ? 'selected ' : '') + (!collapse ? 'custom ' : '') + 'sub-item'"
@@ -20,7 +19,6 @@
 	</div>
 	} } @else { @if (!item?.hidden) {
 	<div
-		[class.border-bottom]="!isLast()"
 		[nbTooltip]="item?.title"
 		nbTooltipPlacement="right"
 		[class]="(selected ? 'sub-item selected' : 'sub-item') + (!collapse ? ' custom' : '')"

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.scss
@@ -1,12 +1,43 @@
+// `themes` must be loaded HERE as well: Sass `@use ... as *` inside
+// menu-item.component.scss makes nb-theme() available to that file only, it is
+// not re-exported. Without this line the rules below compiled to a literal
+// `nb-theme(...)` in the output — an unknown CSS function the browser drops.
+@use 'themes' as *;
+
+// Row layout, hover/active overlays and the icon column all live in the parent
+// stylesheet so both components stay in sync; `:host` resolves to
+// <ga-children-menu-item> here.
 @use '../menu-item/menu-item.component';
 
+// Inline "add" control on a child row. It sits inside a flat menu row, so it
+// is a ghost icon button: no outline, no fill, it only brightens on hover.
 [nbButton].plus.appearance-outline.size-tiny {
-    padding: 2px 3px;
-    border: 2px solid nb-theme(gauzy-border-default-color);
-    color: nb-theme(gauzy-text-color-2);
+  padding: 0.125rem 0.25rem;
+  border: none;
+  background-color: transparent;
+  // `inherit`, not nb-theme(gauzy-text-color-2): that token is undefined in the
+  // material-* themes, and it would also freeze the button at the RESTING label
+  // colour while the row around it brightens on hover/selection. Inheriting from
+  // `.sub-item` tracks the row in every theme and every state.
+  color: inherit;
 
-    i.fa-plus {
-        margin: 0;
-        font-size: 14px;
-    }
+  &:hover {
+    background-color: transparent;
+    color: nb-theme(text-basic-color);
+  }
+
+  // Keyboard focus needs a NON-colour indicator: the hover treatment is a
+  // brightness shift only, which on its own fails WCAG 1.4.11 / 2.4.7. The
+  // outline is inset so it never widens the row.
+  &:focus-visible {
+    background-color: transparent;
+    color: nb-theme(text-basic-color);
+    outline: 2px solid nb-theme(color-primary-default);
+    outline-offset: -2px;
+  }
+
+  i.fa-plus {
+    margin: 0;
+    font-size: 0.75rem;
+  }
 }

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.ts
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/children-menu-item/children-menu-item.component.ts
@@ -162,13 +162,4 @@ export class ChildrenMenuItemComponent implements OnInit {
 		this.focusItemChange.emit({ children: this.item, parent: this.parent });
 		this.router.navigateByUrl(this.item.data.add);
 	}
-
-	/**
-	 * Checks if the current item is the last item among its siblings.
-	 * @returns A boolean indicating whether the current item is the last among its siblings.
-	 */
-	public isLast(): boolean {
-		const last = this.parent.children.slice(-1)[0];
-		return this.item === last;
-	}
 }

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
@@ -1,87 +1,252 @@
 @use 'themes' as *;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Flat (shadcn-like) sidebar rows.
+//
+// WHY this file strips so much: Nebular renders every top level entry as its
+// own <nb-accordion>, and the framework defaults paint that accordion as a
+// CARD — an opaque `accordion-item-background-color` fill, the 0.625rem
+// `accordion-border-radius`, `accordion-shadow`, and a 1px divider under each
+// header. Stacked in a narrow sidebar those cards read as a "rounded block"
+// around every item, which is exactly the look we are removing.
+//
+// The rule from here on: a row paints NOTHING at rest. Only :hover and the
+// active entry get a low contrast overlay on a small radius — never a border,
+// never a per item shadow.
+//
+// The overlays are neutral rgba rather than solid colours on purpose: the same
+// value darkens the light sidebar (#f4f4f5 / #fbfbfb) and lightens the dark one
+// (#141416 / #1e1e22), so no per theme branch is needed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Hover overlay. `gauzy-sidebar-background-3` is rgba(126, 126, 143, 0.1) in
+// every theme that declares it; the literal fallback keeps hover visible in the
+// material-* themes, which never declared the token.
+// TODO(theme): replace with nb-theme(gauzy-menu-item-hover-background).
+$menu-row-hover-background: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+
+// Active overlay — exactly twice the hover alpha. Measured on both surfaces the
+// pair stays distinguishable (light #ededee vs #e2e2e5, dark #2b2b2f vs
+// #313138) while neither reads as a filled block.
+// TODO(theme): replace with nb-theme(gauzy-menu-item-active-background).
+$menu-row-active-background: rgba(126, 126, 143, 0.2);
+
+// 6px. Deliberately NOT nb-theme(border-radius) (0.625rem / 10px): that is the
+// CARD radius, and a 10px pill is a large part of why rows look like blocks.
+// TODO(theme): replace with nb-theme(gauzy-menu-item-radius).
+$menu-row-radius: 0.375rem;
+
+// Resting label colour, muted. Nested fallback because gauzy-text-color-2 is
+// undefined in the material-* themes.
+$menu-row-color: var(--gauzy-text-color-2, var(--text-hint-color));
+
+// Fixed icon column so labels line up whatever glyph an entry uses.
+$menu-icon-column: 1rem;
+
+// Room reserved on the trailing edge for the accordion chevron. Nebular pins
+// the indicator at `right: 1rem`, so the gutter has to clear 1rem + the icon.
+$menu-chevron-gutter: 2rem;
+
+// The inline half of `menu-item-padding` (0.5rem 0.75rem). Needed as a literal
+// wherever the chevron gutter is given back, because a CSS custom property
+// cannot be destructured into its longhand properties.
+// KEEP IN SYNC with `menu-item-padding` in packages/ui-core/static/styles/themes.scss.
+$menu-row-inline-padding: 0.75rem;
+
+// Child rows sit one step in from the parent row's icon column:
+// 0.75rem (row padding) + 0.75rem (step).
+$menu-child-indent: 1.5rem;
+
 :host {
   position: relative;
-  nb-accordion-item-body.item-collapsed ::ng-deep .item-body {
-    padding: 4px;
-  }
+  display: block;
+
+  // ── Container: no card fill, no card radius, no shadow ────────────────────
   nb-accordion {
-    box-shadow: unset;
-    margin-top: 2px;
-    nb-accordion-item.opened {
-      box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
-      nb-accordion-item-header {
-        background-color: nb-theme(gauzy-sidebar-background-3);
-        &.accordion-item-header-expanded {
-          border-radius: nb-theme(border-radius) nb-theme(border-radius) 0 0;
-        }
-      }
-      nb-accordion-item-body {
-        background-color: nb-theme(gauzy-sidebar-background-4);
-        border-radius: 0 0 nb-theme(border-radius) nb-theme(border-radius);
-      }
-    }
-    &.focus {
-      box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.1);
-      nb-accordion-item-header,
-      i {
-        color: rgba(245, 109, 88, 1);
-      }
-    }
-    nb-accordion-item-header.accordion-item-header-collapsed {
-      border-radius: nb-theme(border-radius);
-    }
-    &.closed {
-      nb-accordion-item-header {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        i {
-          margin-right: unset;
-        }
-        ::ng-deep nb-icon {
-          display: none;
-        }
-      }
-    }
-    &.application {
-      nb-accordion-item {
-        nb-accordion-item-header {
-          border: 1px solid nb-theme(background-primary-color-1);
-          color: nb-theme(text-primary-color);
-          border-radius: nb-theme(border-radius);
-        }
-        i {
-          color: nb-theme(text-primary-color);
-        }
-        nb-accordion-item-header ::ng-deep nb-icon {
-          border: 1px solid nb-theme(background-primary-color-1);
-          border-radius: nb-theme(border-radius);
-          width: 1.75rem;
-          height: 1.75rem;
-          @include nb-ltr(margin-right, calc(-1.75rem / 4));
-          @include nb-rtl(margin-left, calc(-1.75rem / 4));
-        }
-      }
-    }
-  }
-  hr.custom-separator {
-    border: 0.5px solid nb-theme(gauzy-border-default-color);
-    border-top: none;
-    border-left: none;
-    border-right: none;
-  }
-  i {
-    color: nb-theme(gauzy-text-color-1);
+    // 2px breathing room between rows (shadcn stacks menu rows with a small gap
+    // instead of dividers).
+    margin-top: 0.125rem;
+    background-color: transparent;
+    border-radius: 0;
+    box-shadow: none;
   }
 
+  nb-accordion-item {
+    background-color: transparent;
+    border-radius: 0;
+  }
+
+  // ── The row ───────────────────────────────────────────────────────────────
   nb-accordion-item-header {
-    color: nb-theme(gauzy-text-color-2);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: nb-theme(menu-item-padding);
+    // Keep the label clear of the absolutely positioned chevron. Logical
+    // property rather than nb-ltr/nb-rtl: it flips with the inherited
+    // `direction` and does not depend on a [dir] attribute being present.
+    padding-inline-end: $menu-chevron-gutter;
+    border-radius: $menu-row-radius;
+    // Nebular draws a 1px divider above/below every header; flat rows have none.
+    border-width: 0;
+    color: $menu-row-color;
     font-size: nb-theme(menu-text-font-size);
     font-weight: nb-theme(menu-text-font-weight);
-    line-height: 16px;
-    letter-spacing: 0em;
-    gap: 0.5rem;
+    line-height: 1.25rem;
+    letter-spacing: 0;
+    transition:
+      background-color 0.12s ease-in-out,
+      color 0.12s ease-in-out;
+
+    // Icons inherit the row colour (muted at rest, brightening with the label)
+    // and sit in a fixed width column so every label starts at the same x.
+    > i {
+      flex: 0 0 auto;
+      width: $menu-icon-column;
+      font-size: 0.875rem;
+      text-align: center;
+      color: inherit;
+    }
+
+    // Label: never wraps, never pushes the chevron — it truncates.
+    > span {
+      flex: 1 1 auto;
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    // Collapsed and expanded headers look identical — the radius must not be
+    // squared off on expand, or the row turns back into the top half of a card.
+    &.accordion-item-header-collapsed,
+    &.accordion-item-header-expanded {
+      border-radius: $menu-row-radius;
+    }
+  }
+
+  // Hover: a tint only. No shadow, no border, no colour shift on the surface
+  // behind it.
+  nb-accordion-item-header:hover {
+    background-color: $menu-row-hover-background;
+    color: nb-theme(text-basic-color);
+  }
+
+  // Nebular makes the header focusable (tabindex="0") but paints nothing on
+  // focus, so keyboard users had no row indicator at all. Same tint as hover
+  // plus an inset outline, because the tint alone is a colour-only signal.
+  nb-accordion-item-header:focus-visible {
+    background-color: $menu-row-hover-background;
+    color: nb-theme(text-basic-color);
+    outline: 2px solid nb-theme(color-primary-default);
+    outline-offset: -2px;
+  }
+
+  // Chevron: muted and sized to the row (nb-icon defaults to 1.25rem, which
+  // towers over a 0.8125rem label). Position stays Nebular's.
+  ::ng-deep nb-icon.expansion-indicator {
+    font-size: 1rem;
+    color: inherit;
+    opacity: 0.55;
+  }
+
+  // A leaf entry cannot expand, so it must not advertise a chevron. The body is
+  // only rendered when the entry has children, which is what :has() tests.
+  nb-accordion-item:not(:has(nb-accordion-item-body)) ::ng-deep nb-icon.expansion-indicator {
+    display: none;
+  }
+
+  // ...and with no chevron to clear, the trailing gutter is dead space that
+  // would truncate the label ~1.25rem early in a ~200px sidebar. Give it back.
+  // Same :has() test as above, so the two always agree: a browser without
+  // :has() keeps BOTH the chevron and its gutter.
+  nb-accordion-item:not(:has(nb-accordion-item-body)) > nb-accordion-item-header {
+    padding-inline-end: $menu-row-inline-padding;
+  }
+
+  // ── Active entry ──────────────────────────────────────────────────────────
+  // `.opened` is bound to `selected`, i.e. this entry owns the current route.
+  // Icon and label share `text-basic-color` on purpose: a single brand accent
+  // cannot clear 3:1 on BOTH the tinted light row (#e2e2e5) and the tinted dark
+  // one (#313138) — color-primary-default measures ~5.4:1 light but only ~2.5:1
+  // dark. Tint + weight already say "current" without a colour.
+  // TODO(theme): a per theme `gauzy-menu-item-active-foreground` would let the
+  // icon carry the accent safely (light: color-primary-600, dark: -300).
+  nb-accordion-item.opened > nb-accordion-item-header {
+    background-color: $menu-row-active-background;
+    color: nb-theme(text-basic-color);
+    font-weight: 600;
+  }
+
+  // ...but when the entry has children the fill belongs to the selected CHILD
+  // row. Filling the parent as well would stack two highlighted rows, which is
+  // the "block" look again — so the parent keeps the emphasis (weight/colour)
+  // and drops the fill. Browsers without :has() simply keep the fill above.
+  nb-accordion-item.opened:has(nb-accordion-item-body) > nb-accordion-item-header {
+    background-color: transparent;
+
+    &:hover {
+      background-color: $menu-row-hover-background;
+    }
+  }
+
+  // ── Sub-list ──────────────────────────────────────────────────────────────
+  nb-accordion-item-body {
+    background-color: transparent;
+    border-radius: 0;
+
+    ::ng-deep .item-body {
+      padding: 0.125rem 0 0.25rem;
+    }
+  }
+
+  // Icon rail (sidebar collapsed): the sub-list is a bare stack of glyphs, so
+  // it needs no horizontal gutter at all.
+  nb-accordion-item-body.item-collapsed ::ng-deep .item-body {
+    padding: 0.25rem 0;
+  }
+
+  // ── Icon rail ─────────────────────────────────────────────────────────────
+  // `.closed` mirrors the sidebar's collapsed state: one centred glyph per row,
+  // no label and no chevron (there is no width to spare for either).
+  nb-accordion.closed {
+    nb-accordion-item-header {
+      justify-content: center;
+      // The chevron is hidden here, so give its gutter back to the glyph.
+      padding-inline-end: $menu-row-inline-padding;
+
+      > i {
+        margin-right: unset;
+      }
+
+      // No room for the chevron in the rail.
+      ::ng-deep nb-icon {
+        display: none;
+      }
+    }
+  }
+
+  // ── Variants ──────────────────────────────────────────────────────────────
+  // "Focus" entry: keeps its accent label/icon colour (it reads on both the
+  // light and the dark sidebar), but no longer floats on its own drop shadow.
+  nb-accordion.focus {
+    nb-accordion-item-header,
+    i {
+      color: rgba(245, 109, 88, 1);
+    }
+  }
+
+  // "Applications" entry: same flat row as everything else; the boxed icon and
+  // outlined header it used to carry were pure block chrome.
+  nb-accordion.application {
+    nb-accordion-item-header {
+      color: nb-theme(text-basic-color);
+      border-width: 0;
+
+      i {
+        color: nb-theme(color-primary-default);
+      }
+    }
   }
 
   a {
@@ -90,34 +255,50 @@
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Child rows. NOTE: this block is consumed by children-menu-item.component.scss
+// via @use, so `:host` resolves to <ga-children-menu-item> there.
+// ─────────────────────────────────────────────────────────────────────────────
 :host .sub-item {
-  padding: 0px 9px;
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  color: nb-theme(gauzy-text-color-2);
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 16px;
-  letter-spacing: 0em;
+  border-radius: $menu-row-radius;
+  color: $menu-row-color;
+  font-size: nb-theme(menu-text-font-size);
+  font-weight: nb-theme(menu-text-font-weight);
+  line-height: 1.25rem;
+  letter-spacing: 0;
   cursor: pointer;
-  &:hover,
-  &.selected {
-    background-color: nb-theme(gauzy-sidebar-background-3);
-    border-radius: nb-theme(border-radius);
-    font-weight: 600;
-    color: nb-theme(gauzy-text-color-1);
-    border: unset;
+  transition:
+    background-color 0.12s ease-in-out,
+    color 0.12s ease-in-out;
+
+  // Hover: tint only — the old rule also fired a 10px drop shadow, which is
+  // what made child rows read as floating blocks.
+  &:hover {
+    background-color: $menu-row-hover-background;
+    color: nb-theme(text-basic-color);
   }
 
-  &:hover {
-    box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.15);
+  // Same treatment as an active top level row — see the contrast note there for
+  // why the icon stays neutral instead of taking the brand accent.
+  &.selected {
+    background-color: $menu-row-active-background;
+    color: nb-theme(text-basic-color);
+    font-weight: 600;
   }
+
+  // Icon rail: no indent, glyph centred, label hidden by the template.
   &.custom {
-    display: flex;
-    align-items: center;
     justify-content: center;
+
+    .info {
+      justify-content: center;
+      padding-inline: 0;
+    }
   }
+
   &.mouse-hover {
     display: flex;
     flex-direction: row;
@@ -129,9 +310,29 @@
   }
 }
 
-.info {
-  padding: 11px 0;
+// The clickable area of a child row. Padding lives here (not on .sub-item) so
+// the whole row height is a hit target, while the tint still spans full width.
+:host .info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: nb-theme(menu-item-padding);
+  padding-inline-start: $menu-child-indent;
+
+  i {
+    flex: 0 0 auto;
+    width: $menu-icon-column;
+    font-size: 0.875rem;
+    text-align: center;
+    color: inherit;
+  }
+
   span {
-    margin: 0 0.625rem;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 }

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-context.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-context.service.ts
@@ -1,0 +1,388 @@
+import { inject, Injectable, InjectionToken } from '@angular/core';
+import { combineLatest, Observable } from 'rxjs';
+import { debounceTime, distinctUntilChanged, filter, map, shareReplay, tap } from 'rxjs/operators';
+import moment from 'moment-timezone';
+import {
+	ID,
+	IDateRangePicker,
+	IOrganization,
+	IOrganizationProject,
+	IOrganizationTeam,
+	ISelectedDateRange,
+	ISelectedEmployee,
+	IUser,
+	PermissionsEnum,
+	TimeFormatEnum
+} from '@gauzy/contracts';
+import { IDashboardWidgetContext } from './dashboard-widget-context';
+import { Store } from '../store/store.service';
+import { DateRangePickerBuilderService } from '../selector-builder/date-range-picker-builder.service';
+
+/**
+ * Time zone used when neither the organization nor the user declares one.
+ * Matches the default of the timesheet `TimeZoneService`.
+ */
+export const DEFAULT_DASHBOARD_TIME_ZONE = 'Etc/UTC';
+
+/**
+ * Settle window applied to the selector streams before a context is published.
+ *
+ * Mirrors the debounce the timesheet dashboard pages use, so a burst of
+ * selector changes (organization + date range + employee arriving in the same
+ * turn) results in ONE context emission instead of five.
+ */
+const CONTEXT_SETTLE_MS = 300;
+
+/**
+ * Minimal shape of the timesheet `TimeZoneService`.
+ *
+ * The real service lives in `@gauzy/ui-core/shared`, which already depends on
+ * `@gauzy/ui-core/core` — importing it here would create a circular secondary
+ * entry point and break the library build. The token below is therefore typed
+ * structurally so the app can alias it without a code dependency:
+ *
+ * ```ts
+ * { provide: DASHBOARD_TIME_ZONE_SOURCE, useExisting: TimeZoneService }
+ * ```
+ */
+export interface IDashboardTimeZoneSource {
+	readonly timeZone$: Observable<string>;
+	readonly timeFormat$: Observable<TimeFormatEnum>;
+}
+
+/**
+ * Optional provider of the user's currently selected time zone / time format.
+ *
+ * Wiring rule — {@link DashboardContextService} is `providedIn: 'root'`, so it
+ * resolves this token in the ROOT injector. A route- or component-level
+ * provider is NOT visible to it and would silently do nothing; the alias must
+ * be registered in the application-level providers:
+ *
+ * ```ts
+ * { provide: DASHBOARD_TIME_ZONE_SOURCE, useExisting: TimeZoneService }
+ * ```
+ *
+ * `TimeZoneService` is itself a root singleton, so a root alias is correct.
+ * Only register it once the dashboard actually renders `<ga-timezone-filter>`:
+ * that filter is what pushes a real selection into `TimeZoneService`, and
+ * without it the service sits on its `Etc/UTC` construction default and widgets
+ * would report different totals than the standard dashboard. When the token is
+ * absent, {@link DashboardContextService} instead reproduces the defaults the
+ * filter applies on init (organization zone for users who may switch employees,
+ * personal zone otherwise), which is the correct answer for a filter-less page.
+ */
+export const DASHBOARD_TIME_ZONE_SOURCE = new InjectionToken<IDashboardTimeZoneSource>('DASHBOARD_TIME_ZONE_SOURCE');
+
+/**
+ * Per-placement narrowing of the ambient dashboard context.
+ *
+ * A widget can be pinned to one project/team/employee even when the page-level
+ * selector says "all".
+ */
+export interface IDashboardWidgetContextOverrides {
+	employeeIds?: ID[];
+	projectIds?: ID[];
+	teamIds?: ID[];
+}
+
+/**
+ * Cheap, allocation-light identity of a context.
+ *
+ * Used for `distinctUntilChanged` and as a cache discriminator. Deliberately
+ * NOT `JSON.stringify(context)`: `organization` is a large object whose
+ * identity changes on every store write without affecting any statistics query.
+ *
+ * @param context - The context to fingerprint.
+ * @returns A stable string key.
+ */
+export function dashboardContextKey(context: IDashboardWidgetContext): string {
+	return [
+		context.tenantId,
+		context.organizationId,
+		context.startDate?.getTime(),
+		context.endDate?.getTime(),
+		context.todayStart?.getTime(),
+		context.todayEnd?.getTime(),
+		context.timeZone,
+		context.timeFormat,
+		context.currency,
+		(context.employeeIds ?? []).join(','),
+		(context.projectIds ?? []).join(','),
+		(context.teamIds ?? []).join(',')
+	].join('|');
+}
+
+/**
+ * Applies per-placement overrides on top of an ambient context.
+ *
+ * Only non-empty override arrays win — an empty array means "inherit", which is
+ * how a widget with no scope configured keeps following the page selectors.
+ *
+ * @param context - The ambient context.
+ * @param overrides - Placement-level scope, if any.
+ * @returns A new context (the input is never mutated).
+ */
+export function narrowDashboardContext(
+	context: IDashboardWidgetContext,
+	overrides?: IDashboardWidgetContextOverrides | null
+): IDashboardWidgetContext {
+	if (!overrides) {
+		return context;
+	}
+
+	const employeeIds = overrides.employeeIds?.length ? overrides.employeeIds : context.employeeIds;
+	const projectIds = overrides.projectIds?.length ? overrides.projectIds : context.projectIds;
+	const teamIds = overrides.teamIds?.length ? overrides.teamIds : context.teamIds;
+
+	return {
+		...context,
+		employeeIds,
+		projectIds,
+		teamIds,
+		// A widget pinned to specific employees is no longer showing the page's
+		// selected employee — drop it so widgets can't render a mismatched avatar.
+		selectedEmployee: overrides.employeeIds?.length ? undefined : context.selectedEmployee
+	};
+}
+
+/**
+ * Verbatim port of `getAdjustDateRangeFutureAllowed` from
+ * `@gauzy/ui-core/shared` (selectors/date-range-picker/date-picker.utils).
+ *
+ * Duplicated rather than imported because `shared` depends on `core`; see the
+ * note on {@link DASHBOARD_TIME_ZONE_SOURCE}. Keep the two in sync — the whole
+ * point of this service is that canvas widgets hit the statistics API with
+ * byte-identical date bounds to the standard dashboard.
+ *
+ * @param request - The selected date range.
+ * @returns The range adjusted so "today" is never truncated.
+ */
+function adjustDateRangeFutureAllowed(request: IDateRangePicker): ISelectedDateRange {
+	const now = moment();
+	let { startDate, endDate } = request;
+
+	// Single day selected: widen to the full day.
+	if (moment(moment(startDate).format('YYYY-MM-DD')).isSame(moment(endDate).format('YYYY-MM-DD'))) {
+		startDate = moment(startDate).startOf('day').utc().toDate();
+		endDate = moment(endDate).endOf('day').utc().toDate();
+	}
+
+	// Range ends today: extend to end of day so a running timer is counted.
+	if (moment(now.format('YYYY-MM-DD')).isSame(moment(endDate).format('YYYY-MM-DD'))) {
+		endDate = moment().endOf('day').utc().toDate();
+	}
+
+	return {
+		startDate: moment(startDate).toDate(),
+		endDate: moment(endDate).toDate()
+	} as ISelectedDateRange;
+}
+
+/**
+ * Single source of truth for "what is the dashboard currently looking at".
+ *
+ * Canvas widgets are instantiated dynamically and therefore cannot rely on the
+ * page-level selector components being their ancestors. This service composes
+ * the exact same inputs the timesheet dashboard pages combine
+ * (`Store.selectedOrganization$` / `selectedEmployee$` / `selectedProject$` /
+ * `selectedTeam$` + `DateRangePickerBuilderService.selectedDateRange$` + the
+ * time zone filter) and publishes them as one hot, replayed stream.
+ *
+ * Nothing is emitted until an organization is selected.
+ */
+@Injectable({ providedIn: 'root' })
+export class DashboardContextService {
+	private readonly _store = inject(Store);
+	private readonly _dateRangePickerBuilderService = inject(DateRangePickerBuilderService);
+	private readonly _timeZoneSource = inject(DASHBOARD_TIME_ZONE_SOURCE, { optional: true });
+
+	/** Last published context, or `null` before the first subscriber. */
+	private _snapshot: IDashboardWidgetContext | null = null;
+
+	private readonly _timeZone$: Observable<string> = this._timeZoneSource
+		? this._timeZoneSource.timeZone$
+		: this._defaultTimeZone$();
+
+	private readonly _timeFormat$: Observable<TimeFormatEnum> = this._timeZoneSource
+		? this._timeZoneSource.timeFormat$
+		: this._defaultTimeFormat$();
+
+	/**
+	 * The reporting window, guaranteed to carry a value.
+	 *
+	 * `DateRangePickerBuilderService.selectedDateRange$` is a `BehaviorSubject`
+	 * seeded with `null` and is only ever written by `<ngx-date-range-picker>`,
+	 * which the theme header renders exclusively when the route asks for the date
+	 * selector. On a dashboard page WITHOUT that selector the stream would stay
+	 * `null` forever, `combineLatest` below would never pass the guard, and every
+	 * widget would sit on its loading spinner with no error to show.
+	 *
+	 * `dates$` is the safe companion: it is seeded with `DEFAULT_DATE_RANGE` (the
+	 * current week — exactly what the picker itself defaults to) and the picker
+	 * writes it on every selection, so preferring `selectedDateRange$` and only
+	 * falling back keeps byte-for-byte parity with the standard dashboard when a
+	 * picker is present.
+	 */
+	private readonly _dateRange$: Observable<IDateRangePicker> = combineLatest([
+		this._dateRangePickerBuilderService.selectedDateRange$,
+		this._dateRangePickerBuilderService.dates$
+	]).pipe(map(([selected, fallback]: [IDateRangePicker | null, IDateRangePicker]) => selected ?? fallback));
+
+	/**
+	 * The current dashboard context.
+	 *
+	 * Hot and replayed (`refCount: false`) so that N widgets subscribing at
+	 * different times all observe the same value without re-running the
+	 * combination, and a widget added later immediately receives the context.
+	 */
+	public readonly context$: Observable<IDashboardWidgetContext> = combineLatest([
+		this._store.selectedOrganization$,
+		this._dateRange$,
+		this._store.selectedEmployee$,
+		this._store.selectedProject$,
+		this._store.selectedTeam$,
+		this._timeZone$,
+		this._timeFormat$
+	]).pipe(
+		// Widgets must never query without a scope — an organization-less request
+		// would either fail or leak numbers across organizations.
+		filter(([organization, dateRange]) => !!organization && !!dateRange),
+		debounceTime(CONTEXT_SETTLE_MS),
+		map(([organization, dateRange, employee, project, team, timeZone, timeFormat]) =>
+			this._buildContext(organization, dateRange, employee, project, team, timeZone, timeFormat)
+		),
+		distinctUntilChanged((previous, current) => dashboardContextKey(previous) === dashboardContextKey(current)),
+		tap((context: IDashboardWidgetContext) => (this._snapshot = context)),
+		shareReplay({ bufferSize: 1, refCount: false })
+	);
+
+	/**
+	 * The most recently published context.
+	 *
+	 * `null` until `context$` has been subscribed at least once — imperative
+	 * callers (e.g. a manual refresh button) should prefer `context$`.
+	 */
+	public get snapshot(): IDashboardWidgetContext | null {
+		return this._snapshot;
+	}
+
+	/**
+	 * A context stream narrowed by per-placement overrides.
+	 *
+	 * Intended for the widget host, which provides the result as
+	 * `DASHBOARD_WIDGET_CONTEXT` for a single widget instance.
+	 *
+	 * @param overrides - Placement-level scope; `null`/`undefined` inherits everything.
+	 * @returns The narrowed, replayed context stream.
+	 */
+	public contextFor(overrides?: IDashboardWidgetContextOverrides | null): Observable<IDashboardWidgetContext> {
+		if (!overrides) {
+			return this.context$;
+		}
+
+		return this.context$.pipe(
+			map((context: IDashboardWidgetContext) => narrowDashboardContext(context, overrides)),
+			distinctUntilChanged((previous, current) => dashboardContextKey(previous) === dashboardContextKey(current)),
+			shareReplay({ bufferSize: 1, refCount: true })
+		);
+	}
+
+	/**
+	 * Assembles the context from the raw selector values.
+	 *
+	 * The date math intentionally mirrors `TimeTrackingComponent.preparePayloads()`
+	 * one-for-one: the range goes through {@link adjustDateRangeFutureAllowed} and
+	 * "today" is the local day boundary. Both are kept as `Date` here; the
+	 * conversion to the API's time-zone-offset string happens once, in the
+	 * statistics cache, so every widget sends the same serialized payload.
+	 */
+	private _buildContext(
+		organization: IOrganization,
+		dateRange: IDateRangePicker,
+		employee: ISelectedEmployee | null,
+		project: IOrganizationProject | null,
+		team: IOrganizationTeam | null,
+		timeZone: string,
+		timeFormat: TimeFormatEnum
+	): IDashboardWidgetContext {
+		const { id: organizationId, tenantId } = organization;
+		const { startDate, endDate } = adjustDateRangeFutureAllowed(dateRange);
+
+		return {
+			tenantId,
+			organizationId,
+			organization,
+			startDate,
+			endDate,
+			todayStart: moment().startOf('day').toDate(),
+			todayEnd: moment().endOf('day').toDate(),
+			timeZone,
+			timeFormat,
+			currency: organization.currency,
+			// `ALL_EMPLOYEES_SELECTED` carries a null id, which must read as "no
+			// scope" rather than "the employee whose id is null".
+			employeeIds: employee?.id ? [employee.id] : [],
+			projectIds: project?.id ? [project.id] : [],
+			teamIds: team?.id ? [team.id] : [],
+			selectedEmployee: employee ?? undefined
+		};
+	}
+
+	/**
+	 * Fallback time zone stream used when no {@link DASHBOARD_TIME_ZONE_SOURCE}
+	 * is provided.
+	 *
+	 * Reproduces `TimezoneFilterComponent`'s init behaviour: managers see the
+	 * organization time zone, everyone else sees their own. Without this a
+	 * builder page rendered WITHOUT the timezone filter would silently fall back
+	 * to UTC and report different totals than the standard dashboard.
+	 *
+	 * `userRolePermissions$` is a source (its value is unused) because the branch
+	 * below READS the permission set imperatively: right after sign-in or a tenant
+	 * switch the permissions resolve AFTER the organization and user have already
+	 * emitted, and without this trigger a manager would keep the personal zone
+	 * forever — the exact drift this fallback exists to prevent.
+	 */
+	private _defaultTimeZone$(): Observable<string> {
+		return combineLatest([
+			this._store.selectedOrganization$,
+			this._store.user$,
+			this._store.userRolePermissions$
+		]).pipe(
+			map(([organization, user]: [IOrganization, IUser, unknown]) =>
+				this._canChangeSelectedEmployee()
+					? organization?.timeZone || DEFAULT_DASHBOARD_TIME_ZONE
+					: user?.timeZone || moment.tz.guess()
+			),
+			distinctUntilChanged()
+		);
+	}
+
+	/**
+	 * Fallback time format stream, normalized exactly like
+	 * `TimezoneFilterComponent.selectTimeFormat()` (anything that is not
+	 * explicitly 24h is 12h).
+	 *
+	 * Includes `userRolePermissions$` for the same reason as {@link _defaultTimeZone$}.
+	 */
+	private _defaultTimeFormat$(): Observable<TimeFormatEnum> {
+		return combineLatest([
+			this._store.selectedOrganization$,
+			this._store.user$,
+			this._store.userRolePermissions$
+		]).pipe(
+			map(([organization, user]: [IOrganization, IUser, unknown]) => {
+				const timeFormat = this._canChangeSelectedEmployee() ? organization?.timeFormat : user?.timeFormat;
+				return timeFormat === TimeFormatEnum.FORMAT_24_HOURS
+					? TimeFormatEnum.FORMAT_24_HOURS
+					: TimeFormatEnum.FORMAT_12_HOURS;
+			}),
+			distinctUntilChanged()
+		);
+	}
+
+	/** Whether the current user may look at other employees' data. */
+	private _canChangeSelectedEmployee(): boolean {
+		return this._store.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE);
+	}
+}

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-layout.utils.spec.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-layout.utils.spec.ts
@@ -1,0 +1,204 @@
+import { IDashboardWidgetPlacement } from '@gauzy/contracts';
+import {
+	addPlacement,
+	clampPlacement,
+	DASHBOARD_GRID_COLUMNS,
+	isLayoutV2,
+	movePlacement,
+	normalizeLayout,
+	packLayout,
+	parseLayout,
+	removePlacement,
+	resizePlacement
+} from './dashboard-layout.utils';
+
+/** Builds a placement with sensible defaults for tests. */
+function place(partial: Partial<IDashboardWidgetPlacement> & { instanceId: string }): IDashboardWidgetPlacement {
+	return { widgetId: 'w', x: 0, y: 0, w: 3, h: 2, ...partial };
+}
+
+/** Do two placements overlap? (independent re-implementation for assertions) */
+function overlaps(a: IDashboardWidgetPlacement, b: IDashboardWidgetPlacement): boolean {
+	return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+function assertNoOverlap(placements: IDashboardWidgetPlacement[]): void {
+	for (let i = 0; i < placements.length; i++) {
+		for (let j = i + 1; j < placements.length; j++) {
+			expect(overlaps(placements[i], placements[j])).toBe(false);
+		}
+	}
+}
+
+describe('parseLayout', () => {
+	it('returns an empty document for nullish content', () => {
+		expect(parseLayout(null)).toEqual({});
+		expect(parseLayout(undefined)).toEqual({});
+		expect(parseLayout('')).toEqual({});
+	});
+
+	it('parses a JSON string (sqlite text column)', () => {
+		expect(parseLayout('{"widgets":[]}')).toEqual({ widgets: [] });
+	});
+
+	it('does not throw on malformed roots', () => {
+		expect(parseLayout('null')).toEqual({});
+		expect(parseLayout('[1,2,3]')).toEqual({});
+		expect(parseLayout('"a string"')).toEqual({});
+		expect(parseLayout('{ not json')).toEqual({});
+	});
+});
+
+describe('normalizeLayout', () => {
+	it('creates a single empty tab for an empty document', () => {
+		const layout = normalizeLayout({});
+		expect(layout.version).toBe(2);
+		expect(layout.tabs).toHaveLength(1);
+		expect(layout.tabs[0].widgets).toEqual([]);
+	});
+
+	it('preserves a legacy v1 snapshot alongside the new empty tab', () => {
+		const v1 = { widgets: [{ position: 2, title: 'Members' }], windows: [] };
+		const layout = normalizeLayout(v1);
+		expect(layout.widgets).toEqual(v1.widgets);
+		expect(layout.tabs).toHaveLength(1);
+	});
+
+	it('sorts tabs by order and re-indexes them', () => {
+		const layout = normalizeLayout({
+			version: 2,
+			tabs: [
+				{ id: 'b', name: 'B', order: 5, widgets: [] },
+				{ id: 'a', name: 'A', order: 1, widgets: [] }
+			]
+		} as never);
+		expect(layout.tabs.map((t) => t.id)).toEqual(['a', 'b']);
+		expect(layout.tabs.map((t) => t.order)).toEqual([0, 1]);
+	});
+
+	it('drops placements without a widgetId and keeps valid ones', () => {
+		const layout = normalizeLayout({
+			version: 2,
+			tabs: [{ id: 't', name: 'T', order: 0, widgets: [{ instanceId: '1' }, place({ instanceId: '2' })] }]
+		} as never);
+		expect(layout.tabs[0].widgets).toHaveLength(1);
+		expect(layout.tabs[0].widgets[0].instanceId).toBe('2');
+	});
+
+	it('replaces an empty tabs array with one empty tab', () => {
+		const layout = normalizeLayout({ version: 2, tabs: [] } as never);
+		expect(layout.tabs).toHaveLength(1);
+	});
+});
+
+describe('isLayoutV2', () => {
+	it('distinguishes v2 documents from v1 snapshots', () => {
+		expect(isLayoutV2({ version: 2, tabs: [] } as never)).toBe(true);
+		expect(isLayoutV2({ widgets: [] })).toBe(false);
+		expect(isLayoutV2(null)).toBe(false);
+		expect(isLayoutV2({ version: 2 } as never)).toBe(false);
+	});
+});
+
+describe('clampPlacement', () => {
+	it('keeps widgets inside the 12 column grid', () => {
+		const clamped = clampPlacement(place({ instanceId: '1', x: 11, w: 6 }));
+		expect(clamped.x + clamped.w).toBeLessThanOrEqual(DASHBOARD_GRID_COLUMNS);
+	});
+
+	it('enforces positive spans and non-negative rows', () => {
+		const clamped = clampPlacement(place({ instanceId: '1', x: -4, y: -2, w: 0, h: 0 }));
+		expect(clamped.x).toBe(0);
+		expect(clamped.y).toBe(0);
+		expect(clamped.w).toBeGreaterThan(0);
+		expect(clamped.h).toBeGreaterThan(0);
+	});
+
+	it('assigns a missing instanceId', () => {
+		expect(clampPlacement({ widgetId: 'w', x: 0, y: 0, w: 3, h: 2 } as never).instanceId).toBeTruthy();
+	});
+});
+
+describe('packLayout', () => {
+	it('compacts widgets upwards, removing vertical gaps', () => {
+		const packed = packLayout([place({ instanceId: '1', y: 7 })]);
+		expect(packed[0].y).toBe(0);
+	});
+
+	it('resolves overlaps', () => {
+		const packed = packLayout([
+			place({ instanceId: '1', x: 0, y: 0, w: 6, h: 2 }),
+			place({ instanceId: '2', x: 0, y: 0, w: 6, h: 2 })
+		]);
+		assertNoOverlap(packed);
+	});
+
+	it('keeps side-by-side widgets on the same row', () => {
+		const packed = packLayout([
+			place({ instanceId: '1', x: 0, y: 0, w: 6, h: 2 }),
+			place({ instanceId: '2', x: 6, y: 0, w: 6, h: 2 })
+		]);
+		expect(packed.every((p) => p.y === 0)).toBe(true);
+	});
+
+	it('is idempotent', () => {
+		const once = packLayout([
+			place({ instanceId: '1', x: 0, y: 3, w: 4, h: 2 }),
+			place({ instanceId: '2', x: 4, y: 9, w: 4, h: 2 }),
+			place({ instanceId: '3', x: 0, y: 1, w: 12, h: 1 })
+		]);
+		expect(packLayout(once)).toEqual(once);
+	});
+
+	it('handles an empty or nullish list', () => {
+		expect(packLayout([])).toEqual([]);
+		expect(packLayout(undefined as never)).toEqual([]);
+	});
+
+	it('never produces overlaps for a dense random-ish set', () => {
+		const placements = Array.from({ length: 20 }, (_, i) =>
+			place({ instanceId: String(i), x: (i * 5) % 10, y: (i * 3) % 7, w: ((i % 3) + 1) * 2, h: (i % 2) + 1 })
+		);
+		assertNoOverlap(packLayout(placements));
+	});
+});
+
+describe('placement mutations', () => {
+	it('adds a placement without overlapping existing ones', () => {
+		const existing = [place({ instanceId: '1', x: 0, y: 0, w: 12, h: 2 })];
+		const next = addPlacement(existing, place({ instanceId: '2', x: 0, y: 0, w: 12, h: 2 }));
+		expect(next).toHaveLength(2);
+		assertNoOverlap(next);
+	});
+
+	it('removes a placement by instance id and repacks', () => {
+		const next = removePlacement(
+			[place({ instanceId: '1', y: 0, w: 12 }), place({ instanceId: '2', y: 2, w: 12 })],
+			'1'
+		);
+		expect(next).toHaveLength(1);
+		expect(next[0].instanceId).toBe('2');
+		expect(next[0].y).toBe(0);
+	});
+
+	it('resizes a placement and clamps it to the grid', () => {
+		const next = resizePlacement([place({ instanceId: '1', x: 8, w: 4 })], '1', { w: 12 });
+		expect(next[0].x + next[0].w).toBeLessThanOrEqual(DASHBOARD_GRID_COLUMNS);
+	});
+
+	it('reorders placements by reading order', () => {
+		const placements = [
+			place({ instanceId: 'a', y: 0, w: 12 }),
+			place({ instanceId: 'b', y: 2, w: 12 }),
+			place({ instanceId: 'c', y: 4, w: 12 })
+		];
+		const moved = movePlacement(placements, 0, 2);
+		const order = [...moved].sort((x, y) => x.y - y.y).map((p) => p.instanceId);
+		expect(order).toEqual(['b', 'c', 'a']);
+	});
+
+	it('ignores an out-of-range move index', () => {
+		const placements = [place({ instanceId: 'a', w: 12 })];
+		expect(movePlacement(placements, 5, 0)).toHaveLength(1);
+	});
+});

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-layout.utils.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-layout.utils.ts
@@ -1,0 +1,260 @@
+import {
+	DashboardLayout,
+	IDashboardLayout,
+	IDashboardLayoutV2,
+	IDashboardTab,
+	IDashboardWidgetPlacement,
+	JsonData
+} from '@gauzy/contracts';
+
+/** Number of columns on a dashboard canvas. */
+export const DASHBOARD_GRID_COLUMNS = 12;
+
+/** Default footprint applied when a widget declares no `defaultSize`. */
+export const DEFAULT_WIDGET_SIZE = { w: 3, h: 2 };
+
+/** Bytes of entropy in a fallback id — 128 bits, same as a v4 UUID. */
+const FALLBACK_ID_BYTES = 16;
+
+/** Monotonic suffix for the no-crypto fallback of {@link createId}. */
+let idCounter = 0;
+
+/**
+ * Generates a stable identifier for tabs and widget placements.
+ *
+ * SECURITY NOTE (rule typescript:S2245): these ids are document identity only —
+ * a tab key, a placement key, a CDK drop-list handle. They are never a secret,
+ * a token, or any part of an access decision: a dashboard is fetched by its own
+ * server-issued id and authorized server-side, so nothing follows from knowing
+ * or predicting a placement id.
+ *
+ * They are still produced from Web Crypto wherever it exists — `randomUUID()`
+ * first, then `getRandomValues()` — with a plain time-plus-counter fallback for
+ * the jsdom/unit-test and insecure-context environments that offer neither.
+ */
+export function createId(): string {
+	const cryptoRef = typeof crypto !== 'undefined' ? crypto : undefined;
+	if (typeof cryptoRef?.randomUUID === 'function') {
+		return cryptoRef.randomUUID();
+	}
+	if (typeof cryptoRef?.getRandomValues === 'function') {
+		const bytes = cryptoRef.getRandomValues(new Uint8Array(FALLBACK_ID_BYTES));
+		return `id-${Array.from(bytes, (byte: number) => byte.toString(16).padStart(2, '0')).join('')}`;
+	}
+	// Last resort: no Web Crypto at all. Counter-suffixed so two calls in the
+	// same millisecond can never collide.
+	return `id-${Date.now().toString(36)}-${(++idCounter).toString(36)}`;
+}
+
+/**
+ * Type guard: is this a v2 (dashboard builder) document?
+ *
+ * @param layout - Any parsed layout document.
+ */
+export function isLayoutV2(layout: DashboardLayout | null | undefined): layout is IDashboardLayoutV2 {
+	return !!layout && (layout as IDashboardLayoutV2).version === 2 && Array.isArray((layout as IDashboardLayoutV2).tabs);
+}
+
+/**
+ * Parses a `Dashboard.contentHtml` payload into a layout document.
+ *
+ * `contentHtml` is a json column on postgres/mysql but `text` on sqlite, so the
+ * value may arrive as an object or as a string. Malformed content (including
+ * the string `"null"`, arrays, and primitives) yields an empty document rather
+ * than throwing — a corrupt row must never break the dashboard.
+ *
+ * @param content - The raw persisted value.
+ */
+export function parseLayout(content: JsonData | undefined | null): DashboardLayout {
+	if (!content) {
+		return {};
+	}
+	let parsed: unknown = content;
+	if (typeof content === 'string') {
+		try {
+			parsed = JSON.parse(content);
+		} catch {
+			return {};
+		}
+	}
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		return {};
+	}
+	return parsed as DashboardLayout;
+}
+
+/**
+ * Normalizes any persisted layout into a v2 document.
+ *
+ * - v2 documents are returned with their tabs sorted and every placement
+ *   clamped to the grid.
+ * - v1 snapshots (and empty documents) become a v2 document with a single
+ *   empty tab, while PRESERVING the original v1 payload so the legacy renderer
+ *   can keep displaying dashboards created before the builder shipped.
+ *
+ * @param layout - A parsed layout document.
+ * @param defaultTabName - Name given to the tab created for legacy/empty documents.
+ */
+export function normalizeLayout(layout: DashboardLayout | null | undefined, defaultTabName = 'Overview'): IDashboardLayoutV2 {
+	if (isLayoutV2(layout)) {
+		const tabs = [...layout.tabs]
+			.filter((tab): tab is IDashboardTab => !!tab && typeof tab === 'object')
+			.map((tab, index) => ({
+				...tab,
+				id: tab.id || createId(),
+				name: tab.name || `${defaultTabName} ${index + 1}`,
+				order: Number.isFinite(tab.order) ? tab.order : index,
+				// `packLayout` (not just `clampPlacement`): clamping fixes each
+				// placement in isolation, so a hand-edited or corrupt document could
+				// still describe two widgets stacked on the same cells. Packing is
+				// idempotent, so a well-formed document passes through unchanged.
+				widgets: packLayout(
+					(Array.isArray(tab.widgets) ? tab.widgets : []).filter(
+						(placement) => !!placement && typeof placement === 'object' && !!placement.widgetId
+					)
+				)
+			}))
+			.sort((a, b) => a.order - b.order)
+			.map((tab, index) => ({ ...tab, order: index }));
+
+		return {
+			...layout,
+			version: 2,
+			tabs: tabs.length ? tabs : [emptyTab(defaultTabName)]
+		};
+	}
+
+	// Legacy (v1) or empty: keep the original snapshot alongside an empty canvas.
+	const legacy = (layout ?? {}) as IDashboardLayout;
+	return {
+		...legacy,
+		version: 2,
+		tabs: [emptyTab(defaultTabName)]
+	};
+}
+
+/** Builds an empty tab. */
+export function emptyTab(name = 'Overview'): IDashboardTab {
+	return { id: createId(), name, order: 0, widgets: [] };
+}
+
+/** Clamps a placement's geometry into the grid and enforces positive spans. */
+export function clampPlacement(placement: IDashboardWidgetPlacement): IDashboardWidgetPlacement {
+	const w = clamp(Math.round(placement.w) || DEFAULT_WIDGET_SIZE.w, 1, DASHBOARD_GRID_COLUMNS);
+	const x = clamp(Math.round(placement.x) || 0, 0, DASHBOARD_GRID_COLUMNS - w);
+	return {
+		...placement,
+		instanceId: placement.instanceId || createId(),
+		x,
+		w,
+		y: Math.max(0, Math.round(placement.y) || 0),
+		h: Math.max(1, Math.round(placement.h) || DEFAULT_WIDGET_SIZE.h)
+	};
+}
+
+/** Clamps `value` into the inclusive range [min, max]. */
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
+}
+
+/** Do two placements overlap on the grid? */
+function collides(a: IDashboardWidgetPlacement, b: IDashboardWidgetPlacement): boolean {
+	return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+/**
+ * Resolves overlaps and compacts placements upwards.
+ *
+ * Placements are processed in reading order (top-to-bottom, then left-to-right)
+ * and each is pulled up to the first row where it collides with nothing already
+ * placed. The result is deterministic, gap-free vertically, and stable for
+ * inputs that are already packed.
+ *
+ * @param placements - The placements of a single tab.
+ * @returns A new array of placements with corrected `y` values.
+ */
+export function packLayout(placements: IDashboardWidgetPlacement[]): IDashboardWidgetPlacement[] {
+	const ordered = [...(placements ?? [])]
+		.map(clampPlacement)
+		.sort((a, b) => (a.y === b.y ? a.x - b.x : a.y - b.y));
+
+	const packed: IDashboardWidgetPlacement[] = [];
+	for (const placement of ordered) {
+		const candidate = { ...placement, y: 0 };
+		// Jump straight past the lowest edge the candidate currently overlaps,
+		// rather than stepping one row at a time: a persisted (or corrupt) `h` of
+		// a few thousand rows would otherwise make this loop run for that many
+		// iterations per widget and freeze the canvas.
+		let blockers = packed.filter((other) => collides(candidate, other));
+		while (blockers.length) {
+			candidate.y = Math.max(...blockers.map((other) => other.y + other.h));
+			blockers = packed.filter((other) => collides(candidate, other));
+		}
+		packed.push(candidate);
+	}
+	return packed;
+}
+
+/**
+ * Inserts a new placement into a tab at the requested grid position, then
+ * repacks so nothing overlaps.
+ *
+ * @param placements - Existing placements.
+ * @param placement - The placement being added.
+ */
+export function addPlacement(
+	placements: IDashboardWidgetPlacement[],
+	placement: IDashboardWidgetPlacement
+): IDashboardWidgetPlacement[] {
+	return packLayout([...(placements ?? []), clampPlacement(placement)]);
+}
+
+/**
+ * Moves the placement identified by `instanceId` to a new index in reading
+ * order (used by the PR-1 ordered-list drag), then repacks.
+ *
+ * @param placements - Existing placements.
+ * @param fromIndex - The index the placement was dragged from.
+ * @param toIndex - The index it was dropped at.
+ */
+export function movePlacement(
+	placements: IDashboardWidgetPlacement[],
+	fromIndex: number,
+	toIndex: number
+): IDashboardWidgetPlacement[] {
+	const ordered = [...(placements ?? [])].sort((a, b) => (a.y === b.y ? a.x - b.x : a.y - b.y));
+	if (fromIndex < 0 || fromIndex >= ordered.length) {
+		return packLayout(ordered);
+	}
+	const [moved] = ordered.splice(fromIndex, 1);
+	// `clamp(NaN, ...)` is NaN and `splice(NaN, ...)` silently inserts at 0, so an
+	// unresolved drop index would jump the widget to the front instead of leaving
+	// it where it was. Anything non-finite therefore lands at the end.
+	const target = Number.isFinite(toIndex) ? clamp(Math.round(toIndex), 0, ordered.length) : ordered.length;
+	ordered.splice(target, 0, moved);
+	// Re-assign rows in the new reading order before packing so the drop sticks.
+	return packLayout(ordered.map((placement, index) => ({ ...placement, y: index })));
+}
+
+/** Removes a placement by instance id. */
+export function removePlacement(
+	placements: IDashboardWidgetPlacement[],
+	instanceId: string
+): IDashboardWidgetPlacement[] {
+	return packLayout((placements ?? []).filter((placement) => placement.instanceId !== instanceId));
+}
+
+/** Resizes a placement, clamping to the grid, then repacks. */
+export function resizePlacement(
+	placements: IDashboardWidgetPlacement[],
+	instanceId: string,
+	size: { w?: number; h?: number }
+): IDashboardWidgetPlacement[] {
+	return packLayout(
+		(placements ?? []).map((placement) =>
+			placement.instanceId === instanceId
+				? clampPlacement({ ...placement, w: size.w ?? placement.w, h: size.h ?? placement.h })
+				: placement
+		)
+	);
+}

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-store.service.ts
@@ -3,8 +3,19 @@ import { Router } from '@angular/router';
 import { BehaviorSubject, combineLatest, from, of, Subject } from 'rxjs';
 import { catchError, filter, startWith, switchMap } from 'rxjs/operators';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { ID, IDashboard, IDashboardLayout, IDashboardLayoutItem, JsonData } from '@gauzy/contracts';
+import {
+	DashboardLayout,
+	ID,
+	IDashboard,
+	IDashboardLayout,
+	IDashboardLayoutItem,
+	IDashboardLayoutV2,
+	IDashboardTab,
+	IDashboardWidgetPlacement,
+	JsonData
+} from '@gauzy/contracts';
 import { DashboardService } from './dashboard.service';
+import { createId, isLayoutV2, normalizeLayout, parseLayout } from './dashboard-layout.utils';
 import { Store } from '../store/store.service';
 
 /** LocalStorage key prefix holding the currently applied custom dashboard ID (suffixed with the user ID). */
@@ -25,6 +36,14 @@ const STANDARD_LAYOUT_BACKUP_KEY = '_standardDashboardLayout';
  *   of that serialized state (`IDashboardLayout`), stored in `IDashboard.contentHtml`.
  * - Preserves the Standard layout in a localStorage backup while a custom
  *   dashboard is active, and restores it when switching back to Standard.
+ *
+ * Two persisted layout shapes coexist in `IDashboard.contentHtml`:
+ * - **v1** (`IDashboardLayout`) — a snapshot of the legacy `GuiDrag` widget
+ *   system, applied to `Store.widgets` / `Store.windows` on selection.
+ * - **v2** (`IDashboardLayoutV2`) — a dashboard builder document (tabs of freely
+ *   placed widget instances) rendered by the canvas. v2 documents are NEVER
+ *   applied to the legacy widget state: doing so would clobber the user's
+ *   Standard arrangement, which is only ever backed up/restored around v1.
  */
 @UntilDestroy()
 @Injectable({
@@ -44,6 +63,13 @@ export class DashboardStoreService {
 	public readonly editing$ = this._editing$.asObservable();
 
 	private readonly _refresh$ = new Subject<void>();
+
+	/**
+	 * In-progress v2 document staged by the canvas while editing, so the
+	 * switcher's Save button (which has no reference to the canvas) can persist
+	 * it. `null` whenever there is nothing unsaved.
+	 */
+	private _pendingLayout: IDashboardLayoutV2 | null = null;
 
 	constructor(
 		private readonly _dashboardService: DashboardService,
@@ -160,6 +186,9 @@ export class DashboardStoreService {
 		}
 		localStorage.removeItem(selectedKey);
 		localStorage.removeItem(backupKey);
+		// Cross-organization teardown: a staged canvas document belongs to the
+		// outgoing organization and must never be saved into the new one.
+		this._pendingLayout = null;
 		this._selectedDashboard$.next(null);
 		this._editing$.next(false);
 		this._dashboards$.next([]);
@@ -226,6 +255,10 @@ export class DashboardStoreService {
 	 * Used by the `custom/:id` route guard BEFORE the widget host component
 	 * initializes, so the layout components pick up the applied state.
 	 *
+	 * For a v2 (builder) dashboard nothing is written into the legacy widget
+	 * state — it renders on the canvas — but the Standard snapshot is still
+	 * taken so returning to Standard restores the untouched arrangement.
+	 *
 	 * @param id - The dashboard ID to apply.
 	 * @throws When the dashboard cannot be found.
 	 */
@@ -245,8 +278,11 @@ export class DashboardStoreService {
 		// Preserve the Standard layout before the first custom dashboard is applied
 		this._snapshotStandardIfNeeded();
 
-		// Apply the saved layout into the widget system state
+		// Apply the saved layout into the widget system state (v1 only — see _applyLayout)
 		this._applyLayout(dashboard.contentHtml);
+
+		// Switching dashboards drops anything the canvas staged for the previous one
+		this._pendingLayout = null;
 
 		// Persist and publish the selection
 		localStorage.setItem(this._selectedKey, dashboard.id as string);
@@ -269,6 +305,7 @@ export class DashboardStoreService {
 
 		this._restoreStandardSnapshot();
 		localStorage.removeItem(this._selectedKey);
+		this._pendingLayout = null;
 		this._selectedDashboard$.next(null);
 		this._editing$.next(false);
 	}
@@ -334,19 +371,25 @@ export class DashboardStoreService {
 	/**
 	 * Creates a new custom dashboard.
 	 *
+	 * A brand new dashboard starts as an EMPTY v2 builder document (a single
+	 * empty tab): the product requirement is a blank canvas the user fills from
+	 * the widget palette, not a copy of the Standard arrangement.
+	 *
 	 * @param name - Display name of the dashboard.
-	 * @param layout - Initial layout; pass `null` for the default arrangement
-	 *   (every widget visible in its declared position).
+	 * @param layout - Explicit initial layout (used by Duplicate, which carries
+	 *   over the source document); `null` creates the empty v2 canvas.
 	 */
-	public async createDashboard(name: string, layout: IDashboardLayout | null = null): Promise<IDashboard> {
+	public async createDashboard(name: string, layout: DashboardLayout | null = null): Promise<IDashboard> {
 		const { id: organizationId, tenantId } = this._store.selectedOrganization || {};
 
 		const dashboard = await this._dashboardService.create({
 			name,
 			identifier: this._slugify(name),
-			// Always persist the layout marker keys so the row is recognized
-			// as a custom layout dashboard (see _isLayoutDashboard).
-			contentHtml: (layout ?? { widgets: [], windows: [] }) as JsonData,
+			// An explicit layout is persisted verbatim so duplicating a legacy
+			// v1 dashboard still yields a v1 dashboard. Either shape carries the
+			// marker keys that make the row a custom layout dashboard
+			// (`version`/`tabs` or `widgets`/`windows` — see _isLayoutDashboard).
+			contentHtml: (layout ?? normalizeLayout({})) as JsonData,
 			organizationId,
 			tenantId,
 			...(this._store.user?.employee?.id ? { employeeId: this._store.user.employee.id } : {})
@@ -360,13 +403,31 @@ export class DashboardStoreService {
 	 * Duplicates the given dashboard (or the current live layout when
 	 * duplicating the Standard dashboard).
 	 *
+	 * A v2 (builder) source is deep-cloned with FRESH tab and placement ids so
+	 * the copy is fully independent — sharing ids would make the two dashboards
+	 * collide in any instance-keyed state (widget config, selection, drag).
+	 *
 	 * @param source - The dashboard to duplicate, or `null` to duplicate the
 	 *   currently applied (Standard) layout.
 	 * @param name - Name for the copy.
 	 */
 	public async duplicateDashboard(source: IDashboard | null, name: string): Promise<IDashboard> {
-		const layout = source ? this._parseLayout(source.contentHtml) : this.captureLayout();
-		return this.createDashboard(name, layout);
+		if (!source) {
+			// Duplicating Standard snapshots the live legacy widget state (v1).
+			return this.createDashboard(name, this.captureLayout());
+		}
+
+		const layout = parseLayout(source.contentHtml);
+		if (isLayoutV2(layout)) {
+			return this.createDashboard(name, this._cloneLayoutV2(normalizeLayout(layout)));
+		}
+
+		// A v1 source is copied verbatim, but only when it actually carries the
+		// marker keys: persisting a marker-less document would create a row that
+		// _isLayoutDashboard filters out, so the copy would vanish from the
+		// switcher and the navigation right after it would fail with "not found".
+		const hasV1Markers = 'widgets' in layout || 'windows' in layout;
+		return this.createDashboard(name, hasV1Markers ? layout : null);
 	}
 
 	/** Renames the given dashboard. */
@@ -422,11 +483,38 @@ export class DashboardStoreService {
 
 	/**
 	 * Persists the current live widget layout into the selected custom dashboard.
+	 *
+	 * For a v2 (builder) dashboard the live widget state is NOT the dashboard's
+	 * content, so the document staged by the canvas is saved instead; capturing
+	 * `Store.widgets`/`Store.windows` here would overwrite the builder document
+	 * with an unrelated legacy snapshot.
 	 */
 	public async saveSelectedLayout(): Promise<IDashboard | null> {
 		const selected = this.selectedDashboard;
 		if (!selected) {
 			return null;
+		}
+
+		// A STAGED document is itself proof that the canvas produced this edit, so
+		// it takes the v2 path even when the persisted row is still v1: a legacy
+		// dashboard that the user just arranged in the builder must save what is
+		// on the canvas, not an unrelated `Store.widgets` snapshot.
+		if (this._pendingLayout || this.isBuilderDashboard(selected)) {
+			const pending = this._pendingLayout;
+			// Nothing staged (canvas already persisted, or no changes): leaving
+			// edit mode is all that is left to do.
+			const saved = pending ? await this.saveLayoutV2(selected.id, pending) : selected;
+			// Leave edit mode only once the write succeeded — a rejected save must
+			// keep the user in the editor (Save / Discard still reachable) with the
+			// staged document intact, exactly like the v1 branch below.
+			//
+			// A still-staged document here means the user kept arranging WHILE the
+			// request was in flight; those edits are unsaved, so the editor has to
+			// stay open for them.
+			if (!this._pendingLayout) {
+				this._editing$.next(false);
+			}
+			return saved;
 		}
 
 		const updated = await this._dashboardService.update(selected.id, {
@@ -447,6 +535,8 @@ export class DashboardStoreService {
 	public cancelEditing(): void {
 		const selected = this.selectedDashboard;
 		this._editing$.next(false);
+		// Drop the staged canvas document — discarding means the persisted one wins.
+		this._pendingLayout = null;
 
 		if (selected) {
 			this._applyLayout(selected.contentHtml);
@@ -456,6 +546,129 @@ export class DashboardStoreService {
 			void this._router
 				.navigateByUrl('/pages/dashboard/switching', { skipLocationChange: true })
 				.then(() => this._router.navigate(['/pages/dashboard/custom', selected.id]));
+		}
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Builder documents (v2)
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Reads a dashboard's persisted content as a v2 (builder) document.
+	 *
+	 * ALWAYS returns a v2 document: a legacy v1 snapshot (or empty/corrupt
+	 * content) is normalized into a single empty tab while its original payload
+	 * is preserved, so the canvas can render any dashboard without special
+	 * casing. Use {@link isBuilderDashboard} to tell the two apart.
+	 *
+	 * @param dashboard - The dashboard to read (tolerates `null`).
+	 * @returns A normalized, grid-clamped v2 document.
+	 */
+	public getLayout(dashboard: IDashboard | null | undefined): IDashboardLayoutV2 {
+		return normalizeLayout(parseLayout(dashboard?.contentHtml));
+	}
+
+	/**
+	 * Persists a v2 (builder) document into the given dashboard.
+	 *
+	 * @param dashboardId - The dashboard to write to.
+	 * @param layout - The document produced by the canvas.
+	 * @returns The updated dashboard.
+	 */
+	public async saveLayoutV2(dashboardId: ID, layout: IDashboardLayoutV2): Promise<IDashboard> {
+		// Normalize on the way out so a canvas bug can never persist tabs without
+		// ids or geometry outside the 12 column grid.
+		const normalized = normalizeLayout(layout);
+		const updated = await this._dashboardService.update(dashboardId, {
+			contentHtml: normalized as JsonData
+		});
+
+		// The write is now the source of truth: drop the staged copy and refresh
+		// the in-memory selection so later reads (cancelEditing, getLayout) do
+		// not see the pre-save content.
+		//
+		// Identity check on purpose: the canvas stages a NEW object on every
+		// change, so a different reference means the user edited while the request
+		// was in flight. Clearing that would silently discard their newer work.
+		if (this._pendingLayout === layout) {
+			this._pendingLayout = null;
+		}
+		const selected = this.selectedDashboard;
+		if (selected?.id === dashboardId) {
+			this._selectedDashboard$.next({
+				...selected,
+				contentHtml: (updated?.contentHtml ?? normalized) as JsonData
+			});
+		}
+
+		this.refresh();
+		return updated;
+	}
+
+	/**
+	 * Stages the canvas' in-progress document so the switcher's Save / Discard
+	 * buttons — which hold no reference to the canvas — act on it.
+	 *
+	 * @param layout - The working document, or `null` once there is nothing unsaved.
+	 */
+	public stagePendingLayout(layout: IDashboardLayoutV2 | null): void {
+		this._pendingLayout = layout;
+	}
+
+	/**
+	 * Whether the dashboard is a v2 builder document (rendered on the canvas)
+	 * rather than a legacy v1 widget snapshot.
+	 *
+	 * @param dashboard - The dashboard to test.
+	 */
+	public isBuilderDashboard(dashboard: IDashboard | null | undefined): boolean {
+		return isLayoutV2(parseLayout(dashboard?.contentHtml));
+	}
+
+	/**
+	 * Deep-clones a v2 document, re-generating every tab and placement id.
+	 *
+	 * Per-instance `config` objects are cloned too, so editing the copy can
+	 * never mutate the source dashboard's persisted settings.
+	 *
+	 * @param layout - The (already normalized) document to clone.
+	 */
+	private _cloneLayoutV2(layout: IDashboardLayoutV2): IDashboardLayoutV2 {
+		return {
+			...layout,
+			version: 2,
+			tabs: (layout.tabs ?? []).map(
+				(tab: IDashboardTab): IDashboardTab => ({
+					...tab,
+					id: createId(),
+					widgets: (tab.widgets ?? []).map(
+						(placement: IDashboardWidgetPlacement): IDashboardWidgetPlacement => ({
+							...placement,
+							instanceId: createId(),
+							...(placement.config ? { config: this._deepClone(placement.config) } : {})
+						})
+					)
+				})
+			)
+		};
+	}
+
+	/**
+	 * Structural clone of a placement's persisted configuration.
+	 *
+	 * The value is plain JSON layout data (it round-trips through the API's json
+	 * column), so `structuredClone` handles it and — unlike the JSON round-trip
+	 * it replaces — copes with cycles too.
+	 */
+	private _deepClone<T>(value: T): T {
+		try {
+			return structuredClone(value);
+		} catch {
+			// Not structurally cloneable (a function or DOM node smuggled into a
+			// config): keep the reference rather than losing the settings entirely.
+			return value;
 		}
 	}
 
@@ -476,9 +689,18 @@ export class DashboardStoreService {
 		};
 	}
 
-	/** Writes the given saved layout into the widget system state. */
+	/**
+	 * Writes the given saved layout into the legacy widget system state.
+	 *
+	 * v2 (builder) documents are skipped: they render on the canvas, and their
+	 * `widgets`/`windows` keys are either absent (so the live Standard
+	 * arrangement would be wiped) or a stale pre-migration snapshot.
+	 */
 	private _applyLayout(content: JsonData | undefined): void {
-		const layout = this._parseLayout(content);
+		const layout = parseLayout(content);
+		if (isLayoutV2(layout)) {
+			return;
+		}
 		// Validate shapes — malformed/hand-edited content must not crash the widget host
 		this._store.widgets = (Array.isArray(layout.widgets) ? layout.widgets : []) as any[];
 		this._store.windows = (Array.isArray(layout.windows) ? layout.windows : []) as any[];
@@ -486,44 +708,17 @@ export class DashboardStoreService {
 
 	/**
 	 * Whether the dashboard row holds a serialized widget layout (i.e. was
-	 * created by this feature). Seeded/legacy rows store arbitrary HTML in
-	 * `contentHtml` and are excluded from the custom dashboard experience.
+	 * created by this feature) — either a v2 builder document or a v1 snapshot.
+	 * Seeded/legacy rows store arbitrary HTML in `contentHtml` and are excluded
+	 * from the custom dashboard experience.
+	 *
+	 * v2 documents MUST be recognized here: they carry no `widgets`/`windows`
+	 * keys, so a v1-only check would filter every builder dashboard out of the
+	 * switcher and out of the default-dashboard redirect.
 	 */
 	private _isLayoutDashboard(item: IDashboard): boolean {
-		const content = item?.contentHtml as JsonData | undefined;
-		if (!content) {
-			return false;
-		}
-		let parsed: unknown = content;
-		if (typeof content === 'string') {
-			try {
-				parsed = JSON.parse(content);
-			} catch {
-				return false;
-			}
-		}
-		return !!parsed && typeof parsed === 'object' && ('widgets' in (parsed as object) || 'windows' in (parsed as object));
-	}
-
-	/** Parses a dashboard `contentHtml` payload into a layout object. */
-	private _parseLayout(content: JsonData | undefined): IDashboardLayout {
-		if (!content) {
-			return {};
-		}
-		let parsed: unknown = content;
-		if (typeof content === 'string') {
-			try {
-				parsed = JSON.parse(content);
-			} catch {
-				return {};
-			}
-		}
-		// Normalize: a null/array/primitive root (e.g. the string "null") must
-		// not reach _applyLayout, which reads `.widgets` off the result.
-		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-			return {};
-		}
-		return parsed as IDashboardLayout;
+		const layout = parseLayout(item?.contentHtml);
+		return isLayoutV2(layout) || 'widgets' in layout || 'windows' in layout;
 	}
 
 	/** Keeps only the serializable `GuiDrag` fields of each layout item. */

--- a/packages/ui-core/core/src/lib/services/dashboard/dashboard-widget-context.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/dashboard-widget-context.ts
@@ -1,0 +1,52 @@
+import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ID, IOrganization, ISelectedEmployee, TimeFormatEnum } from '@gauzy/contracts';
+
+/**
+ * Ambient context handed to every widget rendered on a dashboard canvas.
+ *
+ * A canvas-hosted widget is instantiated dynamically and therefore cannot rely
+ * on the page-level selector components (date range picker, employee/project
+ * selectors) being its ancestors. Instead the canvas resolves the current
+ * selection once and provides it through {@link DASHBOARD_WIDGET_CONTEXT}, with
+ * per-placement overrides applied (a widget can be scoped to one project even
+ * when the page selector says "all projects").
+ */
+export interface IDashboardWidgetContext {
+	tenantId: ID;
+	organizationId: ID;
+	organization?: IOrganization;
+
+	/** Selected reporting window. */
+	startDate: Date;
+	endDate: Date;
+	/** Convenience bounds for "today" widgets, in the organization's time zone. */
+	todayStart: Date;
+	todayEnd: Date;
+
+	timeZone: string;
+	timeFormat?: TimeFormatEnum;
+	currency?: string;
+
+	/** Active scope. Empty/undefined means "everything the user may see". */
+	employeeIds?: ID[];
+	projectIds?: ID[];
+	teamIds?: ID[];
+	selectedEmployee?: ISelectedEmployee;
+}
+
+/**
+ * Stream of the current {@link IDashboardWidgetContext}.
+ *
+ * Provided by the canvas host per widget instance, so each widget can receive a
+ * context narrowed by its own placement configuration.
+ */
+export const DASHBOARD_WIDGET_CONTEXT = new InjectionToken<Observable<IDashboardWidgetContext>>(
+	'DASHBOARD_WIDGET_CONTEXT'
+);
+
+/**
+ * The persisted per-instance configuration of the widget being rendered
+ * (the placement's `config` object). Empty when the widget has no settings.
+ */
+export const DASHBOARD_WIDGET_CONFIG = new InjectionToken<Record<string, unknown>>('DASHBOARD_WIDGET_CONFIG');

--- a/packages/ui-core/core/src/lib/services/dashboard/index.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/index.ts
@@ -1,3 +1,7 @@
 export * from './dashboard.service';
 export * from './dashboard-store.service';
 export * from './dashboard.guards';
+export * from './dashboard-widget-context';
+export * from './dashboard-layout.utils';
+export * from './dashboard-context.service';
+export * from './timesheet-statistics-cache.service';

--- a/packages/ui-core/core/src/lib/services/dashboard/timesheet-statistics-cache.service.ts
+++ b/packages/ui-core/core/src/lib/services/dashboard/timesheet-statistics-cache.service.ts
@@ -1,0 +1,409 @@
+import { inject, Injectable } from '@angular/core';
+import { defer, from, Observable, Subject, throwError } from 'rxjs';
+import { catchError, shareReplay, startWith, switchMap } from 'rxjs/operators';
+import {
+	IActivitiesStatistics,
+	ICountsStatistics,
+	IGetActivitiesStatistics,
+	IGetCountsStatistics,
+	IGetManualTimesStatistics,
+	IGetMembersStatistics,
+	IGetProjectsStatistics,
+	IGetTasksStatistics,
+	IGetTimeSlotStatistics,
+	IManualTimesStatistics,
+	IMembersStatistics,
+	IProjectsStatistics,
+	ITasksStatistics,
+	ITimeLogFilters,
+	ITimeLogTodayFilters,
+	ITimeSlotStatistics
+} from '@gauzy/contracts';
+import { isNotEmpty, toUtcOffset } from '@gauzy/ui-core/common';
+import { IDashboardWidgetContext } from './dashboard-widget-context';
+import { TimesheetStatisticsService } from '../timesheet/timesheet-statistics.service';
+
+/** Date format the timesheet statistics API expects. */
+const API_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+/**
+ * How long a fetched statistics response stays reusable.
+ *
+ * Long enough to collapse the widgets of one dashboard render into a single
+ * request per endpoint, short enough that a user tabbing back to a dashboard
+ * gets fresh numbers.
+ */
+export const STATISTICS_CACHE_TTL_MS = 15_000;
+
+/**
+ * Window in which repeated invalidations of the same scope collapse into one.
+ *
+ * Every widget on a canvas reacts to the same "refresh" click, so without this
+ * the 2nd..Nth `invalidate()` would evict the entry the previous widget had
+ * just re-created — turning one manual refresh into N HTTP requests.
+ */
+const INVALIDATE_COALESCE_MS = 250;
+
+/** Cache discriminator for the statistics endpoints this service wraps. */
+type StatisticsEndpoint = 'counts' | 'time-slots' | 'activities' | 'projects' | 'tasks' | 'manual-times' | 'members';
+
+/**
+ * The payload every statistics endpoint receives.
+ *
+ * Every `IGet*Statistics` interface extends `ITimeLogFilters` and adds only
+ * optional members, so this type is directly assignable to all of them.
+ */
+export type StatisticsRequestPayload = ITimeLogFilters & ITimeLogTodayFilters & { take?: number };
+
+interface ICacheEntry {
+	readonly stream$: Observable<unknown>;
+	readonly expiresAt: number;
+}
+
+/**
+ * Serializes a request object into a stable string, independent of key order.
+ *
+ * The comparator is explicit on purpose: the default `Array.sort()` compares the
+ * UTF-16 code units of the *stringified* elements, which is not a guaranteed
+ * alphabetical order. Since this string IS the cache key, an unstable order
+ * would produce two keys for one request — i.e. duplicate HTTP calls.
+ *
+ * @param value - The object to serialize.
+ * @returns A deterministic string representation.
+ */
+function stableStringify(value: object): string {
+	const record = value as Record<string, unknown>;
+	return Object.keys(record)
+		.sort((a: string, b: string) => a.localeCompare(b))
+		.map((key: string) => `${key}=${JSON.stringify(record[key])}`)
+		.join('&');
+}
+
+/**
+ * Builds the timesheet statistics request payload for a dashboard context.
+ *
+ * This is the parity-critical function: it reproduces
+ * `TimeTrackingComponent.preparePayloads()` exactly — same UTC-offset shift,
+ * same `YYYY-MM-DD HH:mm:ss` serialization, same "omit empty scopes" rule — so
+ * a canvas widget and the standard dashboard send byte-identical requests and
+ * therefore render identical numbers.
+ *
+ * @param context - The ambient dashboard context.
+ * @returns The request payload shared by every statistics endpoint.
+ */
+export function buildStatisticsRequest(context: IDashboardWidgetContext): StatisticsRequestPayload {
+	const { tenantId, organizationId, startDate, endDate, todayStart, todayEnd, timeZone } = context;
+
+	const request: StatisticsRequestPayload = {
+		tenantId,
+		organizationId,
+		todayStart: toUtcOffset(todayStart, timeZone).format(API_DATE_FORMAT),
+		todayEnd: toUtcOffset(todayEnd, timeZone).format(API_DATE_FORMAT),
+		startDate: toUtcOffset(startDate, timeZone).format(API_DATE_FORMAT),
+		endDate: toUtcOffset(endDate, timeZone).format(API_DATE_FORMAT),
+		timeZone
+	};
+
+	// `isNotEmpty` also rejects `[null]`, which is what the "All Employees"
+	// selection produces — sending it would filter on a non-existent employee.
+	if (isNotEmpty(context.employeeIds)) {
+		request.employeeIds = context.employeeIds;
+	}
+	if (isNotEmpty(context.projectIds)) {
+		request.projectIds = context.projectIds;
+	}
+	if (isNotEmpty(context.teamIds)) {
+		request.teamIds = context.teamIds;
+	}
+
+	return request;
+}
+
+/**
+ * Adds the `durationPercentage` field the Apps & URLs widgets render, using the
+ * same total-of-the-page denominator the standard dashboard uses.
+ *
+ * @param activities - Raw activities as returned by the API.
+ * @returns A new array with `durationPercentage` populated.
+ */
+export function withDurationPercentage(activities: IActivitiesStatistics[]): IActivitiesStatistics[] {
+	const list = activities ?? [];
+	// ONE coercion for both the numerator and the denominator: the API may return
+	// a duration as a string or with a fractional part, and mixing `parseInt`
+	// (truncating) with implicit numeric coercion made the shares miss 100%.
+	const duration = (activity: IActivitiesStatistics): number => Number(activity.duration) || 0;
+	const total = list.reduce((sum: number, activity: IActivitiesStatistics) => sum + duration(activity), 0);
+
+	return list.map((activity: IActivitiesStatistics) => ({
+		...activity,
+		durationPercentage: total ? (duration(activity) * 100) / total : 0
+	}));
+}
+
+/**
+ * Request-coalescing cache in front of {@link TimesheetStatisticsService}.
+ *
+ * A dashboard canvas renders many widgets that all describe the same slice of
+ * data — the six counter widgets, for instance, are six views of ONE
+ * `/timesheet/statistics/counts` response. Without this service each of them
+ * would issue its own HTTP request on every context change.
+ *
+ * Keyed by the serialized request payload, so widgets that narrow the context
+ * (pinned to a project, say) correctly get their own request.
+ *
+ * The returned observables are long-lived: they re-resolve against the cache
+ * whenever `invalidate()` fires, so a widget can simply hold one subscription
+ * and receive fresh data after a manual refresh.
+ *
+ * Errors are NOT swallowed — widgets need them to render an error state. As
+ * usual in RxJS an error terminates the subscription, which has one consequence
+ * callers MUST honour: once a stream has errored it is dead and will no longer
+ * react to {@link TimesheetStatisticsCacheService.invalidate}. A widget's
+ * `refresh()` therefore has to RE-CALL the getter (re-subscribe), not merely
+ * call `invalidate()`, or a failed widget can never recover. The failed cache
+ * entry is evicted on error, so the re-call always hits the network.
+ */
+@Injectable({ providedIn: 'root' })
+export class TimesheetStatisticsCacheService {
+	private readonly _timesheetStatisticsService = inject(TimesheetStatisticsService);
+
+	private readonly _cache = new Map<string, ICacheEntry>();
+	private readonly _invalidated$ = new Subject<void>();
+
+	/** Guards against the refresh stampede described on INVALIDATE_COALESCE_MS. */
+	private _lastInvalidatedKey: string | null = null;
+	private _lastInvalidatedAt = 0;
+
+	/** Emits after every effective invalidation. */
+	public readonly invalidated$: Observable<void> = this._invalidated$.asObservable();
+
+	/*
+	|--------------------------------------------------------------------------
+	| Endpoints
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Counts used by the six counter widgets (members worked, projects worked,
+	 * today activity, worked today, worked this period, activity this period).
+	 *
+	 * @param context - The dashboard context to query for.
+	 */
+	public getCounts(context: IDashboardWidgetContext): Observable<ICountsStatistics> {
+		return this._resolve<ICountsStatistics>(context, 'counts', (payload: IGetCountsStatistics) =>
+			this._timesheetStatisticsService.getCounts(payload)
+		);
+	}
+
+	/**
+	 * Application / URL activity buckets.
+	 *
+	 * Returns the raw API payload — use {@link withDurationPercentage} when the
+	 * widget needs the relative share.
+	 *
+	 * @param context - The dashboard context to query for.
+	 */
+	public getActivities(context: IDashboardWidgetContext): Observable<IActivitiesStatistics[]> {
+		return this._resolve<IActivitiesStatistics[]>(context, 'activities', (payload: IGetActivitiesStatistics) =>
+			this._timesheetStatisticsService.getActivities(payload)
+		);
+	}
+
+	/**
+	 * Recent time slots (screenshot / activity strip).
+	 *
+	 * @param context - The dashboard context to query for.
+	 */
+	public getTimeSlots(context: IDashboardWidgetContext): Observable<ITimeSlotStatistics[]> {
+		return this._resolve<ITimeSlotStatistics[]>(context, 'time-slots', (payload: IGetTimeSlotStatistics) =>
+			this._timesheetStatisticsService.getTimeSlots(payload)
+		);
+	}
+
+	/**
+	 * Time tracked per project.
+	 *
+	 * @param context - The dashboard context to query for.
+	 */
+	public getProjects(context: IDashboardWidgetContext): Observable<IProjectsStatistics[]> {
+		return this._resolve<IProjectsStatistics[]>(context, 'projects', (payload: IGetProjectsStatistics) =>
+			this._timesheetStatisticsService.getProjects(payload)
+		);
+	}
+
+	/**
+	 * Time tracked per task.
+	 *
+	 * @param context - The dashboard context to query for.
+	 * @param take - Page size; defaults to the 5 the standard dashboard requests.
+	 */
+	public getTasks(context: IDashboardWidgetContext, take: number = 5): Observable<ITasksStatistics[]> {
+		return this._resolve<ITasksStatistics[]>(
+			context,
+			'tasks',
+			(payload: IGetTasksStatistics) => this._timesheetStatisticsService.getTasksStatistics(payload),
+			{ take }
+		);
+	}
+
+	/**
+	 * Manually entered time entries.
+	 *
+	 * @param context - The dashboard context to query for.
+	 */
+	public getManualTimes(context: IDashboardWidgetContext): Observable<IManualTimesStatistics[]> {
+		return this._resolve<IManualTimesStatistics[]>(context, 'manual-times', (payload: IGetManualTimesStatistics) =>
+			this._timesheetStatisticsService.getManualTimes(payload)
+		);
+	}
+
+	/**
+	 * Per-member weekly / today totals.
+	 *
+	 * @param context - The dashboard context to query for.
+	 */
+	public getMembers(context: IDashboardWidgetContext): Observable<IMembersStatistics[]> {
+		return this._resolve<IMembersStatistics[]>(context, 'members', (payload: IGetMembersStatistics) =>
+			this._timesheetStatisticsService.getMembers(payload)
+		);
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Invalidation
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Drops cached responses so the next subscriber re-fetches, and notifies
+	 * live streams (returned by the getters above) to re-resolve.
+	 *
+	 * Repeated calls for the same scope within {@link INVALIDATE_COALESCE_MS} are
+	 * ignored, so every widget on a canvas may safely call this from its own
+	 * `refresh()` without causing a request storm.
+	 *
+	 * @param context - Limit the invalidation to one context; omit to drop everything.
+	 */
+	public invalidate(context?: IDashboardWidgetContext): void {
+		const scope = context ? this._contextHash(context) : '*';
+		const now = Date.now();
+
+		if (this._lastInvalidatedKey === scope && now - this._lastInvalidatedAt < INVALIDATE_COALESCE_MS) {
+			return;
+		}
+		this._lastInvalidatedKey = scope;
+		this._lastInvalidatedAt = now;
+
+		this._drop(context);
+		this._invalidated$.next();
+	}
+
+	/**
+	 * Unconditionally empties the cache — no coalescing, no notification.
+	 *
+	 * Use on hard boundaries (sign-out, organization switch) where replaying a
+	 * previous tenant's numbers would be wrong.
+	 */
+	public clear(): void {
+		this._cache.clear();
+		this._lastInvalidatedKey = null;
+		this._lastInvalidatedAt = 0;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Internals
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Builds the long-lived stream handed to widgets: it resolves a cache entry
+	 * now and again after every invalidation.
+	 */
+	private _resolve<T>(
+		context: IDashboardWidgetContext,
+		endpoint: StatisticsEndpoint,
+		request: (payload: StatisticsRequestPayload) => Promise<T>,
+		// Deliberately NOT `Record<string, unknown>`: spreading an index-signature
+		// type into the typed payload literal below widens every value to `unknown`.
+		extra?: Partial<StatisticsRequestPayload>
+	): Observable<T> {
+		const payload: StatisticsRequestPayload = { ...buildStatisticsRequest(context), ...extra };
+		const key = `${this._contextHash(context)}::${endpoint}::${extra ? stableStringify(extra) : ''}`;
+
+		return this._invalidated$.pipe(
+			startWith(undefined),
+			switchMap(() => this._cached<T>(key, () => request(payload))),
+			// refCount so the widget's subscription is the only thing keeping this
+			// wrapper alive; the cached entry itself outlives it (that is the point).
+			shareReplay({ bufferSize: 1, refCount: true })
+		);
+	}
+
+	/**
+	 * Returns the shared observable for `key`, creating it on a miss.
+	 *
+	 * `defer` keeps the call lazy (nothing is requested until a widget
+	 * subscribes) and `shareReplay({ refCount: false })` hands the SAME in-flight
+	 * promise to every subsequent subscriber — this is what collapses six
+	 * counter widgets into one HTTP request.
+	 */
+	private _cached<T>(key: string, request: () => Promise<T>): Observable<T> {
+		const now = Date.now();
+		const hit = this._cache.get(key);
+		if (hit && hit.expiresAt > now) {
+			return hit.stream$ as Observable<T>;
+		}
+
+		this._prune(now);
+
+		// Holder so the error handler can identify "its own" entry without a
+		// use-before-assignment dance on the entry const itself.
+		const own: { entry?: ICacheEntry } = {};
+		const stream$: Observable<T> = defer(() => from(request())).pipe(
+			shareReplay({ bufferSize: 1, refCount: false }),
+			catchError((error) => {
+				// A cached failure would be replayed to every subscriber for the whole
+				// TTL; evict it so the next widget (or retry) hits the network again.
+				if (own.entry && this._cache.get(key) === own.entry) {
+					this._cache.delete(key);
+				}
+				return throwError(() => error);
+			})
+		);
+
+		own.entry = { stream$, expiresAt: now + STATISTICS_CACHE_TTL_MS };
+		this._cache.set(key, own.entry);
+
+		return stream$;
+	}
+
+	/** Stable fingerprint of the context-derived part of a request payload. */
+	private _contextHash(context: IDashboardWidgetContext): string {
+		return stableStringify(buildStatisticsRequest(context));
+	}
+
+	/** Removes cache entries for one context, or all of them. */
+	private _drop(context?: IDashboardWidgetContext): void {
+		if (!context) {
+			this._cache.clear();
+			return;
+		}
+
+		const prefix = `${this._contextHash(context)}::`;
+		for (const key of Array.from(this._cache.keys())) {
+			if (key.startsWith(prefix)) {
+				this._cache.delete(key);
+			}
+		}
+	}
+
+	/** Drops expired entries so long sessions don't accumulate dead payload keys. */
+	private _prune(now: number): void {
+		for (const [key, entry] of Array.from(this._cache.entries())) {
+			if (entry.expiresAt <= now) {
+				this._cache.delete(key);
+			}
+		}
+	}
+}

--- a/packages/ui-core/core/src/lib/services/widget/widget-registry.service.ts
+++ b/packages/ui-core/core/src/lib/services/widget/widget-registry.service.ts
@@ -1,5 +1,7 @@
-import { Injectable } from '@angular/core';
-import { IWidgetRegistry, WidgetPageLocationId, WidgetRegistryConfig } from './widget-registry.types';
+import { Injectable, Type, isDevMode } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { IWidgetRegistry, WidgetCategory, WidgetPageLocationId, WidgetRegistryConfig } from './widget-registry.types';
 
 @Injectable({
 	providedIn: 'root'
@@ -12,6 +14,23 @@ export class WidgetRegistryService implements IWidgetRegistry {
 	 * This Map stores arrays of WidgetRegistryConfig objects, keyed by WidgetPageLocationId.
 	 */
 	private readonly registry = new Map<WidgetPageLocationId, WidgetRegistryConfig[]>();
+
+	/**
+	 * Global `widgetId` -> config index, so a persisted placement can resolve
+	 * its widget without knowing which location registered it.
+	 */
+	private readonly byId = new Map<string, WidgetRegistryConfig>();
+
+	/** Resolved component cache, so a widget dropped twice only loads once. */
+	private readonly componentCache = new Map<string, Promise<Type<any>>>();
+
+	private readonly _widgets$ = new BehaviorSubject<WidgetRegistryConfig[]>([]);
+
+	/**
+	 * All registered widgets, emitting again whenever registrations change
+	 * (plugins register during app initialization and may be enabled later).
+	 */
+	public readonly widgets$: Observable<WidgetRegistryConfig[]> = this._widgets$.asObservable();
 
 	/**
 	 * Retrieves the current widget registry.
@@ -66,6 +85,131 @@ export class WidgetRegistryService implements IWidgetRegistry {
 
 		// Update the registry with the new or updated list of widgets for the specified location.
 		this.registry.set(config.location, widgets);
+
+		// `widgetId` is the key persisted on every dashboard placement, so it has
+		// to be unique across ALL locations — not just within one. Registering the
+		// same id at a second location silently re-points every saved placement.
+		// Warn instead of throwing: registration runs during app bootstrap, where
+		// a throw would abort the remaining widgets too.
+		const existing = this.byId.get(config.widgetId);
+		if (existing && existing.location !== config.location && isDevMode()) {
+			console.warn(
+				`[WidgetRegistryService] Widget "${config.widgetId}" is already registered at location "${existing.location}"; the "${config.location}" registration now wins.`
+			);
+		}
+
+		// Index globally by id and publish the change to palette subscribers.
+		this.byId.set(config.widgetId, config);
+		// A replaced entry may declare a different `loadComponent`, so the memoized
+		// component class must go with it.
+		this.componentCache.delete(config.widgetId);
+		this.publish();
+	}
+
+	/**
+	 * Registers a widget, replacing any existing registration with the same id.
+	 *
+	 * Unlike {@link registerWidget} this never throws on duplicates, which makes
+	 * it safe for hot module replacement and for plugins that re-register when
+	 * they are toggled on and off at runtime.
+	 *
+	 * @param config - The configuration object for the widget.
+	 */
+	public registerOrReplaceWidget(config: WidgetRegistryConfig): void {
+		if (!config?.location || !config?.widgetId) {
+			throw new Error('A widget configuration must have location and widgetId properties');
+		}
+
+		// Drop the id from EVERY location first: a re-registration may move the
+		// widget to a different location, and leaving the old entry behind makes
+		// location-based consumers render stale metadata.
+		for (const [location, registered] of this.registry) {
+			this.registry.set(
+				location,
+				registered.filter((widget: WidgetRegistryConfig) => widget.widgetId !== config.widgetId)
+			);
+		}
+
+		const widgets = this.registry.get(config.location) || [];
+		widgets.push(config);
+		this.registry.set(config.location, widgets);
+		this.byId.set(config.widgetId, config);
+		this.componentCache.delete(config.widgetId);
+		this.publish();
+	}
+
+	/**
+	 * Retrieves a widget configuration by its global id, regardless of the
+	 * location it was registered at.
+	 *
+	 * @param widgetId - The registry key persisted on a dashboard placement.
+	 * @returns The widget configuration, or `undefined` when it is not registered
+	 *          (e.g. its plugin is disabled, or the widget was removed).
+	 */
+	public getWidget(widgetId: string): WidgetRegistryConfig | undefined {
+		return this.byId.get(widgetId);
+	}
+
+	/**
+	 * Streams the registered widgets, optionally narrowed to one palette category.
+	 *
+	 * @param category - Optional category filter.
+	 */
+	public getWidgets$(category?: WidgetCategory): Observable<WidgetRegistryConfig[]> {
+		return this.widgets$.pipe(
+			map((widgets: WidgetRegistryConfig[]) =>
+				category ? widgets.filter((widget) => (widget.category ?? 'other') === category) : widgets
+			)
+		);
+	}
+
+	/**
+	 * Resolves (and caches) the component class backing a widget.
+	 *
+	 * @param widgetId - The widget's registry key.
+	 * @returns The component type, or `null` when the widget is unknown or
+	 *          declares no component.
+	 */
+	public resolveComponent(widgetId: string): Promise<Type<any> | null> {
+		// Explicit `!== undefined` rather than truthiness: the cached value is a
+		// Promise, and a Promise in a boolean conditional is ALWAYS truthy — the
+		// check would read as "is it resolved?" while meaning "is it cached?".
+		const cached = this.componentCache.get(widgetId);
+		if (cached !== undefined) {
+			return cached;
+		}
+
+		const config = this.byId.get(widgetId);
+		if (!config?.loadComponent) {
+			return Promise.resolve(null);
+		}
+
+		// `try` (not just `Promise.resolve(...)`): a loader that throws
+		// SYNCHRONOUSLY would otherwise escape before the promise chain exists,
+		// leaving the widget host stuck on its loading skeleton instead of
+		// showing the error state with its Retry button.
+		let loading: Promise<Type<any>>;
+		try {
+			loading = Promise.resolve(config.loadComponent());
+		} catch (error) {
+			return Promise.reject(error);
+		}
+
+		this.componentCache.set(widgetId, loading);
+		// A failed load must not poison the cache — the next render retries. Only
+		// evict OUR entry: a re-registration may already have replaced it, and
+		// dropping that would discard a healthy load.
+		loading.catch(() => {
+			if (this.componentCache.get(widgetId) === loading) {
+				this.componentCache.delete(widgetId);
+			}
+		});
+		return loading;
+	}
+
+	/** Emits the flattened registry to `widgets$` subscribers. */
+	private publish(): void {
+		this._widgets$.next(Array.from(this.byId.values()));
 	}
 
 	/**

--- a/packages/ui-core/core/src/lib/services/widget/widget-registry.types.ts
+++ b/packages/ui-core/core/src/lib/services/widget/widget-registry.types.ts
@@ -17,7 +17,42 @@ export type WidgetGridWidth = 3 | 4 | 6 | 8 | 12;
  * @readonly
  * @enum {string}
  */
-export type WidgetPageLocationId = 'time-tracking' | 'accounting';
+export type WidgetPageLocationId = 'time-tracking' | 'accounting' | 'dashboard';
+
+/**
+ * Palette grouping for a widget. Drives the category accordion in the
+ * dashboard builder's widget palette.
+ */
+export type WidgetCategory =
+	| 'time-tracking'
+	| 'accounting'
+	| 'hr'
+	| 'teams'
+	| 'project-management'
+	| 'plugin'
+	| 'other';
+
+/**
+ * Ambient context every canvas-hosted widget receives (organization, date
+ * range, and the currently selected employee/project/team scope).
+ *
+ * Declared here (rather than importing the concrete interface) so the registry
+ * types stay dependency-free; the concrete shape is `IDashboardWidgetContext`
+ * in `@gauzy/ui-core/core`'s dashboard services.
+ */
+export type WidgetContextRequirement = 'organization' | 'dateRange' | 'employee' | 'project' | 'team';
+
+/**
+ * A configurable setting exposed by a widget, rendered by the builder's
+ * per-widget configuration dialog.
+ */
+export interface WidgetConfigField {
+	key: string;
+	label: string;
+	type: 'text' | 'number' | 'boolean' | 'select' | 'employee' | 'project' | 'team';
+	options?: { label: string; value: unknown }[];
+	default?: unknown;
+}
 
 /**
  * Configuration for registering a widget.
@@ -31,6 +66,71 @@ export interface WidgetRegistryConfig {
 	 * @example 'time-tracking'
 	 */
 	location: WidgetPageLocationId;
+
+	/**
+	 * @description
+	 * Palette grouping for the dashboard builder. Widgets without a category
+	 * are grouped under 'other'.
+	 */
+	category?: WidgetCategory;
+
+	/**
+	 * @description
+	 * Eva/Nebular icon name shown on the palette entry.
+	 *
+	 * @example 'people-outline'
+	 */
+	icon?: string;
+
+	/**
+	 * @description
+	 * Short description shown under the title in the palette. May be a
+	 * translation key.
+	 */
+	description?: string | ResolveFn<string>;
+
+	/**
+	 * @description
+	 * Default grid footprint used when the widget is dropped on a canvas,
+	 * in a 12 column grid (`w`) and row units (`h`).
+	 *
+	 * @example { w: 3, h: 2 }
+	 */
+	defaultSize?: { w: number; h: number };
+
+	/**
+	 * Smallest footprint the widget reads well at.
+	 *
+	 * ADVISORY, builder-UI only: the widget host uses it to narrow the widths it
+	 * offers in the resize menu. The geometry helpers in `dashboard-layout.utils`
+	 * clamp to the 12-column grid and do NOT enforce this bound, so a placement
+	 * that predates a widget's current bounds still renders.
+	 */
+	minSize?: { w: number; h: number };
+
+	/** Largest footprint the widget reads well at. Advisory, see {@link WidgetRegistryConfig.minSize}. */
+	maxSize?: { w: number; h: number };
+
+	/**
+	 * @description
+	 * Per-instance settings this widget accepts, rendered by the builder's
+	 * configuration dialog and persisted in the placement's `config`.
+	 */
+	configSchema?: WidgetConfigField[];
+
+	/**
+	 * @description
+	 * Ambient context the widget needs to render meaningful data. Used to show
+	 * an actionable empty state (e.g. "select an employee") instead of a blank
+	 * or broken widget.
+	 */
+	contextRequirements?: WidgetContextRequirement[];
+
+	/**
+	 * @description
+	 * Feature flag gating the widget, mirroring plugin page extensions.
+	 */
+	featureKey?: string;
 
 	/**
 	 * @description

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -1869,6 +1869,92 @@
 			"DISCARD_CHANGES": "Discard unsaved changes?",
 			"DISCARD_CONFIRM": "You have unsaved layout changes. Switching dashboards will discard them. Continue?"
 		},
+		"BUILDER": {
+			"EDIT_HINT": "Drag widgets from the panel on the right onto the canvas, use the grip to rearrange them, then click Save above.",
+			"UNSAVED_CHANGES": "Unsaved changes",
+			"HOST": {
+				"WIDGET_MENU": "Widget menu",
+				"CONFIGURE": "Configure",
+				"WIDTH": "Width",
+				"WIDTH_COLUMNS": "Width: {{ count }} columns",
+				"REMOVE": "Remove",
+				"RETRY": "Retry",
+				"LOADING": "Loading widget",
+				"HIDDEN": "Hidden",
+				"UNTITLED_WIDGET": "Untitled widget",
+				"LOAD_FAILED": "This widget failed to load",
+				"UNAVAILABLE": "Widget unavailable",
+				"UNAVAILABLE_HINT": "This widget is no longer registered. The plugin that provides it may be disabled.",
+				"NO_ACCESS": "No access",
+				"NO_ACCESS_HINT": "You do not have permission to view this widget."
+			},
+			"CANVAS": {
+				"DRAG_HANDLE": "Drag to move this widget",
+				"EMPTY_TITLE": "Your canvas is empty",
+				"EMPTY_HINT": "Drag widgets from the panel on the right, or click one to add it.",
+				"EMPTY_HINT_READONLY": "Click \"Edit Dashboard\" to start adding widgets to this tab."
+			},
+			"PALETTE": {
+				"TITLE": "Widgets",
+				"HINT": "Drag a widget onto the canvas, or click it to add it.",
+				"SEARCH_PLACEHOLDER": "Search widgets",
+				"CLEAR_SEARCH": "Clear search",
+				"ADD_WIDGET": "Add \"{{ name }}\" to the dashboard",
+				"NO_RESULTS": "No widgets match \"{{ term }}\".",
+				"NO_WIDGETS": "No widgets are available for your permissions."
+			},
+			"TABS": {
+				"TITLE": "Dashboard tabs",
+				"DEFAULT_NAME": "Overview",
+				"ADD_TAB": "Add tab",
+				"RENAME_TAB": "Rename tab",
+				"DUPLICATE_TAB": "Duplicate tab",
+				"DELETE_TAB": "Delete tab",
+				"DELETE_CONFIRM": "Are you sure you want to delete the tab \"{{ name }}\" and all of its widgets?",
+				"TAB_ACTIONS": "Actions for tab {{ name }}",
+				"NAME_LABEL": "Tab name",
+				"NAME_PLACEHOLDER": "Enter tab name",
+				"COPY_SUFFIX": "(Copy)"
+			},
+			"CATEGORIES": {
+				"TIME_TRACKING": "Time Tracking",
+				"ACCOUNTING": "Accounting",
+				"HR": "Human Resources",
+				"TEAMS": "Teams",
+				"PROJECT_MANAGEMENT": "Project Management",
+				"PLUGIN": "Plugins",
+				"OTHER": "Other"
+			},
+			"WIDGETS": {
+				"LOADING": "Loading widget data",
+				"ERROR": "Could not load this widget",
+				"RETRY": "Retry",
+				"MEMBERS_WORKED": {
+					"TITLE": "Members Worked",
+					"DESCRIPTION": "How many members logged time in the selected period, against your total head count."
+				},
+				"PROJECTS_WORKED": {
+					"TITLE": "Projects Worked",
+					"DESCRIPTION": "How many projects received logged time in the selected period, against your total projects."
+				},
+				"TODAY_ACTIVITY": {
+					"TITLE": "Today's Activity",
+					"DESCRIPTION": "Overall activity percentage recorded today."
+				},
+				"WORKED_TODAY": {
+					"TITLE": "Worked Today",
+					"DESCRIPTION": "Total time logged today across the current selection."
+				},
+				"WORKED_THIS_WEEK": {
+					"TITLE": "Worked This Week",
+					"DESCRIPTION": "Total time logged over the selected period; defaults to the current week."
+				},
+				"WEEKLY_ACTIVITY": {
+					"TITLE": "Weekly Activity",
+					"DESCRIPTION": "Overall activity percentage over the selected period; defaults to the current week."
+				}
+			}
+		},
 		"ACCOUNTING": "Accounting",
 		"HUMAN_RESOURCES": "Human Resources",
 		"TIME_TRACKING": "Time Tracking",

--- a/packages/ui-core/shared/src/lib/components/header-title/header-title.component.ts
+++ b/packages/ui-core/shared/src/lib/components/header-title/header-title.component.ts
@@ -11,20 +11,29 @@ import { Store } from '@gauzy/ui-core/core';
     templateUrl: './header-title.component.html',
     styles: [
         `
-			.name,
-			.org-name {
-				font-size: 24px;
-				font-weight: 400;
-				line-height: 30px;
-				letter-spacing: 0em;
+			/*
+			 * Page title, NOT a breadcrumb trail — the real trail is rendered once
+			 * in the header (<ngx-breadcrumbs>). This used to be 24px/600, which
+			 * read as an oversized breadcrumb path; a page heading only needs to
+			 * out-rank body copy, so it now sits at the h5 step of the type scale.
+			 * The org/employee qualifier is deliberately lighter and muted so the
+			 * page name is what the eye lands on.
+			 */
+			:host {
+				font-size: 1.25rem;
+				font-weight: 600;
+				line-height: 1.75rem;
+				letter-spacing: -0.01em;
 				text-align: left;
 			}
-			:host {
-				font-size: 24px;
-				font-weight: 600;
-				line-height: 30px;
-				letter-spacing: 0em;
+			.name,
+			.org-name {
+				font-size: 1.25rem;
+				font-weight: 400;
+				line-height: 1.75rem;
+				letter-spacing: -0.01em;
 				text-align: left;
+				color: var(--text-hint-color);
 			}
 		`
     ],

--- a/packages/ui-core/shared/src/lib/dashboard/index.ts
+++ b/packages/ui-core/shared/src/lib/dashboard/index.ts
@@ -22,3 +22,4 @@ export * from './window/window.service';
 export * from './window/window-template.directive';
 export * from './window-layout/window-layout.component';
 export * from './window-layout/window-layout.module';
+export * from './widget-host';

--- a/packages/ui-core/shared/src/lib/dashboard/widget-host/base-dashboard-widget.component.ts
+++ b/packages/ui-core/shared/src/lib/dashboard/widget-host/base-dashboard-widget.component.ts
@@ -1,0 +1,159 @@
+import { DestroyRef, Directive, OnInit, Signal, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { UntilDestroy } from '@ngneat/until-destroy';
+import { Observable } from 'rxjs';
+import { DASHBOARD_WIDGET_CONFIG, DASHBOARD_WIDGET_CONTEXT, IDashboardWidgetContext } from '@gauzy/ui-core/core';
+
+/**
+ * Base class for every widget rendered on a dashboard canvas.
+ *
+ * A canvas-hosted widget is instantiated dynamically by
+ * `DashboardWidgetHostComponent`, so it cannot rely on the page-level selector
+ * components (date range picker, employee/project selectors) being its
+ * ancestors. Instead the host provides the ambient selection through
+ * {@link DASHBOARD_WIDGET_CONTEXT} — already narrowed by the placement's own
+ * configuration — and the persisted per-instance settings through
+ * {@link DASHBOARD_WIDGET_CONFIG}.
+ *
+ * Subclasses only have to override {@link refresh} and render from
+ * {@link loading} / {@link error} / their own data.
+ *
+ * @example
+ * ```ts
+ * (at)UntilDestroy()
+ * (at)Component({ selector: 'ga-members-worked-widget', standalone: true, templateUrl: './...' })
+ * export class MembersWorkedWidgetComponent extends BaseDashboardWidgetComponent {
+ *   readonly members = signal<IEmployee[]>([]);
+ *
+ *   override refresh(): void {
+ *     const context = this.context();
+ *     if (!context) return;
+ *     this.loading.set(true);
+ *     this.service.getMembers(context).pipe(untilDestroyed(this)).subscribe({
+ *       next: (members) => { this.members.set(members); this.loading.set(false); },
+ *       error: (error) => this.setError(error)
+ *     });
+ *   }
+ * }
+ * ```
+ *
+ * NOTE for subclasses: this class is decorated with `@UntilDestroy()` so
+ * `untilDestroyed(this)` already works, BUT a subclass that declares its own
+ * `ngOnDestroy` shadows the patched one — such subclasses must be decorated
+ * with `@UntilDestroy()` themselves (the repo-wide convention anyway).
+ */
+@UntilDestroy()
+@Directive()
+export abstract class BaseDashboardWidgetComponent implements OnInit {
+	/**
+	 * Ambient dashboard context — organization, reporting window and the
+	 * employee/project/team scope, already narrowed by this placement's config.
+	 */
+	protected readonly context$: Observable<IDashboardWidgetContext> = inject(DASHBOARD_WIDGET_CONTEXT);
+
+	/**
+	 * Latest emitted context, for imperative reads inside handlers and templates.
+	 * `undefined` until the canvas has resolved an organization.
+	 */
+	protected readonly context: Signal<IDashboardWidgetContext | undefined> = toSignal(this.context$);
+
+	/**
+	 * Persisted per-instance configuration of this widget placement.
+	 * Empty object when the widget has no settings, so `this.config['x']` is safe.
+	 */
+	protected readonly config: Record<string, unknown> = inject(DASHBOARD_WIDGET_CONFIG, { optional: true }) ?? {};
+
+	/** True while the widget is fetching its data. Drives the widget's spinner. */
+	public readonly loading = signal(false);
+
+	/** Message of the last failed load, or `null`. Drives the widget's error state. */
+	public readonly error = signal<string | null>(null);
+
+	/** Used for subscriptions owned by this base class (never shadowed by subclasses). */
+	protected readonly destroyRef = inject(DestroyRef);
+
+	/**
+	 * Whether {@link refresh} is re-run every time the ambient context changes
+	 * (date range, organization, employee/project/team scope).
+	 *
+	 * Widgets that fetch nothing — or that manage their own triggers — override
+	 * this with `false` and get a single {@link refresh} call instead.
+	 */
+	protected readonly refreshOnContextChange: boolean = true;
+
+	/**
+	 * Wires the automatic refresh.
+	 *
+	 * Deliberately done in `ngOnInit` rather than the constructor: the context
+	 * stream is replayed, so subscribing during construction would call
+	 * {@link refresh} before the subclass' own field initializers had run.
+	 *
+	 * Subclasses overriding this method MUST call `super.ngOnInit()`.
+	 */
+	public ngOnInit(): void {
+		if (!this.refreshOnContextChange) {
+			this.refresh();
+			return;
+		}
+
+		this.context$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.refresh());
+	}
+
+	/**
+	 * Loads (or reloads) the widget's data.
+	 *
+	 * Called once the context is available, again whenever it changes, and by the
+	 * host's "Retry" action. The base implementation does nothing.
+	 */
+	public refresh(): void {
+		// Intentionally empty — widgets with no data source need no work here.
+	}
+
+	/**
+	 * Reads a typed value out of the per-instance configuration.
+	 *
+	 * @param key - Configuration key, as declared in the widget's `configSchema`.
+	 * @param fallback - Returned when the key is absent or `null`/`undefined`.
+	 */
+	protected getConfig<T>(key: string, fallback: T): T {
+		const value = this.config?.[key];
+		return (value ?? fallback) as T;
+	}
+
+	/**
+	 * Puts the widget into its error state and clears the loading flag.
+	 *
+	 * @param error - Anything thrown/emitted by the failing call.
+	 */
+	protected setError(error: unknown): void {
+		this.loading.set(false);
+		this.error.set(toErrorMessage(error));
+	}
+
+	/** Clears the error state (typically before starting a new load). */
+	protected clearError(): void {
+		this.error.set(null);
+	}
+}
+
+/**
+ * Best-effort human readable message for an unknown thrown value.
+ *
+ * Kept outside the class so widgets and the host can share the same behaviour
+ * without inheriting from each other.
+ *
+ * @param error - Anything thrown, emitted or rejected.
+ */
+export function toErrorMessage(error: unknown): string {
+	if (!error) {
+		return 'Unknown error';
+	}
+	if (typeof error === 'string') {
+		return error;
+	}
+	if (error instanceof Error) {
+		return error.message;
+	}
+	const message = (error as { message?: unknown })?.message;
+	return typeof message === 'string' ? message : 'Unknown error';
+}

--- a/packages/ui-core/shared/src/lib/dashboard/widget-host/dashboard-widget-host.component.html
+++ b/packages/ui-core/shared/src/lib/dashboard/widget-host/dashboard-widget-host.component.html
@@ -1,0 +1,118 @@
+@if (!hidden() || editing()) {
+	<nb-card class="widget-card" [class.is-editing]="editing()" [class.is-hidden]="hidden()">
+		<nb-card-header class="widget-header">
+			<span class="widget-title" [attr.title]="title() | translate">{{ title() | translate }}</span>
+
+			@if (hidden()) {
+				<span class="widget-badge">{{ 'DASHBOARD_PAGE.BUILDER.HOST.HIDDEN' | translate }}</span>
+			}
+
+			@if (editing()) {
+				<button
+					type="button"
+					nbButton
+					ghost
+					size="tiny"
+					class="widget-menu-trigger"
+					[nbPopover]="widgetMenu"
+					nbPopoverTrigger="click"
+					nbPopoverPlacement="bottom"
+					[attr.aria-label]="'DASHBOARD_PAGE.BUILDER.HOST.WIDGET_MENU' | translate"
+				>
+					<nb-icon icon="more-vertical-outline"></nb-icon>
+				</button>
+			}
+		</nb-card-header>
+
+		<nb-card-body class="widget-body">
+			@switch (state()) {
+				@case ('ready') {
+					@if (component(); as widgetComponent) {
+						<ng-container
+							*ngComponentOutlet="widgetComponent; injector: widgetInjector(); inputs: widgetInputs()"
+						/>
+					}
+				}
+				@case ('loading') {
+					<!-- Skeleton rather than a spinner: the card keeps its height, so the
+					     canvas does not reflow when the widget bundle lands. -->
+					<div class="widget-skeleton" [attr.aria-label]="'DASHBOARD_PAGE.BUILDER.HOST.LOADING' | translate">
+						<span class="skeleton-line w-60"></span>
+						<span class="skeleton-line w-90"></span>
+						<span class="skeleton-line w-75"></span>
+					</div>
+				}
+				@case ('error') {
+					<div class="widget-placeholder is-error">
+						<nb-icon icon="alert-triangle-outline"></nb-icon>
+						<p class="placeholder-title">{{ 'DASHBOARD_PAGE.BUILDER.HOST.LOAD_FAILED' | translate }}</p>
+						<p class="placeholder-hint">{{ loadError() }}</p>
+						<button type="button" nbButton size="tiny" status="basic" (click)="retry()">
+							{{ 'DASHBOARD_PAGE.BUILDER.HOST.RETRY' | translate }}
+						</button>
+					</div>
+				}
+				@case ('forbidden') {
+					<div class="widget-placeholder">
+						<nb-icon icon="lock-outline"></nb-icon>
+						<p class="placeholder-title">{{ 'DASHBOARD_PAGE.BUILDER.HOST.NO_ACCESS' | translate }}</p>
+						<p class="placeholder-hint">{{ 'DASHBOARD_PAGE.BUILDER.HOST.NO_ACCESS_HINT' | translate }}</p>
+					</div>
+				}
+				@default {
+					<!-- The widget's plugin was disabled or the widget was removed: a saved
+					     dashboard must stay usable instead of crashing. -->
+					<div class="widget-placeholder">
+						<nb-icon icon="cube-outline"></nb-icon>
+						<p class="placeholder-title">
+							{{ 'DASHBOARD_PAGE.BUILDER.HOST.UNAVAILABLE' | translate }}
+						</p>
+						<p class="placeholder-hint">
+							{{ 'DASHBOARD_PAGE.BUILDER.HOST.UNAVAILABLE_HINT' | translate }}
+						</p>
+						<code class="placeholder-id">{{ widgetId() }}</code>
+					</div>
+				}
+			}
+		</nb-card-body>
+	</nb-card>
+}
+
+<!-- Edit-mode kebab menu -->
+<ng-template #widgetMenu>
+	<div class="widget-menu">
+		<!-- Only offered when the widget actually declares settings, so the action
+		     is never a dead end. -->
+		@if (configurable()) {
+			<button type="button" class="menu-item" (click)="onConfigure()">
+				<nb-icon icon="settings-2-outline"></nb-icon>
+				<span>{{ 'DASHBOARD_PAGE.BUILDER.HOST.CONFIGURE' | translate }}</span>
+			</button>
+		}
+
+		@if (widthOptions().length > 1) {
+			<div class="menu-section">{{ 'DASHBOARD_PAGE.BUILDER.HOST.WIDTH' | translate }}</div>
+			<div class="menu-widths">
+				@for (width of widthOptions(); track width) {
+					<!-- The bare number is meaningless to a screen reader, and the
+					     current width is otherwise conveyed by color alone. -->
+					<button
+						type="button"
+						class="width-option"
+						[class.selected]="width === placement().w"
+						[attr.aria-pressed]="width === placement().w"
+						[attr.aria-label]="'DASHBOARD_PAGE.BUILDER.HOST.WIDTH_COLUMNS' | translate: { count: width }"
+						(click)="onResize(width)"
+					>
+						{{ width }}
+					</button>
+				}
+			</div>
+		}
+
+		<button type="button" class="menu-item is-danger" (click)="onRemove()">
+			<nb-icon icon="trash-2-outline"></nb-icon>
+			<span>{{ 'DASHBOARD_PAGE.BUILDER.HOST.REMOVE' | translate }}</span>
+		</button>
+	</div>
+</ng-template>

--- a/packages/ui-core/shared/src/lib/dashboard/widget-host/dashboard-widget-host.component.scss
+++ b/packages/ui-core/shared/src/lib/dashboard/widget-host/dashboard-widget-host.component.scss
@@ -1,0 +1,236 @@
+@use 'themes' as *;
+
+:host {
+  display: block;
+  height: 100%;
+  min-width: 0;
+}
+
+.widget-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  margin: 0;
+  background-color: nb-theme(gauzy-card-1);
+  border-radius: nb-theme(border-radius);
+  overflow: hidden;
+
+  &.is-editing {
+    // Make the frame legible while widgets are being arranged.
+    border: 1px dashed nb-theme(border-basic-color-4);
+  }
+
+  &.is-hidden {
+    opacity: 0.55;
+  }
+}
+
+.widget-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid nb-theme(border-basic-color-3);
+}
+
+.widget-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: nb-theme(text-subtitle-2-font-size);
+  font-weight: nb-theme(text-subtitle-2-font-weight);
+  color: nb-theme(gauzy-text-color-1);
+}
+
+.widget-badge {
+  flex: 0 0 auto;
+  padding: 0 0.375rem;
+  border-radius: nb-theme(border-radius);
+  background-color: nb-theme(background-basic-color-3);
+  color: nb-theme(text-hint-color);
+  font-size: nb-theme(text-caption-2-font-size);
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.widget-menu-trigger {
+  flex: 0 0 auto;
+  padding: 0;
+}
+
+.widget-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 0.75rem;
+  overflow: auto;
+}
+
+/* ---------- Loading skeleton ---------- */
+
+.widget-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 0.25rem 0;
+
+  .skeleton-line {
+    display: block;
+    height: 0.75rem;
+    border-radius: nb-theme(border-radius);
+    background: linear-gradient(
+      90deg,
+      nb-theme(background-basic-color-3) 25%,
+      nb-theme(background-basic-color-2) 50%,
+      nb-theme(background-basic-color-3) 75%
+    );
+    background-size: 200% 100%;
+    animation: ga-widget-skeleton 1.4s ease-in-out infinite;
+
+    &.w-60 {
+      width: 60%;
+    }
+    &.w-75 {
+      width: 75%;
+    }
+    &.w-90 {
+      width: 90%;
+    }
+  }
+}
+
+@keyframes ga-widget-skeleton {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+// Respect users who asked the OS for less motion.
+@media (prefers-reduced-motion: reduce) {
+  .widget-skeleton .skeleton-line {
+    animation: none;
+  }
+}
+
+/* ---------- Placeholders (missing / forbidden / error) ---------- */
+
+.widget-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  height: 100%;
+  min-height: 5rem;
+  padding: 0.75rem;
+  text-align: center;
+  color: nb-theme(text-hint-color);
+
+  nb-icon {
+    font-size: 1.5rem;
+    color: nb-theme(text-hint-color);
+  }
+
+  .placeholder-title {
+    margin: 0;
+    font-size: nb-theme(text-subtitle-2-font-size);
+    color: nb-theme(gauzy-text-color-1);
+  }
+
+  .placeholder-hint {
+    margin: 0;
+    font-size: nb-theme(text-caption-font-size);
+    overflow-wrap: anywhere;
+  }
+
+  .placeholder-id {
+    font-size: nb-theme(text-caption-2-font-size);
+    color: nb-theme(text-hint-color);
+    overflow-wrap: anywhere;
+  }
+
+  &.is-error {
+    nb-icon,
+    .placeholder-title {
+      color: nb-theme(color-danger-default);
+    }
+  }
+}
+
+/* ---------- Kebab menu ---------- */
+
+.widget-menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 11rem;
+  padding: 0.25rem;
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.5rem;
+    border: none;
+    border-radius: nb-theme(border-radius);
+    background: transparent;
+    color: nb-theme(gauzy-text-color-1);
+    font-size: nb-theme(text-button-tiny-font-size);
+    text-align: start;
+    cursor: pointer;
+
+    nb-icon {
+      font-size: 1rem;
+    }
+
+    &:hover {
+      background-color: nb-theme(background-basic-color-3);
+    }
+
+    &.is-danger {
+      color: nb-theme(color-danger-default);
+
+      nb-icon {
+        color: nb-theme(color-danger-default);
+      }
+    }
+  }
+
+  .menu-section {
+    padding: 0.375rem 0.5rem 0.125rem;
+    color: nb-theme(text-hint-color);
+    font-size: nb-theme(text-caption-2-font-size);
+    text-transform: uppercase;
+  }
+
+  .menu-widths {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0 0.5rem 0.375rem;
+
+    .width-option {
+      min-width: 1.75rem;
+      padding: 0.125rem 0.375rem;
+      border: 1px solid nb-theme(border-basic-color-4);
+      border-radius: nb-theme(border-radius);
+      background: transparent;
+      color: nb-theme(gauzy-text-color-2);
+      font-size: nb-theme(text-caption-font-size);
+      cursor: pointer;
+
+      &:hover {
+        background-color: nb-theme(background-basic-color-3);
+      }
+
+      &.selected {
+        border-color: nb-theme(color-primary-default);
+        background-color: nb-theme(color-primary-transparent-100);
+        color: nb-theme(color-primary-default);
+      }
+    }
+  }
+}

--- a/packages/ui-core/shared/src/lib/dashboard/widget-host/dashboard-widget-host.component.ts
+++ b/packages/ui-core/shared/src/lib/dashboard/widget-host/dashboard-widget-host.component.ts
@@ -1,0 +1,515 @@
+import { CommonModule } from '@angular/common';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	Injector,
+	Type,
+	booleanAttribute,
+	computed,
+	effect,
+	inject,
+	input,
+	isDevMode,
+	output,
+	reflectComponentType,
+	runInInjectionContext,
+	signal,
+	viewChild
+} from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { NbButtonModule, NbCardModule, NbIconModule, NbPopoverDirective, NbPopoverModule } from '@nebular/theme';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Observable, from, isObservable, of } from 'rxjs';
+import { map, shareReplay, take } from 'rxjs/operators';
+import { ID, IDashboardWidgetPlacement, PermissionsEnum } from '@gauzy/contracts';
+import {
+	DASHBOARD_GRID_COLUMNS,
+	DASHBOARD_WIDGET_CONFIG,
+	DASHBOARD_WIDGET_CONTEXT,
+	DashboardContextService,
+	IDashboardWidgetContext,
+	IDashboardWidgetContextOverrides,
+	narrowDashboardContext,
+	Store,
+	WidgetRegistryConfig,
+	WidgetRegistryService
+} from '@gauzy/ui-core/core';
+import { toErrorMessage } from './base-dashboard-widget.component';
+
+/** What the host is currently rendering inside its card body. */
+export type DashboardWidgetHostState = 'missing' | 'forbidden' | 'loading' | 'error' | 'ready';
+
+/** Widths offered in the resize menu when a widget declares no `supportedWidths`. */
+const FALLBACK_WIDTHS: number[] = [3, 4, 6, 8, 12];
+
+/** Shared empty objects, so identity stays stable across change detection. */
+const EMPTY_CONFIG: Record<string, unknown> = Object.freeze({});
+const EMPTY_INPUTS: Record<string, unknown> = Object.freeze({});
+
+/**
+ * Public input names declared by a dynamically rendered component, cached per
+ * component type.
+ *
+ * `ComponentRef.setInput()` logs an NG0303 error for inputs the component does
+ * not declare, and `*ngComponentOutlet` calls it for every key of its `inputs`
+ * binding — so the host must filter the bag down to what the widget accepts.
+ */
+const declaredInputsCache = new WeakMap<Type<unknown>, ReadonlySet<string>>();
+
+/**
+ * Returns the public (template) input names of a component type.
+ *
+ * @param component - The dynamically resolved widget component.
+ */
+function declaredInputs(component: Type<unknown>): ReadonlySet<string> {
+	const cached = declaredInputsCache.get(component);
+	if (cached) {
+		return cached;
+	}
+	const mirror = reflectComponentType(component);
+	const names = new Set<string>((mirror?.inputs ?? []).map((meta) => meta.templateName));
+	declaredInputsCache.set(component, names);
+	return names;
+}
+
+/**
+ * Normalizes whatever a registry `title` resolver returned into an observable.
+ *
+ * A resolver may hand back a plain string, a promise, or an observable, and the
+ * host treats all three the same way.
+ *
+ * @param resolved - The raw value produced by the resolver.
+ */
+function toTitleStream(resolved: unknown): Observable<string> {
+	if (isObservable(resolved)) {
+		return resolved as Observable<string>;
+	}
+	if (resolved instanceof Promise) {
+		return from(resolved as Promise<string>);
+	}
+	return of(resolved as string);
+}
+
+/** Coerces a config value that may hold a single id or a list of ids. */
+function toIdArray(value: unknown): ID[] | undefined {
+	if (Array.isArray(value)) {
+		const ids = value.filter((id): id is ID => typeof id === 'string' && !!id);
+		return ids.length ? ids : undefined;
+	}
+	return typeof value === 'string' && value ? [value as ID] : undefined;
+}
+
+/**
+ * Reads the scope overrides out of a placement's persisted configuration.
+ *
+ * This is what lets the same widget be dropped twice on one canvas and scoped
+ * differently — e.g. one instance pinned to a single project while the page
+ * selector still says "all projects". Both the singular (`projectId`) and plural
+ * (`projectIds`) spellings are accepted, because a `configSchema` field of type
+ * `project` stores a single id while a multi-select stores a list.
+ *
+ * Only the scope is overridable; the reporting window, organization and time
+ * zone always come from the page.
+ *
+ * @param config - The placement's persisted configuration.
+ * @returns The overrides, or `undefined` when the widget inherits everything.
+ */
+export function toContextOverrides(
+	config: Record<string, unknown> | undefined
+): IDashboardWidgetContextOverrides | undefined {
+	if (!config) {
+		return undefined;
+	}
+
+	const employeeIds = toIdArray(config['employeeIds'] ?? config['employeeId']);
+	const projectIds = toIdArray(config['projectIds'] ?? config['projectId']);
+	const teamIds = toIdArray(config['teamIds'] ?? config['teamId']);
+
+	if (!employeeIds && !projectIds && !teamIds) {
+		return undefined;
+	}
+	return { employeeIds, projectIds, teamIds };
+}
+
+/**
+ * Card frame around one widget instance on a dashboard canvas.
+ *
+ * The host owns everything that is NOT the widget's own content: the title, the
+ * edit-mode kebab menu (configure / resize / remove), the loading skeleton, the
+ * error state with retry, and the two placeholders that keep a saved dashboard
+ * usable when its widgets are unavailable —
+ *
+ * - **missing**: the `widgetId` is not in the registry (its plugin was disabled
+ *   or the widget was removed). A saved dashboard must never crash on this.
+ * - **forbidden**: the widget declares permissions the current user lacks.
+ *
+ * The widget itself is created dynamically and receives
+ * {@link DASHBOARD_WIDGET_CONTEXT} (narrowed by `placement.config`) and
+ * {@link DASHBOARD_WIDGET_CONFIG} through a per-instance injector.
+ */
+@UntilDestroy()
+@Component({
+	selector: 'ga-dashboard-widget-host',
+	standalone: true,
+	imports: [CommonModule, NbButtonModule, NbCardModule, NbIconModule, NbPopoverModule, TranslateModule],
+	templateUrl: './dashboard-widget-host.component.html',
+	styleUrls: ['./dashboard-widget-host.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DashboardWidgetHostComponent {
+	private readonly registry = inject(WidgetRegistryService);
+	private readonly store = inject(Store);
+	private readonly injector = inject(Injector);
+	private readonly translateService = inject(TranslateService);
+	private readonly contextService = inject(DashboardContextService);
+
+	/**
+	 * Context stream provided by an ancestor, when the page wants to override the
+	 * default source (mini dashboards, previews, tests). When absent the host
+	 * falls back to the application-wide {@link DashboardContextService}.
+	 */
+	private readonly ambientContext$: Observable<IDashboardWidgetContext> | null = inject(DASHBOARD_WIDGET_CONTEXT, {
+		optional: true
+	});
+
+	/** The placement this host renders. */
+	readonly placement = input.required<IDashboardWidgetPlacement>();
+
+	/** Whether the canvas is in edit mode (shows the kebab menu). */
+	readonly editing = input(false, { transform: booleanAttribute });
+
+	/*
+	|--------------------------------------------------------------------------
+	| Outputs
+	|--------------------------------------------------------------------------
+	| Past-tense / `*Requested` names on purpose: an output named after a native
+	| DOM event (`remove`, `resize`, ...) shadows that event on the host element,
+	| so a consumer binding it can fire twice or bind something else entirely.
+	*/
+
+	/** The user asked to remove this placement from the canvas. */
+	readonly removed = output<IDashboardWidgetPlacement>();
+
+	/**
+	 * The user asked to configure this placement.
+	 *
+	 * Deliberately payload-less: the host does not own the settings dialog, and
+	 * the parent already knows which placement it bound. Emitting a payload here
+	 * would be mistaken for "the new configuration" by canvases that persist it.
+	 */
+	readonly configureRequested = output<void>();
+
+	/** The user picked a new width (in grid columns) for this placement. */
+	readonly resized = output<{ w: number }>();
+
+	/** Bumped whenever the registry changes, so a late-registered plugin appears. */
+	private readonly registryVersion = signal(0);
+
+	/** Bumped whenever role permissions change, so access is re-evaluated. */
+	private readonly permissionsVersion = signal(0);
+
+	/** Bumped on every language change, so a translated title is re-resolved. */
+	private readonly langVersion = signal(0);
+
+	/** The resolved widget component, or `null` while loading/unavailable. */
+	readonly component = signal<Type<unknown> | null>(null);
+
+	/** True while the widget's component bundle is being resolved. */
+	readonly loading = signal(false);
+
+	/** Message of the failed component resolution, or `null`. */
+	readonly loadError = signal<string | null>(null);
+
+	/** Resolved (but not yet translated) widget title. */
+	private readonly resolvedTitle = signal<string>('');
+
+	/** Guards against out-of-order async resolutions. */
+	private loadToken = 0;
+	private titleToken = 0;
+
+	/** The kebab menu popover, so an action can close it. */
+	private readonly popover = viewChild(NbPopoverDirective);
+
+	/** The registry key of the placed widget. */
+	readonly widgetId = computed<string>(() => this.placement().widgetId);
+
+	/** The placement's persisted configuration (stable identity when absent). */
+	readonly widgetConfig = computed<Record<string, unknown>>(() => this.placement().config ?? EMPTY_CONFIG);
+
+	/** Registry entry behind the placement, or `undefined` when unavailable. */
+	readonly widget = computed<WidgetRegistryConfig | undefined>(() => {
+		this.registryVersion();
+		return this.registry.getWidget(this.widgetId());
+	});
+
+	/** Whether the current user may see this widget. */
+	readonly hasAccess = computed<boolean>(() => {
+		this.permissionsVersion();
+		const permissions = this.widget()?.permissions ?? [];
+		// `Store.hasAnyPermission()` answers `false` for an empty list, but a
+		// widget that requires nothing must stay visible to everybody.
+		if (!permissions.length) {
+			return true;
+		}
+		return this.store.hasAnyPermission(...(permissions as PermissionsEnum[]));
+	});
+
+	/** Whether the placement is temporarily hidden. */
+	readonly hidden = computed<boolean>(() => !!this.placement().hidden);
+
+	/** What the card body renders. */
+	readonly state = computed<DashboardWidgetHostState>(() => {
+		const widget = this.widget();
+		if (!widget?.loadComponent) {
+			return 'missing';
+		}
+		if (!this.hasAccess()) {
+			return 'forbidden';
+		}
+		if (this.loadError()) {
+			return 'error';
+		}
+		return this.component() ? 'ready' : 'loading';
+	});
+
+	/** Title (or translation key) shown in the card header. */
+	readonly title = computed<string>(() => this.resolvedTitle() || 'DASHBOARD_PAGE.BUILDER.HOST.UNTITLED_WIDGET');
+
+	/**
+	 * Whether the widget exposes per-instance settings.
+	 *
+	 * The kebab menu only offers "Configure" when this is true, so the action is
+	 * never a dead end: a widget with nothing to configure simply does not show it.
+	 */
+	readonly configurable = computed<boolean>(() => !!this.widget()?.configSchema?.length);
+
+	/** Widths offered by the resize menu, clamped to the widget's min/max size. */
+	readonly widthOptions = computed<number[]>(() => {
+		const widget = this.widget();
+		// Annotated `number[]` on purpose: `supportedWidths` is the literal union
+		// `WidgetGridWidth[]`, and calling `.filter()` on an un-widened
+		// `WidgetGridWidth[] | number[]` union resolves against two overloaded
+		// signatures — which TypeScript refuses to call.
+		const widths: number[] = widget?.supportedWidths?.length ? [...widget.supportedWidths] : FALLBACK_WIDTHS;
+		const min = widget?.minSize?.w ?? 1;
+		const max = widget?.maxSize?.w ?? DASHBOARD_GRID_COLUMNS;
+		return widths
+			.filter((width) => width >= min && width <= max && width <= DASHBOARD_GRID_COLUMNS)
+			.sort((a, b) => a - b);
+	});
+
+	/**
+	 * Per-instance injector handed to the widget.
+	 *
+	 * Depends ONLY on the widget id and the config object identity: changing
+	 * `ngComponentOutletInjector` destroys and recreates the component, so it
+	 * must not change while a placement is merely being dragged or resized (the
+	 * layout utils shallow-copy placements, keeping `config` identity stable).
+	 */
+	readonly widgetInjector = computed<Injector>(() => {
+		const widgetId = this.widgetId();
+		const config = this.widgetConfig();
+		const overrides = toContextOverrides(config);
+		const context$ = this.ambientContext$
+			? this.ambientContext$.pipe(
+					map((context: IDashboardWidgetContext) => narrowDashboardContext(context, overrides)),
+					shareReplay({ bufferSize: 1, refCount: true })
+				)
+			: this.contextService.contextFor(overrides);
+
+		return Injector.create({
+			name: `dashboard-widget:${widgetId}`,
+			parent: this.injector,
+			providers: [
+				{ provide: DASHBOARD_WIDGET_CONTEXT, useValue: context$ },
+				{ provide: DASHBOARD_WIDGET_CONFIG, useValue: config }
+			]
+		});
+	});
+
+	/**
+	 * Inputs forwarded to the widget, filtered down to the ones it declares.
+	 *
+	 * DI is the contract; these are a convenience for simple presentational
+	 * widgets that only need their placement/config.
+	 */
+	readonly widgetInputs = computed<Record<string, unknown>>(() => {
+		const component = this.component();
+		if (!component) {
+			return EMPTY_INPUTS;
+		}
+		const declared = declaredInputs(component);
+		if (!declared.size) {
+			return EMPTY_INPUTS;
+		}
+
+		const candidates: Record<string, unknown> = {
+			placement: this.placement(),
+			config: this.widgetConfig(),
+			editing: this.editing()
+		};
+
+		const inputs: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(candidates)) {
+			if (declared.has(key)) {
+				inputs[key] = value;
+			}
+		}
+		return Object.keys(inputs).length ? inputs : EMPTY_INPUTS;
+	});
+
+	constructor() {
+		// A plugin may register its widgets after the dashboard has rendered — a
+		// "missing widget" placeholder must recover when that happens.
+		this.registry.widgets$.pipe(untilDestroyed(this)).subscribe(() => this.registryVersion.update((v) => v + 1));
+
+		// Role permissions arrive asynchronously after sign-in / tenant switch.
+		this.store.userRolePermissions$
+			.pipe(untilDestroyed(this))
+			.subscribe(() => this.permissionsVersion.update((v) => v + 1));
+
+		// A widget title may be produced by a ResolveFn that translates eagerly, so
+		// it has to be re-resolved on a language change. Routed through a signal
+		// rather than resolved here directly: only the effect below is guaranteed
+		// to run after the required `placement` input has been set.
+		this.translateService.onLangChange
+			.pipe(untilDestroyed(this))
+			.subscribe(() => this.langVersion.update((v) => v + 1));
+
+		// Resolve the component whenever the placed widget (or access to it) changes.
+		effect(() => this.loadWidgetComponent(this.widgetId(), this.widget(), this.hasAccess()));
+
+		// Keep the header title in sync with the placement override / registry entry.
+		effect(() => {
+			this.langVersion();
+			this.resolveTitle(this.placement().title, this.widget());
+		});
+	}
+
+	/** Emits {@link configureRequested} for this placement and closes the menu. */
+	onConfigure(): void {
+		this.closeMenu();
+		this.configureRequested.emit();
+	}
+
+	/** Emits {@link removed} for this placement and closes the menu. */
+	onRemove(): void {
+		this.closeMenu();
+		this.removed.emit(this.placement());
+	}
+
+	/**
+	 * Emits {@link resized} with the picked width and closes the menu.
+	 *
+	 * @param width - New span in grid columns.
+	 */
+	onResize(width: number): void {
+		this.closeMenu();
+		this.resized.emit({ w: width });
+	}
+
+	/** Retries a failed component resolution. */
+	retry(): void {
+		this.loadWidgetComponent(this.widgetId(), this.widget(), this.hasAccess());
+	}
+
+	/** Hides the kebab popover, if it is open. */
+	private closeMenu(): void {
+		this.popover()?.hide();
+	}
+
+	/**
+	 * Resolves (and caches, via the registry) the component backing a placement.
+	 *
+	 * @param widgetId - The placement's registry key.
+	 * @param widget - The registry entry, when it exists.
+	 * @param hasAccess - Whether the user may see the widget.
+	 */
+	private loadWidgetComponent(widgetId: string, widget: WidgetRegistryConfig | undefined, hasAccess: boolean): void {
+		const token = ++this.loadToken;
+		this.component.set(null);
+		this.loadError.set(null);
+
+		// Nothing to load: the placeholders are rendered from `state()` instead.
+		if (!widget?.loadComponent || !hasAccess) {
+			this.loading.set(false);
+			return;
+		}
+
+		this.loading.set(true);
+		this.registry
+			.resolveComponent(widgetId)
+			.then((component: Type<unknown> | null) => {
+				if (token !== this.loadToken) {
+					return; // A newer load superseded this one.
+				}
+				this.loading.set(false);
+				this.component.set(component);
+			})
+			.catch((error: unknown) => {
+				if (token !== this.loadToken) {
+					return;
+				}
+				this.loading.set(false);
+				this.loadError.set(toErrorMessage(error));
+			});
+	}
+
+	/**
+	 * Resolves the header title: the user's override wins, otherwise the registry
+	 * title — which may be a plain string, a translation key, or a `ResolveFn`
+	 * returning any of those (possibly asynchronously).
+	 *
+	 * @param override - `placement.title`, set when the user renamed the widget.
+	 * @param widget - The registry entry, when it exists.
+	 */
+	private resolveTitle(override: string | undefined, widget: WidgetRegistryConfig | undefined): void {
+		const token = ++this.titleToken;
+
+		if (override) {
+			this.resolvedTitle.set(override);
+			return;
+		}
+
+		const title = widget?.title;
+		if (!title) {
+			this.resolvedTitle.set('');
+			return;
+		}
+		if (typeof title === 'string') {
+			this.resolvedTitle.set(title);
+			return;
+		}
+
+		let resolved: unknown;
+		try {
+			// Registry resolvers are plain functions that may call `inject()`, and
+			// they never actually read the route arguments of a `ResolveFn`.
+			resolved = runInInjectionContext(this.injector, () =>
+				(title as ResolveFn<string>)(null as never, null as never)
+			);
+		} catch (error) {
+			if (isDevMode()) {
+				console.warn(`[ga-dashboard-widget-host] Failed to resolve title for "${this.widgetId()}"`, error);
+			}
+			this.resolvedTitle.set('');
+			return;
+		}
+
+		toTitleStream(resolved)
+			.pipe(take(1), untilDestroyed(this))
+			.subscribe({
+				next: (value: string) => {
+					if (token === this.titleToken) {
+						this.resolvedTitle.set(value ?? '');
+					}
+				},
+				error: () => {
+					if (token === this.titleToken) {
+						this.resolvedTitle.set('');
+					}
+				}
+			});
+	}
+}

--- a/packages/ui-core/shared/src/lib/dashboard/widget-host/index.ts
+++ b/packages/ui-core/shared/src/lib/dashboard/widget-host/index.ts
@@ -1,0 +1,2 @@
+export * from './base-dashboard-widget.component';
+export * from './dashboard-widget-host.component';

--- a/packages/ui-core/shared/src/lib/dialogs/prompt/prompt.component.ts
+++ b/packages/ui-core/shared/src/lib/dialogs/prompt/prompt.component.ts
@@ -15,6 +15,8 @@ export interface PromptDialogOptions {
 	cancelText?: string;
 	placeholder?: string;
 	options?: InputOptions[];
+	/** Initial value of the input, e.g. the current name when renaming something. */
+	value?: string;
 }
 
 @Component({
@@ -35,7 +37,15 @@ export class PromptComponent implements OnInit {
 		});
 	}
 
-	ngOnInit() {}
+	/**
+	 * Seeds the input with the caller's initial value, so an "edit" style prompt
+	 * (rename, ...) does not force the user to retype what is already there.
+	 */
+	ngOnInit() {
+		if (this.data?.value) {
+			this.form.patchValue({ input: this.data.value });
+		}
+	}
 
 	close() {
 		this.dialogRef.close();

--- a/packages/ui-core/static/styles/_overlays.scss
+++ b/packages/ui-core/static/styles/_overlays.scss
@@ -1,0 +1,328 @@
+// Forward so mixins/themes are available to importers
+@forward './themes';
+@use './themes' as *;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// shadcn-like overlay menus (context menu / dropdown / popover / option list)
+//
+// The whole point of this file is the CONTAINER / ITEM split:
+//
+//   CONTAINER  one soft 1px hairline + one soft shadow + 8px radius + 4px pad
+//   ITEMS      completely FLAT rows — no border, no shadow, no visible pill.
+//              6px/10px padding, 13px text, muted icon. Hover is nothing but a
+//              low-contrast background tint on a 6px radius; active/selected is
+//              a primary tint plus accent text.
+//
+// Why this lives in a global partial instead of the component styles: Nebular
+// renders every overlay into `.cdk-overlay-container` at the <body> level, so
+// component-scoped rules can only reach it through leaky `::ng-deep`. Several
+// components already do that (see `workspaces.component.scss`, whose top-level
+// `::ng-deep nb-context-menu {…}` compiles to a *global* `nb-context-menu` rule
+// and therefore restyles every context menu in the app). Prefixing everything
+// here with `.cdk-overlay-container` raises specificity by one class so these
+// rules win over those leaks regardless of stylesheet injection order.
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Colours go through CSS custom properties with alpha-neutral fallbacks so the
+// exact same declaration reads correctly on a white surface AND on a dark one.
+// `--gauzy-overlay-border-color`, `--gauzy-hover-tint` and `--gauzy-radius-sm`
+// ARE registered in `themes.scss` (Nebular emits every theme map key as a custom
+// property), so those resolve from the theme; the fallbacks are kept only for
+// the material-* themes, which do not carry the gauzy token set. The remaining
+// `--gauzy-overlay-*` names below are not registered yet — a Sass map entry
+// cannot hold a comma-separated shadow list without changing how it is emitted —
+// so their fallbacks are still the live values.
+
+// 1px hairline: neutral grey at low alpha => light grey on white, soft light
+// line on dark. Never a raw hex that only works on one background.
+$overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+
+// Two-layer soft elevation (shadcn `shadow-md`), instead of Nebular's default
+// `rgba(0, 0, 0, 0.733) 0 4px 8px -2px` which is almost opaque in dark themes.
+// NOTE: a `var()` fallback keeps every comma after the first one, so the whole
+// two-shadow list below is the fallback value. It is written as an interpolated
+// literal so Sass emits it verbatim instead of re-parsing `12px -2px` as maths.
+$overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
+
+// Neutral hover tint (shadcn `accent`) — deliberately NOT the brand colour, so
+// hovering a row does not read as "selected". This is the SAME concept as the
+// sidebar/breadcrumb/settings-menu hover, so it resolves the one registered
+// `gauzy-hover-tint` token instead of introducing a parallel overlay-only name.
+$overlay-item-hover-bg: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+
+// Active / selected: brand tint (never a full-bleed solid fill).
+$overlay-item-active-bg: var(--gauzy-overlay-item-active-background, var(--color-primary-transparent-100));
+
+// Active / selected LABEL. Deliberately `text-basic-color` + weight 600 rather
+// than the brand colour: `--text-primary-color` is `color-primary-500`
+// (#6e49e8) in every gauzy theme, and on the dark themes that sits at ~2.7:1
+// against the tinted row — unreadable at 13px. Weight + tint carry the state
+// instead, which is also how shadcn marks a selected row (it uses a check mark,
+// not coloured text).
+// TODO(theme): once `--gauzy-overlay-item-active-text-color` exists per theme
+// (a light accent on dark, a dark accent on light) this can go back to accent
+// text automatically — the fallback is already wired below.
+$overlay-item-active-color: var(--gauzy-overlay-item-active-text-color, var(--text-basic-color));
+
+// CONTAINER radius. Its own value, not `gauzy-radius-sm`: the panel is a card-like
+// surface, the rows inside it are not.
+$overlay-radius: 8px;
+$overlay-padding: 4px;
+// ITEM radius — the shared flat-chrome row radius (0.375rem / 6px).
+$overlay-item-radius: var(--gauzy-radius-sm, 6px);
+$overlay-item-padding-y: 0.375rem; // 6px
+$overlay-item-padding-x: 0.625rem; // 10px
+
+/**
+ * The soft container chrome shared by every overlay surface that hosts a list
+ * of menu rows.
+ */
+@mixin gauzy-overlay-surface() {
+  border: 1px solid #{$overlay-hairline};
+  border-radius: $overlay-radius;
+  box-shadow: #{$overlay-shadow};
+  background-color: nb-theme(background-basic-color-1);
+}
+
+/**
+ * A single flat menu row. No border, no shadow, no persistent background — the
+ * row only lights up on hover/active, which is what removes the "visible
+ * rounded blocks" the design review flagged.
+ */
+@mixin gauzy-overlay-item() {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: $overlay-item-padding-y $overlay-item-padding-x;
+  border: 0;
+  border-radius: $overlay-item-radius;
+  box-shadow: none;
+  background-color: transparent;
+  color: nb-theme(text-basic-color);
+  font-size: nb-theme(menu-text-font-size);
+  font-weight: nb-theme(menu-text-font-weight);
+  line-height: 1.25rem;
+  text-decoration: none;
+  // Nebular centres context-menu labels by default (`context-menu-text-align`);
+  // shadcn rows are start-aligned. `start` is the logical keyword, so it flips
+  // on its own in RTL without depending on a `dir` attribute being present.
+  text-align: start;
+  // Colour-only transition: transitioning `all` also animates the radius and
+  // makes the row look like it is inflating into a block.
+  transition:
+    background-color 0.12s ease-in-out,
+    color 0.12s ease-in-out;
+}
+
+@mixin gauzy-overlay-menus() {
+  // ── Context menus ───────────────────────────────────────────────────────
+  .cdk-overlay-container nb-context-menu {
+    @include gauzy-overlay-surface();
+    padding: $overlay-padding;
+    // Nebular ships 10rem/15rem; component-level leaks push it to 280/320px,
+    // which makes a two-item support menu absurdly wide.
+    min-width: 11rem;
+    max-width: 20rem;
+
+    nb-menu {
+      background-color: transparent;
+      border-radius: 0;
+      // The container already clips; keeping `overflow: hidden` here would
+      // crop the hover tint of the first/last row against the 4px padding.
+      overflow: visible;
+
+      .menu-items {
+        margin: 0;
+        padding: 0;
+      }
+
+      .menu-item {
+        // Kill any per-item divider inherited from the theme.
+        border: 0;
+        margin: 0;
+
+        > a {
+          @include gauzy-overlay-item();
+        }
+
+        > a:hover {
+          background-color: #{$overlay-item-hover-bg};
+          color: nb-theme(text-basic-color);
+        }
+
+        > a.active {
+          background-color: #{$overlay-item-active-bg};
+          color: #{$overlay-item-active-color};
+          font-weight: 600;
+        }
+
+        // Muted 16px glyph, flush with the label. The previous look wrapped
+        // it in a 32x32 filled rounded box — that box *was* the "rounded
+        // block" inside the popup.
+        > a .menu-icon {
+          flex-shrink: 0;
+          width: 1em;
+          height: 1em;
+          min-width: auto;
+          padding: 0;
+          border: 0;
+          border-radius: 0;
+          background-color: transparent;
+          font-size: 1rem;
+          color: nb-theme(text-hint-color);
+          margin: 0;
+
+          svg {
+            width: 100%;
+            height: 100%;
+          }
+        }
+
+        > a:hover .menu-icon {
+          color: nb-theme(text-basic-color);
+        }
+
+        > a.active .menu-icon {
+          color: #{$overlay-item-active-color};
+        }
+
+        > a .menu-title {
+          flex: 1 1 auto;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+
+        // Trailing chevron of a submenu row: same muted treatment, no box.
+        // `min-width` / `border-radius` / `svg` are reset explicitly because
+        // the leaked component rule targets `nb-icon` as a whole, so it hits
+        // the chevron as well as the leading glyph.
+        > a .expand-state {
+          flex-shrink: 0;
+          width: 0.875em;
+          height: 0.875em;
+          min-width: auto;
+          padding: 0;
+          border: 0;
+          border-radius: 0;
+          font-size: 0.875rem;
+          color: nb-theme(text-hint-color);
+          background-color: transparent;
+
+          svg {
+            width: 100%;
+            height: 100%;
+          }
+        }
+      }
+
+      // Section captions above a group of rows.
+      .menu-group {
+        padding: 0.375rem $overlay-item-padding-x 0.25rem;
+        color: nb-theme(text-hint-color);
+        font-size: nb-theme(text-caption-font-size);
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+    }
+  }
+
+  // ── Popovers ────────────────────────────────────────────────────────────
+  // Template-driven popovers render their content directly (no
+  // `.primitive-overlay` wrapper), so only the container chrome is set here
+  // and the content keeps its own padding.
+  .cdk-overlay-container nb-popover {
+    @include gauzy-overlay-surface();
+
+    // The arrow is two stacked triangles: the element itself is the outline,
+    // `::after` is the fill drawn 3px inside it. The theme paints the outline
+    // with `popover-border-color` (transparent), so it has to be re-pointed at
+    // the hairline or the arrow reads as detached from the bordered panel.
+    .arrow {
+      border-bottom-color: #{$overlay-hairline};
+
+      &::after {
+        border-bottom-color: nb-theme(background-basic-color-1);
+      }
+    }
+  }
+
+  // ── nb-select option lists ──────────────────────────────────────────────
+  .cdk-overlay-container nb-option-list {
+    @include gauzy-overlay-surface();
+
+    // Nebular draws a heavier "adjacent" edge on the side facing the trigger
+    // so the panel reads as glued to the select; a floating shadcn panel is
+    // a uniform hairline on all four sides.
+    &.position-top,
+    &.position-bottom {
+      border-top-color: #{$overlay-hairline};
+      border-bottom-color: #{$overlay-hairline};
+    }
+
+    .option-list {
+      padding: $overlay-padding;
+    }
+  }
+
+  // Nebular emits `nb-option-list.size-#{$size} nb-option` (0,1,2) for the
+  // option metrics; the selector below has the same specificity but is
+  // included later in this very stylesheet, so it wins the cascade.
+  .cdk-overlay-container nb-option-list nb-option {
+    @include gauzy-overlay-item();
+
+    &:hover,
+    &.active,
+    &:focus {
+      background-color: #{$overlay-item-hover-bg};
+      color: nb-theme(text-basic-color);
+    }
+
+    // shadcn marks the selected option with a tint + weight, never with a
+    // full-bleed solid primary fill (Nebular's default is the whole row
+    // painted `color-primary-default` with white text).
+    &.selected,
+    &.selected:hover,
+    &.selected:focus {
+      background-color: #{$overlay-item-active-bg};
+      color: #{$overlay-item-active-color};
+      font-weight: 600;
+    }
+  }
+
+  // The multi-select checkbox ships its own 0.5rem inline margin from a
+  // component-scoped rule; the flex `gap` above is the single source of
+  // spacing, so zero it. Anchoring on `.option-list` (rather than the
+  // `nb-option-list` element) is what buys the specificity to beat that
+  // component rule.
+  .cdk-overlay-container .option-list nb-option nb-checkbox {
+    margin: 0;
+  }
+
+  .cdk-overlay-container nb-option-list nb-option-group .option-group-title {
+    padding: 0.375rem $overlay-item-padding-x 0.25rem;
+    color: nb-theme(text-hint-color);
+    font-size: nb-theme(text-caption-font-size);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+
+  // ── Separators ──────────────────────────────────────────────────────────
+  // 1px hairlines at low alpha, never a thick divider. Bootstrap's reboot
+  // gives every `hr` a 1px `currentColor` border at 25% opacity, which reads
+  // as a hard grey bar inside a menu.
+  .cdk-overlay-container {
+    nb-context-menu hr,
+    nb-popover hr,
+    nb-option-list hr {
+      height: 0;
+      margin: $overlay-padding 0;
+      border: 0;
+      border-top: 1px solid #{$overlay-hairline};
+      opacity: 1;
+    }
+  }
+}

--- a/packages/ui-core/static/styles/_overrides.scss
+++ b/packages/ui-core/static/styles/_overrides.scss
@@ -255,7 +255,10 @@ body {
   }
 
   .ng-dropdown-panel {
-    background-color: var(--gauzy-card-5) !important;
+    // Was `--gauzy-card-5` (a faint lavender that is also undefined in the two
+    // material themes, leaving the panel transparent there). The overlay
+    // surface colour is the same one every other dropdown uses.
+    background-color: nb-theme(background-basic-color-1) !important;
 
     .scroll-host {
       scrollbar-width: thin;
@@ -345,28 +348,69 @@ body {
     @include f-window-mode(nb-theme(layout-window-mode-padding-top));
   }
 
+  // ng-select dropdown rows follow the same shadcn container/item split as the
+  // Nebular overlays (see `_overlays.scss`): the panel owns the border/shadow,
+  // the rows are flat until hovered.
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option {
-    background: nb-theme(background-basic-color-1);
-    color: var(--gauzy-text-color-1);
-    transition-duration: 0.15s;
-    transition-property: border, background-color, color, box-shadow;
-    transition-timing-function: ease-in;
+    // Rows are flat: the panel behind them supplies the surface colour, so an
+    // opaque per-row background would paint a solid block inside the 4px
+    // container padding and re-introduce the "rounded blocks" look.
+    // `!important` because ng-select's own sheet is loaded after this one.
+    background-color: transparent !important;
+    // `--gauzy-text-color-1` only exists in 6 of the 8 registered themes (the
+    // two material ones never define it), where the declaration would be
+    // invalid at computed-value time. `text-basic-color` is defined everywhere
+    // and is the same colour in the themes that do define the gauzy token.
+    color: nb-theme(text-basic-color) !important;
+    transition-duration: 0.12s;
+    transition-property: background-color, color;
+    transition-timing-function: ease-in-out;
+    font-weight: nb-theme(menu-text-font-weight);
+    font-size: nb-theme(menu-text-font-size);
+    line-height: 1.25rem;
+    // Overrides ng-select's own `padding: 8px 10px` (its sheet is loaded after
+    // this one, so a tie would go to it).
+    padding: 0.375rem 0.625rem !important;
+    border-radius: 6px;
+  }
+
+  // Group captions get the same muted treatment as `nb-option-group`. ng-select
+  // hard-codes `color: rgba(0, 0, 0, 0.54)` and a pale blue fill on the
+  // marked/selected states — both illegible on the dark themes.
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-optgroup,
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-optgroup.ng-option-marked,
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-optgroup.ng-option-selected {
+    padding: 0.375rem 0.625rem !important;
+    color: var(--text-hint-color) !important;
+    background-color: transparent !important;
+    font-size: nb-theme(text-caption-font-size);
     font-weight: 600;
-    font-size: 0.8125rem;
-    line-height: 1.5rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
   }
 
+  // Neutral tint, not the brand colour — a hovered row must not read as
+  // "selected".
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option:hover {
-    background-color: var(--color-primary-transparent-default) !important;
+    background-color: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12)) !important;
   }
 
+  // `ng-option-marked` is keyboard focus; give it the same tint as hover so
+  // arrow-key navigation is visible (it used to be reset to nothing).
   .ng-dropdown-panel .ng-dropdown-panel-items .ng-option-marked {
-    background-color: unset !important;
+    background-color: var(--gauzy-overlay-item-hover-background, rgba(126, 126, 143, 0.12)) !important;
   }
 
-  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option-selected {
-    color: var(--text-primary-color) !important;
-    background-color: var(--color-primary-transparent-default) !important;
+  // Selected keeps the accent tint even under the cursor, so the `:hover` rule
+  // above (same specificity, declared earlier) cannot grey it out. The label
+  // stays `text-basic-color` + weight 600 rather than the brand colour, which
+  // sits at ~2.7:1 on the tinted row in the dark themes — see the note on
+  // `$overlay-item-active-color` in `_overlays.scss`.
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option-selected,
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option-selected:hover {
+    color: var(--gauzy-overlay-item-active-text-color, var(--text-basic-color)) !important;
+    background-color: var(--gauzy-overlay-item-active-background, var(--color-primary-transparent-100)) !important;
+    font-weight: 600;
   }
 
   .ng-value-container .ng-input input {
@@ -374,17 +418,49 @@ body {
     color: nb-theme(text-basic-color);
   }
 
+  // NOTE ON `!important` IN THIS BLOCK: `@ng-select/ng-select/themes/default.theme.css`
+  // is listed AFTER `styles.scss` in the app's `styles` array, so its rules win
+  // every specificity tie. Each `!important` below overrides a specific
+  // declaration from that sheet — they are not blanket hammers.
   .ng-dropdown-panel {
-    transform: translateY(10px);
-    box-shadow: var(--gauzy-shadow);
-    border-width: 0 !important;
+    // One soft 1px hairline + one soft shadow on the CONTAINER, mirroring
+    // `gauzy-overlay-surface()`. `--gauzy-overlay-border-color` resolves from
+    // themes.scss; the fallback covers the material-* themes.
+    // Overrides `border: 1px solid #ccc`.
+    border: 1px solid var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)) !important;
+    // Overrides `box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06)`.
+    box-shadow: var(
+      --gauzy-overlay-shadow,
+      0 4px 12px -2px rgba(0, 0, 0, 0.14),
+      0 2px 6px -2px rgba(0, 0, 0, 0.08)
+    ) !important;
+    border-radius: 8px;
 
+    // ng-select squares off the edge facing the trigger (`border-*-radius: 4px`
+    // on the other two corners) so the panel reads as glued to the input; a
+    // floating shadcn panel is uniformly rounded.
+    &.ng-select-bottom,
+    &.ng-select-top,
+    &.ng-select-left,
+    &.ng-select-right {
+      border-radius: 8px !important;
+    }
+
+    // Detach the panel from the trigger by 6px. The offset has to follow the
+    // placement: a `.ng-select-top` panel sits ABOVE the input, so shifting it
+    // down would close the gap and push the panel over the trigger instead.
     &.ng-select-bottom {
-      border-radius: nb-theme(border-radius);
+      transform: translateY(6px);
+    }
+
+    &.ng-select-top {
+      transform: translateY(-6px);
     }
 
     .ng-dropdown-panel-items {
-      border-radius: nb-theme(border-radius);
+      border-radius: 8px;
+      // Breathing room so the 6px item radius never touches the container edge.
+      padding: 4px;
 
       img {
         border-radius: 4px;
@@ -392,6 +468,25 @@ body {
         height: 24px;
         z-index: 10000001;
       }
+    }
+
+    // ng-select rounds the first/last row to the panel's old 4px corners. With
+    // the container padding above, every row is a free-floating 6px pill.
+    &.ng-select-bottom .ng-dropdown-panel-items .ng-option:last-child,
+    &.ng-select-top .ng-dropdown-panel-items .ng-option:first-child,
+    &.ng-select-left .ng-dropdown-panel-items .ng-option:first-child,
+    &.ng-select-right .ng-dropdown-panel-items .ng-option:first-child {
+      border-radius: 6px;
+    }
+
+    // Hairline, not the theme's hard `1px solid #ccc`. `!important` for the same
+    // reason as the rest of this block: ng-select's own sheet is loaded after
+    // this one, so it wins every specificity tie — and its `border-bottom`
+    // shorthand would otherwise reinstate both the colour and the width.
+    .ng-dropdown-header,
+    .ng-dropdown-footer {
+      border-color: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)) !important;
+      padding: 0.375rem 0.625rem !important;
     }
   }
 
@@ -871,9 +966,4 @@ angular2-smart-table {
   angular2-st-tbody-create-cancel {
     display: flex;
   }
-}
-
-.ng-dropdown-panel .ng-dropdown-panel-items .ng-option {
-  background-color: var(--gauzy-card-1) !important;
-  color: var(--gauzy-text-color-1) !important;
 }

--- a/packages/ui-core/static/styles/styles.scss
+++ b/packages/ui-core/static/styles/styles.scss
@@ -20,6 +20,7 @@
 
 // Files that DON'T need Bootstrap can use @use
 @use './overrides' as *;
+@use './overlays' as *;
 @use './material/material-overrides' as *;
 @use './gauzy/gauzy-overrides' as *;
 
@@ -60,4 +61,7 @@
   @include nb-overrides();
   @include material-overrides();
   @include gauzy-overrides();
+  // Last, so the shadcn container/item split wins over the older overlay rules
+  // above (and over the `::ng-deep` leaks coming from component stylesheets).
+  @include gauzy-overlay-menus();
 }

--- a/packages/ui-core/static/styles/themes.scss
+++ b/packages/ui-core/static/styles/themes.scss
@@ -29,6 +29,28 @@ $gauzy-density: (
 	menu-text-font-size: 0.8125rem,
 	menu-text-font-weight: 500,
 	menu-item-divider-width: 0,
+	// Flat-chrome tokens (shadcn-like): a small radius and a low-contrast
+	// hover fill shared by breadcrumb links, sidebar rows, settings menu rows
+	// and overlay menu items, so "hover" reads identically everywhere in all 8
+	// themes.
+	// NOTE: deliberately smaller than `border-radius` (0.625rem) — that is the
+	// CARD radius, and a 10px pill on a 20px row is what made menu items look
+	// like blocks.
+	gauzy-radius-sm: 0.375rem,
+	// Translucent NEUTRAL rather than an alias of a background token: aliasing
+	// `background-basic-color-2` painted an invisible hover in `gauzy-dark`,
+	// where that token is rgba(32, 32, 35, 1) — the exact colour of the surfaces
+	// it sits on (`gauzy-card-1`, and the header/layout backgrounds aliased to
+	// it). A low-alpha grey darkens a light surface and lightens a dark one, so
+	// one value works in every theme without a per-theme branch.
+	gauzy-hover-tint: rgba(126, 126, 143, 0.12),
+	// Active / current row: exactly twice the hover alpha. The pair stays
+	// distinguishable on both surfaces while neither reads as a filled block.
+	gauzy-active-tint: rgba(126, 126, 143, 0.2),
+	// Overlay container hairline — shared by the global overlay rules and by the
+	// popups that are positioned by the layout instead of `.cdk-overlay-container`
+	// (user menu, workspace menu), so all of them resolve one value.
+	gauzy-overlay-border-color: rgba(126, 126, 143, 0.18),
 	menu-item-divider-style: none,
 	// Cards
 	card-padding: 1rem,

--- a/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.html
+++ b/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,40 @@
+@if (breadcrumbs().length) {
+	<nav class="breadcrumb" aria-label="Breadcrumb">
+		<ol class="breadcrumb-list">
+			@for (crumb of breadcrumbs(); track $index; let first = $first, last = $last) {
+				<li class="breadcrumb-item">
+					@if (!first) {
+						<span class="breadcrumb-separator" aria-hidden="true">
+							<nb-icon icon="chevron-right-outline"></nb-icon>
+						</span>
+					}
+
+					@if (crumb.link) {
+						<a class="breadcrumb-link" [routerLink]="crumb.link" [title]="crumb.label">
+							@if (crumb.icon) {
+								<nb-icon [icon]="crumb.icon" [attr.aria-label]="crumb.label"></nb-icon>
+							} @else {
+								{{ crumb.label }}
+							}
+						</a>
+					} @else {
+						<!-- Only the LAST crumb is the current page: intermediate levels without a
+						     route stay muted so they never read as "you are here". -->
+						<span
+							[class.breadcrumb-current]="last"
+							[class.breadcrumb-text]="!last"
+							[title]="crumb.label"
+							[attr.aria-current]="last ? 'page' : null"
+						>
+							@if (crumb.icon) {
+								<nb-icon [icon]="crumb.icon" [attr.aria-label]="crumb.label"></nb-icon>
+							} @else {
+								{{ crumb.label }}
+							}
+						</span>
+					}
+				</li>
+			}
+		</ol>
+	</nav>
+}

--- a/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.scss
+++ b/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,113 @@
+@use '@nebular/theme/styles/global/breakpoints' as *;
+@use 'themes' as *;
+
+// shadcn-style trail: small muted text, thin chevrons, no title styling and no
+// background block. Every value is a theme token so light and dark stay in sync.
+@include nb-install-component() {
+  display: flex;
+  align-items: center;
+  // Never push the header actions around — the trail shrinks and truncates with
+  // an ellipsis instead.
+  min-width: 0;
+  overflow: hidden;
+
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .breadcrumb-list {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 0.125rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    min-width: 0;
+  }
+
+  .breadcrumb-item {
+    display: flex;
+    align-items: center;
+    gap: 0.125rem;
+    min-width: 0;
+    // 13px — same scale as the menu text from the density pass.
+    font-size: nb-theme(menu-text-font-size);
+    line-height: 1.25rem;
+  }
+
+  .breadcrumb-link,
+  .breadcrumb-text,
+  .breadcrumb-current {
+    display: inline-flex;
+    align-items: center;
+    // Long names (custom dashboards, projects) truncate rather than wrap the header.
+    max-width: 12rem;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    padding: 0.0625rem 0.25rem;
+    border-radius: 0.375rem;
+  }
+
+  .breadcrumb-link {
+    color: nb-theme(text-hint-color);
+    text-decoration: none;
+    transition:
+      color 0.15s ease-in-out,
+      background-color 0.15s ease-in-out;
+
+    &:hover {
+      // Low-contrast tint only — no border, no shadow, no pill.
+      color: nb-theme(text-basic-color);
+      background-color: nb-theme(background-basic-color-2);
+      text-decoration: none;
+    }
+
+    &:focus-visible {
+      color: nb-theme(text-basic-color);
+      background-color: nb-theme(background-basic-color-2);
+      outline: 1px solid nb-theme(color-primary-default);
+      outline-offset: 0;
+    }
+  }
+
+  // An intermediate level with no route of its own (a menu section such as
+  // "Organization"): muted like a link, but not interactive.
+  .breadcrumb-text {
+    color: nb-theme(text-hint-color);
+  }
+
+  .breadcrumb-current {
+    // The current page is the only crumb with full-strength text.
+    color: nb-theme(text-basic-color);
+    font-weight: 500;
+  }
+
+  .breadcrumb-separator {
+    display: inline-flex;
+    align-items: center;
+    color: nb-theme(text-hint-color);
+    opacity: 0.65;
+
+    nb-icon {
+      font-size: 0.875rem;
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+  }
+
+  nb-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  // The header band gets crowded on small screens, where the sidebar already
+  // answers "where am I" — drop the trail instead of squeezing the selectors.
+  @include media-breakpoint-down(lg) {
+    display: none;
+  }
+}

--- a/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.ts
+++ b/packages/ui-core/theme/src/lib/components/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,348 @@
+import { Component, Signal, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter, map, startWith } from 'rxjs/operators';
+import { TranslateService } from '@ngx-translate/core';
+import { NavMenuBuilderService, NavMenuSectionItem } from '@gauzy/ui-core/core';
+
+/**
+ * One rendered level of the breadcrumb trail.
+ */
+export interface IBreadcrumb {
+	/** Translated, human readable label. */
+	label: string;
+	/** Absolute router link, or `null` when this level has no navigable route. */
+	link: string | null;
+	/** Optional icon rendered instead of the label (the "home" crumb). */
+	icon?: string;
+}
+
+/**
+ * A navigation menu item paired with the sections it lives under.
+ */
+interface IMenuMatch {
+	item: NavMenuSectionItem;
+	ancestors: NavMenuSectionItem[];
+	/** The item's link, normalized to a bare path. */
+	link: string;
+}
+
+/**
+ * Breadcrumb trail for the current route.
+ *
+ * Labels are resolved from the navigation menu tree instead of the raw URL, so every
+ * crumb shows the same translated wording as the sidebar. Mounted once in the shared
+ * header, which gives every page under `/pages` a trail without touching page templates.
+ */
+@Component({
+	selector: 'ngx-breadcrumbs',
+	templateUrl: './breadcrumb.component.html',
+	styleUrls: ['./breadcrumb.component.scss'],
+	standalone: false
+})
+export class BreadcrumbComponent {
+	/** Application home — `/pages` redirects here. */
+	private static readonly HOME_LINK = '/pages/dashboard';
+
+	/** Segments that are record identifiers (uuid / numeric): they carry no readable meaning. */
+	private static readonly ID_SEGMENT = /^\d+$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+	/**
+	 * Menu sections skipped while matching. "Favorites" mirrors links that already live
+	 * elsewhere in the tree, so a page marked as favorite would otherwise win the match and render
+	 * as "Favorites / …" instead of its real place in the hierarchy.
+	 */
+	private static readonly IGNORED_SECTION_IDS = new Set<string>(['favorites']);
+
+	/** Namespaces probed (in order) when a URL segment has no navigation menu entry. */
+	private static readonly SEGMENT_TRANSLATION_NAMESPACES = ['MENU', 'BUTTONS'];
+
+	private readonly _router = inject(Router);
+	private readonly _navMenuBuilderService = inject(NavMenuBuilderService);
+	private readonly _translateService = inject(TranslateService);
+
+	/** Current URL, tracked across navigations. */
+	private readonly _url = toSignal(
+		this._router.events.pipe(
+			filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+			map((event: NavigationEnd) => event.urlAfterRedirects),
+			startWith(this._router.url)
+		),
+		{ initialValue: this._router.url }
+	);
+
+	/** Navigation menu tree — the source of translated, hierarchy-aware labels. */
+	private readonly _menu = toSignal(this._navMenuBuilderService.menuConfig$, {
+		initialValue: [] as NavMenuSectionItem[]
+	});
+
+	/** Emits on language change so the trail can be re-translated in place. */
+	private readonly _language = toSignal(this._translateService.onLangChange.pipe(startWith(null)), {
+		initialValue: null
+	});
+
+	/** The trail for the current route, outermost level first. */
+	public readonly breadcrumbs: Signal<IBreadcrumb[]> = computed(() => {
+		// Read the language signal so switching language rebuilds (and re-translates) the trail.
+		this._language();
+		return this.buildTrail(this._url(), this._menu());
+	});
+
+	/**
+	 * Builds the breadcrumb trail for a URL.
+	 *
+	 * @param url Current router URL — may carry a query string, fragment or matrix params.
+	 * @param sections Navigation menu sections as defined by the menu builder.
+	 * @returns The ordered trail; empty outside the `/pages` shell.
+	 */
+	private buildTrail(url: string, sections: NavMenuSectionItem[]): IBreadcrumb[] {
+		const path = this.toPath(url);
+
+		// Breadcrumbs describe the in-app page hierarchy only (auth / public routes have none).
+		if (!path.startsWith('/pages')) {
+			return [];
+		}
+
+		const match = this.findDeepestMatch(path, sections);
+		const crumbs: IBreadcrumb[] = match
+			? [
+					this.homeCrumb(),
+					...match.ancestors.map((ancestor: NavMenuSectionItem) => this.toCrumb(ancestor)),
+					this.toCrumb(match.item),
+					...this.segmentCrumbs(path, match.link)
+				]
+			: [this.homeCrumb(), ...this.segmentCrumbs(path, '/pages')];
+
+		return this.finalize(crumbs);
+	}
+
+	/**
+	 * Finds the deepest navigation menu item whose link is an ancestor of (or equal to) the path.
+	 *
+	 * @param path Normalized URL path.
+	 * @param sections Navigation menu sections to search.
+	 * @returns The matched item together with its ancestor sections, or `null` when nothing matches.
+	 */
+	private findDeepestMatch(path: string, sections: NavMenuSectionItem[]): IMenuMatch | null {
+		const matches = this.collectMatches(path, sections, []);
+
+		return matches.reduce((best: IMenuMatch | null, candidate: IMenuMatch) => {
+			// Deepest link wins; on a tie a visible item beats a hidden twin
+			// (several hidden items point at /pages/dashboard, for instance).
+			if (!best) {
+				return candidate;
+			}
+			return this.matchScore(candidate) > this.matchScore(best) ? candidate : best;
+		}, null);
+	}
+
+	/**
+	 * Walks the menu tree and collects every item whose link covers the path.
+	 *
+	 * @param path Normalized URL path.
+	 * @param items Menu items at the current level.
+	 * @param ancestors Sections walked through to reach `items`.
+	 * @returns All matching items, in tree order.
+	 */
+	private collectMatches(path: string, items: NavMenuSectionItem[], ancestors: NavMenuSectionItem[]): IMenuMatch[] {
+		const matches: IMenuMatch[] = [];
+
+		for (const item of items ?? []) {
+			if (BreadcrumbComponent.IGNORED_SECTION_IDS.has(item.id)) {
+				continue;
+			}
+
+			const link = typeof item.link === 'string' ? this.toPath(item.link) : null;
+
+			if (link && this.isAncestorPath(link, path)) {
+				matches.push({ item, ancestors: [...ancestors], link });
+			}
+
+			if (item.items?.length) {
+				matches.push(...this.collectMatches(path, item.items, [...ancestors, item]));
+			}
+		}
+
+		return matches;
+	}
+
+	/**
+	 * Ranks a match: deeper links score higher, and visible items outrank hidden ones.
+	 *
+	 * @param match Candidate match.
+	 * @returns The comparable score.
+	 */
+	private matchScore(match: IMenuMatch): number {
+		return match.link.split('/').length * 2 + (match.item.hidden ? 0 : 1);
+	}
+
+	/**
+	 * Builds crumbs for the URL segments left over after the matched menu link.
+	 *
+	 * These levels are deliberately not links: nothing guarantees an intermediate URL
+	 * resolves to a route (`/pages/employees/edit` on its own is a 404), and a dead
+	 * crumb is worse than a plain one.
+	 *
+	 * @param path Normalized URL path.
+	 * @param basePath The already-covered prefix of the path.
+	 * @returns Crumbs for the remaining, meaningful segments.
+	 */
+	private segmentCrumbs(path: string, basePath: string): IBreadcrumb[] {
+		return path
+			.slice(basePath.length)
+			.split('/')
+			.filter((segment: string) => !!segment && !BreadcrumbComponent.ID_SEGMENT.test(segment))
+			.map((segment: string) => ({ label: this.labelForSegment(segment), link: null }));
+	}
+
+	/**
+	 * Removes empty and repeated levels and marks the last crumb as the current page.
+	 *
+	 * @param crumbs Raw trail.
+	 * @returns The trail ready for rendering.
+	 */
+	private finalize(crumbs: IBreadcrumb[]): IBreadcrumb[] {
+		const trail: IBreadcrumb[] = [];
+
+		for (const crumb of crumbs) {
+			if (!crumb.label && !crumb.icon) {
+				continue;
+			}
+
+			// Collapse repeats — home and the "Dashboards" menu item point at the same route.
+			const previous = trail.at(-1);
+			const duplicate =
+				previous && ((!!crumb.link && previous.link === crumb.link) || previous.label === crumb.label);
+			if (duplicate) {
+				continue;
+			}
+
+			trail.push({ ...crumb });
+		}
+
+		// The current page is never a link — it is announced with aria-current instead.
+		const current = trail.at(-1);
+		if (current) {
+			current.link = null;
+		}
+
+		// A lone home crumb reads better as a word than as a bare icon.
+		if (trail.length === 1) {
+			trail[0] = { ...trail[0], icon: undefined };
+		}
+
+		return trail;
+	}
+
+	/**
+	 * Maps a navigation menu item to a crumb.
+	 *
+	 * @param item Navigation menu item.
+	 * @returns The crumb, linked only when the menu item itself defines a route.
+	 */
+	private toCrumb(item: NavMenuSectionItem): IBreadcrumb {
+		const key = item.data?.translationKey;
+		const link = typeof item.link === 'string' ? this.toPath(item.link) : null;
+
+		if (!key) {
+			return { label: item.title ?? '', link };
+		}
+
+		// `noTranslate` items hold user content (custom dashboard names) — render literally so a
+		// name that happens to match an i18n key is not translated away.
+		if (item.data?.noTranslate) {
+			return { label: key, link };
+		}
+
+		return { label: this.translateOrNull(key) ?? item.title ?? '', link };
+	}
+
+	/**
+	 * The root crumb, pointing at the application home.
+	 *
+	 * @returns The home crumb.
+	 */
+	private homeCrumb(): IBreadcrumb {
+		return {
+			label: this.translateOrNull('MENU.DASHBOARDS') ?? 'Dashboards',
+			link: BreadcrumbComponent.HOME_LINK,
+			icon: 'home-outline'
+		};
+	}
+
+	/**
+	 * Resolves a readable label for a URL segment that has no navigation menu entry.
+	 *
+	 * @param segment Raw URL segment (e.g. `edit`, `expense-recurring`).
+	 * @returns A translated label when a matching i18n key exists, a humanized segment otherwise.
+	 */
+	private labelForSegment(segment: string): string {
+		const key = segment.replace(/[^a-z\d]+/gi, '_').toUpperCase();
+
+		for (const namespace of BreadcrumbComponent.SEGMENT_TRANSLATION_NAMESPACES) {
+			const translated = this.translateOrNull(`${namespace}.${key}`);
+			if (translated) {
+				return translated;
+			}
+		}
+
+		return this.humanize(segment);
+	}
+
+	/**
+	 * Translates a key, treating "missing" as absent.
+	 *
+	 * @param key i18n key.
+	 * @returns The translation, or `null` when the key is unknown (ngx-translate echoes the key back)
+	 *          or resolves to a namespace object rather than a string.
+	 */
+	private translateOrNull(key: string): string | null {
+		const translated = this._translateService.instant(key);
+		return typeof translated === 'string' && translated !== key && translated.trim().length > 0 ? translated : null;
+	}
+
+	/**
+	 * Turns a URL segment into title case words.
+	 *
+	 * @param segment Raw URL segment.
+	 * @returns The humanized text (`expense-recurring` → `Expense Recurring`).
+	 */
+	private humanize(segment: string): string {
+		return segment
+			.replace(/[-_]+/g, ' ')
+			.replace(/([a-z\d])([A-Z])/g, '$1 $2')
+			.replace(/\b\w/g, (char: string) => char.toUpperCase())
+			.trim();
+	}
+
+	/**
+	 * Strips the query string, fragment, matrix params and any trailing slash from a URL.
+	 *
+	 * @param url Router URL or menu link.
+	 * @returns The bare path.
+	 */
+	private toPath(url: string): string {
+		const [withoutQuery = ''] = String(url ?? '').split(/[?#]/);
+		// Matrix params attach to a SINGLE segment (`/pages/settings;tab=1/ai`), so they have to
+		// be stripped segment by segment. Splitting the whole URL on the first `;` instead would
+		// discard every later segment and leave the trail pointing at the wrong page.
+		const path = withoutQuery
+			.split('/')
+			.map((segment: string) => segment.split(';')[0])
+			.join('/');
+
+		return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+	}
+
+	/**
+	 * Checks whether a link addresses the path itself or one of its ancestors, comparing
+	 * whole segments so `/pages/tag` never matches `/pages/tags`.
+	 *
+	 * @param link Candidate ancestor path.
+	 * @param path Current path.
+	 * @returns True when `link` is `path` or a segment-aligned prefix of it.
+	 */
+	private isAncestorPath(link: string, path: string): boolean {
+		return path === link || path.startsWith(`${link}/`);
+	}
+}

--- a/packages/ui-core/theme/src/lib/components/header/header.component.html
+++ b/packages/ui-core/theme/src/lib/components/header/header.component.html
@@ -5,10 +5,16 @@
   </div>
 }
 <div class="main-header">
-  <div class="header-container"
+  <!-- Breadcrumbs live in the header band, which is the single host every page
+       under /pages already renders: page templates stay untouched and the trail
+       costs the page zero vertical space. -->
+  <div class="header-container breadcrumb-container"
     [class.left]="position === 'normal'"
     [class.right]="position === 'inverse'"
-  ></div>
+    [class.compacted]="!expanded"
+  >
+    <ngx-breadcrumbs></ngx-breadcrumbs>
+  </div>
 
   <div class="header-container">
     @if (createQuickActionsMenu?.length > 0) {

--- a/packages/ui-core/theme/src/lib/components/header/header.component.scss
+++ b/packages/ui-core/theme/src/lib/components/header/header.component.scss
@@ -94,6 +94,40 @@ $orange: #f56d58;
       padding: 0 !important;
     }
 
+    // The nav sidebar's container is fixed at top: 0 with z-index 1041 (see the
+    // one-column layout), so it paints OVER the left of the header band and the
+    // trail has to start exactly where the sidebar ends — and follow it when the
+    // sidebar is compacted.
+    //
+    // The offset is the bare sidebar width: `nb-layout-header nav` has its
+    // `header-padding` zeroed globally (_overrides.scss), so there is no padding
+    // to subtract — doing so would tuck the first crumb under the sidebar.
+    .breadcrumb-container {
+      flex: 1 1 auto;
+      min-width: 0;
+      @include nb-ltr(margin-left, nb-theme(sidebar-width));
+      @include nb-rtl(margin-right, nb-theme(sidebar-width));
+
+      &.compacted {
+        @include nb-ltr(margin-left, nb-theme(sidebar-width-compact));
+        @include nb-rtl(margin-right, nb-theme(sidebar-width-compact));
+      }
+
+      // Below `lg` the trail itself is hidden (breadcrumb.component.scss). Drop the
+      // offset with it: an empty spacer carrying a 16rem margin would push the
+      // header actions off a narrow viewport. The element stays in the flow so
+      // `justify-content: space-between` still parks the actions on the right.
+      @include media-breakpoint-down(lg) {
+        @include nb-ltr(margin-left, 0);
+        @include nb-rtl(margin-right, 0);
+
+        &.compacted {
+          @include nb-ltr(margin-left, 0);
+          @include nb-rtl(margin-right, 0);
+        }
+      }
+    }
+
     .header-container {
       display: flex;
       align-items: center;

--- a/packages/ui-core/theme/src/lib/components/index.ts
+++ b/packages/ui-core/theme/src/lib/components/index.ts
@@ -1,3 +1,4 @@
+export * from './breadcrumb/breadcrumb.component';
 export * from './header/header.component';
 export * from './footer/footer.component';
 export * from './gauzy-logo/gauzy-logo.component';

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
@@ -1,18 +1,33 @@
 @use 'themes' as *;
 
+// The account dropdown is a popup, so it follows the same shadcn rules as the
+// overlay menus in `packages/ui-core/static/styles/_overlays.scss`: ONE soft
+// container wrapping FLAT rows. Like the workspace switcher it is absolutely
+// positioned by the layout rather than rendered into `.cdk-overlay-container`,
+// so the container chrome is repeated here. `--gauzy-overlay-border-color` and
+// `--gauzy-hover-tint` resolve from themes.scss; the alpha-neutral fallbacks
+// cover the material-* themes and read correctly on light AND dark surfaces.
+$overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+$overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
+$overlay-item-hover-bg: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+
 :host {
   .main-menu {
     width: 36rem;
     //height: 30.5625rem; // After implement features revert to this height
     height: 18rem;
-    box-shadow: 0rem 0.25rem 1rem rgba(0, 0, 0, 0.25);
-    border-radius: nb-theme(border-radius) nb-theme(border-radius)
-      nb-theme(border-radius) 0rem;
+    border: 1px solid #{$overlay-hairline};
+    box-shadow: #{$overlay-shadow};
+    border-radius: 8px;
     background: nb-theme(background-basic-color-1);
     display: flex;
     .right-menu {
       background: nb-theme(color-primary-transparent-default);
-      border-radius: 0px nb-theme(border-radius) nb-theme(border-radius) 0px;
+      // `direction: rtl` reverses the flex row, so this column moves to the
+      // LEFT edge under RTL while physical corner radii stay put — mirror them
+      // or the panel ends up with two squared outer corners.
+      @include nb-ltr(border-radius, 0 8px 8px 0);
+      @include nb-rtl(border-radius, 8px 0 0 8px);
       width: 50%;
       padding: 13.5px 15.5px 13.5px 26px;
       span {
@@ -32,12 +47,16 @@
     }
     .left-menu {
       width: 50%;
-      border-radius: 0px nb-theme(border-radius) nb-theme(border-radius) 0px;
+      // Mirrored for the same reason as `.right-menu` above.
+      @include nb-ltr(border-radius, 8px 0 0 8px);
+      @include nb-rtl(border-radius, 0 8px 8px 0);
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      @include nb-ltr(padding, 19px 47px 10px 11px);
-      @include nb-rtl(padding, 19px 11px 10px 47px);
+      // Trimmed from 11px/47px: each row now carries its own 10px inline
+      // padding (see `p.link` below), so the column only needs a small inset.
+      @include nb-ltr(padding, 14px 16px 10px 6px);
+      @include nb-rtl(padding, 14px 6px 10px 16px);
       .sub-menu {
         background: rgba(126, 126, 143, 0.05);
         padding: 10px;
@@ -74,10 +93,36 @@
     text-decoration: none;
     color: nb-theme(text-basic-color);
   }
+
   .links {
-    align-items: flex-start;
+    // `stretch` (was `flex-start`) so a hovered row's tint spans the column
+    // instead of hugging the label.
+    align-items: stretch;
     display: flex;
     flex-direction: column;
+    gap: 0.125rem;
+
+    // Flat menu rows: no border, no shadow, no resting fill — only a subtle
+    // background tint on a 6px radius when hovered. Scoped to `.links` so the
+    // right-hand column (whose `p`s wrap full-width selector widgets, not menu
+    // entries) keeps its own alignment.
+    p.link {
+      margin: 0;
+      padding: 0.375rem 0.625rem;
+      border-radius: 6px;
+      font-size: nb-theme(menu-text-font-size);
+      font-weight: nb-theme(menu-text-font-weight);
+      line-height: 1.25rem;
+      // Colour only: transitioning `all` would animate the radius and make the
+      // row look like it is inflating into a block.
+      transition:
+        background-color 0.12s ease-in-out,
+        color 0.12s ease-in-out;
+
+      &:hover {
+        background-color: #{$overlay-item-hover-bg};
+      }
+    }
   }
 
   .right-menu {
@@ -94,7 +139,9 @@
       margin-bottom: 1rem;
 
       .download-apps-label {
-        color: #7e7e8f;
+        // Token, not a raw hex: `#7e7e8f` was a fixed grey that does not lift
+        // on the dark themes.
+        color: nb-theme(text-hint-color);
       }
 
       .download-apps-icons {
@@ -108,7 +155,7 @@
           i {
             padding: 0;
             margin: 0;
-            color: #7e7e8f;
+            color: nb-theme(text-hint-color);
           }
 
           &:hover {
@@ -122,7 +169,7 @@
     }
   }
   .disabled-table {
-	pointer-events: none;
-	opacity: 0.5;
+    pointer-events: none;
+    opacity: 0.5;
   }
 }

--- a/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/workspace-menu/workspace-menu.component.scss
@@ -1,25 +1,44 @@
 @use 'themes' as *;
 
+// The workspace switcher is a popup, so it follows the same shadcn rules as the
+// overlay menus in `packages/ui-core/static/styles/_overlays.scss`: ONE soft
+// container (1px hairline + soft shadow + 8px radius + small padding) wrapping
+// completely FLAT rows.
+//
+// It is NOT rendered into `.cdk-overlay-container` — the layout absolutely
+// positions it — so the global overlay rules never reach it and the container
+// chrome has to be repeated here. `--gauzy-overlay-border-color` resolves from
+// themes.scss; `--gauzy-overlay-shadow` is not registered (a Sass map entry
+// cannot hold a comma-separated shadow list as-is), so each one keeps the same
+// alpha-neutral fallback the global partial uses: a neutral grey at low alpha
+// darkens a light surface and lightens a dark one, so no per-theme branch is
+// needed.
+$overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+$overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
+
 :host {
   .workspace-dropdown {
     height: fit-content;
     max-height: 80vh;
-    box-shadow: 0px 6px 30px 0px rgba(0, 0, 0, 0.2);
-    border-radius: var(--border-radius);
-    background: nb-theme(background-basic-color-2);
-    padding: 0.75rem;
+    border: 1px solid #{$overlay-hairline};
+    border-radius: 8px;
+    box-shadow: #{$overlay-shadow};
+    background: nb-theme(background-basic-color-1);
+    // Just enough inset that a hovered row's radius never touches the edge.
+    padding: 0.375rem;
   }
 
   .workspace-content {
     display: flex;
     width: 100%;
-    gap: 0.75rem;
+    gap: 0.5rem;
   }
 
   .workspace-left-section {
     overflow-y: auto;
-    border-right: 1px solid nb-theme(border-basic-color-4);
-    padding-right: 0.75rem;
+    // 1px hairline at low alpha, not a solid theme divider.
+    border-right: 1px solid #{$overlay-hairline};
+    padding-right: 0.5rem;
     min-width: 180px;
   }
 
@@ -28,31 +47,36 @@
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-    padding-left: 0.75rem;
-    gap: 0.25rem;
+    padding-left: 0.5rem;
+    gap: 0.125rem;
   }
 
-  // Flatten accordion headers in the popup for both nav menus. Settings is a
-  // plain link to /pages/settings (no inline accordion anymore), so its
-  // expansion chevron is hidden the same way as the main nav's.
+  // The two nav menus embedded here are the sidebar's `ga-sidebar-menu`, which
+  // already renders flat rows (see `menu-item.component.scss`). The only thing
+  // that differs in the popup is the accordion chevron: Settings is a plain
+  // link to /pages/settings and the main nav routes straight through, so
+  // nothing ever expands inline and the indicator would be a lie.
   .setting.action ::ng-deep ga-main-nav-menu,
   .setting ::ng-deep ga-settings-nav-menu {
     ga-sidebar-menu {
-      nb-accordion-item {
-        nb-accordion-item-header {
-          box-shadow: unset;
-          border-width: 0;
-          nb-icon {
-            display: none;
-          }
+      nb-accordion-item nb-accordion-item-header {
+        nb-icon {
+          display: none;
         }
+
+        // With no chevron to clear, reclaim the gutter the sidebar rows
+        // reserve for it so the label is not floating in dead space.
+        @include nb-ltr(padding-right, 0.625rem);
+        @include nb-rtl(padding-left, 0.625rem);
       }
     }
   }
 
+  // Spacer under the two menu columns. It used to carry `--gauzy-shadow`,
+  // which drew a stray line across the bottom of an otherwise empty element.
   .item.footer {
-    box-shadow: var(--gauzy-shadow);
-    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    box-shadow: none;
+
     ::ng-deep {
       .item-body {
         padding: 5px;

--- a/packages/ui-core/theme/src/lib/theme.module.ts
+++ b/packages/ui-core/theme/src/lib/theme.module.ts
@@ -57,6 +57,7 @@ import {
 	MATERIAL_LIGHT_THEME
 } from './themes';
 import { WindowModeBlockScrollService } from './services/window-mode-block-scroll.service';
+import { BreadcrumbComponent } from './components/breadcrumb/breadcrumb.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { HeaderComponent } from './components/header/header.component';
 import { ThemeSidebarModule } from './components/theme-sidebar/theme-sidebar.module';
@@ -103,6 +104,7 @@ const MODULES = [
 ];
 
 const COMPONENTS = [
+	BreadcrumbComponent,
 	HeaderComponent,
 	FooterComponent,
 	OneColumnLayoutComponent,


### PR DESCRIPTION
Promotes develop to stage for review.

Since the last cascade (`caf5f1c876`):

- **#9848 — Dashboard builder.** A new custom dashboard now opens as an **empty canvas** with a **widget palette** on the right; compose it by dragging widgets on (or clicking, for keyboard users). Custom dashboards get their own **named, reorderable tabs** (`?tab=` deep-linked). v2 layout document with real widget identity + per-instance config; v1 dashboards keep rendering. First 6 palette widgets (Time Tracking counters), with payload parity proven 75/75 against the existing dashboard. `widgets` is now a first-class plugin capability, so PR 2 can add the remaining ~25.
- **#9849 — UI polish.** AI Providers now renders **with the Settings menu** (the settings shell had no extension point, so the plugin page was a top-level route). **Real breadcrumbs** on every page, clickable, labels from the translated nav tree. Page title dropped from 24px/600 (it read as an oversized breadcrumb path) to 1.25rem. Sidebar + overlay menus flattened — no per-item rounded blocks.

Verified locally: builder 13/13 E2E (empty canvas → palette → drag → save → reload → tabs); polish checked in both gauzy-light and gauzy-dark.

⚠️ Merge with a MERGE COMMIT (not squash) per promotion policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes develop → stage with the new dashboard builder and global UI polish, including breadcrumbs and a settings shell for plugin pages. Addresses #9848 (dashboard builder) and #9849 (UI polish).

- **New Features**
  - Custom dashboards: empty canvas with drag-and-drop widget palette; named, reorderable tabs with `?tab=` deep links; v2 layout with stable widget identity and per-instance config (v1 still renders).
  - Widget system: `WidgetRegistryService` and declarative `widgets` support in `@gauzy/plugin-ui`; initial 6 Time Tracking counter widgets with payload parity; dynamic widget host with loading/error states; shared `DashboardContextService` and timesheet statistics cache to dedupe requests.
  - Routing: new core route `/pages/dashboard/custom/:id`; Time Tracking plugin now only provides its tab and registers widgets to the palette.
  - Navigation/UI: breadcrumbs in the header on every page (labels from the translated nav tree, clickable); settings shell with a new `settings-sections` location so plugin pages render with the settings menu; flatter sidebar and overlay menus; smaller page title for better hierarchy.

<sup>Written for commit cd66f2f517336e3e81d96be84e1e6f70c02ff57d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

