### PR TITLE
ci(e2e): make the Playwright suite actually runnable — split into deps → build → 4 shards

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -7,6 +7,7 @@
 		"scroller",
 		"blockified",
 		"tabindex",
+		"nproc",
 		"echarts",
 		"affordance",
 		"ngcontent",

--- a/.github/workflows/test_playwright.yml
+++ b/.github/workflows/test_playwright.yml
@@ -2,16 +2,34 @@ name: Playwright Tests
 
 # Replaces the dormant Cypress workflows (test_cypress.yml / test_currents.yml, which trigger on
 # branch `nope`). Runs the migrated Playwright e2e suite against a locally-started API + Web.
+#
+# JOB GRAPH — deps ──► build ──► e2e (shard 1..4)
+#
+# This used to be ONE job that bootstrapped the monorepo, built every package, built the Angular
+# app AND ran the 79-spec suite. It never once reached the tests: the self-hosted ARC (k8s) pods
+# drop off GitHub on long heavy jobs, so the run always died mid-way. Measured on develop:
+#
+#   run 30594240884  bootstrap 88 min  → died 23 min into the web build (~2 h in)
+#   run 30267765989  bootstrap 3 h 28  → died 47 min into the web build (~4.5 h in)
+#   run 30224003351  bootstrap 1 h 40  → died 24 min into the web build (~2.2 h in)
+#   run 30330950619  bootstrap failed after 9 min
+#
+# So the split follows the cost: `yarn bootstrap` (8.9 GB / ~900k files) is isolated in its own
+# job and published to the Actions cache, the two compile steps run in a second job, and the test
+# jobs compile NOTHING — they download the prebuilt bundles, boot them and run one shard each.
+# An evicted pod now costs a single phase, and a re-run of a failed job reuses the cached
+# node_modules + the uploaded bundles instead of redoing everything.
 on:
   # Run the e2e suite ONLY when code lands on develop (merge/push). Deliberately NOT on pull_request or
-  # any other branch: the suite is long (~1.3h) and shared-DB flaky, so it's gated to the integration
+  # any other branch: the suite is long and shared-DB flaky, so it's gated to the integration
   # branch. Use the manual "Run workflow" button (workflow_dispatch) to run it on demand from any ref.
   push:
     branches: [develop]
   workflow_dispatch:
 
-# Least-privilege GITHUB_TOKEN (CodeQL: a workflow should limit the token's permissions). This job only
-# checks out code and runs tests against a locally-started stack — it needs no write scopes.
+# Least-privilege GITHUB_TOKEN (CodeQL: a workflow should limit the token's permissions). These jobs
+# only check out code and run tests against a locally-started stack — they need no write scopes.
+# (Same-run artifact upload/download authenticates with the Actions runtime token, not this one.)
 permissions:
   contents: read
 
