### PR TITLE
fix(e2e-ci): build the web bundle without source maps so it fits the runner

### DIFF
--- a/.github/workflows/test_playwright.yml
+++ b/.github/workflows/test_playwright.yml
@@ -173,6 +173,9 @@ jobs:
           echo "container memory: ${limit_mb:-unknown} MB, cpus: $(nproc 2>/dev/null || echo '?') -> node heap ${heap_mb} MB"
           free -h || true
           echo "NODE_OPTIONS=--max-old-space-size=${heap_mb}" >> "$GITHUB_ENV"
+          # Also published on its own so the web build can pass the flag directly on the node
+          # command line. NODE_OPTIONS alone was demonstrably not enough — see that step.
+          echo "NODE_HEAP_MB=${heap_mb}" >> "$GITHUB_ENV"
 
       - name: Build all packages
         shell: bash
@@ -232,9 +235,26 @@ jobs:
         # option outright ("NX  'source-map' is not found in schema"). A configuration NAME is not
         # forwarded — dependencies fall back to their own default — so it is the safe lever here.
         # Keeping `local` untouched also leaves `serve:local` (the dev server) with its source maps.
+        #
+        # The heap flag is passed on the node command line rather than left to NODE_OPTIONS, because
+        # NODE_OPTIONS demonstrably did not reach this build. Both run 30633937038 (NODE_OPTIONS=12288)
+        # and the run before it (24576) died with the SAME ~4 GB ceiling in the GC trace:
+        #   "Scavenge (interleaved) 3983.7 (4051.6) -> 3978.9 (4052.1) MB"
+        #   "FATAL ERROR: Ineffective mark-compacts near heap limit"
+        # ~4 GB is node's default old-space on a 64-bit host — i.e. the process that ran out was on
+        # defaults, whatever NODE_OPTIONS said. The probe below prints what node actually sees so the
+        # next run answers this definitively instead of by inference.
         shell: bash
         run: |
-          yarn nx build gauzy -c ci || { echo "::warning::gauzy build failed — retry 1 (nx cache skips done deps)"; yarn nx build gauzy -c ci; }
+          heap_mb="${NODE_HEAP_MB:-12288}"
+          echo "--- heap probe -------------------------------------------------"
+          echo "NODE_OPTIONS=${NODE_OPTIONS:-(unset)}"
+          node -e "console.log('a plain node process sees heap_size_limit =', Math.round(require('v8').getHeapStatistics().heap_size_limit/1048576), 'MB')"
+          node --max-old-space-size=$heap_mb -e "console.log('with the flag on the command line   =', Math.round(require('v8').getHeapStatistics().heap_size_limit/1048576), 'MB')"
+          echo "----------------------------------------------------------------"
+          # Drive nx through node directly so the ceiling cannot be lost in a wrapper.
+          build() { node --max-old-space-size=$heap_mb ./node_modules/nx/bin/nx.js build gauzy -c ci; }
+          build || { echo "::warning::gauzy build failed — retry 1 (nx cache skips done deps)"; build; }
           # The bundle bakes the API URL as http://localhost:3000; the API runs on :3001 in the test
           # job (this shared runner's :3000 is taken by other dev processes), so repoint the built
           # bundle at :3001 BEFORE it is packed — the test job serves this artifact verbatim.

--- a/.github/workflows/test_playwright.yml
+++ b/.github/workflows/test_playwright.yml
@@ -352,9 +352,20 @@ jobs:
         shell: bash
         # The k8s ARC container runners' system npm prefix (/usr/lib) is root-owned and there
         # is no sudo - route npm -g installs to a user-writable prefix (harmless on VM runners).
+        #
+        # Retried because a single failed request here costs the whole shard: in run
+        # 30646106163 shard 3 died with
+        #   npm error network request to https://registry.npmjs.org/forever failed
+        # before a single test ran, while the other three shards completed. Registry blips
+        # on these runners are common enough that one attempt is not worth a lost shard.
         run: |
           npm config set prefix "$HOME/.npm-global"
-          npm install forever -g
+          for attempt in 1 2 3; do
+            npm install forever -g && break
+            echo "::warning::npm install forever -g failed (attempt ${attempt}/3)"
+            [ "$attempt" = 3 ] && exit 1
+            sleep $((attempt * 10))
+          done
 
       - name: Add npm global bin to PATH
         shell: bash

--- a/.github/workflows/test_playwright.yml
+++ b/.github/workflows/test_playwright.yml
@@ -217,9 +217,24 @@ jobs:
         # The Angular dev server (nx serve gauzy) OOMs over a long e2e run. Build once and serve the
         # static output instead — stable + low memory. The app uses hash routing + an absolute API
         # URL baked into the bundle, so a plain static file server is sufficient (no proxy/SPA fallback).
