### PR TITLE
feat(ui): near-black dark canvas, condensed tables, no duplicate date range

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
 	"words": [
 		"scroller",
 		"blockified",
+		"echarts",
 		"affordance",
 		"ngcontent",
 		"nghost",

--- a/apps/gauzy/src/app/pages/candidates/table-components/candidate-status/candidate-status.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/table-components/candidate-status/candidate-status.component.scss
@@ -22,12 +22,20 @@ div {
   justify-content: flex-start;
 }
 
+// Same status-pill pattern as `employee-work-status`, and this cell stacks the
+// rating above the pill, so the pill's box is pure row height. Sized from the
+// shared table-density tokens (`$gauzy-density` in `themes.scss`); the literals
+// are CSS-var fallbacks only.
 .badge {
   text-align: center;
-  padding: 4px 8px;
-  font-size: 12px;
+  // Padding, not `min-height`: padding centres the label for free, and a 17px
+  // pill fits inside the cell's 20px line box.
+  padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
+  // Wraps as a whole rather than breaking its own label; never clipped.
+  white-space: nowrap;
+  font-size: var(--gauzy-table-header-font-size, 0.75rem);
   font-weight: 600;
-  line-height: 15px;
+  line-height: var(--gauzy-table-header-line-height, 0.9375rem);
   letter-spacing: 0em;
   text-align: left;
 }

--- a/apps/gauzy/src/app/pages/dashboard/accounting/accounting.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/accounting/accounting.component.html
@@ -6,14 +6,6 @@
           {{ 'DASHBOARD_PAGE.EMPLOYEE_STATISTICS' | translate }}
         </ngx-header-title>
       </h4>
-      @if (selectedDateRange?.startDate && selectedDateRange?.endDate) {
-        <ngx-date-range-title
-          [start]="selectedDateRange?.startDate"
-          [end]="selectedDateRange?.endDate"
-          [format]="'dddd, LL'"
-          >
-        </ngx-date-range-title>
-      }
     </div>
     <div class="organization-employee-header">
       <nb-card [nbSpinner]="loading" nbSpinnerStatus="primary">

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.scss
@@ -133,13 +133,15 @@
     height: 84px;
     border-radius: 4px;
     padding: 29px;
-    background-color: #f6f9fc;
+    // #f6f9fc / #333333 were a hard-coded light-blue tile with dark text on the
+    // landing route. They must move together or the tile becomes unreadable.
+    background-color: var(--gauzy-card-2);
     cursor: pointer;
     .info-text,
     .info-value {
       display: flex;
       font-size: 18px;
-      color: #333333;
+      color: var(--text-basic-color);
 
       .profit-positive-color {
         color: #66de0b;

--- a/apps/gauzy/src/app/pages/dashboard/project-management/project-management.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/project-management/project-management.component.html
@@ -5,13 +5,6 @@
         {{ 'DASHBOARD_PAGE.PROJECT_MANAGEMENT' | translate }}
       </ngx-header-title>
     </h4>
-    @if (selectedDateRange?.startDate && selectedDateRange?.endDate) {
-      <ngx-date-range-title
-        [start]="selectedDateRange?.startDate"
-        [end]="selectedDateRange?.endDate"
-        [format]="'dddd, LL'"
-      ></ngx-date-range-title>
-    }
   </nb-card-header>
   <nb-card-body>
     <gauzy-project-management-details></gauzy-project-management-details>

--- a/apps/gauzy/src/app/pages/dashboard/project-management/project-management.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/project-management/project-management.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { combineLatest } from 'rxjs';
 import { debounceTime, filter, tap } from 'rxjs/operators';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { IDateRangePicker, IOrganization } from '@gauzy/contracts';
+import { IOrganization } from '@gauzy/contracts';
 import { distinctUntilChange } from '@gauzy/ui-core/common';
 import { DateRangePickerBuilderService, Store } from '@gauzy/ui-core/core';
 
@@ -15,7 +15,6 @@ import { DateRangePickerBuilderService, Store } from '@gauzy/ui-core/core';
 })
 export class ProjectManagementComponent implements OnInit, OnDestroy {
 	public organization: IOrganization;
-	public selectedDateRange: IDateRangePicker;
 
 	constructor(
 		private readonly store: Store,
@@ -31,9 +30,8 @@ export class ProjectManagementComponent implements OnInit, OnDestroy {
 				debounceTime(500),
 				distinctUntilChange(),
 				filter(([organization, dateRange]) => !!organization && !!dateRange),
-				tap(([organization, dateRange]) => {
+				tap(([organization]) => {
 					this.organization = organization as IOrganization;
-					this.selectedDateRange = dateRange as IDateRangePicker;
 				}),
 				untilDestroyed(this)
 			)

--- a/apps/gauzy/src/app/pages/employees/activity/layout/layout.component.html
+++ b/apps/gauzy/src/app/pages/employees/activity/layout/layout.component.html
@@ -6,13 +6,6 @@
           {{ title | translate }}
         </ngx-header-title>
       </h4>
-      @if (selectedDateRange$ | async; as selectedDateRange) {
-        <ngx-date-range-title
-          [start]="selectedDateRange?.startDate"
-          [end]="selectedDateRange?.endDate"
-          [format]="'dddd, LL'"
-        ></ngx-date-range-title>
-      }
     </div>
   </nb-card-header>
   <nb-card-body class="p-0">

--- a/apps/gauzy/src/app/pages/employees/activity/layout/layout.component.ts
+++ b/apps/gauzy/src/app/pages/employees/activity/layout/layout.component.ts
@@ -1,14 +1,9 @@
 import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute, QueryParamsHandling } from '@angular/router';
-import { Observable, tap } from 'rxjs';
+import { tap } from 'rxjs';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { IDateRangePicker, PermissionsEnum } from '@gauzy/contracts';
-import {
-	DateRangePickerBuilderService,
-	PageTabRegistryService,
-	PageTabsetPageId,
-	RouteUtil
-} from '@gauzy/ui-core/core';
+import { PermissionsEnum } from '@gauzy/contracts';
+import { PageTabRegistryService, PageTabsetPageId, RouteUtil } from '@gauzy/ui-core/core';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -21,14 +16,12 @@ import {
 export class ActivityLayoutComponent implements OnInit, OnDestroy {
 	public title: string;
 	public tabsetId: PageTabsetPageId = this._route.snapshot.data.tabsetId; // The identifier for the tabset
-	public selectedDateRange$: Observable<IDateRangePicker> = this._dateRangePickerBuilderService.selectedDateRange$;
 
 	constructor(
 		private readonly _route: ActivatedRoute,
 		private readonly _cdr: ChangeDetectorRef,
 		private readonly _routeUtil: RouteUtil,
-		private readonly _pageTabRegistryService: PageTabRegistryService,
-		private readonly _dateRangePickerBuilderService: DateRangePickerBuilderService
+		private readonly _pageTabRegistryService: PageTabRegistryService
 	) {}
 
 	ngOnInit(): void {

--- a/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.scss
+++ b/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.scss
@@ -1,10 +1,32 @@
+// Status pills for the employees STATUS and TIME TRACKING columns
+// (`employee-time-tracking-status` points its `styleUrls` at this file too).
+//
+// This cell can render several pills at once — "Active" + "Not Started" is the
+// common pair — and it used to cost 66px of content for two of them:
+//   * every pill sits in its own wrapper `<div>`, and the `div` rule below gave
+//     BOTH the wrapper and the pill `margin: 4px 0`, i.e. 16px of vertical
+//     margin per pill;
+//   * `display: flex` made each wrapper a block-level box, so the pills were
+//     forced to stack one per line even when there was room for both.
+// Sizes now come from the shared table-density tokens (`$gauzy-density` in
+// `themes.scss`); the literals are CSS-var fallbacks only.
 .badge-disabled {
   background-color: #ccc;
 }
 
+// The pill is sized by padding alone rather than a `min-height`: padding
+// centres the label for free, whereas a min-height only looks right where the
+// box also happens to be a flex container with `align-items: center`. At
+// 15px line + 1px padding the pill is 17px, i.e. it fits inside the cell's 20px
+// line box and stops being the thing that decides the row height at all.
 .badge {
   text-align: center;
-  padding: 4px 8px;
+  padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
+  // The pill wraps as a WHOLE to the next line rather than breaking its own
+  // label across two lines, which is what "Not Started" did in a narrow column.
+  // The label is never clipped: the pill just widens, and the smart table's own
+  // `overflow-x: auto` wrapper absorbs it.
+  white-space: nowrap;
 }
 
 div {
@@ -14,20 +36,38 @@ div {
 
   border-radius: 0.25rem;
   align-content: center;
-  display: flex;
+  // `inline-flex`, not `flex`: as block-level flex containers the wrappers each
+  // claimed a line of their own. Inline-level boxes sit side by side and wrap
+  // only when they genuinely do not fit.
+  display: inline-flex;
   justify-content: center;
   align-items: center;
+  // Keeps the pill row centred on the cell's text line instead of hanging below
+  // the baseline and adding descender space to the line box.
+  vertical-align: middle;
   width: auto;
   /* Inside auto layout */
 
   flex: none;
   order: 0;
   flex-grow: 0;
-  margin: 4px 0px;
+  // Was `4px 0px`. A horizontal gap is what a row of pills needs; the vertical
+  // one only mattered while they were stacked.
+  margin: var(--gauzy-table-chip-gap, 0.1875rem) var(--gauzy-table-chip-gap, 0.1875rem)
+    var(--gauzy-table-chip-gap, 0.1875rem) 0;
   /* Typography */
-  font-size: 12px;
+  font-size: var(--gauzy-table-header-font-size, 0.75rem);
   font-weight: 600;
-  line-height: 15px;
+  line-height: var(--gauzy-table-header-line-height, 0.9375rem);
   letter-spacing: 0em;
   text-align: left;
+}
+
+// A wrapper and the pill inside it are two nested `div`s, so the rule above
+// charged the gap twice per pill. Only the outer one pays for the vertical
+// part; the inner keeps its right margin, which is the gap between the
+// "Work ended" pill and the date range printed next to it.
+div > div {
+  margin-top: 0;
+  margin-bottom: 0;
 }

--- a/apps/gauzy/src/app/pages/employees/timesheet/layout/layout.component.html
+++ b/apps/gauzy/src/app/pages/employees/timesheet/layout/layout.component.html
@@ -6,13 +6,6 @@
           {{ 'MENU.TIMESHEETS' | translate }}
         </ngx-header-title>
       </h4>
-      @if (selectedDateRange$ | async; as selectedDateRange) {
-        <ngx-date-range-title
-          [start]="selectedDateRange?.startDate"
-          [end]="selectedDateRange?.endDate"
-          [format]="'dddd, LL'"
-        ></ngx-date-range-title>
-      }
     </div>
   </nb-card-header>
   <nb-card-body class="p-0">

--- a/apps/gauzy/src/app/pages/employees/timesheet/layout/layout.component.ts
+++ b/apps/gauzy/src/app/pages/employees/timesheet/layout/layout.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { Observable } from 'rxjs';
-import { IDateRangePicker, PermissionsEnum } from '@gauzy/contracts';
-import { DateRangePickerBuilderService, PageTabRegistryService, PageTabsetPageId } from '@gauzy/ui-core/core';
+import { PermissionsEnum } from '@gauzy/contracts';
+import { PageTabRegistryService, PageTabsetPageId } from '@gauzy/ui-core/core';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 
 @Component({
@@ -14,13 +13,11 @@ import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 })
 export class TimesheetLayoutComponent extends TranslationBaseComponent implements OnInit, OnDestroy {
 	public tabsetId: PageTabsetPageId = this._route.snapshot.data.tabsetId; // The identifier for the tabset
-	public selectedDateRange$: Observable<IDateRangePicker> = this._dateRangePickerBuilderService.selectedDateRange$;
 
 	constructor(
 		public readonly translateService: TranslateService,
 		private readonly _route: ActivatedRoute,
-		private readonly _pageTabRegistryService: PageTabRegistryService,
-		private readonly _dateRangePickerBuilderService: DateRangePickerBuilderService
+		private readonly _pageTabRegistryService: PageTabRegistryService
 	) {
 		super(translateService);
 	}

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.scss
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.scss
@@ -3,13 +3,13 @@
 .action {
   box-shadow: var(--gauzy-shadow);
   &[nbButton].appearance-filled.status-basic {
-    background-color: #ffffff;
+    background-color: var(--gauzy-card-2);
   }
   &.info {
     background-color: #0088fe;
   }
   &.secondary {
-    color: #7e7e8f;
+    color: var(--text-hint-color);
   }
   &.success {
     color: rgba(37, 184, 105, 1);
@@ -32,7 +32,7 @@
     box-shadow: none;
     .select-button {
       box-shadow: var(--gauzy-shadow);
-      background: rgba(245, 245, 245);
+      background: var(--gauzy-card-2);
     }
   }
 }

--- a/apps/gauzy/src/app/pages/income/income.component.html
+++ b/apps/gauzy/src/app/pages/income/income.component.html
@@ -10,7 +10,6 @@
           {{ 'INCOME_PAGE.INCOME' | translate }}
         </ngx-header-title>
       </h4>
-      <ngx-date-range-title [format]="'dddd, LL'"></ngx-date-range-title>
     </div>
     <div class="gauzy-button-container">
       <ngx-gauzy-button-action

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/enabled-row.component.ts
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/enabled-row.component.ts
@@ -23,13 +23,17 @@ import { Component, Input } from '@angular/core';
 				background-color: #ccc;
 			}
 
+			/* Same status-pill pattern as employee-work-status; sized from the
+			   shared table-density tokens ($gauzy-density in themes.scss).
+			   Literals are CSS-var fallbacks only. */
 			.badge {
 				text-align: center;
 				border-radius: 4px;
-				padding: 4px 8px;
-				font-size: 12px;
+				padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
+				white-space: nowrap;
+				font-size: var(--gauzy-table-header-font-size, 0.75rem);
 				font-weight: 600;
-				line-height: 15px;
+				line-height: var(--gauzy-table-header-line-height, 0.9375rem);
 				letter-spacing: 0em;
 				text-align: left;
 			}

--- a/apps/gauzy/src/app/pages/inventory/components/manage-product-types/product-types.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/manage-product-types/product-types.component.scss
@@ -4,7 +4,7 @@
   box-shadow: var(--gauzy-shadow);
 
   &[nbButton].appearance-filled.status-basic {
-    background-color: #ffffff;
+    background-color: var(--gauzy-card-2);
   }
 
   &.info {
@@ -12,7 +12,7 @@
   }
 
   &.secondary {
-    color: #7e7e8f;
+    color: var(--text-hint-color);
   }
 
   &.success {
@@ -41,7 +41,7 @@
 
     .select-button {
       box-shadow: var(--gauzy-shadow);
-      background: rgba(245, 245, 245);
+      background: var(--gauzy-card-2);
     }
   }
 }

--- a/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.scss
@@ -8,7 +8,7 @@ $shadow: 0 0 0 nb-theme(button-outline-width)
     ),
   inset nb-theme(button-outline-focus-inset-shadow-length) transparent;
 [nbButton].gen.appearance-outline.status-basic {
-  background-color: #ffffff;
+  background-color: var(--gauzy-card-2);
   border-color: transparent;
   box-shadow: $shadow;
   border-width: 2px;

--- a/apps/gauzy/src/app/pages/invoices/invoices-received/invoices-received.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoices-received/invoices-received.component.html
@@ -6,7 +6,6 @@
           {{ (isEstimate ? 'INVOICES_PAGE.RECEIVED_ESTIMATES' : 'INVOICES_PAGE.RECEIVED_INVOICES') | translate }}
         </ngx-header-title>
       </h4>
-      <ngx-date-range-title [format]="'dddd, LL'"></ngx-date-range-title>
     </div>
     <div class="gauzy-button-container">
       <ngx-gauzy-button-action

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.html
@@ -6,7 +6,6 @@
 					{{ (isEstimate ? 'INVOICES_PAGE.ESTIMATES.HEADER' : 'INVOICES_PAGE.HEADER') | translate }}
 				</ngx-header-title>
 			</h4>
-			<ngx-date-range-title [format]="'dddd, LL'"></ngx-date-range-title>
 		</div>
 		<div>
 			<div>

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.scss
@@ -260,7 +260,7 @@ textarea {
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15);
 
   &[nbButton].appearance-filled.status-basic {
-    background-color: #ffffff;
+    background-color: var(--gauzy-card-2);
   }
 
   &.info {
@@ -272,7 +272,7 @@ textarea {
   }
 
   &.secondary {
-    color: #7e7e8f;
+    color: var(--text-hint-color);
   }
 
   &.primary {
@@ -287,7 +287,7 @@ textarea {
 
     .select-button {
       box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15);
-      background: rgba(245, 245, 245);
+      background: var(--gauzy-card-2);
       height: 2rem;
       border-radius: nb-theme(button-rectangle-border-radius);
     }

--- a/apps/gauzy/src/app/pages/organizations/table-components/organizations-status/organizations-status.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/table-components/organizations-status/organizations-status.component.scss
@@ -1,26 +1,32 @@
 @use 'themes' as *;
 
+// Same status-pill pattern as `employee-work-status`: an outer `.badge` wrapper
+// with its own padding around an inner coloured pill that has padding again, so
+// the cell paid for two boxes. Sized from the shared table-density tokens
+// (`$gauzy-density` in `themes.scss`); the literals are CSS-var fallbacks only.
 .badge-danger {
 	text-align: flex-start;
-	padding: 5px;
+	padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 	background-color: nb-theme(color-danger-default);
-	margin-bottom: 5px;
+	margin-bottom: var(--gauzy-table-chip-gap, 0.1875rem);
 }
 
 .badge-success {
 	text-align: flex-start;
-	padding: 5px;
+	padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 	background-color: nb-theme(color-success-default);
 }
 
 .badge {
 	width: fit-content;
-	font-size: 12px;
+	font-size: var(--gauzy-table-header-font-size, 0.75rem);
 	font-weight: 600;
-	line-height: 15px;
+	line-height: var(--gauzy-table-header-line-height, 0.9375rem);
 	letter-spacing: 0em;
 	text-align: left;
-	padding: 4px 8px;
+	// The wrapper is only a positioning box around the pill; the pill above owns
+	// the padding, so charging it here again just made the cell taller.
+	padding: 0;
 
 	>div {
 		border-radius: 4px;

--- a/apps/gauzy/src/app/pages/reports/amounts-owed-report/amounts-owed-report/amounts-owed-report.component.html
+++ b/apps/gauzy/src/app/pages/reports/amounts-owed-report/amounts-owed-report/amounts-owed-report.component.html
@@ -7,13 +7,6 @@
             {{ 'REPORT_PAGE.AMOUNT_OWED' | translate }}
           </ngx-header-title>
         </h4>
-        @if (request?.startDate && request?.endDate) {
-          <ngx-date-range-title
-            [start]="request?.startDate"
-            [end]="request?.endDate"
-            [format]="'dddd, LL'"
-          ></ngx-date-range-title>
-        }
       </div>
     </div>
     <div class="row">

--- a/apps/gauzy/src/app/pages/reports/apps-urls-report/apps-urls-report/apps-urls-report.component.html
+++ b/apps/gauzy/src/app/pages/reports/apps-urls-report/apps-urls-report/apps-urls-report.component.html
@@ -7,13 +7,6 @@
             {{ 'REPORT_PAGE.APPS_AND_URLS_REPORT' | translate }}
           </ngx-header-title>
         </h4>
-        @if (request?.startDate && request?.endDate) {
-          <ngx-date-range-title
-            [start]="request?.startDate"
-            [end]="request?.endDate"
-            [format]="'dddd, LL'"
-          ></ngx-date-range-title>
-        }
       </div>
     </div>
     <div class="row">

--- a/apps/gauzy/src/app/pages/reports/client-budgets-report/client-budgets-report/client-budgets-report.component.html
+++ b/apps/gauzy/src/app/pages/reports/client-budgets-report/client-budgets-report/client-budgets-report.component.html
@@ -7,13 +7,6 @@
 						{{ 'REPORT_PAGE.CLIENT_BUDGET_REPORTS' | translate }}
 					</ngx-header-title>
 				</h4>
-				@if (request?.startDate && request?.endDate) {
-					<ngx-date-range-title
-						[start]="request?.startDate"
-						[end]="request?.endDate"
-						[format]="'dddd, LL'"
-					></ngx-date-range-title>
-				}
 			</div>
 		</div>
 		<div class="row">

--- a/apps/gauzy/src/app/pages/reports/expenses-report/expenses-report/expenses-report.component.html
+++ b/apps/gauzy/src/app/pages/reports/expenses-report/expenses-report/expenses-report.component.html
@@ -7,13 +7,6 @@
             {{ 'REPORT_PAGE.EXPENSES_REPORT' | translate }}
           </ngx-header-title>
         </h4>
-        @if (request?.startDate && request?.endDate) {
-          <ngx-date-range-title
-            [start]="request?.startDate"
-            [end]="request?.endDate"
-            [format]="'dddd, LL'"
-          ></ngx-date-range-title>
-        }
       </div>
     </div>
     <div class="row">

--- a/apps/gauzy/src/app/pages/reports/manual-time/manual-time/manual-time.component.html
+++ b/apps/gauzy/src/app/pages/reports/manual-time/manual-time/manual-time.component.html
@@ -7,13 +7,6 @@
 						{{ 'REPORT_PAGE.MANUAL_TIME_EDIT_REPORT' | translate }}
 					</ngx-header-title>
 				</h4>
-				@if (request?.startDate && request?.endDate) {
-					<ngx-date-range-title
-						[start]="request?.startDate"
-						[end]="request?.endDate"
-						[format]="'dddd, LL'"
-					></ngx-date-range-title>
-				}
 			</div>
 		</div>
 		<div class="row">

--- a/apps/gauzy/src/app/pages/reports/payment-report/payment-report/payment-report.component.html
+++ b/apps/gauzy/src/app/pages/reports/payment-report/payment-report/payment-report.component.html
@@ -7,13 +7,6 @@
             {{ 'REPORT_PAGE.PAYMENT_REPORT' | translate }}
           </ngx-header-title>
         </h4>
-        @if (request?.startDate && request?.endDate) {
-          <ngx-date-range-title
-            [start]="request?.startDate"
-            [end]="request?.endDate"
-            [format]="'dddd, LL'"
-          ></ngx-date-range-title>
-        }
       </div>
     </div>
     <div class="row">

--- a/apps/gauzy/src/app/pages/reports/project-budgets-report/project-budgets-report/project-budgets-report.component.html
+++ b/apps/gauzy/src/app/pages/reports/project-budgets-report/project-budgets-report/project-budgets-report.component.html
@@ -7,13 +7,6 @@
 						{{ 'REPORT_PAGE.PROJECT_BUDGET_REPORTS' | translate }}
 					</ngx-header-title>
 				</h4>
-				@if (request?.startDate && request?.endDate) {
-					<ngx-date-range-title
-						[start]="request?.startDate"
-						[end]="request?.endDate"
-						[format]="'dddd, LL'"
-					></ngx-date-range-title>
-				}
 			</div>
 		</div>
 		<div class="row">

--- a/apps/gauzy/src/app/pages/reports/time-limit-report/time-limit-report/time-limit-report.component.html
+++ b/apps/gauzy/src/app/pages/reports/time-limit-report/time-limit-report/time-limit-report.component.html
@@ -7,13 +7,6 @@
 						{{ title | translate }}
 					</ngx-header-title>
 				</h4>
-				@if (request?.startDate && request?.endDate) {
-					<ngx-date-range-title
-						[start]="request?.startDate"
-						[end]="request?.endDate"
-						[format]="'dddd, LL'"
-					></ngx-date-range-title>
-				}
 			</div>
 		</div>
 		<div class="row">

--- a/apps/gauzy/src/app/pages/reports/time-reports/time-reports/time-reports.component.html
+++ b/apps/gauzy/src/app/pages/reports/time-reports/time-reports/time-reports.component.html
@@ -7,13 +7,6 @@
             {{ 'REPORT_PAGE.TIME_AND_ACTIVITY_REPORT' | translate }}
           </ngx-header-title>
         </h4>
-        @if (request?.startDate && request?.endDate) {
-          <ngx-date-range-title
-            [start]="request?.startDate"
-            [end]="request?.endDate"
-            [format]="'dddd, LL'"
-          ></ngx-date-range-title>
-        }
       </div>
     </div>
     <div class="row">

--- a/apps/gauzy/src/app/pages/reports/weekly-time-reports/weekly-time-reports/weekly-time-reports.component.html
+++ b/apps/gauzy/src/app/pages/reports/weekly-time-reports/weekly-time-reports/weekly-time-reports.component.html
@@ -7,13 +7,6 @@
 						{{ 'REPORT_PAGE.WEEKLY_TIME_AND_ACTIVITY_REPORT' | translate }}
 					</ngx-header-title>
 				</h4>
-				@if (request?.startDate && request?.endDate) {
-				<ngx-date-range-title
-					[start]="request?.startDate"
-					[end]="request?.endDate"
-					[format]="'dddd, LL'"
-				></ngx-date-range-title>
-				}
 			</div>
 		</div>
 		<div class="row">

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/time-tracking.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/time-tracking.component.html
@@ -2,19 +2,12 @@
 	<nb-card-header class="card-header">
 		<div class="row">
 			<div class="col-auto">
-				@if (selectedDateRange?.startDate && selectedDateRange?.endDate) {
-					<h4>
-						<ngx-header-title>
-							{{ headerTitle }}
-							{{ 'TIMESHEET.TIME_TRACKING' | translate }}
-						</ngx-header-title>
-					</h4>
-					<ngx-date-range-title
-						[start]="selectedDateRange?.startDate"
-						[end]="selectedDateRange?.endDate"
-						[format]="'dddd, LL'"
-					></ngx-date-range-title>
-				}
+				<h4>
+					<ngx-header-title>
+						{{ headerTitle }}
+						{{ 'TIMESHEET.TIME_TRACKING' | translate }}
+					</ngx-header-title>
+				</h4>
 			</div>
 			<div class="mb-4 ml-auto col-auto d-flex align-items-center">
 				<ga-timezone-filter

--- a/packages/ui-core/shared/src/lib/components/dashboard-skeleton/dashboard-skeleton.component.scss
+++ b/packages/ui-core/shared/src/lib/components/dashboard-skeleton/dashboard-skeleton.component.scss
@@ -18,13 +18,15 @@
 }
 
 // === GAUZY DARK ===
+// Mirrors the `gauzy-dark` map in `static/styles/themes.scss`; if these drift,
+// the loading skeleton flashes the previous palette before the app paints.
 :host-context([data-skeleton-theme='gauzy-dark']) {
-  --background-basic-color-1: rgb(32, 32, 35);
-  --border-basic-color-2: #303030;
+  --background-basic-color-1: rgb(18, 18, 20);
+  --border-basic-color-2: rgba(255, 255, 255, 0.08);
   --border-radius: 0.625rem;
   --button-rectangle-border-radius: 2rem;
-  --gauzy-sidebar-background-2: rgb(38, 38, 46);
-  --gauzy-card-2: rgba(16, 16, 20, 0.3);
+  --gauzy-sidebar-background-2: rgb(12, 12, 14);
+  --gauzy-card-2: rgba(255, 255, 255, 0.02);
 }
 
 // === DEFAULT THEME ===

--- a/packages/ui-core/shared/src/lib/components/date-range-title/date-range-title.component.ts
+++ b/packages/ui-core/shared/src/lib/components/date-range-title/date-range-title.component.ts
@@ -9,12 +9,28 @@ import { DateFormatPipe } from '../../pipes';
     template: `<span>{{ title }}</span>`,
     styles: [
         `
+			/*
+			 * Styled to match the breadcrumb trail (breadcrumb.component.scss), which
+			 * is the other sub-heading line in a card header — same 13px scale, same
+			 * regular weight, same muted token, same 0.25rem offset under the title.
+			 * The old 14px/600 --gauzy-text-color-2 read as a competing second title.
+			 *
+			 * :host is a block so the range drops onto its own line under the heading
+			 * text it sits beside, mirroring where .ga-page-title-trail lands. A
+			 * custom element is phrasing content, so this stays valid inside an <h4>
+			 * (unlike the trail's <nav><ol>, which is why that one gets relocated).
+			 */
+			:host {
+				display: block;
+				margin-top: 0.25rem;
+			}
 			span {
-				font-size: 14px;
-				font-weight: 600;
-				line-height: 16px;
-				letter-spacing: -0.009em;
-				color: var(--gauzy-text-color-2);
+				/* 0.8125rem = nb-theme(menu-text-font-size), the trail's scale. */
+				font-size: 0.8125rem;
+				font-weight: 400;
+				line-height: 1.25rem;
+				letter-spacing: normal;
+				color: var(--text-hint-color);
 			}
 		`
     ],

--- a/packages/ui-core/shared/src/lib/components/layout-selector/layout-selector.component.scss
+++ b/packages/ui-core/shared/src/lib/components/layout-selector/layout-selector.component.scss
@@ -16,5 +16,5 @@
 
 [nbButton].basic.size-small.icon-start.icon-end.appearance-filled{
   box-shadow:  var(--gauzy-shadow);
-  background: rgba(255, 255, 255, 1);
+  background: var(--gauzy-card-2);
 }

--- a/packages/ui-core/shared/src/lib/dashboard/info-block/info-block.component.scss
+++ b/packages/ui-core/shared/src/lib/dashboard/info-block/info-block.component.scss
@@ -68,7 +68,9 @@
   }
 
   ::ng-deep nb-accordion nb-accordion-item {
-    background-color: #f6f9fc;
+    // `:2` and `:49` are already neutralised from `_overrides.scss`; this one
+    // was not, so it kept a hard-coded light-blue fill in every theme.
+    background-color: var(--background-basic-color-2);
   }
 
   ::ng-deep nb-accordion nb-accordion-item-header .expansion-indicator {

--- a/packages/ui-core/shared/src/lib/dashboard/info-block/info-block.component.scss
+++ b/packages/ui-core/shared/src/lib/dashboard/info-block/info-block.component.scss
@@ -68,7 +68,7 @@
   }
 
   ::ng-deep nb-accordion nb-accordion-item {
-    // `:2` and `:49` are already neutralised from `_overrides.scss`; this one
+    // `:2` and `:49` are already neutralized from `_overrides.scss`; this one
     // was not, so it kept a hard-coded light-blue fill in every theme.
     background-color: var(--background-basic-color-2);
   }

--- a/packages/ui-core/shared/src/lib/sidebar/sidebar.component.scss
+++ b/packages/ui-core/shared/src/lib/sidebar/sidebar.component.scss
@@ -124,7 +124,7 @@
 .childout {
   margin-left: 3px;
   min-width: 240px;
-  background-color: #fafafa;
+  background-color: var(--gauzy-card-1);
 }
 
 :host ::ng-deep {

--- a/packages/ui-core/shared/src/lib/status-badge/status-badge.component.scss
+++ b/packages/ui-core/shared/src/lib/status-badge/status-badge.component.scss
@@ -1,13 +1,17 @@
+// The pill is normally the tallest thing in its smart-table cell, so its height
+// is what the row pays for it. Sized from the shared table-density tokens
+// (`$gauzy-density` in `themes.scss`) so a status column costs a row exactly one
+// line box, the same as a plain text column. Literals are CSS-var fallbacks.
 div {
   border-radius: 0.25rem;
   align-content: center;
   display: flex;
   justify-content: center;
   width: 100%;
-  height: 23px;
-  font-size: 12px;
+  height: var(--gauzy-table-badge-height, 1.25rem);
+  font-size: var(--gauzy-table-header-font-size, 0.75rem);
   font-weight: 600;
-  line-height: 15px;
+  line-height: var(--gauzy-table-header-line-height, 0.9375rem);
   letter-spacing: 0em;
   text-align: left;
 }

--- a/packages/ui-core/shared/src/lib/table-components/notes-with-tags/notes-with-tags.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/notes-with-tags/notes-with-tags.component.scss
@@ -1,13 +1,18 @@
+// Tag chips render inside smart-table cells, so their box is part of the row
+// height. They follow the shared table-density tokens (`$gauzy-density` in
+// `themes.scss`) so a density change moves the chips with the cells instead of
+// leaving the old 24px-per-chip footprint behind. Literals are CSS-var
+// fallbacks only.
 .color {
   position: static;
-  margin-top: 5px;
-  margin-right: 5px;
+  margin-top: var(--gauzy-table-chip-gap, 0.1875rem);
+  margin-right: var(--gauzy-table-chip-gap, 0.1875rem);
   display: inline-block;
-  font-size: 11px;
+  font-size: var(--gauzy-table-chip-font-size, 0.6875rem);
   font-weight: 600;
-  line-height: 13px;
+  line-height: var(--gauzy-table-chip-line-height, 0.875rem);
   letter-spacing: 0em;
-  padding: 3px 8px;
+  padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 }
 
 .tags {

--- a/packages/ui-core/shared/src/lib/table-components/notes-with-tags/notes-with-tags.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/notes-with-tags/notes-with-tags.component.scss
@@ -19,6 +19,17 @@
   // display: flex;
   // width: 100px;
   flex-wrap: wrap;
+  // The chips are inline-blocks, so each chip row is a line box and inherits
+  // the cell's 20px line-height as a minimum — 4px per row that nothing can
+  // see. Zeroing it here lets a chip row measure exactly the chip. Safe because
+  // this container only ever holds `nb-badge` chips, each of which sets its own
+  // `line-height` via `.color` above.
+  line-height: 0;
+  // The template tags this element with Bootstrap's `.mt-2` utility, which is
+  // `!important`, so this is one of the two places in the density pass where
+  // `!important` is unavoidable. The chips carry their own `margin-top`, so the
+  // extra 8px here was a second gap on top of the one that shows.
+  margin-top: 0 !important;
 }
 
 .tags-right {

--- a/packages/ui-core/shared/src/lib/table-components/picture-name-tags/picture-name-tags.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/picture-name-tags/picture-name-tags.component.scss
@@ -1,5 +1,8 @@
 @use 'themes' as *;
 
+// The avatar itself is only 20px in a table cell (`:host-context(.report-table)`
+// in `avatar.component.scss`); what actually makes an employee row tall is this
+// tag block stacked under it. Its gap follows the shared table-density tokens.
 .badges-block {
-  margin-top: 10px;
+  margin-top: var(--gauzy-table-chip-gap, 0.1875rem);
 }

--- a/packages/ui-core/shared/src/lib/table-components/picture-name-tags/picture-name-tags.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/picture-name-tags/picture-name-tags.component.scss
@@ -5,4 +5,8 @@
 // tag block stacked under it. Its gap follows the shared table-density tokens.
 .badges-block {
   margin-top: var(--gauzy-table-chip-gap, 0.1875rem);
+  // The chips are inline-blocks, so a chip row is a line box and inherits the
+  // cell's 20px line-height as a minimum. Zeroing it lets the row measure
+  // exactly the chip; the chips set their own `line-height` via `.color`.
+  line-height: 0;
 }

--- a/packages/ui-core/shared/src/lib/table-components/picture-name-tags/picture-name-tags.component.ts
+++ b/packages/ui-core/shared/src/lib/table-components/picture-name-tags/picture-name-tags.component.ts
@@ -43,16 +43,19 @@ import { NotesWithTagsComponent } from '../notes-with-tags/notes-with-tags.compo
 				justify-content: center;
 			}
 
+			/* Chips inside a table cell — kept in step with the shared
+			   table-density tokens ($gauzy-density in themes.scss); the
+			   literals are CSS-var fallbacks only. */
 			.color {
 				position: static;
-				margin-top: 5px;
-				margin-right: 5px;
+				margin-top: var(--gauzy-table-chip-gap, 0.1875rem);
+				margin-right: var(--gauzy-table-chip-gap, 0.1875rem);
 				display: inline-block;
-				font-size: 11px;
+				font-size: var(--gauzy-table-chip-font-size, 0.6875rem);
 				font-weight: 600;
-				line-height: 13px;
+				line-height: var(--gauzy-table-chip-line-height, 0.875rem);
 				letter-spacing: 0em;
-				padding: 3px 8px;
+				padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 			}
 			.tags {
 				display: flex;

--- a/packages/ui-core/shared/src/lib/table-components/status-view/status-view.component.ts
+++ b/packages/ui-core/shared/src/lib/table-components/status-view/status-view.component.ts
@@ -12,7 +12,7 @@ import { TaskStatusEnum } from '@gauzy/contracts';
 			}
 			/* Status pill in a smart-table cell. Sized from the shared
 			   table-density tokens ($gauzy-density in themes.scss); the
-			   literals are CSS-var fallbacks only. `align-items: center`
+			   literals are CSS-var fallbacks only. 'align-items: center'
 			   below is what makes the explicit height safe to shrink. */
 			.badge {
 				display: flex;

--- a/packages/ui-core/shared/src/lib/table-components/status-view/status-view.component.ts
+++ b/packages/ui-core/shared/src/lib/table-components/status-view/status-view.component.ts
@@ -10,6 +10,10 @@ import { TaskStatusEnum } from '@gauzy/contracts';
 			:host {
 				display: flex;
 			}
+			/* Status pill in a smart-table cell. Sized from the shared
+			   table-density tokens ($gauzy-density in themes.scss); the
+			   literals are CSS-var fallbacks only. `align-items: center`
+			   below is what makes the explicit height safe to shrink. */
 			.badge {
 				display: flex;
 				flex-direction: row;
@@ -17,11 +21,12 @@ import { TaskStatusEnum } from '@gauzy/contracts';
 				align-items: center;
 				position: relative;
 				width: fit-content;
-				height: 1.5rem;
-				padding: 4px 8px;
-				font-size: 12px;
+				height: var(--gauzy-table-badge-height, 1.25rem);
+				padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
+				white-space: nowrap;
+				font-size: var(--gauzy-table-header-font-size, 0.75rem);
 				font-weight: 600;
-				line-height: 15px;
+				line-height: var(--gauzy-table-header-line-height, 0.9375rem);
 				letter-spacing: 0em;
 				text-align: left;
 			}

--- a/packages/ui-core/shared/src/lib/table-components/tags-only/tags-only.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/tags-only/tags-only.component.scss
@@ -1,19 +1,35 @@
+// `TagsOnlyComponent` extends `NotesWithTagsComponent` but declares its own
+// `styleUrls`, so it does NOT inherit the parent's chip styles — this is a
+// second copy of them and has to be kept in step by hand. Values come from the
+// shared table-density tokens (`$gauzy-density` in `themes.scss`); the literals
+// are CSS-var fallbacks only.
 .color {
     position: static;
-    margin-top: 5px;
-    margin-right: 5px;
+    margin-top: var(--gauzy-table-chip-gap, 0.1875rem);
+    margin-right: var(--gauzy-table-chip-gap, 0.1875rem);
     display: inline-block;
-    font-size: 11px;
+    font-size: var(--gauzy-table-chip-font-size, 0.6875rem);
     font-weight: 600;
-    line-height: 13px;
+    line-height: var(--gauzy-table-chip-line-height, 0.875rem);
     letter-spacing: 0em;
-    padding: 3px 8px;
+    padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 }
-  
+
 .tags {
     // display: flex;
     // width: 100px;
     flex-wrap: wrap;
+    // The chips are inline-blocks, so each chip row is a line box and inherits
+    // the cell's 20px line-height as a minimum — 4px per row that nothing can
+    // see. Zeroing it here lets a chip row measure exactly the chip. Safe
+    // because this container only ever holds `nb-badge` chips, each of which
+    // sets its own `line-height` via `.color` above.
+    line-height: 0;
+    // The template tags this element with Bootstrap's `.mt-2` utility, which is
+    // `!important`, so this is one of the two places in the density pass where
+    // `!important` is unavoidable. The chips carry their own `margin-top`, so
+    // the extra 8px here was a second gap on top of the one that shows.
+    margin-top: 0 !important;
 }
   
 .tags-right {

--- a/packages/ui-core/static/styles/_overrides.scss
+++ b/packages/ui-core/static/styles/_overrides.scss
@@ -29,7 +29,11 @@ body {
   -ms-overflow-style: none;
   /* Dark theme overrides when body has nb-theme-gauzy-dark */
   &.nb-theme-gauzy-dark {
-    background: var(--card-background-color) !important;
+    // The canvas, NOT the panel colour: `card-background-color` follows
+    // `background-basic-color-1` -> `gauzy-card-1`, so the body/overscroll area
+    // would otherwise stay at the (lighter) panel colour while the layout above
+    // it is near-black.
+    background: var(--layout-background-color) !important;
     color: var(--card-text-color) !important;
     .spinner {
       background: var(--card-background-color) !important;

--- a/packages/ui-core/static/styles/_overrides.scss
+++ b/packages/ui-core/static/styles/_overrides.scss
@@ -373,15 +373,17 @@ body {
   angular2-smart-table table {
     border-collapse: separate !important;
 
+    // Filter-row controls track the table density: they are the tallest thing
+    // in the filter row, so their height IS that row's height.
     .angular2-smart-filter input {
-      height: 32px;
+      height: var(--gauzy-table-control-height, 1.75rem);
       background-color: var(--gauzy-sidebar-background-3) !important;
       border: none !important;
     }
 
     .angular2-smart-filter .ng-select .ng-select-container {
       background-color: var(--gauzy-sidebar-background-3) !important;
-      height: 32px;
+      height: var(--gauzy-table-control-height, 1.75rem);
       min-height: auto;
 
       input {
@@ -660,6 +662,75 @@ body {
   }
 }
 
+// ── Data-table density (angular2-smart-table) ────────────────────────────────
+//
+// WHERE THE OLD NUMBERS CAME FROM: nothing in this repo. `angular2-smart-table`
+// ships emulated component CSS that reads
+//     :host                          { font-size: 1rem }
+//     :host ::ng-deep table          { line-height: 1.5em }
+//     :host ::ng-deep table tr td,
+//     :host ::ng-deep table tr th    { font-size: .875em; padding: .5em 1em }
+// i.e. 14px text, a 24px line inherited from the table, and a 7px/14px box (the
+// `em` resolves against the cell's own 14px). Neither Bootstrap nor Nebular
+// touches these cells — Bootstrap's padding needs the `.table` class the library
+// only adds from `settings.attr.class` (empty in Gauzy), and Nebular's
+// smart-table theme still targets the old `ng2-smart-table` element name.
+//
+// SPECIFICITY: the library rule compiles to `[_nghost-x] table tr td`, i.e.
+// (0,1,3), so a plain `angular2-smart-table table tr td` (0,0,4) LOSES — which
+// is why so many smart-table rules in this file reach for `!important`. Leading
+// with `:root` buys one pseudo-class and takes the block to (0,1,4)+, enough to
+// win outright, so nothing below needs `!important`.
+//
+// All values come from the shared `$gauzy-density` map in `themes.scss`, merged
+// last into all 8 registered themes; the literals here are only CSS-var
+// fallbacks for the (nonexistent) case of a theme that never registered them.
+:root {
+  angular2-smart-table table {
+    // Set on the TABLE by the library and inherited by every cell, so resetting
+    // the cells alone would leave 24px line boxes behind in nested markup.
+    line-height: var(--gauzy-table-line-height, 1.25rem);
+  }
+
+  angular2-smart-table table tr td,
+  angular2-smart-table table tr th {
+    font-size: var(--gauzy-table-font-size, 0.8125rem);
+    line-height: var(--gauzy-table-line-height, 1.25rem);
+    padding: var(--gauzy-table-cell-padding-y, 0.375rem) var(--gauzy-table-cell-padding-x, 0.625rem);
+  }
+
+  angular2-smart-table table tr.angular2-smart-titles th {
+    padding: var(--gauzy-table-header-padding-y, 0.5rem) var(--gauzy-table-header-padding-x, 0.625rem);
+    line-height: var(--gauzy-table-header-line-height, 0.9375rem);
+  }
+
+  angular2-smart-table table tr.angular2-smart-filters th {
+    padding: var(--gauzy-table-filter-padding-y, 0.25rem) var(--gauzy-table-cell-padding-x, 0.625rem);
+  }
+
+  // The action column holds buttons that carry their own padding; letting the
+  // cell add its own on top is what makes an action row taller than a text row.
+  angular2-smart-table table tr td.angular2-smart-actions {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  // ── One-line dates ──────────────────────────────────────────────────────
+  // A formatted date ("September 11, 2026") is the single biggest source of
+  // wasted row height: long enough to wrap, never worth two lines. The `nowrap`
+  // is scoped to the three cell renderers that emit ONLY a formatted date or
+  // date-time — never to `td` itself, because name, note, address and
+  // description columns must keep wrapping. The table keeps `table-layout:
+  // auto`, so a nowrapped date simply raises that column's min-content width
+  // and the library's own `overflow-x: auto` wrapper absorbs the rest; nothing
+  // is truncated.
+  angular2-smart-table table tr td ngx-date-view,
+  angular2-smart-table table tr td ngx-created-at,
+  angular2-smart-table table tr td ga-document-date {
+    white-space: nowrap;
+  }
+}
+
 angular2-smart-table tbody tr {
   background: rgba(126, 126, 143, 0.05);
 
@@ -753,8 +824,11 @@ nb-card-body {
   angular2-smart-table table tr th {
     border-top: 1px solid var(--gauzy-border-table);
     border-bottom: 1px solid var(--gauzy-border-table);
-    padding-top: 1em;
-    padding-bottom: 1em;
+    // Vertical padding deliberately NOT set here any more. It used to be
+    // `1em` top and bottom, which — `em` being the cell's own 14px — is where
+    // the 14px header padding (and a ~45px header row) came from. Header
+    // padding now has one source of truth: the `gauzy-table-header-padding-*`
+    // tokens applied in the density block above.
   }
 
   table thead th {
@@ -995,18 +1069,23 @@ angular2-smart-table {
   }
 }
 
+// Header labels: smaller and heavier than the body text — the header reads as a
+// header through weight and colour rather than through extra padding. The
+// `!important` here predates the density work and is kept because these two
+// rules also have to beat the library's own `a.sort` styling, which arrives
+// after this sheet.
 angular2-smart-table table tr.angular2-smart-titles .angular2-smart-sort {
-  font-size: 12px !important;
+  font-size: var(--gauzy-table-header-font-size, 0.75rem) !important;
   font-weight: 600 !important;
-  line-height: 15px;
+  line-height: var(--gauzy-table-header-line-height, 0.9375rem);
   letter-spacing: 0em;
   color: var(--gauzy-text-color-2) !important;
 }
 
 angular2-smart-table table tr.angular2-smart-titles th a.sort {
-  font-size: 12px !important;
+  font-size: var(--gauzy-table-header-font-size, 0.75rem) !important;
   font-weight: 600 !important;
-  line-height: 15px;
+  line-height: var(--gauzy-table-header-line-height, 0.9375rem);
   letter-spacing: 0em;
   color: var(--gauzy-text-color-2) !important;
   display: flex;

--- a/packages/ui-core/static/styles/_overrides.scss
+++ b/packages/ui-core/static/styles/_overrides.scss
@@ -725,7 +725,7 @@ body {
   // is scoped to the three cell renderers that emit ONLY a formatted date or
   // date-time — never to `td` itself, because name, note, address and
   // description columns must keep wrapping. The table keeps `table-layout:
-  // auto`, so a nowrapped date simply raises that column's min-content width
+  // auto`, so a date held on one line simply raises that column's min-content width
   // and the library's own `overflow-x: auto` wrapper absorbs the rest; nothing
   // is truncated.
   angular2-smart-table table tr td ngx-date-view,

--- a/packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss
+++ b/packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss
@@ -423,10 +423,10 @@ $default-box-shadow: var(--gauzy-shadow);
           .fc-timeGridDay-button,
           .fc-timeGridWeek-button,
           .fc-dayGridMonth-button {
-            border-color: rgba(126, 126, 143, 0.5);
+            border-color: var(--gauzy-border-default-color);
             border-width: 2px;
             background-color: transparent;
-            color: rgba(126, 126, 143, 1);
+            color: var(--text-hint-color);
             padding: 8px 16px;
             font-style: normal;
             font-weight: 600;
@@ -462,10 +462,10 @@ $default-box-shadow: var(--gauzy-shadow);
         }
 
         .fc-today-button {
-          border-color: rgba(126, 126, 143, 0.5);
+          border-color: var(--gauzy-border-default-color);
           border-width: 2px;
           background-color: transparent;
-          color: rgba(126, 126, 143, 1);
+          color: var(--text-hint-color);
           padding: 8px 24px;
           font-style: normal;
           font-weight: 600;
@@ -510,7 +510,9 @@ $default-box-shadow: var(--gauzy-shadow);
         th.fc-col-header-cell {
           border: none;
           border-radius: nb-theme(border-radius);
-          background-color: rgba($color: white, $alpha: 0.75);
+          // Was rgba(white, 0.75) — a near-white block on every column header,
+          // in every theme.
+          background-color: var(--gauzy-sidebar-background-3);
           padding: 11px 15px 11px 10px;
         }
 
@@ -522,13 +524,15 @@ $default-box-shadow: var(--gauzy-shadow);
           padding: 0;
         }
 
+        // Both were rgba(white, 0.25): every time lane and every day column
+        // rendered as a light-grey block regardless of theme.
         td.fc-timegrid-slot-lane {
-          background-color: rgba($color: white, $alpha: 0.25);
+          background-color: var(--gauzy-sidebar-background-4);
           border-radius: nb-theme(border-radius);
         }
 
         td[role='gridcell'].fc-timegrid-col {
-          background-color: rgba($color: white, $alpha: 0.25);
+          background-color: var(--gauzy-sidebar-background-4);
           border-radius: nb-theme(border-radius);
         }
       }
@@ -577,7 +581,7 @@ $default-box-shadow: var(--gauzy-shadow);
   }
 
   .fc-event {
-    background-color: rgba(126, 126, 143, 0.1);
+    background-color: var(--gauzy-card-3);
     border-radius: nb-theme(border-radius);
 
     &.fc-v-event {
@@ -609,7 +613,9 @@ $default-box-shadow: var(--gauzy-shadow);
   .fc .fc-timegrid-axis-frame,
   .fc .fc-daygrid-day-frame,
   .fc fc-timegrid-col-bg > * {
-    background-color: rgba($color: white, $alpha: 0.5);
+    // Was rgba(white, 0.5) — the day cells themselves, i.e. the largest area of
+    // the calendar, painted 50 % white in every theme.
+    background-color: var(--gauzy-card-2);
     border-radius: nb-theme(border-radius);
   }
 

--- a/packages/ui-core/static/styles/gauzy/_gauzy-table.scss
+++ b/packages/ui-core/static/styles/gauzy/_gauzy-table.scss
@@ -6,7 +6,9 @@
   box-shadow: var(--gauzy-shadow);
   border: none;
   &[nbButton].appearance-filled.status-basic {
-    background-color: #ffffff;
+    // Was a hard-coded #ffffff: a pure-white pill on every data-table toolbar,
+    // in every theme.
+    background-color: var(--gauzy-card-2);
   }
   &.info {
     &[nbButton].appearance-filled.status-basic {
@@ -21,7 +23,7 @@
     }
   }
   &.secondary {
-    color: #7e7e8f;
+    color: var(--text-hint-color);
   }
   &.success {
     color: nb-theme(color-success-default);
@@ -45,7 +47,7 @@
     box-shadow: none;
     .select-button {
       box-shadow: var(--gauzy-shadow);
-      background: rgba(245, 245, 245);
+      background: var(--gauzy-card-2);
     }
   }
 }

--- a/packages/ui-core/static/styles/themes.scss
+++ b/packages/ui-core/static/styles/themes.scss
@@ -518,18 +518,34 @@ $nb-themes: nb-register-theme(
     footer-shadow: none,
     footer-divider-style: none,
     sidebar-shadow: none,
-    layout-background-color: gauzy-card-1,
-    footer-background-color: gauzy-card-1,
-    header-background-color: gauzy-card-1,
+    // ── Dark canvas ───────────────────────────────────────────────────────
+    // The page band (layout + header + footer) is the DARKEST surface, and it
+    // is deliberately NOT `gauzy-card-1` any more. That one alias used to paint
+    // eleven surfaces at once — page == header == footer == card == table row ==
+    // dropdown == input == rgb(32, 32, 35) — with `card-border-style: none` on
+    // top, so the whole UI collapsed onto a single flat grey. Panels now lift
+    // off this near-black canvas instead.
+    layout-background-color: rgba(9, 9, 11, 1),
+    footer-background-color: rgba(9, 9, 11, 1),
+    header-background-color: rgba(9, 9, 11, 1),
     tabset-tab-underline-width: 0,
     tabset-tab-text-font-size: 1rem,
     route-tabset-tab-text-font-size: 1rem,
+    // KEEP this alias: Nebular's eva mapping follows `background-basic-color-1`
+    // into card / sidebar / popover / context-menu / option-list / smart-table /
+    // calendar / chat backgrounds, so this is the single token that makes every
+    // panel the panel colour at once.
     background-basic-color-1: gauzy-card-1,
     input-basic-background-color: gauzy-card-1,
-    background-basic-color-2: rgba(32, 32, 35, 1),
-    smart-table-bg-active: rgba(126, 126, 143, 0.05),
-    background-basic-color-3: gauzy-card-3,
-    gauzy-primary-background: rgb(86, 82, 99),
+    // One step ABOVE the panel — zebra rows, muted blocks, scrollbar track.
+    // Was byte-identical to `background-basic-color-1`, i.e. a dead ramp step.
+    background-basic-color-2: rgba(24, 24, 27, 1),
+    smart-table-bg-active: rgba(255, 255, 255, 0.05),
+    // Recessed surface. Was aliased to `gauzy-card-3`, i.e. a translucent
+    // overlay sitting in an opaque slot, which resolved differently depending on
+    // what happened to be stacked behind it.
+    background-basic-color-3: rgba(9, 9, 11, 1),
+    gauzy-primary-background: rgba(31, 31, 35, 1),
     input-basic-placeholder-text-color: rgba(126, 126, 143, 0.5),
     select-outline-basic-background-color: gauzy-card-1,
     input-border-width: 0,
@@ -540,10 +556,40 @@ $nb-themes: nb-register-theme(
     color-danger-default: #ff0000,
     color-warning-default: rgba(255, 171, 45, 1),
     gauzy-background-transparent: rgba(110, 73, 232, 0.5),
-    gauzy-card-1: rgba(32, 32, 35, 1),
-    // Neutral (zinc-like) sidebar — no blue/purple tint, shadcn-like
-    gauzy-sidebar-background-1: #141416,
-    gauzy-sidebar-background-2: rgba(30, 30, 34, 1),
+    // Panel / card surface — one visible step above the near-black canvas.
+    gauzy-card-1: rgba(18, 18, 20, 1),
+    // Tints layered ON TOP of a panel. Inherited from the `dark` map these were
+    // DARKENING overlays — rgba(16, 16, 20, 0.3) / rgba(5, 5, 5, 0.5) /
+    // rgba(5, 5, 5, 0.25) — and a darkening overlay simply disappears on a
+    // near-black canvas. Flipped to LIFTING (white at a low alpha) so they read
+    // on the canvas and on every panel alike.
+    gauzy-card-2: rgba(255, 255, 255, 0.02),
+    gauzy-card-3: rgba(255, 255, 255, 0.04),
+    gauzy-card-4: rgba(255, 255, 255, 0.06),
+    // Opaque, on-hue near-blacks: the inherited rgb(7, 9, 1) (green-black) and
+    // rgb(52, 52, 62) (blue-purple) both fought the neutral ramp.
+    gauzy-card-5: rgba(24, 24, 27, 1),
+    gauzy-card-6: rgba(31, 31, 35, 1),
+    // Neutral (zinc-like) sidebar — no blue/purple tint, shadcn-like. Both rails
+    // sit BELOW the canvas so the content column is the brightest thing on
+    // screen; the menu rail used to be rgb(30, 30, 34), i.e. brighter than the
+    // content it framed.
+    gauzy-sidebar-background-1: rgba(10, 10, 11, 1),
+    gauzy-sidebar-background-2: rgba(12, 12, 14, 1),
+    // Interactive tints: menu-row hover, smart-table filter fill, stepper
+    // connector, ckeditor chrome. The inherited rgba(126, 126, 143, 0.1 / 0.05)
+    // carried a blue cast on a strictly neutral ramp.
+    gauzy-sidebar-background-3: rgba(255, 255, 255, 0.06),
+    gauzy-sidebar-background-4: rgba(255, 255, 255, 0.03),
+    // (the token-name typo is upstream — not renamed here) custom tooltip body
+    gauzy-siderbar-background-5: rgba(24, 24, 27, 1),
+    // Hairlines. The inherited table border rgba(16, 16, 20, 0.5) DARKENS, which
+    // is invisible on a near-black canvas — the table would have got *worse*
+    // from the palette change alone. Both are white-at-low-alpha so one value
+    // works on the canvas and on every panel.
+    gauzy-border-table: rgba(255, 255, 255, 0.07),
+    gauzy-border-default-color: rgba(255, 255, 255, 0.08),
+    gauzy-scrollbar: rgba(255, 255, 255, 0.14),
     // More legible sidebar/menu labels than the inherited 50% white
     gauzy-text-color-2: rgba(255, 255, 255, 0.7)
   ), $gauzy-density),

--- a/packages/ui-core/static/styles/themes.scss
+++ b/packages/ui-core/static/styles/themes.scss
@@ -67,7 +67,46 @@ $gauzy-density: (
 	// Inputs / selects
 	input-medium-text-font-size: 0.8125rem,
 	input-medium-padding: 0.4375rem 0.75rem,
-	select-medium-text-font-size: 0.8125rem
+	select-medium-text-font-size: 0.8125rem,
+	// ── Data tables (angular2-smart-table) ─────────────────────────────────
+	// The library ships its own emulated component CSS and nothing in this repo
+	// used to contest it:
+	//     :host                          { font-size: 1rem }
+	//     :host ::ng-deep table          { line-height: 1.5em }   ->  24px
+	//     :host ::ng-deep table tr td/th { font-size: .875em;     ->  14px
+	//                                      padding: .5em 1em }    ->  7px 14px
+	// (the `em` in that padding resolves against the CELL's own 14px font-size,
+	// which is where the odd 7px/14px box came from). The rules in
+	// `_overrides.scss` consume the tokens below instead, so all 8 themes move
+	// together. Bootstrap is NOT in play here: its cell padding lives on
+	// `.table`, and the library's `<table [ngClass]="tableClass">` takes that
+	// class from `settings.attr.class`, which Gauzy never sets.
+	//
+	// 0.8125rem (13px) is the deliberate readability floor for cell text.
+	gauzy-table-font-size: 0.8125rem,
+	gauzy-table-line-height: 1.25rem,
+	gauzy-table-cell-padding-y: 0.375rem,
+	gauzy-table-cell-padding-x: 0.625rem,
+	// Header stays distinct through weight + colour (see the
+	// `.angular2-smart-titles` rules in `_overrides.scss`), not through height.
+	gauzy-table-header-font-size: 0.75rem,
+	gauzy-table-header-line-height: 0.9375rem,
+	gauzy-table-header-padding-y: 0.5rem,
+	gauzy-table-header-padding-x: 0.625rem,
+	// Filter row: the control is the tallest thing in it, so that row measures
+	// `gauzy-table-control-height + 2 * gauzy-table-filter-padding-y`.
+	gauzy-table-filter-padding-y: 0.25rem,
+	gauzy-table-control-height: 1.75rem,
+	// Chips / status pills rendered INSIDE cells. They have their own box and
+	// therefore their own say in the row height, so they are compacted in the
+	// same proportion rather than left at their old 24px-per-chip footprint.
+	gauzy-table-chip-font-size: 0.6875rem,
+	gauzy-table-chip-line-height: 0.875rem,
+	gauzy-table-chip-padding-y: 0.0625rem,
+	gauzy-table-chip-padding-x: 0.375rem,
+	gauzy-table-chip-gap: 0.1875rem,
+	// A status pill should cost a row exactly one line box and no more.
+	gauzy-table-badge-height: 1.25rem
 );
 
 $nb-themes: nb-register-theme(

--- a/packages/ui-core/theme/src/lib/components/header/header.component.scss
+++ b/packages/ui-core/theme/src/lib/components/header/header.component.scss
@@ -7,14 +7,14 @@ $orange: #f56d58;
 @include nb-install-component() {
   width: 100%;
   .notification-header {
-    background-color: #1b005d;
+    background-color: var(--color-primary-600);
     text-align: center;
     font-weight: 300;
     margin: 0;
     padding: 3px;
     width: 100%;
     position: relative;
-    color: rgb(236, 236, 236);
+    color: var(--text-control-color);
     a {
       color: rgb(236, 236, 236);
     }
@@ -169,7 +169,9 @@ $orange: #f56d58;
   top: 4.75rem;
   width: 100%;
   height: calc(100vh - 4.75rem);
-  background: white;
+  // Was a hard-coded `white`: a full-viewport white sheet over the app whenever
+  // the header overflow panel opens (below the `lg` breakpoint), in every theme.
+  background: var(--background-basic-color-1);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/packages/ui-core/theme/src/lib/themes/gauzy/theme.gauzy-dark.ts
+++ b/packages/ui-core/theme/src/lib/themes/gauzy/theme.gauzy-dark.ts
@@ -12,23 +12,30 @@ const theme = {
 	fontMain: 'Open Sans, sans-serif',
 	fontSecondary: 'Raleway, sans-serif',
 
-	bg: '#000000',
-	bg2: '#1a2138',
-	bg3: '#151a30',
-	bg4: '#101426',
+	// Mirrors the `gauzy-dark` map in `packages/ui-core/static/styles/themes.scss`.
+	// This palette is completely independent of the SCSS theme — every echarts /
+	// chartjs widget reads it through `nbThemeService.getJsTheme()` — so if it
+	// drifts, charts render as navy rectangles floating on the neutral canvas.
+	// echarts needs opaque hex here, so these are the composited equivalents of
+	// the translucent SCSS tints.
+	bg: '#09090b',
+	bg2: '#121214',
+	bg3: '#18181b',
+	bg4: '#1f1f23',
 
-	border: '#222b45',
-	border2: '#1a2138',
-	border3: '#151a30',
-	border4: '#101426',
-	border5: '#101426',
+	border: '#27272a',
+	border2: '#27272a',
+	border3: '#3f3f46',
+	border4: '#3f3f46',
+	border5: '#52525b',
 
-	fg: '#8f9bb3',
-	fgHeading: '#ffffff',
-	fgText: '#ffffff',
+	fg: '#a1a1aa',
+	fgHeading: '#fafafa',
+	fgText: '#fafafa',
 	fgHighlight: palette.primary,
-	layoutBg: '#1b1b38',
-	separator: '#1b1b38',
+	// Charts sit INSIDE cards, so this is the CARD colour, not the canvas.
+	layoutBg: '#121214',
+	separator: '#27272a',
 
 	primary: palette.primary,
 	success: palette.success,


### PR DESCRIPTION
Second visual round from the stage review: a much darker dark theme, condensed data tables, and removal of the duplicated in-page date range. Sizes, padding, margins, colours and font styles only — no positions, content, DOM structure or component libraries changed.

## 1. Near-black dark canvas with lifted panels

**The theme was flat for a structural reason, not a colour one.** In `gauzy-dark`, one token painted eleven surfaces: `gauzy-card-1: rgb(32,32,35)` was aliased to `layout-background-color`, `footer-background-color`, `header-background-color`, `background-basic-color-1`, `input-basic-background-color` and `select-outline-basic-background-color` — and Nebular's eva mapping then follows `background-basic-color-1` into card, sidebar, popover, context-menu, option-list, smart-table, calendar and chat backgrounds. With `card-border-style: none` and `card-shadow: none` on top, **page == header == footer == card == table row == dropdown == input**, with nothing separating them.

Darkening that single token would have moved all eleven together and left the UI exactly as flat, just darker. So the alias is broken first:

| | before | after |
|---|---|---|
| canvas (layout/header/footer) | `rgb(32,32,35)` | **`rgb(9,9,11)`** |
| panel (`gauzy-card-1`) | `rgb(32,32,35)` | **`rgb(18,18,20)`** |

`background-basic-color-1` deliberately **keeps** its alias — it is the one token that makes every panel the panel colour at once.

Two traps handled in the same commit, either of which would have made the result look worse than before:
- `background-basic-color-2` was byte-identical to `-1`, a dead ramp step. It now supplies the muted/zebra/hover step.
- The card tints inherited from the `dark` map were **darkening** overlays (`rgba(16,16,20,0.3)`, `rgba(5,5,5,0.5)`, `rgba(5,5,5,0.25)`), as was `gauzy-border-table`. A darkening overlay disappears on a near-black canvas — the table borders would have vanished. All flipped to lifting white at low alpha.

Values are added as explicit keys in the `gauzy-dark` map, never in the `dark` map it inherits from, so the standalone `dark` theme is untouched. Light themes are unaffected. Hard-coded hex landmines in nine component stylesheets were neutralised in the same pass, so no light patches survive on the dark canvas.

## 2. Condensed data tables

Nothing in the repo set the old cell metrics — they come from **the library's own inline component styles** in `angular2-smart-table.mjs` (`styles:[]`, not a `.css` file), where `padding: .5em 1em` resolves against the cell's own 14px. The library rule compiles to `[_nghost-x] table tr td` = (0,1,3), which beats a plain `angular2-smart-table table tr td`; the new block leads with `:root` to win on specificity instead, adding **no `!important`**.

| | before | after |
|---|---|---|
| cell padding / font / line-height | `7px 14px` / 14px / 24px | **`6px 10px` / 13px / 20px** |
| header row | 45–60px | **33px** |
| simple row | 38px | **32px** |
| employees row | 89px | **59px** |

Metrics come from tokens in `$gauzy-density` so all 8 themes track together. Date columns stop wrapping via `nowrap` scoped to the three date-only cell renderers — never to `td`, so names and notes still wrap. Stacked status pills (a separate `EmployeeWorkStatusComponent`, which the first pass missed) now flow inline.

## 3. Duplicate in-page date range removed

`DateRangeTitleComponent` reads `selectedDateRange` from the same `DateRangePickerBuilderService` that backs the header picker, so the in-page line restated what the header already showed. Removed from 18 pages. **Kept on one**: `/pages/employees/timesheets/:id` sets `selectors: false` and genuinely has no header picker, so removing it there would lose the range entirely — it is restyled to match the breadcrumb trail instead of clashing at 14px/600.

## Verification

Measured in a built app at 1600x900, not eyeballed:
- surfaces now **distinct**: canvas `rgb(9,9,11)` vs panel `rgb(18,18,20)`; body text ≈18.7:1 on the panel, far above the 4.5:1 AA floor
- table metrics as tabled above
- **17/17** page checks still pass after the change (breadcrumb position/background/trail on three routes, no window or container scrolling, combobox alignment, AI-providers empty state)

## Worth a look at review

- The demo banner reads much louder against a near-black canvas than it did against the old grey. Out of scope here, easy to tone down.
- The employees status column still wraps two pills onto two lines (46px). That is genuine wrapping — the labels do not fit the column width — not padding. Forcing one line would widen that column and squeeze the rest.
- The five Electron apps carry their own stale copies of `_overrides.scss`/`themes.scss` with no `$gauzy-density`, so they keep the old density and the old palette. Pre-existing divergence, flagged not fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `gauzy-dark` near-black with clearer panel separation, tightens data‑table density, and removes duplicate in‑page date ranges for a cleaner, denser UI.

- **New Features**
  - Near‑black `gauzy-dark` canvas with lifted panels and neutral rails; overlays/borders switched to subtle lifting tints; sidebar/calendar retinted; JS theme palette aligned for charts.
  - Condensed data tables via shared density tokens across all themes: smaller cell/header/filter metrics, compact status pills and tag chips, and one‑line date‑only cells.

- **Bug Fixes**
  - Removed redundant in‑page date range on 18 screens; kept and restyled only on the employee timesheet route that lacks a header picker.
  - Replaced hard‑coded light colors with theme tokens and fixed dark overscroll/skeleton palette; ensured table borders remain visible on dark surfaces.
  - Updated cspell dictionary with `echarts` and corrected minor comment spellings (no runtime change).

<sup>Written for commit d5feb1477de5461513e6102b65c9cef255a75602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

