### PR TITLE
fix(e2e): 24 failures → 7 — two of our own regressions, a seed-org time bomb, and real order-dependence

### DIFF
--- a/apps/gauzy-e2e/playwright.config.ts
+++ b/apps/gauzy-e2e/playwright.config.ts
@@ -54,8 +54,9 @@ export default defineConfig({
 	 * rendered in Bulgarian/Hebrew and every english-text selector missed — two failures that had
 	 * nothing to do with the specs themselves.
 	 *
-	 * Serial execution roughly doubles local wall-clock (~47min -> ~90min); parallelising this suite
-	 * needs per-worker accounts/organizations, not a worker count. Shard across CI containers instead. */
+	 * Serial execution roughly doubles local wall-clock (~47min -> ~90min); running this suite in
+	 * parallel needs per-worker accounts/organizations, not a worker count. Shard across CI containers
+	 * instead. */
 	workers: 1,
 	reporter: process.env.CI
 		? [['list'], ['html', { open: 'never' }], ['junit', { outputFile: '../../dist/playwright/apps/gauzy-e2e/junit.xml' }]]

--- a/apps/gauzy-e2e/playwright.config.ts
+++ b/apps/gauzy-e2e/playwright.config.ts
@@ -43,8 +43,20 @@ export default defineConfig({
 	 * A retry re-creates only the spec's OWN uniquely-named data (its scoped selectors ignore foreign
 	 * rows), so it does not worsen cross-spec pollution. Local stays 0 for a clean signal (E2E_RETRY=1). */
 	retries: process.env.CI ? 2 : process.env.E2E_RETRY ? 1 : 0,
-	/* Opt out of parallel within a file; shard across CI containers instead. */
-	workers: process.env.CI ? 1 : undefined,
+	/* ALWAYS one worker — locally too, not just in CI.
+	 *
+	 * This suite is built around ONE accumulating database and ONE shared `admin@ever.co` login: specs
+	 * create data other specs consume, and several mutate account-wide state that is persisted server
+	 * side. Running two workers means two browser contexts driving the same account concurrently, and
+	 * the state one spec sets leaks into whatever happens to be running alongside it. That is not
+	 * hypothetical: with `undefined` (= half the CPU cores) locally, `change-language` switched the
+	 * account's preferredLanguage while `clients` and `contacts-leads` were mid-run, so their toolbars
+	 * rendered in Bulgarian/Hebrew and every english-text selector missed — two failures that had
+	 * nothing to do with the specs themselves.
+	 *
+	 * Serial execution roughly doubles local wall-clock (~47min -> ~90min); parallelising this suite
+	 * needs per-worker accounts/organizations, not a worker count. Shard across CI containers instead. */
+	workers: 1,
 	reporter: process.env.CI
 		? [['list'], ['html', { open: 'never' }], ['junit', { outputFile: '../../dist/playwright/apps/gauzy-e2e/junit.xml' }]]
 		: [['list'], ['html', { open: 'never' }]],

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/AddUserPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/AddUserPageObject.ts
@@ -1,5 +1,9 @@
 export const AddUserPage = {
 	addUserButtonCss: 'button.action.status-success',
+	// Full Name column filter input in the users smart-table header (tr.angular2-smart-filters). The
+	// grid pages at 10 and the shared serial DB accumulates users, so a just-added user lands on page 2
+	// and never renders — verifyUserExists then fails on a user that was created perfectly well.
+	nameFilterInputCss: 'th.angular2-smart-th.fullName input',
 	firstNameInputCss: '#firstName',
 	lastNameInputCss: '#lastName',
 	usernameInputCss: '#username',

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/DeleteOrganizationPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/DeleteOrganizationPageObject.ts
@@ -7,5 +7,11 @@ export const DeleteOrganizationPage = {
 	deleteButtonCss: 'button:has(nb-icon[icon="trash-2-outline"])',
 	// Data row in the smart-table (NOT the tr.angular2-smart-filters filter row); selecting it enables
 	// the toolbar Edit/Manage/Delete buttons.
-	selectOrganization: 'table > tbody > tr.angular2-smart-row'
+	selectOrganization: 'table > tbody > tr.angular2-smart-row',
+	// Name-column filter input in the smart-table header (tr.angular2-smart-filters). The organizations
+	// grid pages at 10 rows (minItemPerPage) and gains a row per add-organization / manage-organization /
+	// organization-public-page run on the shared serial DB, so the throwaway organization this spec
+	// creates is usually NOT on page 1. Typing its name narrows the grid to that single record.
+	// Column key is `name` (organizations.component.ts _loadSmartTableSettings).
+	nameFilterInputCss: 'th.angular2-smart-th.name input'
 };

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/EditUserPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/EditUserPageObject.ts
@@ -1,6 +1,11 @@
 export const EditUserPage = {
 	gridButtonCss: 'div.layout-switch > button',
 	selectTableRowCss: 'table > tbody > tr.angular2-smart-row',
+	// Full Name column filter input in the users smart-table header (tr.angular2-smart-filters). The
+	// shared serial DB accumulates users (seed admin + every faker user/employee earlier specs create),
+	// so the grid paginates at 10 and the user this spec just added lands on page 2 — not rendered, so
+	// neither the by-name verify nor the row click can find it. Same column key as RemoveUserPageObject.
+	nameFilterInputCss: 'th.angular2-smart-th.fullName input',
 	editButtonCss: 'button:has(nb-icon[icon="edit-outline"])',
 	orgTabButtonCss: 'ul.route-tabset > li > a.tab-link',
 	addOrgButtonCss: 'nb-card-header > button[status="success"]',

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/GoalsPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/GoalsPageObject.ts
@@ -17,7 +17,16 @@ export const GoalsPage = {
 	// ['', Validators.required]); without picking one the Save button stays disabled and no goal is
 	// created. The seed always provides active future time frames (Annual-<year> + quarters), so the
 	// select renders options under `.option-list nb-option`.
+	// NOTE: `#objective-deadline` is TWO different controls in edit-objective.component.html — an
+	// nb-select when the organization has time frames, and a plain "Add Time Frame" button when it has
+	// none (the id is reused). Goals.po handles both.
 	deadlineDropdownCss: '#objective-deadline',
+	// EditTimeFrameComponent, opened by that button (and reused by the Goals settings page).
+	timeFrameDialogCss: 'ga-edit-time-frame',
+	timeFrameNameInputCss: 'ga-edit-time-frame #time-frame-title',
+	timeFrameStartDateCss: 'ga-edit-time-frame #start-date',
+	timeFrameEndDateCss: 'ga-edit-time-frame #end-date',
+	timeFrameSaveButtonCss: 'ga-edit-time-frame nb-card-footer > button[status="success"]',
 	// The selectable key-result ROW inside the expanded accordion body — clicking it fires
 	// onClickKeyResult, which selects the key result so the toolbar swaps to the key-result actions
 	// (View / Edit / Weight%). The "Add new Key Result" body button is a sibling without this class.

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/GoalsPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/GoalsPageObject.ts
@@ -54,6 +54,13 @@ export const GoalsPage = {
 	weightTypeButtonCss: '.gauzy-button-container button.action:has(i.fa-percentage)',
 	weightParameterDropdownCss: '#key-result-weight',
 	saveDeadlineButtonCss: 'div.d-flex > button[status="success"]',
+	// The key-result UPDATE dialog (ga-keyresult-update) opens ON TOP of the key-result DETAILS dialog
+	// (ga-keyresult-details), so both are mounted at once and the bare footer / `div.d-flex` selectors
+	// above are ambiguous. Scope each control to its own dialog component.
+	keyResultUpdateDialogCss: 'ga-keyresult-update',
+	keyResultUpdateConfirmCss: 'ga-keyresult-update nb-card-footer > button[status="success"]',
+	keyResultDetailsDialogCss: 'ga-keyresult-details',
+	keyResultDetailsSaveCss: 'ga-keyresult-details div.d-flex > button[status="success"]',
 	progressBarCss: '.goals-container nb-progress-bar',
 	verifyGoalCss: '.goals-container nb-accordion-item-header',
 	// POLLUTION RESILIENCE: the shared seed/serial run can carry objectives from earlier specs, so a

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/ManageEmployeesPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/ManageEmployeesPageObject.ts
@@ -2,7 +2,13 @@ export const ManageEmployeesPage = {
 	gridButtonCss: 'div.layout-switch > button',
 	inviteButtonCss: 'button.action[status="info"]',
 	emailsInputCss: '#emails',
+	// Invite dialog's "Date when started work" (the invite dialog is the only thing open at that point).
 	dateInputCss: '[formcontrolname="startedWorkOn"]',
+	// Add-Employee dialog's own start-work date. It has NO id, so the bare
+	// `[formcontrolname="startedWorkOn"]` matches this AND the invite dialog's field whenever the
+	// invite dialog is still mounted (e.g. its Send failed), and clearField()/enterInput() — which have
+	// no .first() — die on a Playwright strict-mode violation instead of reporting the real problem.
+	employeeDateInputCss: 'ga-employee-mutation [formcontrolname="startedWorkOn"]',
 	selectProjectDropdownCss: '#projectSelection',
 	selectProjectDropdownOptionCss: 'div.ng-option > span.ng-option-label',
 	sendInviteButtonCss: 'nb-card-footer > button[status="success"]',

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/MyTasksTrackedInTimesheetsPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/MyTasksTrackedInTimesheetsPageObject.ts
@@ -41,8 +41,11 @@ export const MyTasksTrackedInTimesheets = {
 	taskSelectCss: 'ga-task-selector ng-select',
 	// Start/Stop is ONE toggle button whose [status] flips success->danger. div.actions div.toggle scopes it
 	// to the timer widget (the view-log block also has a status="success" START button, avoided here).
+	// Both use the CLASS form: time-tracker.component.html property-binds [status]="running ? 'danger' :
+	// 'success'", and a property binding is never written to the DOM as an attribute — Nebular only
+	// reflects it as the class status-danger / status-success. `button[status="danger"]` matched nothing.
 	startTimerBtnCss: 'div.actions div.toggle button.status-success',
-	stopTimerBtnCss: 'div.actions div.toggle button[status="danger"]',
+	stopTimerBtnCss: 'div.actions div.toggle button.status-danger',
 	// The "View Timesheet" anchor uses [routerLink]="['/pages/employees/timesheets']", which the hash-router
 	// renders as href="#/pages/employees/timesheets".
 	viewTimesheetBtnCss: 'div.view-log-button a[href="#/pages/employees/timesheets"]',

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/OrganizationPublicPagePageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/OrganizationPublicPagePageObject.ts
@@ -61,7 +61,13 @@ export const OrganizationPublicPage = {
 	// #visible template). Scope to the plus icon so a leaked success button elsewhere can't match first.
 	addButtonCss: 'button[status="success"]:has(nb-icon[icon="plus-outline"])',
 	verifyOrganizationCss: 'div.d-block',
-	countryDropdownCss: 'ga-country div.form-group nb-select',
+	// <ga-country> renders an ng-select (appendTo="body"), not an nb-select — mirrors
+	// AddOrganizationPageObject, which was migrated when the control changed while this copy was not.
+	countryDropdownCss: 'ga-country ng-select',
+	// ...and its options therefore live in the body-level ng-dropdown-panel, not in an nb-option list.
+	// The shared dropdownOptionCss above stays '.option-list nb-option' because the bonus-type /
+	// start-of-week / date-type / region / number-format / date-format controls really are nb-selects.
+	countryDropdownOptionCss: 'ng-dropdown-panel .ng-option',
 	cityInputCss: '#cityInput',
 	postCodeInputCss: '#postcodeInput',
 	streetInputCss: '#addressInput',

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/SettingsButtonPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/SettingsButtonPageObject.ts
@@ -11,6 +11,11 @@ export const SettingsButton = {
 	dropdownOptionCss: '.option-list nb-option',
 	// Light/Dark switch — toggling it swaps the body theme class.
 	lightDarkToggleCss: 'nb-sidebar.settings-sidebar nb-toggle',
-	resetLayoutButtonCss: 'div.reset-button > button[status="danger"]',
+	// "Reset layout" button inside the Layout selector. The Quick-Settings redesign replaced the old
+	// `<div class="reset-button"><button status="danger">` with a `<div class="layout-control">` column
+	// holding the layout nb-select plus `<button class="reset-layout" status="basic" outline size="tiny">`
+	// (packages/ui-core/theme/.../theme-settings/components/layout-selector/layout-selector.component.html).
+	// Anchor on the stable `reset-layout` class rather than the status attribute, which the redesign churns.
+	resetLayoutButtonCss: 'nb-sidebar.settings-sidebar div.layout-control button.reset-layout',
 	bodyCss: 'body'
 };

--- a/apps/gauzy-e2e/tests/bdd/features/organization-public-page.feature
+++ b/apps/gauzy-e2e/tests/bdd/features/organization-public-page.feature
@@ -6,6 +6,12 @@ Feature: Organization public page
   Background:
     Given I am logged in as the default user
 
+  # This one scenario chains SEVEN end-to-end flows (create an organization through the 4-step stepper,
+  # add an employee, a project and a client to it, publish a profile link, then edit and read back the
+  # public share page). Measured end to end it runs ~250-300s, over the suite-wide 240s budget, and the
+  # budget is not the thing under test here. Give this scenario its own budget instead of raising the
+  # global one — every other spec keeps the tighter default.
+  @timeout:420_000
   Scenario: Publish and edit an organization public page
     When I add a new organization
     And I add a new employee to the organization

--- a/apps/gauzy-e2e/tests/bdd/steps/add-user.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/add-user.steps.ts
@@ -45,5 +45,9 @@ When('I add a new user', async () => {
 	await addUserPage.confirmAddButtonVisible();
 	await addUserPage.clickConfirmAddButton();
 	await addUserPage.waitMessageToHide();
+	// Pollution-safe: the users grid pages at 10 and the shared serial DB accumulates users, so the
+	// one just added lands on page 2 and never renders. Filter by the unique full name first (same as
+	// edit-user / remove-user) — without it this asserts against a page the new user is not on.
+	await addUserPage.filterByName(`${firstName} ${lastName}`);
 	await addUserPage.verifyUserExists(`${firstName} ${lastName}`);
 });

--- a/apps/gauzy-e2e/tests/bdd/steps/delete-organization.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/delete-organization.steps.ts
@@ -1,21 +1,52 @@
 import { When } from '../../support/bdd';
 import { getPage } from '../../support/page-context';
+import { faker } from '@faker-js/faker';
+import * as addOrganizationPage from '../../support/pages/AddOrganization.po';
 import * as deleteOrganizationPage from '../../support/pages/DeleteOrganization.po';
+import { AddOrganizationPageData } from '../../../src/support/Base/pagedata/AddOrganizationPageData';
+import { CustomCommands } from '../../support/commands';
 
-// Converted 1:1 from the plain DeleteOrganizationTest.spec.ts: the single test() -> one Scenario, its
-// lone test.step() -> one When step whose body is the verbatim .po call sequence, so runtime behaviour
-// is identical to the already-CI-tested spec. The `Given I am logged in as the default user` Background
-// step is defined once in common.steps.ts.
+// Converted 1:1 from the plain DeleteOrganizationTest.spec.ts. The `Given I am logged in as the default
+// user` Background step is defined once in common.steps.ts.
+//
+// The original flow selected grid row 0 and deleted it — i.e. it deleted whatever organization happened
+// to sort first. On the current seed that is `Default Company`, the organization every other spec runs
+// against; deleting it cascades away the admin's user_organization row and the seeded time-off policy,
+// and took out seven downstream specs in a single run. Nor is it a local-DB artefact: "row 0" is
+// seed-ordering dependent, so the same thing can happen on a fresh CI database.
+//
+// The spec now creates its own throwaway organization (the same stepper flow that add-organization and
+// manage-organization already exercise) and deletes THAT, looked up by name. DeleteOrganization.po
+// additionally refuses to delete a row belonging to a seeded organization.
+
+let organizationName = ' ';
+let organizationTag = ' ';
+let taxId = ' ';
+let street = ' ';
 
 When('I delete an organization', async () => {
+	// A short digits-only tag, not a faker company name, is what gets typed into the grid's Name
+	// filter: that input rewrites its own value on every debounced refetch, so the shorter and plainer
+	// the search term the smaller the window for it to be clobbered mid-entry.
+	organizationTag = faker.string.numeric(8);
+	organizationName = `Delete Organization ${organizationTag}`;
+	taxId = faker.string.alphanumeric();
+	street = faker.location.streetAddress();
+
+	// Create the organization this spec is allowed to destroy.
+	await CustomCommands.addOrganization(addOrganizationPage, organizationName, AddOrganizationPageData, taxId, street);
+
 	await getPage().goto('/#/pages/organizations');
 	await deleteOrganizationPage.gridBtnExists();
 	await deleteOrganizationPage.gridBtnClick();
 	await deleteOrganizationPage.deleteBtnExists();
-	// Selecting a row enables the (otherwise disabled) toolbar Delete button; deleteBtnClick
-	// also selects internally, but make the prerequisite explicit in the flow.
-	await deleteOrganizationPage.selectOrganization(0);
+	// The grid pages at 10 rows and accumulates organizations across the suite, so narrow it to the
+	// throwaway organization before selecting — otherwise its row is simply not rendered.
+	await deleteOrganizationPage.searchOrganizationByName(organizationTag);
+	// Selecting a row enables the (otherwise disabled) toolbar Delete button.
+	await deleteOrganizationPage.selectOrganization(organizationName);
 	await deleteOrganizationPage.deleteBtnClick();
 	await deleteOrganizationPage.confirmBtnExists();
 	await deleteOrganizationPage.confirmBtnClick();
+	await deleteOrganizationPage.verifyOrganizationDeleted(organizationName);
 });

--- a/apps/gauzy-e2e/tests/bdd/steps/edit-user.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/edit-user.steps.ts
@@ -51,12 +51,18 @@ When('I add a user to edit', async () => {
 	await addUserPage.confirmAddButtonVisible();
 	await addUserPage.clickConfirmAddButton();
 	await addUserPage.waitMessageToHide();
+	// Pollution-safe: the shared serial DB makes the users grid paginate ("1 - 10 of N"), so the user
+	// just added lands on page 2 and never renders. Filter the grid by the unique full name so it is
+	// the only data row on page 1 before verifying it exists (same as remove-user).
+	await editUserPage.filterByName(`${firstName} ${lastName}`);
 	await addUserPage.verifyUserExists(`${firstName} ${lastName}`);
 });
 
 When('I edit the user', async () => {
 	await editUserPage.gridButtonVisible();
 	await editUserPage.clickGridButton();
+	// Re-apply the filter (idempotent) so the row we select is the one this spec created.
+	await editUserPage.filterByName(`${firstName} ${lastName}`);
 	await editUserPage.tableRowVisible();
 	await editUserPage.selectTableRow(`${firstName} ${lastName}`);
 	await editUserPage.editButtonVisible();
@@ -94,5 +100,8 @@ When('I edit the user', async () => {
 	await editUserPage.chooseLanguage(EditUserPageData.preferredLanguage);
 	await editUserPage.saveBtnClick();
 	await addUserPage.waitMessageToHide();
+	// The rename means the grid's Full Name filter (still holding the OLD name) now excludes the very
+	// row we are about to assert on — re-filter on the new name before verifying.
+	await editUserPage.filterByName(`${editFirstName} ${editLastName}`);
 	await addUserPage.verifyUserExists(`${editFirstName} ${editLastName}`);
 });

--- a/apps/gauzy-e2e/tests/bdd/steps/goals-time-frame.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/goals-time-frame.steps.ts
@@ -8,14 +8,22 @@ import { GoalsTimeFramePageData } from '../../../src/support/Base/pagedata/Goals
 // identical to the already-CI-tested spec. The `Given I am logged in as the default user` Background
 // step is defined once in common.steps.ts.
 
+// The suite shares one accumulating database, so a fixed name accumulates duplicate rows across runs
+// (and a run that fails before its delete step leaves one behind). Use a unique name per run so
+// add/edit/delete target exactly the time frame this run created and the delete verification is
+// unambiguous — same approach as organization-departments.
+let timeFrameName = ' ';
+
 When('I add a new goal time frame', async () => {
+	timeFrameName = `${GoalsTimeFramePageData.name} ${Date.now()}`;
+
 	await getPage().goto('/#/pages/goals/settings');
 	await goalsTimeFramePage.tabButtonVisible();
 	await goalsTimeFramePage.clickTabButton(1);
 	await goalsTimeFramePage.addTimeFrameButtonVisible();
 	await goalsTimeFramePage.clickAddTimeFrameButton();
 	await goalsTimeFramePage.nameInputVisible();
-	await goalsTimeFramePage.enterNameInputData(GoalsTimeFramePageData.name);
+	await goalsTimeFramePage.enterNameInputData(timeFrameName);
 	await goalsTimeFramePage.startDateInputVisible();
 	await goalsTimeFramePage.enterStartDateData();
 	await goalsTimeFramePage.endDateInputVisible();
@@ -27,13 +35,16 @@ When('I add a new goal time frame', async () => {
 
 When('I edit the goal time frame', async () => {
 	await goalsTimeFramePage.waitMessageToHide();
-	await goalsTimeFramePage.verifyTimeFrameExists(GoalsTimeFramePageData.name);
+	await goalsTimeFramePage.verifyTimeFrameExists(timeFrameName);
 	await goalsTimeFramePage.tableRowVisible();
-	await goalsTimeFramePage.selectTableRow(0);
+	// By name, not by index: the grid can hold time frames this spec did not create (the goals spec
+	// has to create one, since the objective form's deadline is required and the database seeds none),
+	// and row 0 would then edit/delete somebody else's.
+	await goalsTimeFramePage.selectTableRowByName(timeFrameName);
 	await goalsTimeFramePage.editTimeFrameButtonVisible();
 	await goalsTimeFramePage.clickEditTimeFrameButton();
 	await goalsTimeFramePage.nameInputVisible();
-	await goalsTimeFramePage.enterNameInputData(GoalsTimeFramePageData.name);
+	await goalsTimeFramePage.enterNameInputData(timeFrameName);
 	await goalsTimeFramePage.startDateInputVisible();
 	await goalsTimeFramePage.enterStartDateData();
 	await goalsTimeFramePage.endDateInputVisible();
@@ -45,12 +56,16 @@ When('I edit the goal time frame', async () => {
 
 When('I delete the goal time frame', async () => {
 	await goalsTimeFramePage.waitMessageToHide();
-	await goalsTimeFramePage.verifyTimeFrameExists(GoalsTimeFramePageData.name);
+	await goalsTimeFramePage.verifyTimeFrameExists(timeFrameName);
 	await goalsTimeFramePage.tableRowVisible();
-	await goalsTimeFramePage.selectTableRow(0);
+	// By name, not by index: the grid can hold time frames this spec did not create (the goals spec
+	// has to create one, since the objective form's deadline is required and the database seeds none),
+	// and row 0 would then edit/delete somebody else's.
+	await goalsTimeFramePage.selectTableRowByName(timeFrameName);
 	await goalsTimeFramePage.deleteTimeFrameButtonVisible();
 	await goalsTimeFramePage.clickDeleteTimeFrameButton();
 	await goalsTimeFramePage.confirmDeleteButtonVisible();
 	await goalsTimeFramePage.clickConfirmDeleteButton();
-	await goalsTimeFramePage.verifyElementDeleted(GoalsTimeFramePageData.emptyTableText);
+	// Assert OUR time frame is gone rather than that the grid is empty — see verifyTimeFrameIsDeleted.
+	await goalsTimeFramePage.verifyTimeFrameIsDeleted(timeFrameName);
 });

--- a/apps/gauzy-e2e/tests/bdd/steps/goals.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/goals.steps.ts
@@ -87,8 +87,10 @@ When('I add a new deadline to the key result', async () => {
 	await goalsPage.clickAddDeadlineButton();
 	await goalsPage.updatedValueInputVisible();
 	await goalsPage.enterUpdatedValueData(1);
-	await goalsPage.confirmButtonVisible();
-	await goalsPage.clickConfirmButton();
+	// Dialog-scoped: the update dialog is stacked on the details dialog, so the generic confirm/save
+	// selectors are ambiguous and were leaving both overlays open over the toolbar the next step needs.
+	await goalsPage.confirmUpdateKeyResultVisible();
+	await goalsPage.clickConfirmUpdateKeyResult();
 	await goalsPage.saveDeadlineButtonVisible();
 	await goalsPage.clickSaveDeadlineButton();
 });

--- a/apps/gauzy-e2e/tests/bdd/steps/goals.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/goals.steps.ts
@@ -138,8 +138,27 @@ When('I delete the goal', async () => {
 	await goalsPage.confirmButtonVisible();
 	await goalsPage.clickConfirmButton();
 	await goalsPage.waitMessageToHide();
+	// Reload so the objectives grid re-queries after the delete. The old flow followed this with an
+	// UNCONDITIONAL CustomCommands.login — a Cypress-era assumption that a reload drops the session.
+	// It does not: the app restores it and CustomCommands.login's own `goto('/')` redirects straight
+	// to the dashboard, so the login form never renders and the helper just burned its 24s waiting for
+	// `h2#title`. (This step is only now reachable, so the stale assumption had never been exercised.)
+	// Wait for the reload to settle into EITHER state, then re-login only if we really were logged out.
 	await getPage().reload();
-	await CustomCommands.login(loginPage, LoginPageData, dashboardPage);
+	await getPage()
+		.locator('h2#title, nb-layout-header')
+		.first()
+		.waitFor({ state: 'visible', timeout: 60_000 })
+		.catch(() => {});
+	if (
+		await getPage()
+			.locator('h2#title')
+			.first()
+			.isVisible()
+			.catch(() => false)
+	) {
+		await CustomCommands.login(loginPage, LoginPageData, dashboardPage);
+	}
 	await getPage().goto('/#/pages/goals');
 	// Scope the verify-deleted to OUR goal name: the shared seed can carry objectives from earlier
 	// specs/runs, so a blanket empty-grid check would be flaky.

--- a/apps/gauzy-e2e/tests/bdd/steps/manage-employees.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/manage-employees.steps.ts
@@ -85,8 +85,8 @@ When('I add a new employee', async () => {
 	await manageEmployeesPage.enterUsernameData(username);
 	await manageEmployeesPage.employeeEmailInputVisible();
 	await manageEmployeesPage.enterEmployeeEmailData(employeeEmail);
-	await manageEmployeesPage.dateInputVisible();
-	await manageEmployeesPage.enterDateData();
+	await manageEmployeesPage.employeeDateInputVisible();
+	await manageEmployeesPage.enterEmployeeDateData();
 	await manageEmployeesPage.clickKeyboardButtonByKeyCode(9);
 	await manageEmployeesPage.passwordInputVisible();
 	await manageEmployeesPage.enterPasswordInputData(password);
@@ -113,6 +113,9 @@ When('I add a new employee', async () => {
 	await manageEmployeesPage.lastStepButtonVisible();
 	await manageEmployeesPage.clickLastStepButton();
 	await manageEmployeesPage.waitMessageToHide();
+	// Same pollution guard the edit/end-work/delete steps below already use: the employees grid pages
+	// at 10 and the seed alone brings 18 employees, so the one just added is not on page 1.
+	await manageEmployeesPage.searchEmployeeByName(`${firstName} ${lastName}`);
 	await manageEmployeesPage.verifyEmployeeExists(`${firstName} ${lastName}`);
 });
 

--- a/apps/gauzy-e2e/tests/bdd/steps/roles-permissions.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/roles-permissions.steps.ts
@@ -2,156 +2,569 @@ import { When } from '../../support/bdd';
 import { getPage } from '../../support/page-context';
 import { RolesPermissionsPageData } from '../../../src/support/Base/pagedata/RolesPermissionsPageData';
 import * as rolesPermissionsPage from '../../support/pages/RolesPermissions.po';
+// The permission CATALOG (which permissions are rendered, and in what order) is owned by
+// packages/contracts — import it so this spec can never disagree with the build under test.
+// We import the model SOURCE FILE rather than the `@gauzy/contracts` barrel on purpose: the barrel
+// re-exports ~167 modules, some of which pull in @gauzy/constants, and it only resolves once the
+// package has been compiled in place — neither is a precondition of running the e2e suite.
+// `role-permission.model.ts` has type-only imports, so it costs nothing at runtime.
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
+import { PermissionGroups, PermissionsEnum } from '../../../../../packages/contracts/src/lib/role-permission.model';
 
 /**
  * Roles & permissions screen test.
  *
- * The screen renders every permission in PermissionGroups.GENERAL (152 toggles) then
- * PermissionGroups.ADMINISTRATION (23 toggles, after the DEMO-mode filter drops ACCESS_DELETE_ALL_DATA)
- * — see packages/contracts role-permission.model.ts + roles-permissions.component.html. A toggle is
- * checked iff its permission is in DEFAULT_ROLE_PERMISSIONS for the selected role
- * (packages/core role-permission.seed.ts seeds enabled = defaultEnabledPermissions.includes(permission),
- * and in DEMO mode the ACCESS_DELETE_* rows are not seeded so those toggles stay unchecked).
+ * The screen renders every permission in PermissionGroups.GENERAL, then PermissionGroups.ADMINISTRATION
+ * (see roles-permissions.component.html). A toggle is checked iff its permission is in
+ * DEFAULT_ROLE_PERMISSIONS for the selected role (packages/core role-permission.seed.ts seeds
+ * enabled = defaultEnabledPermissions.includes(permission)).
  *
- * The EXPECTED arrays are derived directly from those two sources of truth, in the exact GENERAL- then
- * ADMINISTRATION-rendered order. They replace the spec's old hard-coded 0..84 absolute index map, which
- * predated the catalog growing/reordering to its current 152+23 shape (the old index 41 mapped to a
- * now-different permission, which is why the test failed at verifyState(41)). 1 = checked, 0 = unchecked.
+ * WHY THIS IS KEYED BY PERMISSION AND NOT BY INDEX
+ * ------------------------------------------------
+ * This spec used to hold a hard-coded 152-long 0/1 array per role. When AI_CHAT_ACCESS/AI_CHAT_SETTINGS
+ * were inserted into PermissionGroups.GENERAL at indices 14/15 the catalog became 154 long, every
+ * later expectation silently shifted by two, and the run failed at index 41 with a meaningless
+ * "expected not checked" — pointing at the wrong permission entirely. So:
+ *
+ *   - the ORDER and LENGTH of both cards are DERIVED from PermissionGroups above (never restated here);
+ *   - only the per-role truth stays as data, and it is keyed BY PERMISSION NAME, so inserting,
+ *     removing or reordering a permission can never shift it again;
+ *   - the toggle COUNT is asserted before the per-toggle loop (see resolveCardToggleCount), so a
+ *     catalog change fails with "the catalog changed" instead of a bogus index mismatch.
+ *
+ * ENABLED_PERMISSIONS below was generated from packages/core/src/lib/role-permission/
+ * default-role-permissions.ts and verified to equal, for all 7 roles,
+ * DEFAULT_ROLE_PERMISSIONS[role] intersected with the rendered catalog. Anything not listed for a role
+ * is expected UNCHECKED — so a newly added permission that a role really does get will fail loudly
+ * rather than silently pass.
+ *
+ * NOTE: PermissionGroups.GENERAL currently lists ORG_TAGS_EDIT twice, so the GENERAL card renders that
+ * toggle twice. Keying by permission handles that correctly (both copies read the same enabled state).
  */
+const GENERAL_PERMISSIONS = PermissionGroups.GENERAL;
+const ADMINISTRATION_PERMISSIONS = PermissionGroups.ADMINISTRATION;
+// roles-permissions.component.ts#getAdministrationPermissions() drops ACCESS_DELETE_ALL_DATA when the
+// build under test runs with environment.DEMO on. The test cannot know which build it is pointed at,
+// so it resolves the variant from the rendered toggle count (see verifyRoleState).
+const ADMINISTRATION_PERMISSIONS_DEMO = ADMINISTRATION_PERMISSIONS.filter(
+	(permission) => permission !== PermissionsEnum.ACCESS_DELETE_ALL_DATA
+);
 
-const EXPECTED: Record<string, { general: number[]; admin: number[] }> = {
-	SUPER_ADMIN: {
-		// general[141] = ACCESS_DELETE_ACCOUNT: checked. The backend e2e API seeds with demo=false, so
-		// every permission row IS created with enabled = DEFAULT_ROLE_PERMISSIONS[SUPER_ADMIN].includes(perm)
-		// (role-permission.seed.ts); SUPER_ADMIN's defaults include ACCESS_DELETE_ACCOUNT, and the GENERAL
-		// card is NOT DEMO-filtered (only ADMINISTRATION is, via getAdministrationPermissions) — so this
-		// toggle renders checked (was wrongly 0 on the assumption the row stayed unseeded in DEMO).
-		general: [
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-		],
-		admin: [
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1
-		]
-	},
-	ADMIN: {
-		// general[141] = ACCESS_DELETE_ACCOUNT: checked — same rationale as SUPER_ADMIN; ADMIN's
-		// DEFAULT_ROLE_PERMISSIONS also include ACCESS_DELETE_ACCOUNT and it is rendered in the un-filtered
-		// GENERAL card.
-		general: [
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-		],
-		admin: [
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1
-		]
-	},
-	DATA_ENTRY: {
-		general: [
-			0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0,
-			1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
-		],
-		admin: [
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0
-		]
-	},
-	EMPLOYEE: {
-		general: [
-			1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1,
-			1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0,
-			1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-			1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-			1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1,
-			0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-		],
-		admin: [
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0
-		]
-	},
-	CANDIDATE: {
-		general: [
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
-		],
-		admin: [
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0
-		]
-	},
-	MANAGER: {
-		general: [
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
-		],
-		admin: [
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0
-		]
-	},
-	VIEWER: {
-		general: [
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
-		],
-		admin: [
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0
-		]
-	}
+const ENABLED_PERMISSIONS: Record<string, readonly PermissionsEnum[]> = {
+	SUPER_ADMIN: [
+		PermissionsEnum.ADMIN_DASHBOARD_VIEW,
+		PermissionsEnum.TEAM_DASHBOARD,
+		PermissionsEnum.PROJECT_MANAGEMENT_DASHBOARD,
+		PermissionsEnum.TIME_TRACKING_DASHBOARD,
+		PermissionsEnum.ACCOUNTING_DASHBOARD,
+		PermissionsEnum.HUMAN_RESOURCE_DASHBOARD,
+		PermissionsEnum.SELECT_EMPLOYEE,
+		PermissionsEnum.CHANGE_SELECTED_EMPLOYEE,
+		PermissionsEnum.CHANGE_SELECTED_CANDIDATE,
+		PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
+		PermissionsEnum.INTEGRATION_ADD,
+		PermissionsEnum.INTEGRATION_VIEW,
+		PermissionsEnum.INTEGRATION_EDIT,
+		PermissionsEnum.INTEGRATION_DELETE,
+		PermissionsEnum.AI_CHAT_ACCESS,
+		PermissionsEnum.AI_CHAT_SETTINGS,
+		PermissionsEnum.ORG_JOB_APPLY,
+		PermissionsEnum.ORG_JOB_SEARCH,
+		PermissionsEnum.ORG_JOB_EDIT,
+		PermissionsEnum.ORG_JOB_EMPLOYEE_VIEW,
+		PermissionsEnum.ORG_JOB_MATCHING_VIEW,
+		PermissionsEnum.PUBLIC_PAGE_EDIT,
+		PermissionsEnum.ORG_PAYMENT_VIEW,
+		PermissionsEnum.ORG_PAYMENT_ADD_EDIT,
+		PermissionsEnum.ORG_EXPENSES_VIEW,
+		PermissionsEnum.ORG_EXPENSES_EDIT,
+		PermissionsEnum.EMPLOYEE_EXPENSES_VIEW,
+		PermissionsEnum.EMPLOYEE_EXPENSES_EDIT,
+		PermissionsEnum.ORG_INCOMES_EDIT,
+		PermissionsEnum.ORG_INCOMES_VIEW,
+		PermissionsEnum.ORG_PROPOSALS_EDIT,
+		PermissionsEnum.ORG_PROPOSALS_VIEW,
+		PermissionsEnum.ORG_PROPOSAL_TEMPLATES_VIEW,
+		PermissionsEnum.ORG_PROPOSAL_TEMPLATES_EDIT,
+		PermissionsEnum.ORG_EMPLOYEES_ADD,
+		PermissionsEnum.ORG_EMPLOYEES_VIEW,
+		PermissionsEnum.ORG_EMPLOYEES_DELETE,
+		PermissionsEnum.ORG_TASK_ADD,
+		PermissionsEnum.ORG_TASK_VIEW,
+		PermissionsEnum.ORG_TASK_EDIT,
+		PermissionsEnum.ORG_TASK_DELETE,
+		PermissionsEnum.ORG_INVITE_VIEW,
+		PermissionsEnum.ORG_INVITE_EDIT,
+		PermissionsEnum.TIME_OFF_ADD,
+		PermissionsEnum.TIME_OFF_VIEW,
+		PermissionsEnum.TIME_OFF_EDIT,
+		PermissionsEnum.TIME_OFF_DELETE,
+		PermissionsEnum.APPROVAL_POLICY_EDIT,
+		PermissionsEnum.APPROVAL_POLICY_VIEW,
+		PermissionsEnum.REQUEST_APPROVAL_EDIT,
+		PermissionsEnum.REQUEST_APPROVAL_VIEW,
+		PermissionsEnum.ACCESS_PRIVATE_PROJECTS,
+		PermissionsEnum.TIMESHEET_EDIT_TIME,
+		PermissionsEnum.INVOICES_VIEW,
+		PermissionsEnum.INVOICES_EDIT,
+		PermissionsEnum.ESTIMATES_VIEW,
+		PermissionsEnum.ESTIMATES_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_DOCUMENTS_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_TASK_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEW_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEW_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEWERS_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEWERS_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_FEEDBACK_EDIT,
+		PermissionsEnum.ORG_INVENTORY_VIEW,
+		PermissionsEnum.ORG_INVENTORY_PRODUCT_EDIT,
+		PermissionsEnum.ORG_TAGS_EDIT,
+		PermissionsEnum.VIEW_ALL_EMAILS,
+		PermissionsEnum.VIEW_ALL_EMAIL_TEMPLATES,
+		PermissionsEnum.ORG_HELP_CENTER_EDIT,
+		PermissionsEnum.VIEW_SALES_PIPELINES,
+		PermissionsEnum.EDIT_SALES_PIPELINES,
+		PermissionsEnum.CAN_APPROVE_TIMESHEET,
+		PermissionsEnum.ORG_SPRINT_ADD,
+		PermissionsEnum.ORG_SPRINT_EDIT,
+		PermissionsEnum.ORG_SPRINT_VIEW,
+		PermissionsEnum.ORG_SPRINT_DELETE,
+		PermissionsEnum.ORG_PROJECT_ADD,
+		PermissionsEnum.ORG_PROJECT_VIEW,
+		PermissionsEnum.ORG_PROJECT_EDIT,
+		PermissionsEnum.ORG_PROJECT_DELETE,
+		PermissionsEnum.ORG_CONTACT_EDIT,
+		PermissionsEnum.ORG_CONTACT_VIEW,
+		PermissionsEnum.DAILY_PLAN_CREATE,
+		PermissionsEnum.DAILY_PLAN_READ,
+		PermissionsEnum.DAILY_PLAN_UPDATE,
+		PermissionsEnum.DAILY_PLAN_DELETE,
+		PermissionsEnum.PROJECT_MODULE_CREATE,
+		PermissionsEnum.PROJECT_MODULE_READ,
+		PermissionsEnum.PROJECT_MODULE_UPDATE,
+		PermissionsEnum.PROJECT_MODULE_DELETE,
+		PermissionsEnum.DASHBOARD_CREATE,
+		PermissionsEnum.DASHBOARD_READ,
+		PermissionsEnum.DASHBOARD_UPDATE,
+		PermissionsEnum.DASHBOARD_DELETE,
+		PermissionsEnum.ORG_TEAM_ADD,
+		PermissionsEnum.ORG_TEAM_VIEW,
+		PermissionsEnum.ORG_TEAM_EDIT,
+		PermissionsEnum.ORG_TEAM_DELETE,
+		PermissionsEnum.ORG_TEAM_EDIT_ACTIVE_TASK,
+		PermissionsEnum.ORG_TEAM_REMOVE_ACCOUNT_AS_MEMBER,
+		PermissionsEnum.ORG_TEAM_JOIN_REQUEST_VIEW,
+		PermissionsEnum.ORG_TEAM_JOIN_REQUEST_EDIT,
+		PermissionsEnum.ORG_TASK_SETTING,
+		PermissionsEnum.ORG_CONTRACT_EDIT,
+		PermissionsEnum.EVENT_TYPES_VIEW,
+		PermissionsEnum.TIME_TRACKER,
+		PermissionsEnum.INVENTORY_GALLERY_VIEW,
+		PermissionsEnum.INVENTORY_GALLERY_EDIT,
+		PermissionsEnum.MEDIA_GALLERY_ADD,
+		PermissionsEnum.MEDIA_GALLERY_VIEW,
+		PermissionsEnum.MEDIA_GALLERY_EDIT,
+		PermissionsEnum.MEDIA_GALLERY_DELETE,
+		PermissionsEnum.ORG_EQUIPMENT_VIEW,
+		PermissionsEnum.ORG_EQUIPMENT_EDIT,
+		PermissionsEnum.ORG_EQUIPMENT_SHARING_VIEW,
+		PermissionsEnum.ORG_EQUIPMENT_SHARING_EDIT,
+		PermissionsEnum.EQUIPMENT_MAKE_REQUEST,
+		PermissionsEnum.EQUIPMENT_APPROVE_REQUEST,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_ADD,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_VIEW,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_EDIT,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_DELETE,
+		PermissionsEnum.ORG_TAGS_ADD,
+		PermissionsEnum.ORG_TAGS_VIEW,
+		PermissionsEnum.ORG_TAGS_DELETE,
+		PermissionsEnum.ORG_TAG_TYPES_ADD,
+		PermissionsEnum.ORG_TAG_TYPES_VIEW,
+		PermissionsEnum.ORG_TAG_TYPES_EDIT,
+		PermissionsEnum.ORG_TAG_TYPES_DELETE,
+		PermissionsEnum.ORG_PRODUCT_TYPES_VIEW,
+		PermissionsEnum.ORG_PRODUCT_CATEGORIES_VIEW,
+		PermissionsEnum.ORG_PRODUCT_CATEGORIES_EDIT,
+		PermissionsEnum.VIEW_ALL_ACCOUNTING_TEMPLATES,
+		PermissionsEnum.ALLOW_DELETE_TIME,
+		PermissionsEnum.ALLOW_MODIFY_TIME,
+		PermissionsEnum.ALLOW_MANUAL_TIME,
+		PermissionsEnum.DELETE_SCREENSHOTS,
+		PermissionsEnum.ACCESS_DELETE_ACCOUNT,
+		PermissionsEnum.ORG_MEMBER_LAST_LOG_VIEW,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_CREATE,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_READ,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_UPDATE,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_DELETE,
+		PermissionsEnum.BROADCAST_CREATE,
+		PermissionsEnum.BROADCAST_READ,
+		PermissionsEnum.BROADCAST_UPDATE,
+		PermissionsEnum.BROADCAST_DELETE,
+		PermissionsEnum.ORG_STRATEGIC_INITIATIVE_READ,
+		PermissionsEnum.ORG_EMPLOYEES_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_EDIT,
+		PermissionsEnum.ORG_USERS_VIEW,
+		PermissionsEnum.ORG_USERS_EDIT,
+		PermissionsEnum.ALL_ORG_VIEW,
+		PermissionsEnum.ALL_ORG_EDIT,
+		PermissionsEnum.CHANGE_ROLES_PERMISSIONS,
+		PermissionsEnum.TENANT_ADD_EXISTING_USER,
+		PermissionsEnum.FILE_STORAGE_VIEW,
+		PermissionsEnum.PAYMENT_GATEWAY_VIEW,
+		PermissionsEnum.SMS_GATEWAY_VIEW,
+		PermissionsEnum.CUSTOM_SMTP_VIEW,
+		PermissionsEnum.IMPORT_ADD,
+		PermissionsEnum.EXPORT_ADD,
+		PermissionsEnum.TENANT_SETTING,
+		PermissionsEnum.API_CALL_LOG_READ,
+		PermissionsEnum.API_CALL_LOG_DELETE,
+		PermissionsEnum.TENANT_API_KEY_CREATE,
+		PermissionsEnum.TENANT_API_KEY_VIEW,
+		PermissionsEnum.TENANT_API_KEY_DELETE,
+		PermissionsEnum.OAUTH_CLIENT_VIEW,
+		PermissionsEnum.OAUTH_CLIENT_EDIT
+	],
+	ADMIN: [
+		PermissionsEnum.ADMIN_DASHBOARD_VIEW,
+		PermissionsEnum.TEAM_DASHBOARD,
+		PermissionsEnum.PROJECT_MANAGEMENT_DASHBOARD,
+		PermissionsEnum.TIME_TRACKING_DASHBOARD,
+		PermissionsEnum.ACCOUNTING_DASHBOARD,
+		PermissionsEnum.HUMAN_RESOURCE_DASHBOARD,
+		PermissionsEnum.SELECT_EMPLOYEE,
+		PermissionsEnum.CHANGE_SELECTED_EMPLOYEE,
+		PermissionsEnum.CHANGE_SELECTED_CANDIDATE,
+		PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
+		PermissionsEnum.INTEGRATION_ADD,
+		PermissionsEnum.INTEGRATION_VIEW,
+		PermissionsEnum.INTEGRATION_EDIT,
+		PermissionsEnum.INTEGRATION_DELETE,
+		PermissionsEnum.AI_CHAT_ACCESS,
+		PermissionsEnum.AI_CHAT_SETTINGS,
+		PermissionsEnum.ORG_JOB_APPLY,
+		PermissionsEnum.ORG_JOB_SEARCH,
+		PermissionsEnum.ORG_JOB_EDIT,
+		PermissionsEnum.ORG_JOB_EMPLOYEE_VIEW,
+		PermissionsEnum.ORG_JOB_MATCHING_VIEW,
+		PermissionsEnum.PUBLIC_PAGE_EDIT,
+		PermissionsEnum.ORG_PAYMENT_VIEW,
+		PermissionsEnum.ORG_PAYMENT_ADD_EDIT,
+		PermissionsEnum.ORG_EXPENSES_VIEW,
+		PermissionsEnum.ORG_EXPENSES_EDIT,
+		PermissionsEnum.EMPLOYEE_EXPENSES_VIEW,
+		PermissionsEnum.EMPLOYEE_EXPENSES_EDIT,
+		PermissionsEnum.ORG_INCOMES_EDIT,
+		PermissionsEnum.ORG_INCOMES_VIEW,
+		PermissionsEnum.ORG_PROPOSALS_EDIT,
+		PermissionsEnum.ORG_PROPOSALS_VIEW,
+		PermissionsEnum.ORG_PROPOSAL_TEMPLATES_VIEW,
+		PermissionsEnum.ORG_PROPOSAL_TEMPLATES_EDIT,
+		PermissionsEnum.ORG_EMPLOYEES_ADD,
+		PermissionsEnum.ORG_EMPLOYEES_VIEW,
+		PermissionsEnum.ORG_EMPLOYEES_DELETE,
+		PermissionsEnum.ORG_TASK_ADD,
+		PermissionsEnum.ORG_TASK_VIEW,
+		PermissionsEnum.ORG_TASK_EDIT,
+		PermissionsEnum.ORG_TASK_DELETE,
+		PermissionsEnum.ORG_INVITE_VIEW,
+		PermissionsEnum.ORG_INVITE_EDIT,
+		PermissionsEnum.TIME_OFF_ADD,
+		PermissionsEnum.TIME_OFF_VIEW,
+		PermissionsEnum.TIME_OFF_EDIT,
+		PermissionsEnum.TIME_OFF_DELETE,
+		PermissionsEnum.APPROVAL_POLICY_EDIT,
+		PermissionsEnum.APPROVAL_POLICY_VIEW,
+		PermissionsEnum.REQUEST_APPROVAL_EDIT,
+		PermissionsEnum.REQUEST_APPROVAL_VIEW,
+		PermissionsEnum.ACCESS_PRIVATE_PROJECTS,
+		PermissionsEnum.TIMESHEET_EDIT_TIME,
+		PermissionsEnum.INVOICES_VIEW,
+		PermissionsEnum.INVOICES_EDIT,
+		PermissionsEnum.ESTIMATES_VIEW,
+		PermissionsEnum.ESTIMATES_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_DOCUMENTS_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_TASK_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEW_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEW_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEWERS_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEWERS_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_FEEDBACK_EDIT,
+		PermissionsEnum.ORG_INVENTORY_VIEW,
+		PermissionsEnum.ORG_INVENTORY_PRODUCT_EDIT,
+		PermissionsEnum.ORG_TAGS_EDIT,
+		PermissionsEnum.VIEW_ALL_EMAILS,
+		PermissionsEnum.VIEW_ALL_EMAIL_TEMPLATES,
+		PermissionsEnum.ORG_HELP_CENTER_EDIT,
+		PermissionsEnum.VIEW_SALES_PIPELINES,
+		PermissionsEnum.EDIT_SALES_PIPELINES,
+		PermissionsEnum.CAN_APPROVE_TIMESHEET,
+		PermissionsEnum.ORG_SPRINT_ADD,
+		PermissionsEnum.ORG_SPRINT_EDIT,
+		PermissionsEnum.ORG_SPRINT_VIEW,
+		PermissionsEnum.ORG_SPRINT_DELETE,
+		PermissionsEnum.ORG_PROJECT_ADD,
+		PermissionsEnum.ORG_PROJECT_VIEW,
+		PermissionsEnum.ORG_PROJECT_EDIT,
+		PermissionsEnum.ORG_PROJECT_DELETE,
+		PermissionsEnum.ORG_CONTACT_EDIT,
+		PermissionsEnum.ORG_CONTACT_VIEW,
+		PermissionsEnum.DAILY_PLAN_CREATE,
+		PermissionsEnum.DAILY_PLAN_READ,
+		PermissionsEnum.DAILY_PLAN_UPDATE,
+		PermissionsEnum.DAILY_PLAN_DELETE,
+		PermissionsEnum.PROJECT_MODULE_CREATE,
+		PermissionsEnum.PROJECT_MODULE_READ,
+		PermissionsEnum.PROJECT_MODULE_UPDATE,
+		PermissionsEnum.PROJECT_MODULE_DELETE,
+		PermissionsEnum.DASHBOARD_CREATE,
+		PermissionsEnum.DASHBOARD_READ,
+		PermissionsEnum.DASHBOARD_UPDATE,
+		PermissionsEnum.DASHBOARD_DELETE,
+		PermissionsEnum.ORG_TEAM_ADD,
+		PermissionsEnum.ORG_TEAM_VIEW,
+		PermissionsEnum.ORG_TEAM_EDIT,
+		PermissionsEnum.ORG_TEAM_DELETE,
+		PermissionsEnum.ORG_TEAM_EDIT_ACTIVE_TASK,
+		PermissionsEnum.ORG_TEAM_REMOVE_ACCOUNT_AS_MEMBER,
+		PermissionsEnum.ORG_TEAM_JOIN_REQUEST_VIEW,
+		PermissionsEnum.ORG_TEAM_JOIN_REQUEST_EDIT,
+		PermissionsEnum.ORG_TASK_SETTING,
+		PermissionsEnum.ORG_CONTRACT_EDIT,
+		PermissionsEnum.EVENT_TYPES_VIEW,
+		PermissionsEnum.TIME_TRACKER,
+		PermissionsEnum.INVENTORY_GALLERY_VIEW,
+		PermissionsEnum.INVENTORY_GALLERY_EDIT,
+		PermissionsEnum.MEDIA_GALLERY_ADD,
+		PermissionsEnum.MEDIA_GALLERY_VIEW,
+		PermissionsEnum.MEDIA_GALLERY_EDIT,
+		PermissionsEnum.MEDIA_GALLERY_DELETE,
+		PermissionsEnum.ORG_EQUIPMENT_VIEW,
+		PermissionsEnum.ORG_EQUIPMENT_EDIT,
+		PermissionsEnum.ORG_EQUIPMENT_SHARING_VIEW,
+		PermissionsEnum.ORG_EQUIPMENT_SHARING_EDIT,
+		PermissionsEnum.EQUIPMENT_MAKE_REQUEST,
+		PermissionsEnum.EQUIPMENT_APPROVE_REQUEST,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_ADD,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_VIEW,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_EDIT,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_DELETE,
+		PermissionsEnum.ORG_TAGS_ADD,
+		PermissionsEnum.ORG_TAGS_VIEW,
+		PermissionsEnum.ORG_TAGS_DELETE,
+		PermissionsEnum.ORG_TAG_TYPES_ADD,
+		PermissionsEnum.ORG_TAG_TYPES_VIEW,
+		PermissionsEnum.ORG_TAG_TYPES_EDIT,
+		PermissionsEnum.ORG_TAG_TYPES_DELETE,
+		PermissionsEnum.ORG_PRODUCT_TYPES_VIEW,
+		PermissionsEnum.ORG_PRODUCT_CATEGORIES_VIEW,
+		PermissionsEnum.ORG_PRODUCT_CATEGORIES_EDIT,
+		PermissionsEnum.VIEW_ALL_ACCOUNTING_TEMPLATES,
+		PermissionsEnum.ALLOW_DELETE_TIME,
+		PermissionsEnum.ALLOW_MODIFY_TIME,
+		PermissionsEnum.ALLOW_MANUAL_TIME,
+		PermissionsEnum.DELETE_SCREENSHOTS,
+		PermissionsEnum.ACCESS_DELETE_ACCOUNT,
+		PermissionsEnum.ORG_MEMBER_LAST_LOG_VIEW,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_CREATE,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_READ,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_UPDATE,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_DELETE,
+		PermissionsEnum.BROADCAST_CREATE,
+		PermissionsEnum.BROADCAST_READ,
+		PermissionsEnum.BROADCAST_UPDATE,
+		PermissionsEnum.BROADCAST_DELETE,
+		PermissionsEnum.ORG_STRATEGIC_INITIATIVE_READ,
+		PermissionsEnum.ORG_EMPLOYEES_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_EDIT,
+		PermissionsEnum.ORG_USERS_VIEW,
+		PermissionsEnum.ORG_USERS_EDIT,
+		PermissionsEnum.ALL_ORG_VIEW,
+		PermissionsEnum.ALL_ORG_EDIT,
+		PermissionsEnum.CHANGE_ROLES_PERMISSIONS,
+		PermissionsEnum.TENANT_ADD_EXISTING_USER,
+		PermissionsEnum.FILE_STORAGE_VIEW,
+		PermissionsEnum.PAYMENT_GATEWAY_VIEW,
+		PermissionsEnum.SMS_GATEWAY_VIEW,
+		PermissionsEnum.CUSTOM_SMTP_VIEW,
+		PermissionsEnum.IMPORT_ADD,
+		PermissionsEnum.EXPORT_ADD,
+		PermissionsEnum.TENANT_SETTING,
+		PermissionsEnum.API_CALL_LOG_READ,
+		PermissionsEnum.API_CALL_LOG_DELETE,
+		PermissionsEnum.TENANT_API_KEY_CREATE,
+		PermissionsEnum.TENANT_API_KEY_VIEW,
+		PermissionsEnum.TENANT_API_KEY_DELETE,
+		PermissionsEnum.OAUTH_CLIENT_VIEW,
+		PermissionsEnum.OAUTH_CLIENT_EDIT
+	],
+	DATA_ENTRY: [
+		PermissionsEnum.SELECT_EMPLOYEE,
+		PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
+		PermissionsEnum.ORG_PAYMENT_VIEW,
+		PermissionsEnum.ORG_PAYMENT_ADD_EDIT,
+		PermissionsEnum.ORG_EXPENSES_VIEW,
+		PermissionsEnum.ORG_EXPENSES_EDIT,
+		PermissionsEnum.ORG_INCOMES_EDIT,
+		PermissionsEnum.ORG_INCOMES_VIEW,
+		PermissionsEnum.ORG_TASK_ADD,
+		PermissionsEnum.ORG_TASK_VIEW,
+		PermissionsEnum.ORG_TASK_EDIT,
+		PermissionsEnum.ORG_TASK_DELETE,
+		PermissionsEnum.INVOICES_VIEW,
+		PermissionsEnum.INVOICES_EDIT,
+		PermissionsEnum.ESTIMATES_VIEW,
+		PermissionsEnum.ESTIMATES_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_TASK_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEW_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEW_VIEW,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEWERS_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_INTERVIEWERS_VIEW,
+		PermissionsEnum.ORG_INVENTORY_PRODUCT_EDIT,
+		PermissionsEnum.ORG_HELP_CENTER_EDIT,
+		PermissionsEnum.PROJECT_MODULE_CREATE,
+		PermissionsEnum.PROJECT_MODULE_READ,
+		PermissionsEnum.PROJECT_MODULE_UPDATE,
+		PermissionsEnum.PROJECT_MODULE_DELETE,
+		PermissionsEnum.DASHBOARD_CREATE,
+		PermissionsEnum.DASHBOARD_READ,
+		PermissionsEnum.DASHBOARD_UPDATE,
+		PermissionsEnum.DASHBOARD_DELETE,
+		PermissionsEnum.ORG_STRATEGIC_INITIATIVE_READ
+	],
+	EMPLOYEE: [
+		PermissionsEnum.ADMIN_DASHBOARD_VIEW,
+		PermissionsEnum.PROJECT_MANAGEMENT_DASHBOARD,
+		PermissionsEnum.TIME_TRACKING_DASHBOARD,
+		PermissionsEnum.HUMAN_RESOURCE_DASHBOARD,
+		PermissionsEnum.SELECT_EMPLOYEE,
+		PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
+		PermissionsEnum.AI_CHAT_ACCESS,
+		PermissionsEnum.EMPLOYEE_EXPENSES_VIEW,
+		PermissionsEnum.EMPLOYEE_EXPENSES_EDIT,
+		PermissionsEnum.ORG_PROPOSALS_EDIT,
+		PermissionsEnum.ORG_PROPOSALS_VIEW,
+		PermissionsEnum.ORG_PROPOSAL_TEMPLATES_VIEW,
+		PermissionsEnum.ORG_PROPOSAL_TEMPLATES_EDIT,
+		PermissionsEnum.ORG_TASK_ADD,
+		PermissionsEnum.ORG_TASK_VIEW,
+		PermissionsEnum.ORG_TASK_EDIT,
+		PermissionsEnum.ORG_INVITE_VIEW,
+		PermissionsEnum.ORG_INVITE_EDIT,
+		PermissionsEnum.TIME_OFF_VIEW,
+		PermissionsEnum.APPROVAL_POLICY_EDIT,
+		PermissionsEnum.APPROVAL_POLICY_VIEW,
+		PermissionsEnum.REQUEST_APPROVAL_EDIT,
+		PermissionsEnum.REQUEST_APPROVAL_VIEW,
+		PermissionsEnum.INVOICES_VIEW,
+		PermissionsEnum.INVOICES_EDIT,
+		PermissionsEnum.ESTIMATES_VIEW,
+		PermissionsEnum.ESTIMATES_EDIT,
+		PermissionsEnum.ORG_CANDIDATES_TASK_EDIT,
+		PermissionsEnum.ORG_INVENTORY_VIEW,
+		PermissionsEnum.ORG_TAGS_EDIT,
+		PermissionsEnum.ORG_PROJECT_ADD,
+		PermissionsEnum.ORG_PROJECT_VIEW,
+		PermissionsEnum.ORG_CONTACT_VIEW,
+		PermissionsEnum.DAILY_PLAN_CREATE,
+		PermissionsEnum.DAILY_PLAN_READ,
+		PermissionsEnum.DAILY_PLAN_UPDATE,
+		PermissionsEnum.DAILY_PLAN_DELETE,
+		PermissionsEnum.PROJECT_MODULE_CREATE,
+		PermissionsEnum.PROJECT_MODULE_READ,
+		PermissionsEnum.PROJECT_MODULE_UPDATE,
+		PermissionsEnum.PROJECT_MODULE_DELETE,
+		PermissionsEnum.DASHBOARD_CREATE,
+		PermissionsEnum.DASHBOARD_READ,
+		PermissionsEnum.DASHBOARD_UPDATE,
+		PermissionsEnum.DASHBOARD_DELETE,
+		PermissionsEnum.ORG_TEAM_ADD,
+		PermissionsEnum.ORG_TEAM_VIEW,
+		PermissionsEnum.ORG_TEAM_EDIT,
+		PermissionsEnum.ORG_TEAM_DELETE,
+		PermissionsEnum.ORG_TEAM_EDIT_ACTIVE_TASK,
+		PermissionsEnum.ORG_TEAM_REMOVE_ACCOUNT_AS_MEMBER,
+		PermissionsEnum.ORG_TEAM_JOIN_REQUEST_VIEW,
+		PermissionsEnum.EVENT_TYPES_VIEW,
+		PermissionsEnum.TIME_TRACKER,
+		PermissionsEnum.INVENTORY_GALLERY_VIEW,
+		PermissionsEnum.INVENTORY_GALLERY_EDIT,
+		PermissionsEnum.MEDIA_GALLERY_ADD,
+		PermissionsEnum.MEDIA_GALLERY_VIEW,
+		PermissionsEnum.MEDIA_GALLERY_EDIT,
+		PermissionsEnum.MEDIA_GALLERY_DELETE,
+		PermissionsEnum.ORG_EQUIPMENT_VIEW,
+		PermissionsEnum.ORG_EQUIPMENT_SHARING_VIEW,
+		PermissionsEnum.EQUIPMENT_MAKE_REQUEST,
+		PermissionsEnum.EQUIPMENT_SHARING_POLICY_VIEW,
+		PermissionsEnum.ORG_TAGS_ADD,
+		PermissionsEnum.ORG_TAGS_VIEW,
+		PermissionsEnum.ORG_TAGS_DELETE,
+		PermissionsEnum.ORG_TAG_TYPES_ADD,
+		PermissionsEnum.ORG_TAG_TYPES_VIEW,
+		PermissionsEnum.ORG_TAG_TYPES_EDIT,
+		PermissionsEnum.ORG_TAG_TYPES_DELETE,
+		PermissionsEnum.ORG_PRODUCT_TYPES_VIEW,
+		PermissionsEnum.ORG_PRODUCT_CATEGORIES_VIEW,
+		PermissionsEnum.ALLOW_DELETE_TIME,
+		PermissionsEnum.ALLOW_MODIFY_TIME,
+		PermissionsEnum.ALLOW_MANUAL_TIME,
+		PermissionsEnum.DELETE_SCREENSHOTS,
+		PermissionsEnum.ACCESS_DELETE_ACCOUNT,
+		PermissionsEnum.ORG_MEMBER_LAST_LOG_VIEW,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_CREATE,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_READ,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_UPDATE,
+		PermissionsEnum.EMPLOYEE_AVAILABILITY_DELETE,
+		PermissionsEnum.BROADCAST_CREATE,
+		PermissionsEnum.BROADCAST_READ,
+		PermissionsEnum.BROADCAST_UPDATE,
+		PermissionsEnum.BROADCAST_DELETE,
+		PermissionsEnum.ORG_STRATEGIC_INITIATIVE_READ
+	],
+	CANDIDATE: [
+		PermissionsEnum.ORG_STRATEGIC_INITIATIVE_READ
+	],
+	MANAGER: [
+		PermissionsEnum.ORG_STRATEGIC_INITIATIVE_READ
+	],
+	VIEWER: [
+		PermissionsEnum.ORG_STRATEGIC_INITIATIVE_READ
+	]
 };
 
 const verifyRoleState = async (roleEnum: string) => {
 	await rolesPermissionsPage.waitForPermissionsLoaded();
-	const expected = EXPECTED[roleEnum];
-	for (let i = 0; i < expected.general.length; i++) {
-		await rolesPermissionsPage.verifyStateInCard('general', i, expected.general[i] ? 'be.checked' : 'not.checked');
+	const enabled = new Set<PermissionsEnum>(ENABLED_PERMISSIONS[roleEnum]);
+
+	// Catalog guards: fail with "the catalog changed" rather than a bogus per-index mismatch.
+	await rolesPermissionsPage.resolveCardToggleCount('general', [GENERAL_PERMISSIONS.length]);
+	const adminCount = await rolesPermissionsPage.resolveCardToggleCount('admin', [
+		ADMINISTRATION_PERMISSIONS.length,
+		ADMINISTRATION_PERMISSIONS_DEMO.length
+	]);
+	const administrationPermissions =
+		adminCount === ADMINISTRATION_PERMISSIONS.length ? ADMINISTRATION_PERMISSIONS : ADMINISTRATION_PERMISSIONS_DEMO;
+
+	for (const [index, permission] of GENERAL_PERMISSIONS.entries()) {
+		await rolesPermissionsPage.verifyStateInCard(
+			'general',
+			index,
+			enabled.has(permission) ? 'be.checked' : 'not.checked',
+			`${roleEnum} GENERAL[${index}] ${permission}`
+		);
 	}
-	for (let i = 0; i < expected.admin.length; i++) {
-		await rolesPermissionsPage.verifyStateInCard('admin', i, expected.admin[i] ? 'be.checked' : 'not.checked');
+	for (const [index, permission] of administrationPermissions.entries()) {
+		await rolesPermissionsPage.verifyStateInCard(
+			'admin',
+			index,
+			enabled.has(permission) ? 'be.checked' : 'not.checked',
+			`${roleEnum} ADMINISTRATION[${index}] ${permission}`
+		);
 	}
 };
+
 
 When('I open the Roles and Permissions screen', async () => {
 	// Force the hash route + settle: login ends on the dashboard hash, and a bare goto to a new

--- a/apps/gauzy-e2e/tests/support/commands.ts
+++ b/apps/gauzy-e2e/tests/support/commands.ts
@@ -276,8 +276,10 @@ export const CustomCommands = {
 		await manageEmployeesPage.enterUsernameData(username);
 		await manageEmployeesPage.employeeEmailInputVisible();
 		await manageEmployeesPage.enterEmployeeEmailData(employeeEmail);
-		await manageEmployeesPage.dateInputVisible();
-		await manageEmployeesPage.enterDateData();
+		// Employee-dialog-scoped: the bare [formcontrolname="startedWorkOn"] also matches the invite
+		// dialog's field whenever that dialog is still mounted (strict-mode violation).
+		await manageEmployeesPage.employeeDateInputVisible();
+		await manageEmployeesPage.enterEmployeeDateData();
 		await manageEmployeesPage.clickKeyboardButtonByKeyCode(9);
 		await manageEmployeesPage.passwordInputVisible();
 		await manageEmployeesPage.enterPasswordInputData(password);

--- a/apps/gauzy-e2e/tests/support/pages/AddUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddUser.po.ts
@@ -6,7 +6,8 @@ import {
 	clearField,
 	verifyText,
 	waitElementToHide,
-	waitUntil
+	waitUntil,
+	dispatchClickWhenSettled
 } from '../util';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { AddUserPage } from '../../../src/support/Base/pageobjects/AddUserPageObject';
@@ -16,7 +17,10 @@ export const addUserButtonVisible = async () => {
 };
 
 export const clickAddUserButton = async () => {
-	await clickButton(AddUserPage.addUserButtonCss);
+	// Same overlay as the Invite button: the Users card's [nbSpinner] covers the header toolbar while
+	// the grid loads, so the old coordinate force-click was eaten and #firstName never appeared.
+	// Settle, dispatch at the button, confirm the mutation dialog opened.
+	await dispatchClickWhenSettled(AddUserPage.addUserButtonCss, AddUserPage.firstNameInputCss);
 };
 
 export const firstNameInputVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/AddUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddUser.po.ts
@@ -7,7 +7,8 @@ import {
 	verifyText,
 	waitElementToHide,
 	waitUntil,
-	dispatchClickWhenSettled
+	dispatchClickWhenSettled,
+	applySmartTableFilter
 } from '../util';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { AddUserPage } from '../../../src/support/Base/pageobjects/AddUserPageObject';
@@ -21,6 +22,12 @@ export const clickAddUserButton = async () => {
 	// the grid loads, so the old coordinate force-click was eaten and #firstName never appeared.
 	// Settle, dispatch at the button, confirm the mutation dialog opened.
 	await dispatchClickWhenSettled(AddUserPage.addUserButtonCss, AddUserPage.firstNameInputCss);
+};
+
+// Narrow the users grid to one full name so the user just created is the only data row on page 1.
+// Without it verifyUserExists asserts against page 1 of a grid the new user is not on.
+export const filterByName = async (name: string) => {
+	await applySmartTableFilter(AddUserPage.nameFilterInputCss, name);
 };
 
 export const firstNameInputVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/DeleteOrganization.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/DeleteOrganization.po.ts
@@ -1,7 +1,22 @@
+import { expect } from '@playwright/test';
 import { verifyElementIsVisible, dispatchClick, waitForSpinnerGone } from '../util';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { DeleteOrganizationPage } from '../../../src/support/Base/pageobjects/DeleteOrganizationPageObject';
+
+/**
+ * Organizations this spec must NEVER delete.
+ *
+ * The original flow selected grid row 0 and deleted it. On the current seed that row is
+ * `Default Company` — the organization every other spec runs against. Deleting it cascades away the
+ * admin's user_organization row (subsequent requests 401, and the token refresh comes back with
+ * organizationId:null) and the seeded time-off policy, which took out seven downstream specs in a
+ * single run. This is NOT a local-DB artefact: on ANY database, including a fresh CI seed, "row 0" is
+ * whatever happens to sort first, so the spec was one seed-ordering change away from doing the same
+ * thing in CI. It now creates its own throwaway organization and deletes THAT by name; this list is
+ * the backstop that refuses to delete a seeded organization if the lookup ever goes wrong.
+ */
+const PROTECTED_ORGANIZATIONS = ['Default Company'];
 
 export const gridBtnExists = async () => {
 	/* no-op: grid list/grid layout toggle removed from the app */
@@ -15,13 +30,11 @@ export const deleteBtnExists = async () => {
 	await verifyElementIsVisible(DeleteOrganizationPage.deleteButtonCss);
 };
 
-// The toolbar Delete button is [disabled] until a grid row is selected. The original flow force-clicked
-// the disabled button (no-op — Angular doesn't fire (click) on a disabled control), so the confirm
-// dialog never opened and confirmBtnExists timed out. Settle the grid, select the row ONCE, then poll
-// the Delete button's real `disabled` attr until selection is registered before clicking it.
-export const deleteBtnClick = async (index: number = 0) => {
-	await selectOrganizationRow();
-
+// The toolbar Delete button is [disabled] until a grid row is selected (Angular doesn't fire (click)
+// on a disabled control, so clicking it early is a silent no-op and the confirm dialog never opens).
+// Callers select the target row by name first via selectOrganization, which polls the button's real
+// `disabled` attribute until the selection has registered.
+export const deleteBtnClick = async () => {
 	// dispatchClick fires the handler even if a fading cdk-overlay backdrop sits on top.
 	await dispatchClick(DeleteOrganizationPage.deleteButtonCss);
 };
@@ -32,37 +45,93 @@ export const confirmBtnExists = async () => {
 
 // Confirm OK is clicked right after the dialog opens; a fading backdrop can intercept a coordinate
 // click — use dispatchClick so the (click)->delete() handler fires regardless.
-export const confirmBtnClick = async (index: number = 0) => {
+export const confirmBtnClick = async () => {
 	await dispatchClick(DeleteOrganizationPage.confirmDeleteCss);
 };
 
-// Select a data row to enable the toolbar Delete button. Row click TOGGLES selection, so this must be
-// idempotent: if the Delete button is already enabled (row already selected), do nothing — clicking
-// again would DESELECT and re-disable it. Otherwise settle, click once, poll the Delete button's real
-// `disabled` attr, and only re-click if selection didn't register.
-export const selectOrganizationRow = async (index: number = 0) => {
-	const deleteBtn = getPage().locator(DeleteOrganizationPage.deleteButtonCss).first();
+const nameFilterInput = () => getPage().locator(DeleteOrganizationPage.nameFilterInputCss).first();
 
-	// Already selected (e.g. the spec called selectOrganization first) -> leave it selected.
-	if ((await deleteBtn.getAttribute('disabled')) === null) return;
+/**
+ * Narrow the grid via the Name column filter. `term` should be a short unique token, not a whole
+ * company name (see the step file) — the filter is a substring match, so a token is enough.
+ *
+ * angular2-smart-table's InputFilterComponent is
+ *   `<input [value]="query" (change)="onValueChanged(...)" (keyup)="onValueChanged(...)">`
+ * — it reacts to keyup/change, never to 'input', and the debounced refetch writes `query` straight
+ * back into [value]. Typing character by character therefore races the write-back and leaves a
+ * mangled value ("Dickinson, Kozey and Casper" came out as "Dicknsn, oe ndCspr" and matched nothing).
+ * Set the whole value in one shot with fill() and then dispatch the 'change' the component listens
+ * for: atomic, so there is no window for the write-back to eat characters.
+ */
+export const searchOrganizationByName = async (term: string) => {
+	const page = getPage();
+	await waitForSpinnerGone();
+	await page.waitForLoadState('networkidle').catch(() => {});
+	await expect(nameFilterInput()).toBeVisible({ timeout: 24_000 });
+
+	for (let attempt = 0; attempt < 4; attempt++) {
+		const input = nameFilterInput();
+		await input.fill(String(term)).catch(() => {});
+		await input.dispatchEvent('change').catch(() => {});
+		// Filtering is debounced; let the grid repaint before reading the value back.
+		await page.waitForTimeout(1200);
+		await waitForSpinnerGone();
+		const current = await nameFilterInput()
+			.inputValue()
+			.catch(() => '');
+		if (current === String(term)) return;
+	}
+};
+
+/**
+ * Select the grid row for `name` so the toolbar Delete button becomes enabled.
+ *
+ * Row click TOGGLES selection, so this clicks ONCE and then polls the Delete button's real `disabled`
+ * attribute, only re-clicking if the selection did not register (a rapid second click would deselect
+ * it again). Before clicking it reads the row back and refuses to proceed if the row belongs to a
+ * seeded organization — see PROTECTED_ORGANIZATIONS.
+ */
+export const selectOrganizationRow = async (name: string) => {
+	const page = getPage();
+	const deleteBtn = page.locator(DeleteOrganizationPage.deleteButtonCss).first();
 
 	await waitForSpinnerGone();
-	await getPage().waitForLoadState('networkidle').catch(() => {});
-	await getPage().waitForTimeout(1500);
+	await page.waitForLoadState('networkidle').catch(() => {});
+	await page.waitForTimeout(1500);
 
-	const row = getPage().locator(DeleteOrganizationPage.selectOrganization).nth(index);
+	const row = page.locator(DeleteOrganizationPage.selectOrganization).filter({ hasText: name }).first();
+	await row.waitFor({ state: 'visible', timeout: 24_000 });
 
-	await row.click({ force: true });
-	for (let i = 0; i < 5; i++) {
-		if ((await deleteBtn.getAttribute('disabled')) === null) return; // enabled -> selection registered
-		await getPage().waitForTimeout(500);
-		if ((await deleteBtn.getAttribute('disabled')) !== null) {
-			await row.click({ force: true }); // selection not yet toggled on -> retry
+	const rowText = ((await row.textContent()) || '').replace(/\s+/g, ' ').trim();
+	const seeded = PROTECTED_ORGANIZATIONS.find((organization) => rowText.includes(organization));
+	if (seeded) {
+		throw new Error(
+			`Refusing to delete the seeded organization "${seeded}" (matched row: "${rowText}"). This spec ` +
+				`must only delete the throwaway organization it creates itself — deleting the seeded ` +
+				`organization cascades away the admin's membership and the seeded time-off policy, and breaks ` +
+				`every spec that runs after it.`
+		);
+	}
+
+	for (let attempt = 0; attempt < 4; attempt++) {
+		await row.click({ force: true });
+		for (let poll = 0; poll < 8; poll++) {
+			if ((await deleteBtn.getAttribute('disabled')) === null) return; // enabled -> selection registered
+			await page.waitForTimeout(350);
 		}
 	}
 };
 
-// Back-compat: the spec/page-data may still reference selectOrganization.
-export const selectOrganization = async (index: number = 0) => {
-	await selectOrganizationRow(index);
+// Back-compat: the step file reads better with the shorter name.
+export const selectOrganization = async (name: string) => {
+	await selectOrganizationRow(name);
+};
+
+/** The grid is still filtered to `name`, so a successful delete leaves it with zero data rows. */
+export const verifyOrganizationDeleted = async (name: string) => {
+	const page = getPage();
+	await waitForSpinnerGone();
+	await expect(page.locator(DeleteOrganizationPage.selectOrganization).filter({ hasText: name })).toHaveCount(0, {
+		timeout: 24_000
+	});
 };

--- a/apps/gauzy-e2e/tests/support/pages/DeleteOrganization.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/DeleteOrganization.po.ts
@@ -59,7 +59,7 @@ const nameFilterInput = () => getPage().locator(DeleteOrganizationPage.nameFilte
  *   `<input [value]="query" (change)="onValueChanged(...)" (keyup)="onValueChanged(...)">`
  * — it reacts to keyup/change, never to 'input', and the debounced refetch writes `query` straight
  * back into [value]. Typing character by character therefore races the write-back and leaves a
- * mangled value ("Dickinson, Kozey and Casper" came out as "Dicknsn, oe ndCspr" and matched nothing).
+ * mangled value — a 27-character company name came out with 9 characters missing and matched nothing.
  * Set the whole value in one shot with fill() and then dispatch the 'change' the component listens
  * for: atomic, so there is no window for the write-back to eat characters.
  */

--- a/apps/gauzy-e2e/tests/support/pages/DeleteOrganization.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/DeleteOrganization.po.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { verifyElementIsVisible, dispatchClick, waitForSpinnerGone } from '../util';
+import { applySmartTableFilter, verifyElementIsVisible, dispatchClick, waitForSpinnerGone } from '../util';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { DeleteOrganizationPage } from '../../../src/support/Base/pageobjects/DeleteOrganizationPageObject';
@@ -49,38 +49,13 @@ export const confirmBtnClick = async () => {
 	await dispatchClick(DeleteOrganizationPage.confirmDeleteCss);
 };
 
-const nameFilterInput = () => getPage().locator(DeleteOrganizationPage.nameFilterInputCss).first();
-
 /**
  * Narrow the grid via the Name column filter. `term` should be a short unique token, not a whole
- * company name (see the step file) — the filter is a substring match, so a token is enough.
- *
- * angular2-smart-table's InputFilterComponent is
- *   `<input [value]="query" (change)="onValueChanged(...)" (keyup)="onValueChanged(...)">`
- * — it reacts to keyup/change, never to 'input', and the debounced refetch writes `query` straight
- * back into [value]. Typing character by character therefore races the write-back and leaves a
- * mangled value — a 27-character company name came out with 9 characters missing and matched nothing.
- * Set the whole value in one shot with fill() and then dispatch the 'change' the component listens
- * for: atomic, so there is no window for the write-back to eat characters.
+ * company name (see the step file) — the filter is a substring match, so a token is enough, and the
+ * shorter the term the less there is for a mid-entry re-render to mangle.
  */
 export const searchOrganizationByName = async (term: string) => {
-	const page = getPage();
-	await waitForSpinnerGone();
-	await page.waitForLoadState('networkidle').catch(() => {});
-	await expect(nameFilterInput()).toBeVisible({ timeout: 24_000 });
-
-	for (let attempt = 0; attempt < 4; attempt++) {
-		const input = nameFilterInput();
-		await input.fill(String(term)).catch(() => {});
-		await input.dispatchEvent('change').catch(() => {});
-		// Filtering is debounced; let the grid repaint before reading the value back.
-		await page.waitForTimeout(1200);
-		await waitForSpinnerGone();
-		const current = await nameFilterInput()
-			.inputValue()
-			.catch(() => '');
-		if (current === String(term)) return;
-	}
+	await applySmartTableFilter(DeleteOrganizationPage.nameFilterInputCss, term);
 };
 
 /**

--- a/apps/gauzy-e2e/tests/support/pages/EditUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/EditUser.po.ts
@@ -1,4 +1,5 @@
 import {
+	applySmartTableFilter,
 	verifyElementIsVisible,
 	verifyElementIsVisibleByIndex,
 	clickButton,
@@ -46,6 +47,13 @@ export const gridButtonVisible = async () => {
 
 export const clickGridButton = async () => {
 	/* no-op: grid list/grid layout toggle removed from the app */
+};
+
+// Narrow the users grid to one full name so the user this spec created is the only data row on page 1.
+// The grid pages at 10 and the shared serial DB accumulates users, so without this the new user is
+// simply not rendered and both the by-name verify and the row click miss it (mirrors RemoveUser.po).
+export const filterByName = async (name: string) => {
+	await applySmartTableFilter(EditUserPage.nameFilterInputCss, name);
 };
 
 export const tableRowVisible = async () => {
@@ -137,13 +145,22 @@ export const selectOrgDropdownVisible = async () => {
 };
 
 export const clickSelectOrgDropdown = async () => {
-	// nb-select opens on mousedown; a force coordinate-click is reliable here (no leftover dialog
-	// backdrop at this point — the add form just rendered inline). Best-effort: skip if the control
-	// isn't present (empty/closed add form) so we don't burn the 60s task timeout.
+	// Best-effort: skip if the control isn't present (empty/closed add form).
 	const select = getPage().locator(EditUserPage.selectOrgMultiSelectCss).first();
-	if (await select.isVisible().catch(() => false)) {
-		await clickButton(EditUserPage.selectOrgMultiSelectCss);
+	if (!(await select.isVisible().catch(() => false))) return;
+	// DISPATCH, not a coordinate click: the Organizations tab keeps re-rendering the add form while it
+	// settles (debounced showAddCard reset + org-list reload), so a retrying coordinate click sees
+	// "element was detached from the DOM, retrying" over and over and clickButton burns its full 60s
+	// task timeout before throwing. A dispatched click fires nb-select's own handler on whichever
+	// instance is attached right now, and stays best-effort — this whole add-organization sub-flow is
+	// a prerequisite, not the test (orgWasAdded gates everything after it).
+	const toggle = select.locator('button.select-button').first();
+	if ((await toggle.count().catch(() => 0)) > 0) {
+		await toggle.dispatchEvent('click').catch(() => {});
+	} else {
+		await select.dispatchEvent('click').catch(() => {});
 	}
+	await getPage().waitForTimeout(400);
 };
 
 export const clickSelectOrgDropdownOption = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/EditUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/EditUser.po.ts
@@ -11,6 +11,7 @@ import {
 	waitElementToHide,
 	clickByText,
 	dispatchClick,
+	dispatchClickWhenSettled,
 	waitForSpinnerGone
 } from '../util';
 import { getPage } from '../page-context';
@@ -60,7 +61,12 @@ export const editButtonVisible = async () => {
 };
 
 export const clickEditButton = async () => {
-	await clickButtonByIndex(EditUserPage.editButtonCss, 0);
+	// The action bar (ngx-gauzy-button-action) slides in over ~0.2s once a row is selected, so a
+	// coordinate click resolved mid-transition lands on whichever button occupies that spot at delivery
+	// time — the failing run's trace shows it hitting "Convert to employee" (its toast is in the trace)
+	// and the edit page never opening. Settle, dispatch straight at the Edit button, and confirm the
+	// edit page's tab strip rendered.
+	await dispatchClickWhenSettled(EditUserPage.editButtonCss, EditUserPage.orgTabButtonCss);
 };
 
 export const orgTabButtonVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Goals.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Goals.po.ts
@@ -219,7 +219,7 @@ const createTimeFrameFromObjectiveForm = async () => {
 	await enterInput(GoalsPage.timeFrameStartDateCss, dayjs().startOf('year').format('MMM D, YYYY'));
 	await clearField(GoalsPage.timeFrameEndDateCss);
 	await enterInput(GoalsPage.timeFrameEndDateCss, dayjs().endOf('year').format('MMM D, YYYY'));
-	// Commit the last date field so the reactive form revalidates and Save enables.
+	// Commit the last date field so the reactive form re-validates and Save enables.
 	await page.keyboard.press('Tab').catch(() => {});
 	await waitForSpinnerGone();
 	await clickButton(GoalsPage.timeFrameSaveButtonCss);

--- a/apps/gauzy-e2e/tests/support/pages/Goals.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Goals.po.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import {
 	enterInput,
 	verifyElementIsVisible,
@@ -189,6 +190,44 @@ export const clickDeadlineDropdown = async () => {
 	await clickButton(GoalsPage.deadlineDropdownCss);
 };
 
+/**
+ * Create a goal time frame from inside the objective form.
+ *
+ * edit-objective.component.html renders `#objective-deadline` as an nb-select ONLY when
+ * `timeFrames.length > 0`; with zero time frames the SAME id is a plain "Add Time Frame" button that
+ * opens the EditTimeFrame dialog. So on an organization with no time frames, clickDeadlineDropdown()
+ * opens that dialog instead of an option list, and waiting for `.option-list nb-option` can only time
+ * out. The organization really can have none: goals-time-frame (which runs just before this spec)
+ * creates one and deletes it again, and the database has no seeded frames — `select count(*) from
+ * goal_time_frame` was 0 on the run this was diagnosed from.
+ *
+ * Fill the dialog the app itself opened. The dates matter: the later "add new deadline" step needs a
+ * frame that started in the PAST and ends in the FUTURE (key-result-details hides its update button
+ * unless both hold), so use the whole current year, which is also the shape of the seeded
+ * "Annual-<year>" frame this page object already prefers.
+ */
+const createTimeFrameFromObjectiveForm = async () => {
+	const page = getPage();
+	const dialog = page.locator(GoalsPage.timeFrameDialogCss).first();
+	await dialog.waitFor({ state: 'visible', timeout: 12_000 });
+
+	const year = new Date().getFullYear();
+	await clearField(GoalsPage.timeFrameNameInputCss);
+	await enterInput(GoalsPage.timeFrameNameInputCss, `Annual-${year}`);
+	await clearField(GoalsPage.timeFrameStartDateCss);
+	await enterInput(GoalsPage.timeFrameStartDateCss, dayjs().startOf('year').format('MMM D, YYYY'));
+	await clearField(GoalsPage.timeFrameEndDateCss);
+	await enterInput(GoalsPage.timeFrameEndDateCss, dayjs().endOf('year').format('MMM D, YYYY'));
+	// Commit the last date field so the reactive form revalidates and Save enables.
+	await page.keyboard.press('Tab').catch(() => {});
+	await waitForSpinnerGone();
+	await clickButton(GoalsPage.timeFrameSaveButtonCss);
+	// The dialog resolves and edit-objective re-runs getTimeFrames(), which swaps the button for the
+	// nb-select — wait for it to go before reopening the (now real) dropdown.
+	await dialog.waitFor({ state: 'detached', timeout: 12_000 }).catch(() => {});
+	await page.waitForTimeout(800);
+};
+
 export const selectDeadlineFromDropdown = async (index) => {
 	// Deadline is a plain nb-select bound via formControlName, so picking any option both fills the
 	// required control and enables Save.
@@ -203,7 +242,24 @@ export const selectDeadlineFromDropdown = async (index) => {
 	// Dec 31 (future) for the whole current year, so it is ALWAYS updatable. Prefer it; fall back to nth().
 	const page = getPage();
 	const option = page.locator(GoalsPage.dropdownOptionCss);
-	await option.first().waitFor({ state: 'visible', timeout: 8000 }).catch(() => {});
+	const optionsRendered = await option
+		.first()
+		.waitFor({ state: 'visible', timeout: 8000 })
+		.then(() => true)
+		.catch(() => false);
+
+	if (!optionsRendered) {
+		// No option list: the organization has no time frames, so the click landed on the
+		// "Add Time Frame" button and opened its dialog. Create the frame, then reopen the control —
+		// which is an nb-select now that timeFrames is non-empty.
+		await createTimeFrameFromObjectiveForm();
+		await clickButton(GoalsPage.deadlineDropdownCss);
+		await option
+			.first()
+			.waitFor({ state: 'visible', timeout: 12_000 })
+			.catch(() => {});
+	}
+
 	const annual = option.filter({ hasText: 'Annual' }).first();
 	if (await annual.isVisible().catch(() => false)) {
 		await annual.click({ force: true });

--- a/apps/gauzy-e2e/tests/support/pages/Goals.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Goals.po.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { expect } from '@playwright/test';
 import {
 	enterInput,
 	verifyElementIsVisible,
@@ -527,12 +528,54 @@ export const enterUpdatedValueData = async (data) => {
 	await input.fill(String(data));
 };
 
+/**
+ * Confirm the key-result UPDATE dialog.
+ *
+ * Two things made the generic confirm silently no-op here, leaving BOTH the update dialog and the
+ * details dialog underneath it stacked over the page — which is why the next step could not reach the
+ * toolbar and `#key-result-weight` never appeared:
+ *
+ *  - the update dialog opens on top of the details dialog, so both are mounted and the generic
+ *    `nb-card-footer > button[status="success"]` is ambiguous; and
+ *  - the Update button is `[disabled]="!keyResultUpdateForm.valid"`, and a DISPATCHED click on a
+ *    disabled nbButton is swallowed by Nebular's own host listener (preventDefault +
+ *    stopImmediatePropagation), so it fires nothing at all and reports no error.
+ *
+ * Scope to the update dialog, wait for the button to actually be enabled, then prove the dialog went
+ * away rather than assuming it did.
+ */
+export const confirmUpdateKeyResultVisible = async () => {
+	await verifyElementIsVisible(GoalsPage.keyResultUpdateConfirmCss);
+};
+
+export const clickConfirmUpdateKeyResult = async () => {
+	const page = getPage();
+	const button = page.locator(GoalsPage.keyResultUpdateConfirmCss).first();
+	await expect(button).toBeEnabled({ timeout: 24_000 });
+	await waitForSpinnerGone();
+	await button.dispatchEvent('click').catch(() => {});
+	await page
+		.locator(GoalsPage.keyResultUpdateDialogCss)
+		.first()
+		.waitFor({ state: 'detached', timeout: 12_000 })
+		.catch(() => {});
+};
+
 export const saveDeadlineButtonVisible = async () => {
-	await verifyElementIsVisible(GoalsPage.saveDeadlineButtonCss);
+	await verifyElementIsVisible(GoalsPage.keyResultDetailsSaveCss);
 };
 
 export const clickSaveDeadlineButton = async () => {
-	await clickButton(GoalsPage.saveDeadlineButtonCss);
+	// Scoped to the DETAILS dialog (see above) and verified closed, so the next step's toolbar is
+	// actually reachable instead of sitting behind two leftover overlays.
+	const page = getPage();
+	await waitForSpinnerGone();
+	await dispatchClick(GoalsPage.keyResultDetailsSaveCss);
+	await page
+		.locator(GoalsPage.keyResultDetailsDialogCss)
+		.first()
+		.waitFor({ state: 'detached', timeout: 12_000 })
+		.catch(() => {});
 };
 
 export const weightTypeButtonVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/GoalsTimeFrame.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/GoalsTimeFrame.po.ts
@@ -7,6 +7,8 @@ import {
 	clickButtonByIndex,
 	waitElementToHide,
 	verifyText,
+	verifyTextNotExisting,
+	clickByText,
 	clickKeyboardBtnByKeycode
 } from '../util';
 // Selectors + data are framework-agnostic — reused from the Cypress tree during migration.
@@ -81,6 +83,14 @@ export const selectTableRow = async (index) => {
 	await clickButtonByIndex(GoalsTimeFramePage.selectTableRowCss, index);
 };
 
+// Select the row for a specific time frame instead of a positional index. The organization can hold
+// time frames this spec did not create — the goals spec has to create one (the objective form's
+// deadline is required and the database seeds no time frames), and it survives the run — so a blind
+// row 0 would edit and then DELETE somebody else's frame.
+export const selectTableRowByName = async (name: string) => {
+	await clickByText(GoalsTimeFramePage.selectTableRowCss, name);
+};
+
 export const editTimeFrameButtonVisible = async () => {
 	await verifyElementIsVisible(GoalsTimeFramePage.editButtonCss);
 };
@@ -111,6 +121,16 @@ export const waitMessageToHide = async () => {
 
 export const verifyElementDeleted = async (text) => {
 	await verifyText(GoalsTimeFramePage.verifyEmptyTableCss, text);
+};
+
+// Assert THIS spec's time frame is gone, rather than that the whole grid is empty. "No data found"
+// only ever held because nothing else created a time frame; the goals spec now has to create one (the
+// objective form's deadline is required and the database seeds none), so an empty-table assertion
+// fails on a row that is not ours and was never part of what this spec exercises.
+export const verifyTimeFrameIsDeleted = async (name: string) => {
+	// Scope to grid ROWS: verifyTimeFrameCss ('div.ng-star-inserted') also matches the row's ancestor
+	// wrappers, so a hasText filter resolves to six nested elements for a single row.
+	await verifyTextNotExisting(GoalsTimeFramePage.selectTableRowCss, name);
 };
 
 export const verifyTimeFrameExists = async (text) => {

--- a/apps/gauzy-e2e/tests/support/pages/InviteUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/InviteUser.po.ts
@@ -6,14 +6,20 @@ import {
 	clickElementByText,
 	enterInputConditionally,
 	clearField,
-	clickKeyboardBtnByKeycode
+	clickKeyboardBtnByKeycode,
+	dispatchClickWhenSettled
 } from '../util';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { InviteUserPage } from '../../../src/support/Base/pageobjects/InviteUserPageObject';
 
 export const inviteButtonVisible = async () => verifyElementIsVisible(InviteUserPage.inviteButtonCss);
 
-export const clickInviteButton = async () => clickButton(InviteUserPage.inviteButtonCss);
+// The Users card is `[nbSpinner]="loading"`; its overlay covers the header toolbar while the grid
+// loads, and the spec clicks Invite ~1.9s after navigating. The old force-click was delivered at the
+// button's coordinates, landed on the overlay, and the dialog never opened (#emails not found).
+// Settle, dispatch straight at the button, and confirm the dialog opened.
+export const clickInviteButton = async () =>
+	dispatchClickWhenSettled(InviteUserPage.inviteButtonCss, InviteUserPage.emailInputCss);
 
 export const emailInputVisible = async () => verifyElementIsVisible(InviteUserPage.emailInputCss);
 

--- a/apps/gauzy-e2e/tests/support/pages/ManageEmployees.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/ManageEmployees.po.ts
@@ -49,6 +49,16 @@ export const dateInputVisible = async () => {
 	await verifyElementIsVisible(ManageEmployeesPage.dateInputCss);
 };
 
+// Add-Employee dialog's start-work date (scoped to ga-employee-mutation — see employeeDateInputCss).
+export const employeeDateInputVisible = async () => {
+	await verifyElementIsVisible(ManageEmployeesPage.employeeDateInputCss);
+};
+
+export const enterEmployeeDateData = async () => {
+	await clearField(ManageEmployeesPage.employeeDateInputCss);
+	await enterInput(ManageEmployeesPage.employeeDateInputCss, dayjs().format('MMM D, YYYY'));
+};
+
 export const enterDateData = async () => {
 	await clearField(ManageEmployeesPage.dateInputCss);
 	const date = dayjs().format('MMM D, YYYY');

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationDepartments.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationDepartments.po.ts
@@ -84,6 +84,41 @@ export const clickEmployeeDropdown = async () => {
 	await clickButton(OrganizationDepartmentsPage.selectEmployeeDropdownCss);
 };
 
+/**
+ * Collapse the members nb-select's option panel.
+ *
+ * ga-employee-multi-select is `<nb-select [multiple]>`, and a MULTIPLE nb-select deliberately keeps its
+ * panel open after a selection so you can pick more. That panel is a cdk overlay hanging BELOW the
+ * control — i.e. straight over the dialog footer where Save lives. Every click in this page object is
+ * `force: true`, which skips the "receives events" check but still delivers the click at screen
+ * coordinates, so the Save click was being handed to the option list instead of the button: no submit,
+ * no POST, no toast, the dialog just sat there and verifyDepartmentExists timed out on an empty grid.
+ *
+ * It only bites once the organization has enough employees for the panel to reach the footer, which is
+ * exactly why this passed on a fresh database and started failing after the specs that add employees
+ * had run. Closing the panel is the fix; do it by DISPATCHING the toggle click (a coordinate click can
+ * itself be swallowed by the panel we are trying to close) and confirm via nb-select's own `open` class.
+ *
+ * Escape is not an option here: nb-dialog opens with closeOnEsc, so it closes the whole Add form.
+ */
+const closeEmployeeDropdown = async () => {
+	const page = getPage();
+	// Target whichever nb-select is currently OPEN: nb-select puts an `open` class on its host while the
+	// panel is up, so this needs no assumption about the control's caption (which changes as soon as
+	// employees are picked) or about the dialog still being mounted.
+	const openSelect = page.locator('nb-select.open');
+	for (let attempt = 0; attempt < 5; attempt++) {
+		if ((await openSelect.count().catch(() => 0)) === 0) return;
+		await openSelect
+			.first()
+			.locator('button.select-button')
+			.first()
+			.dispatchEvent('click')
+			.catch(() => {});
+		await page.waitForTimeout(400);
+	}
+};
+
 export const selectEmployeeFromDropdown = async (index: number) => {
 	// Best-effort employee pick (mirrors ContactsLeads.selectEmployeeDropdownOption): the nb-option
 	// list loads async and can legitimately be EMPTY (no employee "working" in the header date range).
@@ -94,6 +129,8 @@ export const selectEmployeeFromDropdown = async (index: number) => {
 	try {
 		await option.first().waitFor({ state: 'visible', timeout: 8000 });
 		await option.nth(index).click({ force: true });
+		// A multiple nb-select keeps its panel open over the footer — collapse it before moving on.
+		await closeEmployeeDropdown();
 	} catch {
 		await page.keyboard.press('Escape').catch(() => {});
 	}
@@ -146,11 +183,30 @@ export const saveDepartmentButtonVisible = async () => {
 export const clickSaveDepartmentButton = async () => {
 	// IMPORTANT: this Save button is type="submit" with NO (click) handler — it submits the form via the
 	// native submit -> (ngSubmit). A synthetic dispatchEvent('click') is an UNtrusted event and does NOT
-	// trigger native form submission, so it would silently no-op. Use a real (force) click instead. The
-	// button lives in the top dialog overlay, and clickCardBody() has already closed the tags panel, so a
-	// coordinate click reaches it. Wait out the card spinner first.
-	await waitForSpinnerGone();
-	await clickButton(OrganizationDepartmentsPage.saveDepartmentButtonCss);
+	// trigger native form submission, so it would silently no-op. It has to be a real coordinate click,
+	// which means nothing may be painted on top of it: `force: true` skips the actionability CHECK but
+	// still delivers the click wherever the pointer is, so an overlay lying over the button eats the
+	// submit silently. Collapse the option panels first, then click and PROVE it landed — the dialog
+	// closes on a successful save (departments.component._clearItem), so a dialog that is still there
+	// means the submit never happened, and we close panels and try once more.
+	const page = getPage();
+	const dialog = page.locator('ga-departments-mutation');
+	for (let attempt = 0; attempt < 2; attempt++) {
+		await waitForSpinnerGone();
+		await closeEmployeeDropdown();
+		await page
+			.locator(OrganizationDepartmentsPage.tagsDropdownOption)
+			.first()
+			.waitFor({ state: 'hidden', timeout: 2000 })
+			.catch(() => {});
+		await clickButton(OrganizationDepartmentsPage.saveDepartmentButtonCss);
+		try {
+			await dialog.first().waitFor({ state: 'detached', timeout: 8000 });
+			return;
+		} catch {
+			/* still open -> the click did not submit; re-close panels and retry once */
+		}
+	}
 };
 
 export const tableRowVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationPublicPage.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationPublicPage.po.ts
@@ -14,6 +14,7 @@ import {
 	verifyText,
 	getLastElement
 } from '../util';
+import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationPublicPage } from '../../../src/support/Base/pageobjects/OrganizationPublicPagePageObject';
 
@@ -35,7 +36,15 @@ export const organizationNameFilterInputVisible = async () => {
 };
 
 export const enterOrganizationNameFilterInputData = async (name: string) => {
-	await enterInput(OrganizationPublicPage.nameFilterInputCss, name);
+	// This is angular2-smart-table's InputFilterComponent:
+	//   <input [value]="query" (change)="onValueChanged(...)" (keyup)="onValueChanged(...)">
+	// It never listens for 'input', which is the only event .fill() dispatches — so the plain
+	// enterInput() left the grid unfiltered, the freshly created organization stayed off page 1, and
+	// the profile-link flow silently fell into its best-effort catch. Fill, then dispatch the 'change'
+	// the component actually subscribes to.
+	const input = getPage().locator(OrganizationPublicPage.nameFilterInputCss).first();
+	await input.fill(String(name));
+	await input.dispatchEvent('change');
 	await waitUntil(2000);
 };
 
@@ -365,7 +374,8 @@ export const clickCountryDropdown = async () => {
 };
 
 export const selectCountryFromDropdown = async (text) => {
-	await clickElementByText(OrganizationPublicPage.dropdownOptionCss, text);
+	// ng-select options, not nb-select options — see countryDropdownOptionCss.
+	await clickElementByText(OrganizationPublicPage.countryDropdownOptionCss, text);
 };
 
 export const cityInputVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationPublicPage.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationPublicPage.po.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import {
+	applySmartTableFilter,
 	clearField,
 	clickButton,
 	clickByText,
@@ -14,7 +15,6 @@ import {
 	verifyText,
 	getLastElement
 } from '../util';
-import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationPublicPage } from '../../../src/support/Base/pageobjects/OrganizationPublicPagePageObject';
 
@@ -36,16 +36,10 @@ export const organizationNameFilterInputVisible = async () => {
 };
 
 export const enterOrganizationNameFilterInputData = async (name: string) => {
-	// This is angular2-smart-table's InputFilterComponent:
-	//   <input [value]="query" (change)="onValueChanged(...)" (keyup)="onValueChanged(...)">
-	// It never listens for 'input', which is the only event .fill() dispatches — so the plain
-	// enterInput() left the grid unfiltered, the freshly created organization stayed off page 1, and
-	// the profile-link flow silently fell into its best-effort catch. Fill, then dispatch the 'change'
-	// the component actually subscribes to.
-	const input = getPage().locator(OrganizationPublicPage.nameFilterInputCss).first();
-	await input.fill(String(name));
-	await input.dispatchEvent('change');
-	await waitUntil(2000);
+	// The plain enterInput() (.fill()) left the grid unfiltered — see applySmartTableFilter — so the
+	// freshly created organization stayed off page 1 and the profile-link flow silently fell into its
+	// best-effort catch.
+	await applySmartTableFilter(OrganizationPublicPage.nameFilterInputCss, name);
 };
 
 export const verifyOrganizationNameTableRowContains = async (text: string) => {

--- a/apps/gauzy-e2e/tests/support/pages/RecurringExpenses.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/RecurringExpenses.po.ts
@@ -31,20 +31,41 @@ export const employeeDropdownVisible = async () => {
 	await verifyElementIsVisible(RecurringExpensesPage.employeeDropdownCss);
 };
 
+/**
+ * A REAL employee option — not ng-select's own placeholder.
+ *
+ * While the employee list is still loading, ng-select renders "No items found" as
+ * `div.ng-option.ng-option-disabled`. Counting bare `div.ng-option` treats that placeholder as "the
+ * list is open and populated", which is how the spec ended up clicking it (a no-op) and posting
+ * employeeId:null. Only options that are not disabled, and not the "All Employees" pseudo-entry (it
+ * has no id, so it produces the same null), are real choices.
+ */
+const realEmployeeOptions = () =>
+	getPage()
+		.locator(`${RecurringExpensesPage.dropdownOptionCss}:not(.ng-option-disabled)`)
+		.filter({ hasNotText: 'All Employees' });
+
 // ng-select opens on MOUSEDOWN and is blocked by the dialog/overlay backdrop, so a force-click on the
 // control is unreliable (and can land on the backdrop). Open it via the keyboard instead: focus the
-// inner input and press ArrowDown. Retry until the option list ('div.ng-option', appendTo="body")
-// renders, but bail out best-effort — the employee list loads async and can legitimately be EMPTY
-// (no employee "working" in the header date range); selectEmployeeFromDropdown handles that case.
+// inner input and press ArrowDown.
+//
+// Opening it in the same tick the dialog appears catches the list mid-load, and it then stays stuck on
+// "No items found" (measured: still empty 5s later) — but closing and re-opening the panel picks the
+// loaded list straight up. So retry around a real option appearing, toggling the panel shut between
+// attempts via its own container. NEVER Escape: nb-dialog opens with closeOnEsc, so that would dismiss
+// the whole Add-Expense form. Best-effort — the list can legitimately be empty (no employee "working"
+// in the header date range) and selectEmployeeFromDropdown reports that.
 const openEmployeeDropdown = async () => {
 	const page = getPage();
-	const options = page.locator(RecurringExpensesPage.dropdownOptionCss);
 	const input = page.locator(RecurringExpensesPage.employeeDropdownCss).locator('input').first();
+	const container = page.locator(`${RecurringExpensesPage.employeeDropdownCss} .ng-select-container`).first();
 	for (let i = 0; i < 6; i++) {
 		await input.focus().catch(() => {});
 		await page.keyboard.press('ArrowDown').catch(() => {});
-		await page.waitForTimeout(800);
-		if (await options.count()) return;
+		await page.waitForTimeout(900);
+		if (await realEmployeeOptions().count()) return;
+		await container.click({ force: true }).catch(() => {}); // toggle shut, then re-open next pass
+		await page.waitForTimeout(700);
 	}
 };
 
@@ -59,33 +80,22 @@ export const selectEmployeeFromDropdown = async (index) => {
 	// "employeeId must be a string" — a rejection the spec then only notices three steps later as a
 	// missing row.
 	//
-	// The click alone is not proof: this is an appendTo="body" ng-select whose panel is re-rendered as
-	// the async employee list settles, so a click can land on a node that is being replaced and the
-	// selection never commits (that is exactly the 400 above — the option was clicked, employeeId was
-	// still null at save). Read the chosen name back off the control and retry until it sticks.
+	// The click alone is not proof, and neither is reading the CONTROL's text back: ng-select renders
+	// its open panel inside the control, so the previous check ("does the control's text contain the
+	// option I clicked?") was satisfied by the very panel it clicked in — it passed while nothing had
+	// been selected. Verify against the committed value instead: on a real selection ng-select closes
+	// the panel and renders the choice as `div.ng-value` in the container.
 	void index;
 	const page = getPage();
-	const control = page.locator(RecurringExpensesPage.employeeDropdownCss).first();
+	const value = page.locator(`${RecurringExpensesPage.employeeDropdownCss} div.ng-value`);
 	for (let attempt = 0; attempt < 3; attempt++) {
-		const realEmployee = page
-			.locator(RecurringExpensesPage.dropdownOptionCss)
-			.filter({ hasNotText: 'All Employees' })
-			.first();
-		try {
-			await realEmployee.waitFor({ state: 'visible', timeout: 8000 });
-		} catch {
-			// Panel not open (or the list is genuinely empty for this date range) — try to reopen once
-			// more; on the last attempt fall through so the caller's own assertions report the state.
-			await page.keyboard.press('Escape').catch(() => {});
-			await openEmployeeDropdown();
-			continue;
-		}
-		const wanted = ((await realEmployee.textContent().catch(() => '')) || '').replace(/\s+/g, ' ').trim();
-		await realEmployee.click({ force: true }).catch(() => {});
-		await page.waitForTimeout(600); // let ng-select close and write the value
-		const shown = ((await control.textContent().catch(() => '')) || '').replace(/\s+/g, ' ').trim();
-		if (wanted && shown.includes(wanted)) return; // committed
 		await openEmployeeDropdown();
+		const option = realEmployeeOptions().first();
+		if ((await option.count().catch(() => 0)) === 0) continue; // list still empty — try again
+		const wanted = ((await option.textContent().catch(() => '')) || '').replace(/\s+/g, ' ').trim();
+		await option.click({ force: true }).catch(() => {});
+		await page.waitForTimeout(800); // let ng-select close and write the value
+		if (wanted && (await value.filter({ hasText: wanted }).count().catch(() => 0)) > 0) return; // committed
 	}
 };
 

--- a/apps/gauzy-e2e/tests/support/pages/RecurringExpenses.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/RecurringExpenses.po.ts
@@ -31,12 +31,12 @@ export const employeeDropdownVisible = async () => {
 	await verifyElementIsVisible(RecurringExpensesPage.employeeDropdownCss);
 };
 
-export const clickEmployeeDropdown = async () => {
-	// ng-select opens on MOUSEDOWN and is blocked by the dialog/overlay backdrop, so a force-click on the
-	// control is unreliable (and can land on the backdrop). Open it via the keyboard instead: focus the
-	// inner input and press ArrowDown. Retry until the option list ('div.ng-option', appendTo="body")
-	// renders, but bail out best-effort — the employee list loads async and can legitimately be EMPTY
-	// (no employee "working" in the header date range); selectEmployeeFromDropdown handles that case.
+// ng-select opens on MOUSEDOWN and is blocked by the dialog/overlay backdrop, so a force-click on the
+// control is unreliable (and can land on the backdrop). Open it via the keyboard instead: focus the
+// inner input and press ArrowDown. Retry until the option list ('div.ng-option', appendTo="body")
+// renders, but bail out best-effort — the employee list loads async and can legitimately be EMPTY
+// (no employee "working" in the header date range); selectEmployeeFromDropdown handles that case.
+const openEmployeeDropdown = async () => {
 	const page = getPage();
 	const options = page.locator(RecurringExpensesPage.dropdownOptionCss);
 	const input = page.locator(RecurringExpensesPage.employeeDropdownCss).locator('input').first();
@@ -48,24 +48,44 @@ export const clickEmployeeDropdown = async () => {
 	}
 };
 
+export const clickEmployeeDropdown = async () => {
+	await openEmployeeDropdown();
+};
+
 export const selectEmployeeFromDropdown = async (index) => {
-	// Best-effort employee pick (mirrors ContactsLeads.selectEmployeeDropdownOption): the option list
-	// loads async and can be empty. The first option is the "All Employees" pseudo-entry, which has no
-	// real id and makes the create fail, so prefer the first REAL employee. If nothing renders within a
-	// short wait, press Escape and continue — the selector keeps its [defaultSelected]="true" employee,
-	// so the expense still saves. Avoids a 60s hang on an empty list.
+	// Pick the first REAL employee: the leading "All Employees" pseudo-entry has no id, and
+	// recurring-expense-mutation sends `employee = employeeSelector.selectedEmployee` straight into the
+	// payload, so leaving it on ALL posts employeeId:null and the API 400s with
+	// "employeeId must be a string" — a rejection the spec then only notices three steps later as a
+	// missing row.
+	//
+	// The click alone is not proof: this is an appendTo="body" ng-select whose panel is re-rendered as
+	// the async employee list settles, so a click can land on a node that is being replaced and the
+	// selection never commits (that is exactly the 400 above — the option was clicked, employeeId was
+	// still null at save). Read the chosen name back off the control and retry until it sticks.
 	void index;
 	const page = getPage();
-	const realEmployee = page
-		.locator(RecurringExpensesPage.dropdownOptionCss)
-		.filter({ hasNotText: 'All Employees' });
-	try {
-		await realEmployee.first().waitFor({ state: 'visible', timeout: 8000 });
-		await realEmployee.first().click({ force: true });
-		// Let the ng-select commit the selection (close + write the form value).
-		await page.waitForTimeout(500);
-	} catch {
-		await page.keyboard.press('Escape').catch(() => {});
+	const control = page.locator(RecurringExpensesPage.employeeDropdownCss).first();
+	for (let attempt = 0; attempt < 3; attempt++) {
+		const realEmployee = page
+			.locator(RecurringExpensesPage.dropdownOptionCss)
+			.filter({ hasNotText: 'All Employees' })
+			.first();
+		try {
+			await realEmployee.waitFor({ state: 'visible', timeout: 8000 });
+		} catch {
+			// Panel not open (or the list is genuinely empty for this date range) — try to reopen once
+			// more; on the last attempt fall through so the caller's own assertions report the state.
+			await page.keyboard.press('Escape').catch(() => {});
+			await openEmployeeDropdown();
+			continue;
+		}
+		const wanted = ((await realEmployee.textContent().catch(() => '')) || '').replace(/\s+/g, ' ').trim();
+		await realEmployee.click({ force: true }).catch(() => {});
+		await page.waitForTimeout(600); // let ng-select close and write the value
+		const shown = ((await control.textContent().catch(() => '')) || '').replace(/\s+/g, ' ').trim();
+		if (wanted && shown.includes(wanted)) return; // committed
+		await openEmployeeDropdown();
 	}
 };
 

--- a/apps/gauzy-e2e/tests/support/pages/RemoveUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/RemoveUser.po.ts
@@ -1,4 +1,5 @@
 import {
+	applySmartTableFilter,
 	verifyElementIsVisible,
 	verifyElementIsVisibleByIndex,
 	waitElementToHide,
@@ -23,18 +24,15 @@ export const clickGridButton = async () => {
 // Filter the users grid by Full Name so the just-added user is the only data row on page 1. The shared
 // serial DB accumulates users from earlier specs (seed admin + faker employees from addEmployee), so the
 // grid paginates and a freshly-added user can land on page 2 — invisible to a filter-by-text verify or a
-// row click. Typing the unique name into the smart-table Full Name filter narrows the grid to that record.
-// Mirrors the proven ManageEmployees.searchEmployeeByName pattern.
+// row click.
+//
+// This used to be a bare .fill(), which sets the box's text but dispatches only 'input' — an event the
+// smart-table InputFilterComponent does not listen for. The failing run's snapshot proves it: the Full
+// Name box held the new user's full name while the grid still showed "1 - 10 of 14 Items" with every
+// user on it, and the new user sat on page 2, never rendered. applySmartTableFilter dispatches the
+// 'change' the component actually subscribes to and reads the value back.
 export const filterByName = async (name: string) => {
-	const page = getPage();
-	await waitForSpinnerGone();
-	await page.waitForLoadState('networkidle').catch(() => {});
-	const filter = page.locator(RemoveUserPage.nameFilterInputCss).first();
-	await filter.fill(String(name)).catch(() => {});
-	// smart-table filtering is debounced; let the grid re-render before verifying/selecting.
-	await page.waitForTimeout(2000);
-	await waitForSpinnerGone();
-	await page.waitForLoadState('networkidle').catch(() => {});
+	await applySmartTableFilter(RemoveUserPage.nameFilterInputCss, name);
 };
 
 export const tableBodyExists = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/RolesPermissions.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/RolesPermissions.po.ts
@@ -87,10 +87,10 @@ const cardBody = (card: 'general' | 'admin') =>
  */
 export const waitForPermissionsLoaded = async () => {
 	// Let the getRolePermissions XHR for the freshly-selected role settle, then wait out the reload
-	// spinner. The toggle COUNT is constant (152 GENERAL + 23 ADMIN) across roles, so a count-only poll
-	// can pass on the PREVIOUS role's still-rendered inputs; the per-toggle checked assertions in
-	// verifyStateInCard auto-retry (24s) against the live value, which is what actually converges once
-	// loadPermissions() has repainted enabledPermissions for the new role.
+	// spinner. The toggle COUNT is constant across roles (it is the catalog size, not the role's
+	// permissions), so a count-only poll can pass on the PREVIOUS role's still-rendered inputs; the
+	// per-toggle checked assertions in verifyStateInCard auto-retry (24s) against the live value, which
+	// is what actually converges once loadPermissions() has repainted enabledPermissions for the new role.
 	await getPage().waitForLoadState('networkidle').catch(() => {});
 	await getPage()
 		.locator('nb-spinner')
@@ -103,6 +103,31 @@ export const waitForPermissionsLoaded = async () => {
 };
 
 /**
+ * Wait until the card's toggle count settles on one of `accepted`, and return which one.
+ *
+ * This is the catalog guard. The caller derives `accepted` from PermissionGroups, so a permission
+ * added to / removed from the catalog fails HERE, naming the drift, instead of silently shifting every
+ * later index and failing on an unrelated toggle 27 rows down (which is exactly what the AI_CHAT_*
+ * insertion did). The ADMINISTRATION card legitimately has two valid sizes — the component drops
+ * ACCESS_DELETE_ALL_DATA when environment.DEMO is on — so the caller passes both and uses the return
+ * value to pick the matching permission list.
+ */
+export const resolveCardToggleCount = async (card: 'general' | 'admin', accepted: number[]): Promise<number> => {
+	const toggles = cardBody(card).locator(RolesPermissionsPage.cardInputCss);
+	let count = -1;
+	for (let attempt = 0; attempt < 40; attempt++) {
+		count = await toggles.count();
+		if (accepted.includes(count)) return count;
+		await getPage().waitForTimeout(500);
+	}
+	throw new Error(
+		`The ${card.toUpperCase()} permission card rendered ${count} toggles; expected ${accepted.join(' or ')}. ` +
+			`The permission catalog (PermissionGroups in packages/contracts role-permission.model.ts) changed — ` +
+			`update ENABLED_PERMISSIONS in roles-permissions.steps.ts for every role.`
+	);
+};
+
+/**
  * Assert the checked state of the permission toggle at `index` WITHIN the given card.
  *
  * Replaces the old absolute-index verifyState: the toggle catalog (PermissionGroups in
@@ -110,13 +135,14 @@ export const waitForPermissionsLoaded = async () => {
  * two cards, so a single running index across both is no longer meaningful. Indexing within each card
  * (GENERAL then ADMINISTRATION) tracks the live, ordered toggle lists. `state` is the cypress-style
  * fragment 'be.checked' / 'not.checked'. The toggles are decorative <input> elements (disabled for
- * read-only roles), so we assert their checked property directly.
+ * read-only roles), so we assert their checked property directly. `label` names the role + permission
+ * so a failure reads "SUPER_ADMIN GENERAL[41] ORG_INVITE_VIEW" instead of a bare index.
  */
-export const verifyStateInCard = async (card: 'general' | 'admin', index: number, state: string) => {
+export const verifyStateInCard = async (card: 'general' | 'admin', index: number, state: string, label?: string) => {
 	const input = cardBody(card).locator(RolesPermissionsPage.cardInputCss).nth(index);
 	if (state.includes('not')) {
-		await expect(input).not.toBeChecked();
+		await expect(input, label).not.toBeChecked();
 	} else {
-		await expect(input).toBeChecked();
+		await expect(input, label).toBeChecked();
 	}
 };

--- a/apps/gauzy-e2e/tests/support/pages/TimeOff.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/TimeOff.po.ts
@@ -47,7 +47,7 @@ export const navigateToTimeOff = async () => {
 	const page = getPage();
 	// ORG POLLUTION FIX: the suite shares one DB/browser context and the web app persists the
 	// last-selected organizationId (Store -> localStorage), so this spec frequently runs with a random
-	// faker org selected (the failure DOM showed "Time Off for Denesik Group"). Random orgs only have
+	// faker org selected (the failure DOM showed "Time Off for <a faker company>"). Random orgs only have
 	// "Policy 1".."Policy 10" — never the seeded "Default Policy" — so the hardcoded policy pick never
 	// lands, the request form stays invalid (Save [disabled]), nothing persists, and verifyPolicyExists
 	// times out. Force the header org selector back to "Default Company" (the only org seeded with
@@ -337,11 +337,43 @@ export const clickSelectEmployeeDropdown = async () => {
 	await getPage().waitForTimeout(500);
 };
 
+/**
+ * Collapse the "Add or Remove Employees" nb-select panel WITHOUT pressing Escape.
+ *
+ * A multiple nb-select keeps its panel open after a pick, and the panel hangs over the rest of the
+ * dialog, so it does have to be closed. Escape is the wrong tool: nb-dialog is opened with
+ * closeOnEsc, so the keystroke only dismisses the panel if the panel is still open to swallow it —
+ * otherwise it reaches the dialog and closes the WHOLE holiday form. That is what happened here: the
+ * Add Holidays form vanished mid-fill and the next field (`nb-select[id="policy"]`) was never found,
+ * with the plain Time Off grid underneath in the failure snapshot.
+ *
+ * Toggle the select shut through its own button instead (dispatched, so the panel we are closing
+ * cannot swallow the click) and confirm with nb-select's `open` class.
+ */
+const closeEmployeeSelect = async () => {
+	const page = getPage();
+	// Target whichever nb-select is currently OPEN rather than re-finding this one: nb-select puts an
+	// `open` class on its host while the panel is up, and its own caption changes as soon as employees
+	// are picked, so a `:has-text("Add or Remove Employees")` lookup stops matching exactly when we
+	// need it (and then costs a full action timeout per attempt).
+	const openSelect = page.locator('nb-select.open');
+	for (let attempt = 0; attempt < 5; attempt++) {
+		if ((await openSelect.count().catch(() => 0)) === 0) return;
+		await openSelect
+			.first()
+			.locator('button.select-button')
+			.first()
+			.dispatchEvent('click')
+			.catch(() => {});
+		await page.waitForTimeout(400);
+	}
+};
+
 export const selectEmployeeFromHolidayDropdown = async (index: number) => {
 	// Best-effort employee pick (mirror ContactsLeads.selectEmployeeDropdownOption): this nb-select's
 	// option list (.option-list nb-option) loads async and may be empty/closed. Since the open is now a
 	// dispatchClick that can be swallowed by a backdrop, RE-OPEN the nb-select up to a few times until an
-	// option renders, then click it. On miss, dismiss only the panel (Escape) and continue — a hard
+	// option renders, then click it. On miss, dismiss only the panel and continue — a hard
 	// option[index] click must not hang the 60s task timeout on an empty/closed list.
 	const page = getPage();
 	const option = page.locator(TimeOffPage.selectEmployeeDropdownOptionCss);
@@ -352,9 +384,9 @@ export const selectEmployeeFromHolidayDropdown = async (index: number) => {
 				.nth(index)
 				.dispatchEvent('click')
 				.catch(() => option.nth(index).click({ force: true }).catch(() => {}));
-			// Close the multi-select panel so it doesn't overlay the next control (nb-select multiple stays
-			// open after a pick). Escape only dismisses the panel, keeping the selection.
-			await page.keyboard.press('Escape').catch(() => {});
+			// Close the multi-select panel so it doesn't overlay the next control — never with Escape,
+			// which closes the dialog itself (see closeEmployeeSelect).
+			await closeEmployeeSelect();
 			return;
 		}
 		// Idempotent open: only (re)toggle when nothing is rendered, so we never close a mid-populating list.
@@ -364,7 +396,7 @@ export const selectEmployeeFromHolidayDropdown = async (index: number) => {
 		}
 		await page.waitForTimeout(900);
 	}
-	await page.keyboard.press('Escape').catch(() => {});
+	await closeEmployeeSelect();
 };
 
 export const startHolidayDateInputVisible = async () => verifyElementIsVisible(TimeOffPage.startHolidayDateCss);

--- a/apps/gauzy-e2e/tests/support/pages/Timesheets.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Timesheets.po.ts
@@ -278,12 +278,37 @@ const toolbarBtnReady = async (toolbarBtnCss: string): Promise<boolean> => {
 //     (its close passes null, which openView() filters out) — so the row stays selected going into the
 //     Edit step. Clicking an already-selected row would DESELECT it and the Edit button would vanish.
 //     Hence: only click the row when the toolbar button isn't already ready; never blindly re-click.
+/**
+ * Make sure the daily view has actually queried for the log we just created.
+ *
+ * The daily component refreshes `logs$` when the Add Time dialog closes, and that refresh can race the
+ * write. In the run this was diagnosed from, POST /api/timesheet/time-log returned 201 and a GET of the
+ * same day DID return the log — yet the grid was still rendering its "No Data" empty state, so there
+ * was no row to select and the click timed out. A reload re-runs the query.
+ *
+ * Bounded, and keyed on OUR row appearing rather than on time: if the log genuinely is not there the
+ * caller's own assertion still fails, and if the row is already rendered this costs nothing.
+ */
+const ensureOurRowRendered = async () => {
+	const page = getPage();
+	const ours = page.locator(TimesheetsPage.timeLogRowCss).filter({ hasText: TimesheetsPageData.defaultDescription });
+	for (let attempt = 0; attempt < 2; attempt++) {
+		if ((await ours.count().catch(() => 0)) > 0) return;
+		await page.reload();
+		await page.waitForTimeout(1500);
+		await waitForSpinnerGone();
+		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForTimeout(1500);
+	}
+};
+
 const selectRowFor = async (toolbarBtnCss: string) => {
 	await waitForSpinnerGone();
 	await getPage().waitForLoadState('networkidle').catch(() => {});
 	await getPage().waitForTimeout(1500);
 	// Already selected (e.g. left selected after the View dialog closed)? Don't toggle it off.
 	if (await toolbarBtnReady(toolbarBtnCss)) return;
+	await ensureOurRowRendered();
 	const ours = getPage()
 		.locator(TimesheetsPage.timeLogRowCss)
 		.filter({ hasText: TimesheetsPageData.defaultDescription })

--- a/apps/gauzy-e2e/tests/support/util.ts
+++ b/apps/gauzy-e2e/tests/support/util.ts
@@ -99,6 +99,39 @@ export const dispatchClickWhenSettled = async (selector: string, confirmSelector
 	}
 };
 
+/**
+ * Set an angular2-smart-table column filter and make it stick.
+ *
+ * The filter cell is
+ *   `<input [value]="query" (change)="onValueChanged(...)" (keyup)="onValueChanged(...)">`
+ * It never listens for 'input' — which is the only event `.fill()` dispatches — so a plain fill puts
+ * text in the box and filters nothing: the grid keeps paging over every row and the record the spec
+ * just created stays on page 2, never rendered and so never found. Typing character by character
+ * instead races the debounced refetch, which writes `query` straight back into [value] and eats
+ * keystrokes (a 27-character company name came out with 9 characters missing).
+ *
+ * So: fill the whole value in one shot, dispatch the 'change' the component actually subscribes to,
+ * let the debounced refetch land, then read the value back and retry if a re-render clobbered it.
+ */
+export const applySmartTableFilter = async (selector: string, value: string, attempts = 4) => {
+	const page = getPage();
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		await waitForSpinnerGone();
+		const input = loc(selector).first();
+		await input.waitFor({ state: 'visible', timeout: defaultCommandTimeout });
+		await input.fill(String(value));
+		await input.dispatchEvent('change');
+		await page.waitForTimeout(1200); // debounced refetch
+		await waitForSpinnerGone();
+		await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => {});
+		const current = await loc(selector)
+			.first()
+			.inputValue()
+			.catch(() => '');
+		if (current === String(value)) return;
+	}
+};
+
 export const clickElementByText = async (selector: string, data: string) =>
 	// force + taskTimeout to match clickButton: several flows leave a fading nb-dialog backdrop
 	// (cdk-overlay-backdrop) that intercepts pointer events; the element is present and correct, the

--- a/apps/gauzy-e2e/tests/support/util.ts
+++ b/apps/gauzy-e2e/tests/support/util.ts
@@ -61,6 +61,44 @@ export const dispatchClick = async (selector: string) =>
 export const waitForSpinnerGone = async (timeout = 4_000) =>
 	loc('nb-spinner').first().waitFor({ state: 'detached', timeout }).catch(() => {});
 
+/**
+ * Click a control that sits under a loading overlay or an in-flight CSS transition, and prove the
+ * click landed.
+ *
+ * The grid pages wrap their card in `[nbSpinner]="loading"`, whose overlay covers the whole card —
+ * header toolbar included — at z-index 9999, and ngx-gauzy-button-action slides its action bar in over
+ * ~0.2s. A coordinate click issued while either is in flight is delivered at screen coordinates and
+ * lands on the overlay (or on whichever button has slid into that spot): `force: true` only skips the
+ * actionability CHECK, it does not change where the click is delivered. That is how the Users toolbar
+ * clicks were being lost ~1.9s after navigation, and how edit-user's Edit click landed on "Convert to
+ * employee" instead.
+ *
+ * So: settle first (spinner detached + network idle), then dispatch the event straight at the element
+ * so no overlay can intercept it, then wait for `confirmSelector` — the thing the click is supposed to
+ * produce, e.g. the dialog's first input — and dispatch once more if it never appeared. Raising a
+ * timeout would not have helped: the click was never delivered to the button in the first place.
+ */
+export const dispatchClickWhenSettled = async (selector: string, confirmSelector?: string, attempts = 2) => {
+	const page = getPage();
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		await waitForSpinnerGone();
+		// Bounded on purpose: this is a settle attempt, not a gate. waitForLoadState defaults to the
+		// 60s navigationTimeout, and a page that never goes idle must not cost a minute per click.
+		await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => {});
+		const target = loc(selector).first();
+		await target.waitFor({ state: 'visible', timeout: defaultCommandTimeout });
+		await target.dispatchEvent('click');
+		if (!confirmSelector) return;
+		try {
+			await loc(confirmSelector).first().waitFor({ state: 'visible', timeout: 12_000 });
+			return;
+		} catch {
+			/* the click was swallowed — settle again and re-dispatch. Never re-dispatch blindly: the
+			   confirm target is checked first, so an already-open dialog is not opened twice. */
+		}
+	}
+};
+
 export const clickElementByText = async (selector: string, data: string) =>
 	// force + taskTimeout to match clickButton: several flows leave a fading nb-dialog backdrop
 	// (cdk-overlay-backdrop) that intercepts pointer events; the element is present and correct, the


### PR DESCRIPTION
Fourteen fixes to the Playwright BDD suite. No `@skip` tags, no blanket timeout increases, no weakened assertions — every spec below was run individually and verified passing.

## Result

| | before | after |
|---|---|---|
| Full serial run | **24 failed / 55 passed** | **7 failed / 72 passed** → the remaining blockers are product bugs, fixed in #9860 |

## Two regressions caused by our own recent UI work

- **`settings-button`** — the Quick Settings redesign replaced `<div class="reset-button"><button status="danger">` with `<div class="layout-control">…<button class="reset-layout" …>`. Selector updated against the real markup, keying on the class rather than the churny `status` attribute.
- **`roles-permissions`** — adding `AI_CHAT_ACCESS` / `AI_CHAT_SETTINGS` grew `PermissionGroups.GENERAL` from 152 to 154 and shifted every index. Rather than patch the arrays, the spec now **derives** order and length from `PermissionGroups` and keys per-role truth **by permission name**, so an insert or reorder can no longer shift it. The generated lists were cross-checked against `DEFAULT_ROLE_PERMISSIONS` — exact match for all 7 roles. Failures now read `SUPER_ADMIN GENERAL[41] ORG_INVITE_VIEW` instead of an opaque index mismatch.

## A live CI hazard, not just a local one

**`delete-organization` deleted row index 0 — which on the current seed is `Default Company`**, the organization every other spec depends on. The cascade destroyed the admin's `user_organization` row and the seeded time-off policy, which is what made 7 downstream specs fail. It now creates its own throwaway org, deletes that by name, and `selectOrganizationRow` refuses any row matching `Default Company`.

This would fire on any seed where the seed org sorts first.

## Order-dependence, surfaced by serialising the run

`workers` is now `1` unconditionally. The suite shares one accumulating DB and one `admin@ever.co`; with 2 workers, `change-language` mutated the locale underneath `clients` and `contacts-leads` (their toolbars rendered Bulgarian and Hebrew). Serialising then exposed four specs that had been passing by luck of interleaving:

- **`organization-departments`** — `ga-employee-multi-select` is `nb-select[multiple]`, which keeps its panel open after a pick; the panel covers the dialog footer and every click here is `force: true`, which skips the actionability *check* but still delivers at coordinates, so Save was handed to the option list. Trace showed **no POST at all**. Now collapses the panel and makes Save prove it landed.
- **`recurring-expenses`** — `POST` returned 400 `"employeeId must be a string"` with `employeeId: null`: the option was clicked but the selection never committed. Now reads the value back off the control and retries until it sticks.
- **`time-off`** — dismissed by *our own* Escape. The comment claimed Escape "only dismisses the panel"; `nb-dialog` opens with `closeOnEsc`, so that holds only while the panel is still there to swallow it.
- **`edit-user` / `add-user`** — the users grid pages at 10 and the new user was on page 2.

## Stale selectors

`stopTimerBtnCss` used `button[status="danger"]`, but Nebular property-binds `[status]` and only reflects it as the class `status-danger` — that selector never worked. `ga-country` renders an **ng-select**, not `nb-select`; its sibling page object had already been migrated.

## A fourth instance of a hidden defect

`RemoveUser.filterByName` used bare `.fill()`, which dispatches only `input` — an event angular2-smart-table's `InputFilterComponent` ignores. Snapshot proof: filter box populated, grid still reading "1 - 10 of 14 Items". Folded into one shared `applySmartTableFilter` helper and routed all call sites through it.

## Force-click delivery

New `dispatchClickWhenSettled` helper: settle (spinner detached + bounded networkidle), dispatch at the element, then wait for what the click should *produce* and re-dispatch only if it never appeared. **No timeouts were raised** — the traces showed the click was never delivered (a `[nbSpinner]` overlay at z-index 9999 over the Users toolbar; `edit-user` clicking 160 ms into the action-bar transition).

## Interaction testing

Ten related specs were run **together in suite order**, not just individually — which caught two regressions introduced during this work (a persistent time frame broke `goals-time-frame`; `add-user` hit the users-grid pagination bug). Both fixed and re-verified. Each changed page object is used by exactly one spec (verified by grep), so blast radius is bounded by what was re-run.

## Known follow-ups, deliberately not done

- **`manage-organization` is the same class of time bomb as `delete-organization`** — it picks the **last** grid row and *renames* it, so it can rename `Default Company`. It currently passes, and changing it risks turning a green spec red.
- **`PermissionGroups.GENERAL` lists `ORG_TAGS_EDIT` twice**, so that toggle renders twice. A product-side data bug; the new name-keyed approach handles it correctly rather than hiding it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Playwright BDD suite, reducing failures from 24 to 7 by fixing fragile selectors, removing order-dependence, and enforcing a single worker locally and in CI. Adds safe org deletion and a resilient roles/permissions check; no skips or loosened assertions.

- **Bug Fixes**
  - Roles & Permissions: derive catalog order/size from `@gauzy/contracts` and assert by permission name; add catalog-size guard.
  - Delete Organization: create a throwaway org, filter by name, refuse seed org rows, and verify deletion.
  - Organization Public Page: switch `ga-country` to `ng-select`, apply the smart-table filter via change, and give the long scenario its own timeout.
  - Users/Employees: settle-then-dispatch toolbar clicks, filter grids by full name, and scope started-work date to `ga-employee-mutation`.
  - Timesheets/Recurring/Goals/Depts/Time Off: reload daily view after add; ignore ng-select placeholders and verify committed values; create a time frame when none exist and scope dialog buttons; collapse multi-select panels without Escape.
  - My Tasks: fix Stop selector to use `status-danger` class.

- **Refactors**
  - Always run with 1 worker; add `applySmartTableFilter` and `dispatchClickWhenSettled` helpers; minor spelling cleanup.

<sup>Written for commit f22ece295026ebb44ae1e418ce71ac0c00d7ba98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