+        #
+        # Builds the `ci` configuration, which is `local` with `sourceMap: false` — that is what makes
+        # this build FIT. Source maps are the single largest memory consumer in an Angular build, and
+        # run 30633937038 died twice with
+        #   "FATAL ERROR: Ineffective mark-compacts near heap limit — JavaScript heap out of memory"
+        # on a 16384 MB container (heap capped at 12288 MB). They are also pure waste here: the suite
+        # drives headless Chromium, which only fetches `.map` with devtools open, and the `Pack build
+        # output` step below already excludes `*.map` from the tarball — so they were being generated
+        # at peak memory cost and thrown away one step later.
+        #
+        # This is a separate configuration rather than `-c local --source-map=false` because nx
+        # forwards raw CLI flags to dependency tasks, and ui-config's executor rejects the unknown
+        # option outright ("NX  'source-map' is not found in schema"). A configuration NAME is not
+        # forwarded — dependencies fall back to their own default — so it is the safe lever here.
+        # Keeping `local` untouched also leaves `serve:local` (the dev server) with its source maps.
         shell: bash
         run: |
-          yarn nx build gauzy -c local || { echo "::warning::gauzy build failed — retry 1 (nx cache skips done deps)"; yarn nx build gauzy -c local; }
+          yarn nx build gauzy -c ci || { echo "::warning::gauzy build failed — retry 1 (nx cache skips done deps)"; yarn nx build gauzy -c ci; }
           # The bundle bakes the API URL as http://localhost:3000; the API runs on :3001 in the test
           # job (this shared runner's :3000 is taken by other dev processes), so repoint the built
           # bundle at :3001 BEFORE it is packed — the test job serves this artifact verbatim.

--- a/apps/gauzy/project.json
+++ b/apps/gauzy/project.json
@@ -127,6 +127,27 @@
 							"maximumError": "20mb"
 						}
 					]
+				},
+				"ci": {
+					"optimization": false,
+					"buildOptimizer": false,
+					"vendorChunk": true,
+					"extractLicenses": false,
+					"sourceMap": false,
+					"namedChunks": true,
+					"progress": false,
+					"budgets": [
+						{
+							"type": "initial",
+							"maximumWarning": "100mb",
+							"maximumError": "150mb"
+						},
+						{
+							"type": "anyComponentStyle",
+							"maximumWarning": "1000kb",
+							"maximumError": "20mb"
+						}
+					]
 				}
 			}
 		},


### PR DESCRIPTION
## The problem

`Build API + Web` has failed **every run** since the e2e pipeline was sharded, taking all four shards with it — they report `skipped`, which means the Playwright specs have still **never once executed in CI**.

Run [30633937038](https://github.com/ever-co/ever-gauzy/actions/runs/30633937038) finally made the cause legible:

```
container memory: 16384 MB, cpus: 36 -> node heap 12288 MB
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

Two problems were stacked here.

**The first is already fixed.** The old workflow asked V8 for `--max-old-space-size=24576` on a container that only has 16384 MB. The heap ceiling sat *above* the cgroup limit, so V8 never self-limited and the kernel OOM-killed the pod instead — which is exactly why those jobs used to vanish mid-step with no step marked failed. Deriving the ceiling from the container's real limit turned that invisible death into the clean, diagnosable OOM quoted above.

**This PR fixes the second:** 12288 MB genuinely isn't enough for this build, and the reason is source maps.

## Why source maps

They are the largest single memory consumer in an Angular build, and in this pipeline they are pure waste:

- the suite drives headless Chromium, which only fetches `.map` with devtools open;
- the `Pack build output` step **already excludes `*.map`** from the tarball.

So they were being generated at peak memory cost and thrown away one step later.

## Why a new configuration instead of a flag

The obvious one-liner does **not** work. nx forwards raw CLI flags to dependency tasks, and `ui-config`'s executor rejects the unknown option outright:

```
$ nx build gauzy -c local --source-map=false
NX   'source-map' is not found in schema
Failed tasks: - ui-config:build:development
```

A configuration *name* is not forwarded — dependencies fall back to their own default (`:development`) — so a separate `ci` configuration is the safe lever. It is `local` with `sourceMap: false` and nothing else changed. Leaving `local` untouched also keeps source maps in `serve:local`, the dev server.

## Verification

Reproduced CI's exact ceiling locally — `--max-old-space-size=12288`, `NX_DAEMON=false` (the daemon swallows `NODE_OPTIONS`), `--skip-nx-cache`:

```
NX   Successfully ran target build for project gauzy and 23 tasks it depends on
EXIT: 0        OOM count: 0        .map files in dist: 0
```

Also confirmed the 23 dependency tasks resolve without the flag leaking into them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the web bundle without source maps in CI to stop Node heap OOMs and unblock the e2e shards. Also retries the global `npm` install to avoid losing shards to transient registry blips.

- **Bug Fixes**
  - Added `ci` config in `apps/gauzy/project.json` (`sourceMap: false`); dev `serve:local` unchanged.
  - Updated `.github/workflows/test_playwright.yml` to build with `-c ci`, drive `nx` via `node --max-old-space-size=$NODE_HEAP_MB`, and retry the build on failure.
  - Published `NODE_HEAP_MB` and printed a heap probe to verify the effective limit; used a named config since `nx` forwards unknown CLI flags to deps.
  - Retried `npm install -g forever` up to 3 times with backoff to prevent a single registry error from costing a shard.

<sup>Written for commit 249f25e8b404818b9277503e61c3f46945c7ab15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

