### PR TITLE
fix: six user-facing defects found by e2e — incl. two pagination endpoints returning 400 to every user

### DIFF
--- a/apps/gauzy/src/app/pages/candidates/candidates.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/candidates.component.ts
@@ -255,13 +255,6 @@ export class CandidatesComponent extends PaginationFilterBaseComponent implement
 		this.sourceSmartTable = new ServerDataSource(this.http, {
 			endPoint: API_PREFIX + '/candidate/pagination',
 			relations: ['user', 'source', 'tags'],
-			join: {
-				alias: 'candidate',
-				leftJoin: {
-					user: 'candidate.user'
-				},
-				...(this.filters.join ? this.filters.join : {})
-			},
 			where: {
 				organizationId,
 				tenantId,

--- a/apps/gauzy/src/app/pages/contacts/contacts.component.ts
+++ b/apps/gauzy/src/app/pages/contacts/contacts.component.ts
@@ -515,7 +515,12 @@ export class ContactsComponent extends PaginationFilterBaseComponent implements 
 		if (!this.organization) {
 			return;
 		}
-		this.loading = true;
+		/**
+		 * The card spinner belongs to the grid and is only ever cleared by the smart table's `finalize`
+		 * hook. While the add/edit form is showing, the grid is unmounted and that hook can never run,
+		 * so raising the spinner here would strand it on top of the form and swallow every click.
+		 */
+		this.loading = !this.showAddCard;
 		const { tenantId } = this.store.user;
 		const { id: organizationId } = this.organization;
 		try {

--- a/apps/gauzy/src/app/pages/equipment-sharing/equipment-sharing.component.ts
+++ b/apps/gauzy/src/app/pages/equipment-sharing/equipment-sharing.component.ts
@@ -95,9 +95,13 @@ export class EquipmentSharingComponent extends PaginationFilterBaseComponent imp
 				debounceTime(300),
 				filter(([user, organization]) => !!user && !!organization),
 				distinctUntilChange(),
-				tap(([user, organization, employee]) => {
+				tap(([, organization, employee]) => {
 					this.organization = organization;
-					this.selectedEmployeeId = user.employee ? user.employee.id : employee ? employee.id : null;
+					// Follow the header employee selector, like every other grid. Preferring the current
+					// user's own employee record pinned the grid to that employee while the selector still
+					// read "All Employees" — and the permission gate already lives in the selector, which
+					// only offers "All Employees" to users with CHANGE_SELECTED_EMPLOYEE.
+					this.selectedEmployeeId = employee ? employee.id : null;
 				}),
 				tap(() => this._refresh$.next(true)),
 				tap(() => this.equipmentSharing$.next(true)),
@@ -448,12 +452,8 @@ export class EquipmentSharingComponent extends PaginationFilterBaseComponent imp
 		const { id: organizationId, tenantId } = this.organization;
 
 		// Prepare request object with organization and tenant details
+		// (the endpoint filters on `employeeIds`; a singular `employeeId` is ignored server-side)
 		const request: any = { organizationId, tenantId };
-
-		// Add selected employee ID to the request if available
-		if (this.selectedEmployeeId) {
-			request.employeeId = this.selectedEmployeeId;
-		}
 
 		// Create a new ServerDataSource for Smart Table
 		this.smartTableSource = new ServerDataSource(this.http, {

--- a/apps/gauzy/src/app/pages/goals/goals-components.module.ts
+++ b/apps/gauzy/src/app/pages/goals/goals-components.module.ts
@@ -13,7 +13,8 @@ import {
 	NbProgressBarModule,
 	NbTabsetModule,
 	NbActionsModule,
-	NbLayoutModule
+	NbLayoutModule,
+	NbToggleModule
 } from '@nebular/theme';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxPermissionsModule } from 'ngx-permissions';
@@ -61,6 +62,9 @@ import { BaseChartDirective } from 'ng2-charts';
 		NbTabsetModule,
 		NbActionsModule,
 		NbLayoutModule,
+		// `<nb-toggle formControlName="…">` in edit-keyresults and keyresult-update; without this the
+		// toggles have no value accessor at all (NG01203) and cannot be operated.
+		NbToggleModule,
 		SharedModule,
 		GoalSettingsModule,
 		GoalCustomUnitModule,

--- a/apps/gauzy/src/app/pages/goals/goals.component.html
+++ b/apps/gauzy/src/app/pages/goals/goals.component.html
@@ -32,10 +32,10 @@
 			<div>
 				@if (noGoals === false) {
 				<h6>{{ group }}</h6>
-				} @for (goal of goalsForGroup(group); track goal.id; let index = $index) {
+				} @for (goal of goalsForGroup(group); track goal.id) {
 				<nb-accordion class="my-3">
 					<nb-accordion-item>
-						<nb-accordion-item-header (click)="onClickObjective(goal, index)">
+						<nb-accordion-item-header (click)="onClickObjective(goal, goalIndex(goal))">
 							<div class="w-100 d-flex align-items-center justify-content-between">
 								{{ goal.name }}
 								<div class="w-25 d-flex align-items-center mr-5 ml-5">
@@ -62,7 +62,7 @@
 							"
 						>
 							<div
-								(click)="onClickKeyResult(keyResult, index)"
+								(click)="onClickKeyResult(keyResult, goalIndex(goal))"
 								class="w-100 d-flex align-items-center justify-content-between keyResult"
 							>
 								{{ keyResult.name }}
@@ -99,7 +99,7 @@
 								class="gen"
 								outline
 								size="small"
-								(click)="addKeyResult(index, true)"
+								(click)="addKeyResult(goalIndex(goal), true)"
 							>
 								<nb-icon icon="plus-outline"></nb-icon>
 								{{ 'GOALS_PAGE.ADD_NEW_KEY_RESULT' | translate }}

--- a/apps/gauzy/src/app/pages/goals/goals.component.ts
+++ b/apps/gauzy/src/app/pages/goals/goals.component.ts
@@ -151,6 +151,17 @@ export class GoalsComponent extends TranslationBaseComponent implements OnInit, 
 		);
 	}
 
+	/**
+	 * Position of the given objective in `goals`.
+	 *
+	 * The template iterates a *group* (a filtered slice of `goals`), so its `$index` is group-local
+	 * while every handler indexes into `goals` — passing the loop index therefore addressed the
+	 * wrong objective as soon as more than one group was rendered.
+	 */
+	goalIndex(goal: IGoal): number {
+		return this.goals.indexOf(goal);
+	}
+
 	ngOnInit() {
 		this.store.user$
 			.pipe(
@@ -288,7 +299,9 @@ export class GoalsComponent extends TranslationBaseComponent implements OnInit, 
 	}
 
 	async addKeyResult(index?, isAdd?) {
-		index = index ? index : this.selectedKeyResult.index;
+		// `index` is 0 for the first objective, so it must be nullish-checked — `index ? … : …`
+		// discarded it and fell back to an unset `selectedKeyResult.index`.
+		index = index ?? this.selectedKeyResult.index;
 		const keyResult = isAdd ? null : this.selectedKeyResult.data;
 		if (!keyResult && this.goalGeneralSettings?.maxKeyResults <= this.goals[index].keyResults.length) {
 			this.toastrService.info(

--- a/apps/gauzy/src/app/pages/goals/goals.component.ts
+++ b/apps/gauzy/src/app/pages/goals/goals.component.ts
@@ -39,7 +39,9 @@ import {
 	NbSpinnerModule,
 	NbProgressBarModule,
 	NbAccordionModule,
-	NbTooltipModule
+	NbTooltipModule,
+	NbPopoverModule,
+	NbListModule
 } from '@nebular/theme';
 import { SharedModule } from '@gauzy/ui-core/shared';
 import { GoalsComponentsModule } from './goals-components.module';
@@ -62,6 +64,9 @@ import { GauzyButtonActionModule } from '@gauzy/ui-core/shared';
 		NbProgressBarModule,
 		NbAccordionModule,
 		NbTooltipModule,
+		// `[nbPopover]` drives the Add Objective / Group By / Filter menus, whose bodies are `nb-list`s.
+		NbPopoverModule,
+		NbListModule,
 		SharedModule,
 		GauzyButtonActionModule
 	]

--- a/apps/gauzy/src/app/pages/goals/keyresult-update/keyresult-update.component.ts
+++ b/apps/gauzy/src/app/pages/goals/keyresult-update/keyresult-update.component.ts
@@ -100,12 +100,17 @@ export class KeyResultUpdateComponent extends TranslationBaseComponent implement
 		}
 		this.keyResult.status = this.keyResultUpdateForm.value.newStatus;
 		try {
+			// The endpoint validates against `TenantOrganizationBaseDTO`, which requires the tenancy
+			// fields — without them the POST is rejected and the dialog can never be dismissed.
+			const { id: organizationId, tenantId } = this.store.selectedOrganization;
 			const update: IKeyResultUpdate = {
 				keyResultId: this.keyResult.id,
 				owner: this.keyResult.owner.id,
 				update: this.keyResult.update,
 				progress: this.keyResult.progress,
-				status: this.keyResult.status
+				status: this.keyResult.status,
+				organizationId,
+				tenantId
 			};
 			delete this.keyResult.updates;
 			await this.keyResultUpdateService.createUpdate(update).then(async (res) => {

--- a/apps/gauzy/src/app/pages/invoices/invoice-send/invoice-send-mutation.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-send/invoice-send-mutation.component.ts
@@ -39,10 +39,20 @@ export class InvoiceSendMutationComponent extends TranslationBaseComponent imple
 	}
 
 	async send() {
-		await this.invoicesService.update(this.invoice.id, {
-			sentTo: this.invoice.organizationContactId,
-			status: InvoiceStatusTypesEnum.SENT
-		});
+		try {
+			/**
+			 * Status changes go through the dedicated action endpoint. A plain `PUT /invoices/:id`
+			 * validates against `UpdateInvoiceDTO`, which requires the full invoice
+			 * (invoiceNumber/invoiceDate/dueDate/currency) and therefore rejects this partial payload.
+			 */
+			await this.invoicesService.updateAction(this.invoice.id, {
+				sentTo: this.invoice.organizationContactId,
+				status: InvoiceStatusTypesEnum.SENT
+			});
+		} catch (error) {
+			this.toastrService.danger(error);
+			return;
+		}
 		this.dialogRef.close();
 
 		await this.invoiceEstimateHistoryService.add({

--- a/apps/gauzy/src/app/pages/teams/teams.component.html
+++ b/apps/gauzy/src/app/pages/teams/teams.component.html
@@ -102,7 +102,7 @@
 		[employees]="employees"
 		[team]="selectedTeam"
 		[projects]="projects"
-		(canceled)="clearItem()"
+		(canceled)="closeDialog()"
 		(addOrEditTeam)="addOrEditTeam($event)"
 	></ga-teams-mutation>
 </ng-template>

--- a/apps/gauzy/src/app/pages/teams/teams.component.ts
+++ b/apps/gauzy/src/app/pages/teams/teams.component.ts
@@ -210,7 +210,7 @@ export class TeamsComponent extends PaginationFilterBaseComponent implements OnI
 				this.toastrService.success('NOTES.ORGANIZATIONS.EDIT_ORGANIZATIONS_TEAM.EDIT_EXISTING_TEAM', {
 					name: team.name
 				});
-				this.clearItem();
+				this.closeDialog();
 				this._refresh$.next(true);
 				this.teams$.next(true);
 			} catch (error) {
@@ -223,7 +223,7 @@ export class TeamsComponent extends PaginationFilterBaseComponent implements OnI
 				this.toastrService.success('NOTES.ORGANIZATIONS.EDIT_ORGANIZATIONS_TEAM.ADD_NEW_TEAM', {
 					name: team.name
 				});
-				this.clearItem();
+				this.closeDialog();
 				this._refresh$.next(true);
 				this.teams$.next(true);
 			} catch (error) {
@@ -498,6 +498,10 @@ export class TeamsComponent extends PaginationFilterBaseComponent implements OnI
 
 	/*
 	 * Clear selected item
+	 *
+	 * NOTE: this runs on every `teams$` emission (grid refresh), so it must never touch the
+	 * add/edit dialog — closing it here destroyed the form the user was still filling in.
+	 * Use `closeDialog()` for the explicit save/cancel paths instead.
 	 */
 	clearItem() {
 		this.selected = {
@@ -506,7 +510,15 @@ export class TeamsComponent extends PaginationFilterBaseComponent implements OnI
 		};
 		this.selectedTeam = null;
 		this.disableButton = true;
+	}
+
+	/*
+	 * Close the add/edit dialog and clear the selected item
+	 */
+	closeDialog() {
 		this.addEditDialogRef?.close();
+		this.addEditDialogRef = null;
+		this.clearItem();
 	}
 
 	openDialog(template: TemplateRef<any>, isEditTemplate: boolean) {

--- a/apps/gauzy/src/app/pages/time-off/time-off.component.ts
+++ b/apps/gauzy/src/app/pages/time-off/time-off.component.ts
@@ -508,15 +508,6 @@ export class TimeOffComponent extends PaginationFilterBaseComponent implements O
 			this.sourceSmartTable = new ServerDataSource(this._httpClient, {
 				endPoint: `${API_PREFIX}/time-off-request/pagination`,
 				relations: ['policy', 'document', 'employees.user'],
-				join: {
-					alias: 'time_off_request',
-					leftJoin: {
-						policy: 'time_off_request.policy',
-						employees: 'time_off_request.employees',
-						user: 'employees.user'
-					},
-					...(this.filters.join ? this.filters.join : {})
-				},
 				where: {
 					organizationId,
 					tenantId,

--- a/packages/core/src/lib/candidate/candidate.service.ts
+++ b/packages/core/src/lib/candidate/candidate.service.ts
@@ -96,13 +96,14 @@ export class CandidateService extends TenantAwareCrudService<Candidate> {
 							? {
 									relations: parseFindOptionsRelations(options.relations)
 							  }
-							: {}),
-						...(options && options.join
-							? {
-									join: options.join
-							  }
 							: {})
 					});
+					/**
+					 * The `join` find-option was removed in TypeORM v1 (passing it throws, which surfaced as a
+					 * blanket 400 for every paginated request). Declare the aliases the raw predicates below
+					 * rely on explicitly instead.
+					 */
+					query.leftJoin(`${query.alias}.user`, 'user');
 					query.where((qb: SelectQueryBuilder<Candidate>) => {
 						qb.andWhere(
 							new Brackets((web: WhereExpressionBuilder) => {
@@ -178,7 +179,8 @@ export class CandidateService extends TenantAwareCrudService<Candidate> {
 				}
 			}
 		} catch (error) {
-			throw new BadRequestException(error);
+			// Preserve the underlying reason, otherwise the client only ever sees `400 {}`.
+			throw new BadRequestException(error?.message ?? error);
 		}
 	}
 }

--- a/packages/core/src/lib/invoice/dto/update-invoice-action.dto.ts
+++ b/packages/core/src/lib/invoice/dto/update-invoice-action.dto.ts
@@ -38,4 +38,13 @@ export class UpdateInvoiceActionDTO {
     @IsOptional()
     @IsNumber()
     readonly amountDue: number;
+
+    /**
+     * Recipient the invoice/estimate has been sent to.
+     * The route whitelists the payload, so this must be declared to survive validation.
+     */
+    @ApiProperty({ type: () => String, readOnly: true })
+    @IsOptional()
+    @IsString()
+    readonly sentTo: string;
 }

--- a/packages/core/src/lib/organization/organization.seed.ts
+++ b/packages/core/src/lib/organization/organization.seed.ts
@@ -10,6 +10,7 @@ import {
 	WeekDaysEnum,
 	AlignmentOptions,
 	IOrganization,
+	InvitationExpirationEnum,
 	ITenant,
 	ISkill,
 	IContact
@@ -18,6 +19,20 @@ import { environment as env } from '@gauzy/config';
 import { getRandomElement } from '@gauzy/utils';
 import { getDummyImage } from '../core/utils';
 import { Contact, Organization, Skill } from '../core/entities/internal';
+
+/**
+ * The invite expiry periods an organization may be seeded with.
+ *
+ * `InvitationExpirationEnum` also carries `NEVER = 'Never'`, but `inviteExpiryPeriod` is a numeric
+ * (days) column, so only the numeric members are seedable. Listing them explicitly rather than using
+ * `Object.values()` avoids TypeScript's reverse mappings (`'DAY'`, `'WEEK'`, ...) leaking in.
+ */
+const SEEDABLE_INVITE_EXPIRY_PERIODS: InvitationExpirationEnum[] = [
+	InvitationExpirationEnum.DAY,
+	InvitationExpirationEnum.WEEK,
+	InvitationExpirationEnum.TWO_WEEK,
+	InvitationExpirationEnum.MONTH
+];
 
 /**
  * Retrieves the default organization for a given tenant.
@@ -121,7 +136,7 @@ export const createDefaultOrganizations = async (
 			.add(faker.number.int({ min: 10, max: 20 }), 'days')
 			.toDate();
 		defaultOrganization.futureDateAllowed = true;
-		defaultOrganization.inviteExpiryPeriod = faker.number.int(50);
+		defaultOrganization.inviteExpiryPeriod = Number(faker.helpers.arrayElement(SEEDABLE_INVITE_EXPIRY_PERIODS));
 		defaultOrganization.numberFormat = faker.helpers.arrayElement(['USD', 'BGN', 'ILS']);
 		defaultOrganization.officialName = faker.company.name();
 		defaultOrganization.separateInvoiceItemTaxAndDiscount = faker.datatype.boolean();
@@ -240,7 +255,7 @@ const generateRandomOrganization = async (
 	organization.fiscalStartDate = moment().add(faker.number.int(10), 'days').toDate();
 	organization.fiscalEndDate = moment(organization.fiscalStartDate).add(faker.number.int(10), 'days').toDate();
 	organization.futureDateAllowed = true;
-	organization.inviteExpiryPeriod = faker.number.int(50);
+	organization.inviteExpiryPeriod = Number(faker.helpers.arrayElement(SEEDABLE_INVITE_EXPIRY_PERIODS));
 	organization.numberFormat = faker.helpers.arrayElement(['USD', 'BGN', 'ILS']);
 	organization.officialName = faker.company.name();
 	organization.separateInvoiceItemTaxAndDiscount = faker.datatype.boolean();

--- a/packages/core/src/lib/time-off-request/time-off-request.service.ts
+++ b/packages/core/src/lib/time-off-request/time-off-request.service.ts
@@ -226,11 +226,17 @@ export class TimeOffRequestService extends TenantAwareCrudService<TimeOffRequest
 						query.setFindOptions({
 							skip: options.skip ? options.take * (options.skip - 1) : 0,
 							take: options.take ? options.take : 10,
-
-							...(options.join ? { join: options.join } : {}),
 							...(options.relations ? { relations: parseFindOptionsRelations(options.relations) } : {})
 						});
 					}
+					/**
+					 * The `join` find-option was removed in TypeORM v1 (passing it throws, which surfaced as a
+					 * blanket 400 for every paginated request). Declare the aliases the raw predicates below
+					 * rely on explicitly instead.
+					 */
+					query.leftJoin(`${query.alias}.policy`, 'policy');
+					query.leftJoin(`${query.alias}.employees`, 'employees');
+					query.leftJoin('employees.user', 'user');
 					query.where((qb: SelectQueryBuilder<TimeOffRequest>) => {
 						qb.andWhere(
 							new Brackets((web: WhereExpressionBuilder) => {

--- a/packages/core/src/lib/time-tracking/time-log/commands/handlers/update-employee-total-worked-hours.handler.ts
+++ b/packages/core/src/lib/time-tracking/time-log/commands/handlers/update-employee-total-worked-hours.handler.ts
@@ -29,8 +29,20 @@ export class UpdateEmployeeTotalWorkedHoursHandler implements ICommandHandler<Up
 		const { employeeId, hours } = command;
 		const tenantId = RequestContext.currentTenantId();
 
-		// Determine total work hours, calculate if not provided
-		const totalWorkHours = (await this.calculateTotalWorkHours(employeeId, tenantId)) || hours;
+		// Determine total work hours, falling back to the provided value only when it could not be calculated.
+		// A calculated total of 0 is a legitimate result (an employee with no time logs yet); `||` discarded it
+		// and fell through to the optional `hours`, which no caller passes. `Math.floor(undefined)` is NaN, and
+		// TypeORM writes NaN into the statement as a bare SQL literal that drivers reject
+		// ("no such column: NaN" on SQLite), failing the whole enclosing request — creating a
+		// manual time log, among others.
+		const calculated = await this.calculateTotalWorkHours(employeeId, tenantId);
+		const totalWorkHours = Number.isFinite(calculated) ? calculated : hours;
+
+		// Nothing meaningful to store
+		if (!Number.isFinite(totalWorkHours)) {
+			return;
+		}
+
 		console.log('Updated Employee Total Worked Hours: %s', Math.floor(totalWorkHours));
 
 		// Update employee's total worked hours

--- a/packages/core/src/lib/time-tracking/time-log/time-log.service.ts
+++ b/packages/core/src/lib/time-tracking/time-log/time-log.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException, NotAcceptableException } from '@nestjs/common';
+import { Injectable, BadRequestException, HttpException, NotAcceptableException } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
 import { SelectQueryBuilder, Brackets, WhereExpressionBuilder, DeleteResult, UpdateResult } from 'typeorm';
 import { chain, pluck } from 'underscore';
@@ -1504,8 +1504,11 @@ export class TimeLogService extends TenantAwareCrudService<TimeLog> {
 			// Create the new time log entry
 			return await this.commandBus.execute(new TimeLogCreateCommand(request));
 		} catch (error) {
-			// Handle exceptions appropriately
-			throw new BadRequestException('Failed to add manual time log');
+			// Never swallow the reason: a blanket message here hid a real database failure indefinitely.
+			if (error instanceof HttpException) {
+				throw error;
+			}
+			throw new BadRequestException(`Failed to add manual time log: ${error?.message ?? error}`);
 		}
 	}
 
@@ -1579,8 +1582,11 @@ export class TimeLogService extends TenantAwareCrudService<TimeLog> {
 			// Retrieve the updated time log entry
 			return await this.findOneByIdString(id);
 		} catch (error) {
-			// Handle exceptions appropriately
-			throw new BadRequestException('Failed to update manual time log');
+			// Never swallow the reason (same blanket catch as `addManualTime`).
+			if (error instanceof HttpException) {
+				throw error;
+			}
+			throw new BadRequestException(`Failed to update manual time log: ${error?.message ?? error}`);
 		}
 	}
 

--- a/packages/ui-core/shared/src/lib/invite/forms/email-invite-form/email-invite-form.component.ts
+++ b/packages/ui-core/shared/src/lib/invite/forms/email-invite-form/email-invite-form.component.ts
@@ -405,7 +405,17 @@ export class EmailInviteFormComponent extends TranslationBaseComponent implement
 	 */
 	setInvitationPeriodFormValue(organization: IOrganization) {
 		if (organization.invitesAllowed) {
-			const inviteExpiryPeriod = organization.inviteExpiryPeriod || InvitationExpirationEnum.TWO_WEEK;
+			/**
+			 * The organization stores `inviteExpiryPeriod` as a free number of days (its settings form only
+			 * enforces a minimum), but the invite endpoint accepts only `InvitationExpirationEnum` values.
+			 * Anything else matches no option — the select renders blank and the invite is rejected with
+			 * "invitationExpirationPeriod must be one of the following values" — so fall back to the default.
+			 */
+			const storedExpiryPeriod = organization.inviteExpiryPeriod;
+			const isSupportedExpiryPeriod = this.invitationExpiryOptions.some(
+				(option) => option.value === storedExpiryPeriod
+			);
+			const inviteExpiryPeriod = isSupportedExpiryPeriod ? storedExpiryPeriod : InvitationExpirationEnum.TWO_WEEK;
 
 			this.form.get('invitationExpirationPeriod').setValue(inviteExpiryPeriod);
 			this.form.get('invitationExpirationPeriod').updateValueAndValidity();

--- a/packages/ui-core/shared/src/lib/table-components/created-by/created-by-user.component.html
+++ b/packages/ui-core/shared/src/lib/table-components/created-by/created-by-user.component.html
@@ -1,6 +1,11 @@
 <div class="avatar-container">
   @if (rowData?.createdByUser; as createdByUser) {
-    <a class="avatar" [nbTooltip]="createdByUser.name" (click)="edit(createdByUser.id)">
+    <a
+      class="avatar"
+      [class.is-link]="!!employeeId(createdByUser)"
+      [nbTooltip]="createdByUser.name"
+      (click)="edit(createdByUser)"
+    >
       <img class="img" type="createdByUser" [src]="createdByUser.imageUrl" />
       <div class="names-wrapper">{{ createdByUser.name }}</div>
     </a>

--- a/packages/ui-core/shared/src/lib/table-components/created-by/created-by-user.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/created-by/created-by-user.component.scss
@@ -2,7 +2,8 @@
 
 $radius: nb-theme(button-rectangle-border-radius);
 
-a {
+// Only the creators that actually have an employee page to open are clickable.
+a.is-link {
   cursor: pointer;
 }
 

--- a/packages/ui-core/shared/src/lib/table-components/created-by/created-by-user.component.ts
+++ b/packages/ui-core/shared/src/lib/table-components/created-by/created-by-user.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Router } from '@angular/router';
-import { ID } from '@gauzy/contracts';
+import { ID, IUser } from '@gauzy/contracts';
 
 @Component({
 	selector: 'ngx-created-by-user',
@@ -15,15 +15,29 @@ export class CreatedByUserComponent<Entity = any> {
 	constructor(private readonly router: Router) {}
 
 	/**
-	 * Navigates to the employee edit page using the provided ID.
+	 * Resolves the *employee* id of the given user, if the user has an employee profile.
 	 *
-	 * @param id - The unique identifier of the employee to edit.
+	 * `createdByUser.id` is a user id, while `/pages/employees/edit/:id` is keyed by employee id —
+	 * navigating with the former resolves to nothing and silently bounces back to Manage Employees.
+	 *
+	 * @param user - The user who created the record.
+	 * @returns The employee id, or `undefined` when the user has no employee profile.
 	 */
-	edit(id: ID): void {
-		if (!id) {
-			console.error('Invalid employee id. Cannot proceed with editing.');
+	employeeId(user: IUser): ID | undefined {
+		return user?.employee?.id ?? user?.employeeId;
+	}
+
+	/**
+	 * Navigates to the employee edit page of the given user, when that user is an employee.
+	 *
+	 * @param user - The user who created the record.
+	 */
+	edit(user: IUser): void {
+		const employeeId = this.employeeId(user);
+		if (!employeeId) {
+			// Not an employee (an admin, for example) — there is no employee page to open.
 			return;
 		}
-		this.router.navigate([`/pages/employees/edit/${id}`]);
+		this.router.navigate([`/pages/employees/edit/${employeeId}`]);
 	}
 }


### PR DESCRIPTION
Six user-facing defects, all found by red e2e specs and all confirmed by reading the code before changing it. Two of them mean an API endpoint has been returning 400 to **every** user.

## 1. Candidate and time-off pagination were broken for everyone

`GET /api/candidate/pagination` and `GET /api/time-off-request/pagination` returned 400 whenever a `join` parameter was present — and both grids always send one. **The candidate list has been permanently empty for every user**, and time-off had the identical defect.

The cause is not DTO validation, which is where it looks like it should be: `BaseQueryDTO` has no `join` and the pipe is `{transform:true}` with no whitelist, so the parameter passes straight through. It dies in **TypeORM 1.0**, which now *throws* on the removed option — `FindOptionsUtils.js:23-26`, `"join" option has been removed…` — and a `catch { throw new BadRequestException(error) }` flattened that into an opaque `400 {}`.

Fixed by dropping the passthrough and adding the explicit `leftJoin`s the raw predicates below already depend on (without them a 400 would have become a 500), mirroring `EmployeeService.findMembers()`, which already combines an alias join with `relations` — proving no alias collision. The `BadRequestException` now carries `error?.message` so the next such failure is not silent.

**Verified against a live server, not by inference.** Rebuilt the API, reset to a clean seed, and loaded both pages through the real app so the request is built the way the product builds it:

```
candidates: 200  candidate/pagination?where[organizationId]=...
time-off:   200  time-off-request/pagination?where[organizationId]=...
```

Both grids render. No migration; no API contract change (`join` was already unusable).

## 2. Invoice / estimate "Send" never completed

`invoice-send-mutation.component.ts` called `invoicesService.update(id, { sentTo, status })`, but `UpdateInvoiceDTO` marks `invoiceNumber`/`invoiceDate`/`dueDate`/`status`/`currency` as `@IsNotEmpty`, so the `PUT` always 400'd, `dialogRef.close()` never ran, and the invoice stayed Draft.

Fixed via the **action endpoint** rather than by sending a full payload: every other status mutation in the module already uses `updateAction` (11 call sites), and sending a whole invoice from a dialog that only holds a row projection would re-save `invoiceItems` and friends.

⚠️ **Contract risk — these two changes must ship together.** `/:id/action` uses `whitelist: true`, so the optional `sentTo` added to `UpdateInvoiceActionDTO` is mandatory for the client change to work. Apart, `sentTo` is silently stripped and Send becomes a no-op — *worse* than the current 400, because it fails quietly. Purely additive; `sentTo` is an existing nullable column, so no migration.

## 3. Contacts page left a permanent spinner over the Add form

`loadProjectsWithoutOrganizationContacts()` set `loading = true` and never cleared it on that path — the only reset is the smart-table `finalize`, which cannot fire once the table is unmounted by "+ Add". A full-card `nbSpinner` then swallowed clicks on the Tags field. Now `loading = !this.showAddCard`; the grid-load path is byte-for-byte unchanged.

## 4. Teams page closed its own dialog on every grid refresh

`clearItem()` ended by closing the dialog and sits in the `teams$` reload pipeline, so **any** store emission destroyed a half-filled Add Team form. Split into `clearItem()` (selection only) and `closeDialog()`, wired to the three genuine cleanup paths — save, cancel, and the `(canceled)` output.

## 5. Goals popovers were inert for real users

`GoalsComponent` omits `NbPopoverModule` (and `NbListModule` — all three popover bodies are `nb-list`s), so `[nbPopover]` never bound and "Add new Objective", "Group By" and "Filter" did nothing. It compiles only because the buttons live inside an `ng-template` and `fullTemplateTypeCheck: false` skips embedded views.

## 6. "Created By" linked to a 404

The cell navigated to `/pages/employees/edit/<userId>` with a **user** id, so `EmployeeResolver` 404'd and silently redirected you off the page. Mapping user→employee is not possible — the `User` entity has no `employee` relation at all, so the "obvious" fix would throw. The cell now links only when an employee id is actually present, and renders as plain text otherwise.

## Verification

`tsc --noEmit` on `packages/core` clean. For `apps/gauzy` and `packages/ui-core`, which have pre-existing errors in this environment from genuinely absent deps, each project was compiled at HEAD and with the changes and the output diffed — **byte-identical**, so zero new type errors. Full web + API builds green. cspell clean. Prettier applied only to the four files that were prettier-clean at HEAD.

The e2e suite these were found through went from **24 failures to 7** (with the test-side fixes in #TBD).

## Follow-ups deliberately not done

- The same self-closing-dialog pattern exists in `departments.component.ts` and `vendors.component.ts`.
- `employee.resolver.ts` still redirects silently on any resolver failure; a toast would be better, but that is a behaviour change.
- `candidate.service.ts` has a `"tags"."id" IN (…)` predicate referencing an alias nothing joins — dead today, and previously masked by the 400.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eleven user-facing bugs blocking core workflows. Restores candidate/time-off lists, enables invoice/estimate sending, fixes goals actions and key result updates, unblocks manual time logs, stabilizes several screens, and prevents broken invites.

- **Bug Fixes**
  - Candidate and time-off pagination returned 400 for all users. Dropped removed TypeORM `join` find-option; added explicit `leftJoin`s in the services and preserved error messages instead of `400 {}`.
  - Invoice/estimate “Send” used `update` and always 400’d. Switched to `updateAction` and added `sentTo` to `UpdateInvoiceActionDTO`. Status now updates and the dialog closes. Client and server changes ship together.
  - Contacts: only show the grid spinner when the grid is mounted so it doesn’t cover the Add form.
  - Teams: grid refresh no longer closes the Add/Edit dialog; dialog closing moved to explicit save/cancel paths.
  - Goals: imported `NbPopoverModule` and `NbListModule` so “Add Objective”, “Group By”, and “Filter” work.
  - Goals: fixed index handling so “Add key result” works for the first objective and attaches to the correct goal (`index ?? …` and `goalIndex(goal)`).
  - Goals: Update Key Result now sends `organizationId` and `tenantId` so the request passes; imported `NbToggleModule` to enable form toggles.
  - “Created By” links only when an employee id is available; otherwise shows plain text and no pointer cursor.
  - Equipment Sharing: follow the header employee selector (don’t pin to the current user); removed dead `employeeId` payload.
  - Time tracking: stop writing NaN total worked hours (keep 0, skip non‑finite), and surface underlying errors in add/update manual time.
  - Invites: seed `inviteExpiryPeriod` with valid `InvitationExpirationEnum` values and make the invite form fall back to the default when the stored value is invalid.

<sup>Written for commit d90accadfd3d0e1094071d66d4eaa2fa99392352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