@@ -20,21 +38,146 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-playwright:
+  # ---------------------------------------------------------------------------------------------
+  # 1) deps — pay `yarn bootstrap` ONCE per lockfile and hand node_modules to every other job.
+  # ---------------------------------------------------------------------------------------------
+  deps:
+    name: Install dependencies
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
-    timeout-minutes: 360
+    # Cold path (cache miss) is the whole budget: bootstrap alone has been measured at 88 min and
+    # once at 3 h 28 on these runners, plus the cache save of a ~9 GB tree. Warm path is a no-op
+    # (~2 min). Nothing else runs here, so an eviction costs only the install.
+    timeout-minutes: 240
+    outputs:
+      # Single source of truth for the cache key — every downstream job restores with this exact
+      # value, so a key change can never silently split the cache.
+      node-modules-key: ${{ steps.cache-key.outputs.value }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Compute node_modules cache key
+        id: cache-key
+        shell: bash
+        run: echo "value=${{ runner.os }}-${{ runner.arch }}-e2e-node-modules-${{ hashFiles('yarn.lock', 'patches/**', '.scripts/postinstall.js') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore node_modules cache
+        id: cache
+        uses: actions/cache/restore@v5
+        with:
+          # yarn workspaces hoist to the root, but package.json `nohoist` (@angular*, @ngtools,
+          # @types/jasmine*) keeps per-workspace copies — cache those too or the restored tree is
+          # incomplete and Angular builds fail. Exact key only, never restore-keys: a partially
+          # matching node_modules is worse than no node_modules.
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+            packages/plugins/*/node_modules
+            tools/node_modules
+          key: ${{ steps.cache-key.outputs.value }}
+
       - name: Install Packages & Bootstrap
-        run: yarn bootstrap
+        if: steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        # Retry once: run 30330950619 died here after 9 min. A transient registry/FS hiccup on
+        # these container runners is common and the second attempt reuses whatever yarn already
+        # unpacked. (A pod eviction can't be retried in-step — that's what the job split is for.)
+        run: |
+          yarn bootstrap \
+            || { echo "::warning::yarn bootstrap failed — retry 1"; yarn bootstrap; }
+
+      - name: Save node_modules cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        # Explicit save (not the combined actions/cache post-step) so a FAILED bootstrap can never
+        # publish a half-installed tree: this step only runs when every step above succeeded.
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+            packages/plugins/*/node_modules
+            tools/node_modules
+          key: ${{ steps.cache-key.outputs.value }}
+
+  # ---------------------------------------------------------------------------------------------
+  # 2) build — compile the API bundle and the static web bundle. No tests run here.
+  # ---------------------------------------------------------------------------------------------
+  build:
+    name: Build API + Web
+    needs: deps
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    # Observed: build:package:all 7-13 min, web build >47 min (it never finished before the pod
+    # died). 120 min is a realistic ceiling once node_modules comes from the cache; if it is
+    # exceeded the right answer is another split, not a bigger budget.
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Restore node_modules cache
+        id: cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+            packages/plugins/*/node_modules
+            tools/node_modules
+          key: ${{ needs.deps.outputs.node-modules-key }}
+
+      - name: Install Packages & Bootstrap (cache fallback)
+        if: steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        # Safety net only — `deps` just populated this key. A miss here means the Actions cache
+        # service is not usable from these runners, which is worth shouting about because every
+        # job then pays the full install again.
+        run: |
+          echo "::warning::node_modules cache miss — falling back to a full bootstrap (1-3 h on these runners)."
+          yarn bootstrap \
+            || { echo "::warning::yarn bootstrap failed — retry 1"; yarn bootstrap; }
+
+      - name: Size the Node heap to this container
+        shell: bash
+        # The old fixed `--max-old-space-size=24576` is a prime suspect for the web build dying in
+        # three of the last four runs: these ARC pods are memory-limited, and a heap ceiling above
+        # the cgroup limit lets V8 grow until the kernel OOM-kills the pod — which surfaces on
+        # GitHub as a job that simply stops with its step still "pending". Derive the ceiling from
+        # the container's real limit instead, keeping ~25% for webpack workers + the runner agent.
+        # Capped at the previous 24 GB so a large machine is no worse off than before.
+        run: |
+          # true only for a non-empty, all-digits value
+          is_number() { [ -n "$1" ] && [ -z "${1//[0-9]/}" ]; }
+
+          limit_mb=''
+          limit_bytes=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || true)
+          if is_number "$limit_bytes"; then limit_mb=$((limit_bytes / 1024 / 1024)); fi
+          # An unlimited cgroup reports "max" or a host-sized number — fall back to real RAM.
+          if ! is_number "$limit_mb" || [ "$limit_mb" -eq 0 ] || [ "$limit_mb" -gt 262144 ]; then
+            limit_mb=$(free -m 2>/dev/null | awk '/^Mem:/{print $2}' || true)
+          fi
+          if is_number "$limit_mb" && [ "$limit_mb" -gt 0 ]; then
+            heap_mb=$((limit_mb * 3 / 4))
+            if [ "$heap_mb" -gt 24576 ]; then heap_mb=24576; fi
+            if [ "$heap_mb" -lt 4096 ]; then heap_mb=4096; fi
+          else
+            # Neither source answered. Fall back to the heap the API has always run with rather
+            # than to the floor — this step must never be the thing that fails a build.
+            echo "::warning::could not determine this container's memory limit — defaulting the Node heap to 12288 MB"
+            heap_mb=12288
+          fi
+          echo "container memory: ${limit_mb:-unknown} MB, cpus: $(nproc 2>/dev/null || echo '?') -> node heap ${heap_mb} MB"
+          free -h || true
+          echo "NODE_OPTIONS=--max-old-space-size=${heap_mb}" >> "$GITHUB_ENV"
 
       - name: Build all packages
         shell: bash
-        # --parallel=1: the self-hosted Windows runner kills large lib builds (core:build, exit 130)
-        # under parallel pressure ("flaky task"). core builds fine alone (verified locally), so build
+        # --parallel=1: the self-hosted runner kills large lib builds (core:build, exit 130) under
+        # parallel pressure ("flaky task"). core builds fine alone (verified locally), so build
         # serially — cached libs skip fast, only cache-misses rebuild. Once core caches, reruns are
         # fast. Retry once for any residual flake (nx cache makes the retry cheap).
         run: |
@@ -42,13 +185,133 @@ jobs:
             || { echo "::warning::build:package:all failed — retry 1 (nx cache skips built projects)"; yarn build:package:all --parallel=1; }
         env:
           NX_NO_CLOUD: true
-          # Self-hosted Windows runner: Nx isolated plugin workers fail to spawn
-          # ("Failed to start plugin worker") → run plugins in-process and skip the daemon.
+          # Nx isolated plugin workers fail to spawn on this runner ("Failed to start plugin
+          # worker") → run plugins in-process and skip the daemon.
           NX_ISOLATE_PLUGINS: 'false'
           NX_DAEMON: 'false'
 
       - name: Generate dev config
+        # Writes packages/ui-config/src/lib/environments/environment.ts (gitignored), which the web
+        # bundle compiles in — so it must precede the gauzy build. Kept in its original position,
+        # right after build:package:all.
         run: yarn config:dev
+
+      - name: Build API (bundle) for the test jobs
+        shell: bash
+        # The test job used to get its API from `yarn start:api:forever` (= forever + `nx serve
+        # api`), i.e. it webpack-compiled the whole API itself. `nx serve api` is just
+        # `nx build api -c development` followed by `node dist/apps/api/main.js`, so building that
+        # same bundle here — once — lets every shard skip the compile and run without a webpack
+        # watcher competing for the pod's RAM. The build also copies the built @gauzy/* packages
+        # into dist/apps/api/node_modules/@gauzy (apps/api/config/custom-webpack.config.js), so the
+        # tarball carries everything the bundle resolves at runtime.
+        run: |
+          yarn nx build api -c development --parallel=1 \
+            || { echo "::warning::api build failed — retry 1 (nx cache skips built deps)"; yarn nx build api -c development --parallel=1; }
+        env:
+          NX_NO_CLOUD: true
+          NX_ISOLATE_PLUGINS: 'false'
+          NX_DAEMON: 'false'
+
+      - name: Build Web (gauzy) for static serving
+        # The Angular dev server (nx serve gauzy) OOMs over a long e2e run. Build once and serve the
+        # static output instead — stable + low memory. The app uses hash routing + an absolute API
+        # URL baked into the bundle, so a plain static file server is sufficient (no proxy/SPA fallback).
+        shell: bash
+        run: |
+          yarn nx build gauzy -c local || { echo "::warning::gauzy build failed — retry 1 (nx cache skips done deps)"; yarn nx build gauzy -c local; }
+          # The bundle bakes the API URL as http://localhost:3000; the API runs on :3001 in the test
+          # job (this shared runner's :3000 is taken by other dev processes), so repoint the built
+          # bundle at :3001 BEFORE it is packed — the test job serves this artifact verbatim.
+          matches=$(grep -rl 'localhost:3000' dist/apps/gauzy --include='*.js' || true)
+          if [ -n "$matches" ]; then
+            printf '%s\n' "$matches" | xargs -r sed -i 's#localhost:3000#localhost:3001#g'
+            echo "repointed $(printf '%s\n' "$matches" | wc -l) bundle file(s) at :3001"
+          fi
+          # Assert the END STATE rather than the edit: the whole suite fails at login if the served
+          # bundle talks to the wrong port, and that must not be discovered 79 specs later.
+          if grep -rq 'localhost:3000' dist/apps/gauzy --include='*.js'; then
+            echo "::error::dist/apps/gauzy still references localhost:3000 after the rewrite"; exit 1
+          fi
+          if ! grep -rq 'localhost:3001' dist/apps/gauzy --include='*.js'; then
+            echo "::error::dist/apps/gauzy references no API URL on :3001 — the built bundle would never reach the e2e API"; exit 1
+          fi
+        env:
+          NX_NO_CLOUD: true
+          NX_ISOLATE_PLUGINS: 'false'
+          NX_DAEMON: 'false'
+
+      - name: Pack build output
+        shell: bash
+        # One tarball per app instead of raw directories: dist/apps/api alone is ~17k files (the
+        # copied @gauzy/* packages) and upload/download-artifact is far slower per-file than
+        # per-byte. Source maps are dropped — nothing in an e2e run reads them (headless Chromium
+        # only fetches .map with devtools open, node only with --enable-source-maps) and they are
+        # roughly half the payload.
+        run: |
+          tar --exclude='*.map' -cf api-dist.tar dist/apps/api
+          tar --exclude='*.map' -cf web-dist.tar dist/apps/gauzy
+          ls -lh api-dist.tar web-dist.tar
+
+      - name: Upload prebuilt API + Web bundles
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-dist
+          path: |
+            api-dist.tar
+            web-dist.tar
+          # Consumed by the e2e jobs of this same run only — no reason to keep it around.
+          retention-days: 1
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------------------------
+  # 3) e2e — boot the prebuilt stack and run one Playwright shard. Compiles nothing.
+  # ---------------------------------------------------------------------------------------------
+  e2e-playwright:
+    name: e2e (shard ${{ matrix.shard }})
+    needs: [deps, build]
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    # Fixed cost per shard is ~25 min (cache restore + artifact download + browser install + the
+    # API's fresh-DB seed); the shard's own tests are capped at 75 min by the step timeout below,
+    # which leaves the job room to still upload its report before this ceiling.
+    timeout-minutes: 120
+    strategy:
+      # One evicted / failing shard must not cancel the others — a partial result set can still be
+      # triaged, a cancelled one cannot.
+      fail-fast: false
+      matrix:
+        # playwright.config.ts pins workers:1 in CI (one accumulating sqlite DB per runner), so
+        # wall-clock only comes down by splitting across containers, exactly as that config says
+        # ("shard across CI containers instead"). Each shard gets its OWN API + freshly seeded DB,
+        # so shards cannot pollute each other. `strategy.job-total` used below is this list's
+        # length, so the shard count lives in one place.
+        shard: [1, 2, 3, 4]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Restore node_modules cache
+        id: cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+            packages/plugins/*/node_modules
+            tools/node_modules
+          key: ${{ needs.deps.outputs.node-modules-key }}
+
+      - name: Install Packages & Bootstrap (cache fallback)
+        if: steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        # node_modules is still needed at runtime here: the API bundle keeps third-party deps
+        # external, and Playwright/playwright-bdd run from it.
+        run: |
+          echo "::warning::node_modules cache miss — falling back to a full bootstrap (1-3 h on these runners)."
+          yarn bootstrap \
+            || { echo "::warning::yarn bootstrap failed — retry 1"; yarn bootstrap; }
 
       - name: Install forever package
         shell: bash
@@ -62,16 +325,49 @@ jobs:
         shell: bash
         run: echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
+      - name: Download prebuilt API + Web bundles
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-dist
+          path: .artifacts
+
+      - name: Unpack prebuilt API + Web bundles
+        shell: bash
+        # Both tarballs carry workspace-root-relative paths, so they land exactly where the API
+        # (dist/apps/api) and the static server (dist/apps/gauzy) expect them. Clear the targets
+        # first: this runner's filesystem persists between runs (same reason the DB is reset
+        # below), and tar only overwrites — leftovers from an older build would linger.
+        run: |
+          rm -rf dist/apps/api dist/apps/gauzy
+          tar -xf .artifacts/api-dist.tar
+          tar -xf .artifacts/web-dist.tar
+          test -f dist/apps/api/main.js || { echo "::error::dist/apps/api/main.js missing after unpack"; exit 1; }
+          test -f dist/apps/gauzy/index.html || { echo "::error::dist/apps/gauzy/index.html missing after unpack"; exit 1; }
+          # The bundle this job is about to serve must point at the API port this job starts.
+          if grep -rq 'localhost:3000' dist/apps/gauzy --include='*.js'; then
+            echo "::error::served web bundle still references localhost:3000 — the :3001 rewrite did not survive the build job"; exit 1
+          fi
+          echo "✅ unpacked API + web bundles (web repointed at :3001)"
+
       - name: Reset DB for a clean, deterministic seed
         shell: bash
         # The self-hosted runner persists the filesystem; a stale/accumulated DB from a prior run
         # causes flaky failures (duplicate names, wrong grid counts) or a demo-state onboarding
         # redirect. Start each run from an empty DB so the API auto-seeds the default org/admin.
+        # MUST stay in the job that runs the tests, immediately before the API boots.
         run: rm -f apps/api/data/gauzy.sqlite3*
 
       - name: Run API in background
-        run: yarn start:api:forever
+        shell: bash
+        # Was `yarn start:api:forever` (forever + `nx serve api`). `nx serve` only builds and then
+        # runs dist/apps/api/main.js, and that build now happens in the `build` job — so run the
+        # prebuilt bundle directly. Same file, same workspace-root cwd — which is what both the
+        # .env lookup and the sqlite path in @gauzy/config resolve against — minus the webpack
+        # watcher.
+        run: forever start dist/apps/api/main.js
         env:
+          # The heap ceiling `start:api:forever` used.
+          NODE_OPTIONS: --max-old-space-size=12288
           DEMO: 'false'
           # MUST be set in the process env (not just .env) before the API starts: the sqlite-vs-postgres
           # column-type guards (isBetterSqlite3() in @gauzy/config) are captured at module load, before
@@ -83,27 +379,18 @@ jobs:
           API_PORT: '3001'
           API_BASE_URL: 'http://localhost:3001'
 
-      - name: Build Web (gauzy) for static serving
-        # The Angular dev server (nx serve gauzy) OOMs over a long e2e run. Build once and serve the
-        # static output instead — stable + low memory. The app uses hash routing + an absolute API
-        # URL baked into the bundle, so a plain static file server is sufficient (no proxy/SPA fallback).
-        shell: bash
-        run: |
-          yarn nx build gauzy -c local || { echo "::warning::gauzy build failed — retry 1 (nx cache skips done deps)"; yarn nx build gauzy -c local; }
-          # The bundle bakes the API URL as http://localhost:3000; the API runs on :3001 here (shared
-          # runner), so repoint the built bundle at :3001 to match.
-          grep -rl 'localhost:3000' dist/apps/gauzy --include='*.js' | xargs -r sed -i 's#localhost:3000#localhost:3001#g'
-        env:
-          NX_NO_CLOUD: true
-          NX_ISOLATE_PLUGINS: 'false'
-          NX_DAEMON: 'false'
-          NODE_OPTIONS: --max-old-space-size=24576
-
       - name: Serve Web (static) in background
         run: forever start apps/gauzy-e2e/tools/serve-web.js dist/apps/gauzy 4200
 
       - name: Install Playwright browser (chromium)
-        run: npx playwright install --with-deps chromium
+        shell: bash
+        # `--with-deps` shells out to apt-get via sudo, which the k8s ARC container runners do not
+        # have (same constraint as the npm global prefix above). Fall back to the browser-only
+        # install rather than losing the whole shard — the runner image already carries the shared
+        # libraries chromium needs.
+        run: |
+          npx playwright install --with-deps chromium \
+            || { echo "::warning::playwright install --with-deps failed (no sudo/apt?) — installing the browser only"; npx playwright install chromium; }
 
       - name: Wait for API and Web to be ready
         shell: bash
@@ -142,9 +429,14 @@ jobs:
         # MUST be bash: `run:` defaults to PowerShell on this Windows self-hosted runner, where `&&` is a
         # parse error (FullyQualifiedErrorId: InvalidEndOfLine) — so the chained command never runs.
         shell: bash
+        # Step budget deliberately below the job's, so a shard that overruns still reaches the
+        # report upload below instead of being killed together with the job.
+        timeout-minutes: 75
         # bddgen regenerates the Playwright specs from the .feature (Gherkin) files + step definitions
         # before the run; the plain *.spec.ts and the generated BDD specs run together (see playwright.config).
-        run: npx bddgen && npx playwright test
+        # --shard splits the FULL suite across the matrix jobs — no spec is skipped or filtered, each
+        # shard runs its slice with the same retries/timeouts as before.
+        run: npx bddgen && npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           CI: 'true'
           E2E_BASE_URL: http://localhost:4200
@@ -153,6 +445,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report
+          # One report per shard — download all four to triage a full run.
+          name: playwright-report-shard-${{ matrix.shard }}
           path: apps/gauzy-e2e/playwright-report
           retention-days: 14


### PR DESCRIPTION
## The e2e suite has never actually run in CI

The `e2e-playwright` check has been red, but **not because of test failures** — the job dies during setup and never reaches the `Run Playwright tests` step. Across the last four runs on develop:

| Run | `Install Packages & Bootstrap` | Died |
|---|---|---|
| 30594240884 | 88 min (succeeded) | 23 min into `Build Web` |
| 30267765989 | 3 h 28 min (succeeded) | 47 min into `Build Web` |
| 30224003351 | 1 h 40 min (succeeded) | 24 min into `Build Web` |
| 30330950619 | failed after 9 min | — |

In every case `Run Playwright tests` is still `pending` when the job stops. So "e2e green" has been unreachable regardless of test quality.

Two distinct causes, not one:

1. **`yarn bootstrap` costs 1.5–3.5 hours** (8.9 GB, ~900k files) and is repaid on every run.
2. **The web build is where the pod vanishes.** Likely contributor: `NODE_OPTIONS=--max-old-space-size=24576` sets a 24 GB heap ceiling on a memory-limited pod, so V8 can grow past the cgroup limit. A kernel OOM-kill of the runner presents on GitHub exactly as observed — job stops, step stuck `pending`, no failed step.

## What changed

`deps` → `build` → `e2e` × 4 shards.

- **node_modules cache is the linchpin.** Splitting jobs *without* it would be worse — each job would repay the install. `deps` pays it once per lockfile and publishes to the Actions cache. Exact key only, no `restore-keys`: a partially-matching `node_modules` is worse than none. Save is an explicit `actions/cache/save` step so a *failed* bootstrap can never publish a half-installed tree.
- **Artifacts instead of rebuilding the API.** `nx serve api` is just `nx build api` + `node main.js` (`@nx/js:node`), and `.deploy/api/Dockerfile` runs `CMD ["node","main.js"]` — the same path used in production. `build` produces the bundle once; shards run it directly, with no webpack watcher competing for pod RAM.
- **Sharding is justified by retries, not just length.** The config pins `workers: 1` in CI and its own comment says "shard across CI containers instead". With `retries: 2` and 24 currently-failing specs, a serial run can burn hours on retries alone. Each shard gets its own API and freshly seeded DB, so shards cannot pollute each other.
- **Heap sized to the container** rather than a fixed 24 GB: reads the cgroup limit (v2 then v1), takes 75%, clamps to [4 GB, 24 GB], falls back to 12288 MB with a `::warning::`.

**Rejected: reusing the published Docker images.** They are production images (postgres defaults, no dev deps, no Playwright), the container runners cannot be assumed to run docker, and the image for a given SHA is built by an independent workflow with no ordering guarantee.

## Preserved deliberately

Every hard-won detail in the old workflow is intact: no `nx serve` (it OOMs over a long run — still builds once and serves static); the `:3000`→`:3001` bundle rewrite, now moved into `build` so the artifact the test job serves is already correct **and asserted** rather than assumed; the deterministic DB reset, still immediately before the API starts; the retry-once wrappers; `--parallel=1`; the npm-prefix workaround; the fail-fast `forever … STOPPED` wait loop; and `Upload Playwright report` with `if: always()` (now one artifact per shard).

**Not weakened:** no `continue-on-error`, no `--grep`, no spec removal, same retries, timeouts and reporters. This PR makes CI *able* to run the suite — it does not make the check green. The suite currently has 24 real failures, fixed separately.

## Verification

PyYAML parse; `@action-validator/cli` schema check (confirmed it flags a deliberately broken file); all 20 `run:` blocks extracted and checked with `bash -n` under `set -eo pipefail`, which caught two real bugs pre-commit; cspell clean. Artifact/path flow traced by hand against `project.json` output paths, including that `packages/config/src/lib/database.ts:294` still resolves the sqlite path correctly under the new launch path.

## Biggest assumption

**Whether the Actions cache service is usable from these ARC runners at all**, and what a ~9 GB save/restore costs there. If it is not, every job falls back to a full bootstrap and emits a loud `::warning::`, and the shards would blow their budget. The first run answers this — as it also answers the OOM theory, since the heap-sizing step prints the detected cgroup limit.

Note: the check name changes from `e2e-playwright` to `e2e (shard N)`. Matrix jobs cannot keep a single stable name; this workflow does not run on `pull_request`, so it is not a required PR check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the CI `Playwright` workflow into `deps` → `build` → `e2e` (4 shards) so tests actually run, using cached `node_modules` and prebuilt API/Web artifacts. Sizes the Node heap to the container to avoid OOMs and serves the built web statically; each shard uploads its own report.

- **Refactors**
  - `deps`: runs `yarn bootstrap` once, publishes exact-key cache via `actions/cache` with explicit save.
  - `build`: uses `nx build api` and `nx build gauzy`, rewrites `localhost:3000` → `:3001`, asserts rewrite, uploads tar artifacts.
  - `e2e`: runs `playwright test --shard=i/n` with `fail-fast: false`; each shard restores cache/artifacts, seeds a fresh DB, and starts its own API + static web via `forever`.
  - Timeouts: 240 (deps) / 120 (build) / 120 (e2e job), with a 75-min `Playwright` step to ensure report upload.
  - cspell: adds `nproc` to the dictionary used in heap-sizing logs.

- **Bug Fixes**
  - Replaces fixed `NODE_OPTIONS=--max-old-space-size=24576` with a cgroup-derived cap (75% of container RAM, clamped to 4–24 GB).
  - Adds retry-once for bootstrap/build; `playwright install --with-deps` falls back to browser-only on ARC runners.
  - Ensures deterministic DB reset per shard; uploads per-shard reports via `actions/upload-artifact`.

<sup>Written for commit b5d0a60f500d141b1151b49f5e84430c9efc40fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

