### PR TITLE
test(e2e): attack the causes behind the rotating failures, not the symptoms

### DIFF
--- a/apps/gauzy-e2e/src/support/Base/pageobjects/AddTasksPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/AddTasksPageObject.ts
@@ -16,7 +16,10 @@ export const AddTaskPage = {
 	selectTableRowCss: 'table > tbody > tr.angular2-smart-row',
 	selectTableFirstRowCss: 'tr.angular2-smart-row.selected',
 	tagsSelectCss: '#addTags',
-	tagsSelectOptionCss: '[type="checkbox"]',
+	// The tags ng-select option ITSELF, not the checkbox its template happens to render: '[type="checkbox"]'
+	// matched every checkbox on the page (grid row selectors included), and it is the option div that carries
+	// ng-select's (click)="toggleItem(item)". ':not(.ng-option-disabled)' is applied by the shared driver.
+	tagsSelectOptionCss: 'div.ng-option',
 	closeTagsMultiSelectDropdownCss: '.ng-select-container > .ng-arrow-wrapper',
 	confirmDuplicateOrEditTaskButtonCss: 'nb-card-footer > button[status="success"]',
 	confirmEditTaskButtonCss: '',

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/EditUserPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/EditUserPageObject.ts
@@ -27,7 +27,10 @@ export const EditUserPage = {
 	repeatPasswordInputCss: '[placeholder="Repeat Password"]',
 	emailInputCss: '#email',
 	tagsSelectCss: '#addTags',
-	tagsSelectOptionCss: 'div.ng-dropdown-panel-items.scroll-host',
+	// The OPTIONS, not the scroll host: 'div.ng-dropdown-panel-items.scroll-host' is the panel's scroll
+	// container, so nth(i) addressed the container itself and the pick relied on the coordinate click
+	// happening to land on an option. ':not(.ng-option-disabled)' is applied by the shared driver.
+	tagsSelectOptionCss: 'div.ng-option',
 	roleSelectCss: 'nb-select#role>button',
 	// Options render as nb-option inside the cdk-overlay ul.option-list; filter-by-text needs the
 	// individual options, not the whole list (the bare .option-list contains every role name).

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/EmployeeAddInfoPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/EmployeeAddInfoPageObject.ts
@@ -3,7 +3,10 @@ export const EmployeeAddInfoPage = {
 	addNewLevelButtonCss: 'button[status="success"]:has(nb-icon[icon="plus-outline"])',
 	newLevelInputCss: '[placeholder="Level name"]',
 	tagsSelectCss: '#addTags',
-	tagsSelectOptionCss: '[type="checkbox"]',
+	// The tags ng-select option ITSELF, not the checkbox its template happens to render: '[type="checkbox"]'
+	// matched every checkbox on the page, and it is the option div that carries ng-select's
+	// (click)="toggleItem(item)". ':not(.ng-option-disabled)' is applied by the shared driver.
+	tagsSelectOptionCss: 'div.ng-option',
 	saveNewLevelButtonCss: 'button[status="success"]:has-text("Save")',
     cancelNewLevelButtonCss: 'button[status="basic"]:has-text("Cancel")',
     toastrMessageCss: 'nb-toast.ng-trigger',

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/JobsProposalsPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/JobsProposalsPageObject.ts
@@ -20,5 +20,10 @@ export const JobsProposalsPage = {
 	confirmFirstDialogButtonCss: 'ngx-confirm nb-card-footer button[status="primary"]',
 	confirmDeleteButtonCss: 'ga-delete-confirmation nb-card-footer button[status="danger"]',
 	toastrMessageCss: 'nb-toast.ng-trigger',
-	verifyProposalCss: 'div.ng-star-inserted'
+	// Scope the row assertions to the GRID (mirrors ProposalsPageObject). 'div.ng-star-inserted' matched
+	// every Angular-inserted div on the page, so "the proposal exists" could be satisfied by anything the
+	// create/edit dialog still had mounted — the proposal's own form, an ng-select label, a chip — rather
+	// than by a committed row. The mirror assertion 'is it deleted?' is weakened the same way: it passes
+	// as soon as the text disappears from ANY div, grid included or not.
+	verifyProposalCss: 'angular2-smart-table'
 };

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/OrganizationTagsPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/OrganizationTagsPageObject.ts
@@ -15,6 +15,10 @@ export const OrganizationTagsPage = {
 	cancelDeleteTagButtonCss: 'nb-card-footer > button[status="basic"]',
 	toastrMessageCss: 'nb-toast.ng-trigger',
 	verifyTagCss: 'angular2-smart-table tbody',
-	filterNameInputCss: '[placeholder="Name"]',
+	// The Name column's filter input, addressed by COLUMN KEY (angular2-smart-table puts the key on the
+	// header cell) rather than by placeholder — the placeholder is the translated column title, so it
+	// stops matching as soon as a spec switches the UI language. The tags grid paginates at 10 and the
+	// suite accumulates tags, so every row assertion has to filter through this first.
+	filterNameInputCss: 'th.angular2-smart-th.name input',
 	firstTableCellTagCss: 'tbody > tr.angular2-smart-row:first-of-type > td:first-of-type'
 };

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/OrganizationTeamsPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/OrganizationTeamsPageObject.ts
@@ -15,6 +15,12 @@ export const OrganizationTeamsPage = {
 	tagsSelectCss: '.editable #addTags',
 	tagsSelectOptionCss: 'div.ng-option',
 	selectTableRowCss: 'table > tbody > tr.angular2-smart-row',
+	// The Name column's filter input, addressed by COLUMN KEY (angular2-smart-table puts the key on the
+	// header cell) rather than by its translated placeholder. The teams grid is server-paginated at 10
+	// rows and this suite keeps adding teams to one shared DB, so both the row assertions and the row
+	// selection have to narrow the grid to this spec's team first — otherwise they only ever look at
+	// page 1 and fail once enough teams have accumulated.
+	nameFilterInputCss: 'th.angular2-smart-th.name input',
 	// Neutral, dialog-internal click target to dismiss an open ng-select panel without closing the
 	// nb-dialog itself (Escape would close the whole dialog; the page nb-card-body sits behind a backdrop).
 	cardBodyCss: '.editable h5.title',

--- a/apps/gauzy-e2e/tests/bdd/steps/expenses.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/expenses.steps.ts
@@ -122,14 +122,21 @@ When('I delete the expense', async () => {
 	await expensesPage.verifyElementIsDeleted();
 });
 
+// RUN-UNIQUE category name. POST /api/expense-categories is guarded by
+// IsExpenseCategoryAlreadyExist, so re-using the FIXED name against this suite's one accumulating
+// database means every run after the first is rejected — and verifyCategoryExists then passes on the
+// LEFTOVER row, so the step asserts nothing. Same trap that made organization-teams fail. (The
+// EXPENSE above still picks the stock ExpensePageData.defaultCategory; only the category CREATED
+// here needs to be unique.)
 When('I add a new expense category', async () => {
+	const categoryName = `${ExpensePageData.defaultCategory} ${faker.string.alphanumeric(6)}`;
 	await expensesPage.waitMessageToHide();
 	await expensesPage.manageCategoriesButtonVisible();
 	await expensesPage.clickManageCategoriesButton();
 	await expensesPage.addExpenseButtonVisible();
 	await expensesPage.clickAddExpenseButton();
 	await expensesPage.newCategoryInputVisible();
-	await expensesPage.enterNewCategoryInputData(ExpensePageData.defaultCategory);
+	await expensesPage.enterNewCategoryInputData(categoryName);
 	await expensesPage.tagsDropdownVisible();
 	await expensesPage.clickTagsDropdown();
 	await expensesPage.selectTagFromDropdown(0);
@@ -137,7 +144,7 @@ When('I add a new expense category', async () => {
 	await expensesPage.clickKeyboardButtonByKeyCode(9);
 	await expensesPage.SaveCategoryButtonVisible();
 	await expensesPage.clickSaveCategoryButton();
-	await expensesPage.verifyCategoryExists(ExpensePageData.defaultCategory);
+	await expensesPage.verifyCategoryExists(categoryName);
 	await expensesPage.backButtonVisible();
 	await expensesPage.clickBackButton();
 });

--- a/apps/gauzy-e2e/tests/bdd/steps/organization-teams.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/organization-teams.steps.ts
@@ -5,13 +5,29 @@ import { OrganizationTeamsPageData } from '../../../src/support/Base/pagedata/Or
 import * as organizationTagsUserPage from '../../support/pages/OrganizationTags.po';
 import { OrganizationTagsPageData } from '../../../src/support/Base/pagedata/OrganizationTagsPageData';
 import { CustomCommands } from '../../support/commands';
+import { faker } from '@faker-js/faker';
 
 // Converted 1:1 from the plain OrganizationTeamsTest.spec.ts: the single test() -> one Scenario, each
 // test.step() -> one When step whose body is the verbatim .po call sequence (verification folded in),
 // so runtime behaviour is identical to the already-CI-tested spec. The `Given I am logged in as the
 // default user` Background step is defined once in common.steps.ts.
 
+
+// RUN-UNIQUE team names. The API rejects a duplicate name with 400 "The team name X is already in use",
+// and teams.component swallows that in a bare catch, so with the old FIXED names the very first run to
+// leave a team behind poisoned every later run: the create silently failed, the dialog stayed open, and
+// verifyTeamExists still passed — on the LEFTOVER row. The spec only fell over two steps later, on a
+// second stacked dialog. Unique-per-run names (the pattern the rest of the suite already uses, see
+// clients.steps.ts) make the create succeed and make every assertion below refer to THIS run's record.
+// Initialised at the very start of the first step, and shared across steps at module scope.
+let teamName = OrganizationTeamsPageData.name;
+let editTeamName = OrganizationTeamsPageData.editName;
+
 When('I add a new team', async () => {
+	const suffix = faker.string.alphanumeric(6);
+	teamName = `${OrganizationTeamsPageData.name} ${suffix}`;
+	editTeamName = `${OrganizationTeamsPageData.editName} ${suffix}`;
+
 	await CustomCommands.addTag(
 		organizationTagsUserPage,
 		OrganizationTagsPageData
@@ -45,7 +61,7 @@ When('I add a new team', async () => {
 	await organizationTeamsPage.clickAddTeamButton();
 	await organizationTeamsPage.nameInputVisible();
 	await organizationTeamsPage.enterNameInputData(
-		OrganizationTeamsPageData.name
+		teamName
 	);
 	await organizationTeamsPage.tagsMultiSelectVisible();
 	await organizationTeamsPage.clickTagsMultiSelect();
@@ -60,19 +76,19 @@ When('I add a new team', async () => {
 	await organizationTeamsPage.saveButtonVisible();
 	await organizationTeamsPage.clickSaveButton();
 	await organizationTeamsPage.waitMessageToHide();
-	await organizationTeamsPage.verifyTeamExists(OrganizationTeamsPageData.name);
+	await organizationTeamsPage.verifyTeamExists(teamName);
 });
 
 When('I edit the team', async () => {
 	await organizationTeamsPage.tableRowVisible();
 	// Scope to the team we just created (not the seeded "Default" team) — the grid is shared across
 	// the serial suite, so a plain row-0 pick can select the wrong record.
-	await organizationTeamsPage.selectTableRow(OrganizationTeamsPageData.name);
+	await organizationTeamsPage.selectTableRow(teamName);
 	await organizationTeamsPage.editButtonVisible();
 	await organizationTeamsPage.clickEditButton();
 	await organizationTeamsPage.nameInputVisible();
 	await organizationTeamsPage.enterNameInputData(
-		OrganizationTeamsPageData.editName
+		editTeamName
 	);
 	await organizationTeamsPage.tagsMultiSelectVisible();
 	await organizationTeamsPage.clickTagsMultiSelect();
@@ -88,19 +104,19 @@ When('I edit the team', async () => {
 	await organizationTeamsPage.clickSaveButton();
 	await organizationTeamsPage.waitMessageToHide();
 	await organizationTeamsPage.verifyTeamExists(
-		OrganizationTeamsPageData.editName
+		editTeamName
 	);
 });
 
 When('I delete the team', async () => {
 	// After the rename the row is now under editName — scope to it (not the seeded "Default" team).
-	await organizationTeamsPage.selectTableRow(OrganizationTeamsPageData.editName);
+	await organizationTeamsPage.selectTableRow(editTeamName);
 	await organizationTeamsPage.deleteButtonVisible();
 	await organizationTeamsPage.clickDeleteButton();
 	await organizationTeamsPage.confirmDeleteButtonVisible();
 	await organizationTeamsPage.clickConfirmDeleteButton();
 	await organizationTeamsPage.waitMessageToHide();
 	await organizationTeamsPage.verifyTeamIsDeleted(
-		OrganizationTeamsPageData.editName
+		editTeamName
 	);
 });

--- a/apps/gauzy-e2e/tests/support/ng-select.ts
+++ b/apps/gauzy-e2e/tests/support/ng-select.ts
@@ -60,7 +60,7 @@ const REAL_OPTION_GRACE = 8_000;
  * `div.ng-option[role="option"]`, `div.ng-option > span.ng-option-label`, and comma-separated lists
  * that also carry unrelated `nb-option` branches (those are Nebular, and are left untouched).
  *
- * The lookaheads make it precise and idempotent:
+ * The two negative look-ahead assertions make it precise and idempotent:
  *  • `(?![\w-])`  — `.ng-option-label` / `.ng-option-selected` / `.ng-option-disabled` are DIFFERENT
  *                   classes and must not be rewritten;
  *  • `(?!:not\(…)` — an already-hardened selector is returned unchanged, so applying this twice
@@ -194,7 +194,12 @@ export const selectNgOption = async (
 		}
 		if (wanted) {
 			// Single select replacing an existing value keeps the count at 1 — match on the text instead.
-			return (await values.filter({ hasText: wanted }).count().catch(() => 0)) > 0;
+			return (
+				(await values
+					.filter({ hasText: wanted })
+					.count()
+					.catch(() => 0)) > 0
+			);
 		}
 		return false;
 	};

--- a/apps/gauzy-e2e/tests/support/ng-select.ts
+++ b/apps/gauzy-e2e/tests/support/ng-select.ts
@@ -69,9 +69,6 @@ const REAL_OPTION_GRACE = 8_000;
 export const realOptionSelector = (selector: string): string =>
 	selector.replace(/\.ng-option(?![\w-])(?!:not\(\.ng-option-disabled\))/g, '.ng-option:not(.ng-option-disabled)');
 
-/** Does this selector address ng-select options at all? (Nebular `nb-option` selectors do not.) */
-export const isNgOptionSelector = (selector: string): boolean => realOptionSelector(selector) !== selector;
-
 /** Locator for the REAL options of an ng-select — placeholders excluded. */
 export const realOptions = (optionSelector: string) => getPage().locator(realOptionSelector(optionSelector));
 

--- a/apps/gauzy-e2e/tests/support/ng-select.ts
+++ b/apps/gauzy-e2e/tests/support/ng-select.ts
@@ -1,0 +1,245 @@
+import { getPage } from './page-context';
+
+/**
+ * ONE place that knows how to drive an `<ng-select>`.
+ *
+ * ────────────────────────────────────────────────────────────────────────────────────────────────
+ * WHY THIS EXISTS — the `div.ng-option` placeholder trap
+ * ────────────────────────────────────────────────────────────────────────────────────────────────
+ * ng-select renders its own status rows with the SAME `ng-option` class as real choices:
+ *
+ *   @if (showNoItemsFound())   <div class="ng-option ng-option-disabled">No items found</div>
+ *   @if (showTypeToSearch())   <div class="ng-option ng-option-disabled">Type to search</div>
+ *   @if (loading() && …)       <div class="ng-option ng-option-disabled">Loading…</div>
+ *
+ * (verbatim from @ng-select/ng-select's dropdown template). So a bare `div.ng-option` selector is
+ * satisfied by a panel that has loaded NOTHING:
+ *
+ *   • `count() > 0` / `toBeVisible()` on `div.ng-option` reports "the list is open and populated"
+ *     while it is still empty, so the spec proceeds too early;
+ *   • `.first()` / `.nth(i)` then CLICKS that placeholder — which is a no-op, because ng-select
+ *     ignores clicks on disabled items. Nothing is selected, the form silently submits `null`, and
+ *     the failure only surfaces several steps later as a missing row.
+ *
+ * That was proven on `recurring-expenses`: the POST came back 400 `"employeeId must be a string"`
+ * with `employeeId: null`. Measured: opening the panel in the same tick the dialog appears can leave
+ * it stuck on that placeholder for 5+ SECONDS — waiting longer does not fix it, but closing and
+ * re-opening the panel picks the loaded list up immediately.
+ *
+ * ────────────────────────────────────────────────────────────────────────────────────────────────
+ * AND — the verification that validates itself
+ * ────────────────────────────────────────────────────────────────────────────────────────────────
+ * Unless the control sets `appendTo="body"`, ng-select renders the OPEN PANEL INSIDE the
+ * `<ng-select>` element. So "read the control's text back and check it contains the option I just
+ * clicked" is satisfied by the very panel that was clicked in — it reports success while nothing is
+ * selected. The only honest proof of a commit is `div.ng-value`, which ng-select renders in the
+ * value container and ONLY once a value is actually bound (single select: one node; multi select:
+ * one per chip — see tags-color-input.component.html's ng-multi-label-tmp).
+ *
+ * ────────────────────────────────────────────────────────────────────────────────────────────────
+ * HOW THIS DRIVES THE CONTROL
+ * ────────────────────────────────────────────────────────────────────────────────────────────────
+ * • Open via the KEYBOARD (focus the inner <input>, press ArrowDown), never a click on the host:
+ *   ng-select opens on MOUSEDOWN and the host is routinely covered by a dialog/overlay backdrop, so
+ *   a coordinate click — even `{ force: true }` — lands on the backdrop instead.
+ * • Re-open by toggling the panel shut via its OWN `.ng-select-container`. NEVER press Escape:
+ *   `nb-dialog` opens with `closeOnEsc`, so Escape dismisses the whole form the control sits in.
+ * • Only `div.ng-option:not(.ng-option-disabled)` counts as a real option.
+ * • Confirm against `div.ng-value` inside the control, never against the control's own text.
+ */
+
+/** How long a caller will wait for a real option before assuming the list is legitimately empty. */
+const REAL_OPTION_GRACE = 8_000;
+
+/**
+ * Rewrite an option selector so ng-select's own disabled status rows ("No items found" / "Loading…"
+ * / "Type to search") can never match.
+ *
+ * Operates on the `ng-option` CLASS TOKEN wherever it appears, so it survives every shape the suite
+ * uses — `div.ng-option`, `ng-dropdown-panel > div.ng-dropdown-panel-items div.ng-option`,
+ * `div.ng-option[role="option"]`, `div.ng-option > span.ng-option-label`, and comma-separated lists
+ * that also carry unrelated `nb-option` branches (those are Nebular, and are left untouched).
+ *
+ * The lookaheads make it precise and idempotent:
+ *  • `(?![\w-])`  — `.ng-option-label` / `.ng-option-selected` / `.ng-option-disabled` are DIFFERENT
+ *                   classes and must not be rewritten;
+ *  • `(?!:not\(…)` — an already-hardened selector is returned unchanged, so applying this twice
+ *                   (helper + util layer) is safe.
+ */
+export const realOptionSelector = (selector: string): string =>
+	selector.replace(/\.ng-option(?![\w-])(?!:not\(\.ng-option-disabled\))/g, '.ng-option:not(.ng-option-disabled)');
+
+/** Does this selector address ng-select options at all? (Nebular `nb-option` selectors do not.) */
+export const isNgOptionSelector = (selector: string): boolean => realOptionSelector(selector) !== selector;
+
+/** Locator for the REAL options of an ng-select — placeholders excluded. */
+export const realOptions = (optionSelector: string) => getPage().locator(realOptionSelector(optionSelector));
+
+/**
+ * Resolve an option selector to its placeholder-free form — but only once a real option has actually
+ * rendered.
+ *
+ * This is the zero-knowledge variant used by the shared util layer, which is handed an option
+ * selector with no idea which control produced it. It is STRICTLY more robust than the raw selector:
+ * when the list populates (the overwhelmingly common case) every caller is now pinned to real
+ * options; when the list is legitimately empty it hands back the ORIGINAL selector, so behaviour is
+ * byte-for-byte what it was before. It can therefore never turn a passing step into a failing one.
+ */
+export const resolveOptionSelector = async (selector: string, timeout = REAL_OPTION_GRACE): Promise<string> => {
+	const hardened = realOptionSelector(selector);
+	if (hardened === selector) {
+		return selector; // not an ng-select option selector — nothing to do
+	}
+	try {
+		await getPage().locator(hardened).first().waitFor({ state: 'attached', timeout });
+		return hardened;
+	} catch {
+		return selector; // no real option ever came — fall back to the pre-existing behaviour
+	}
+};
+
+/** The COMMITTED values of an ng-select: `div.ng-value` exists only once a value is really bound. */
+export const committedValues = (controlSelector: string) =>
+	getPage().locator(controlSelector).first().locator('div.ng-value');
+
+/**
+ * What the CLOSED control displays — the selected value(s) or, when nothing is selected, the
+ * placeholder.
+ *
+ * Use this instead of reading the `<ng-select>` element's own text. ng-select's markup is
+ *
+ *   <ng-select>
+ *     <div class="ng-select-container"> … ng-value / ng-placeholder … </div>
+ *     <ng-dropdown-panel> … ng-option … </ng-dropdown-panel>   <!-- only when NOT appendTo="body" -->
+ *   </ng-select>
+ *
+ * so the host's text includes the OPEN OPTION LIST, and a "does the control show X?" check is then
+ * satisfied by an option in the panel rather than by anything committed. `.ng-select-container` is a
+ * sibling of the panel, so it is never contaminated — whether or not the control sets appendTo.
+ */
+export const controlText = async (controlSelector: string): Promise<string> =>
+	(await getPage()
+		.locator(controlSelector)
+		.first()
+		.locator('.ng-select-container')
+		.first()
+		.innerText()
+		.catch(() => '')) || '';
+
+/**
+ * Open an ng-select and wait until it holds at least one REAL option.
+ *
+ * Returns whether real options are present, so callers can distinguish "the list loaded" from "the
+ * list is genuinely empty" instead of clicking blindly into a placeholder.
+ */
+export const openNgSelect = async (controlSelector: string, optionSelector: string, attempts = 5): Promise<boolean> => {
+	const page = getPage();
+	const control = page.locator(controlSelector).first();
+	const input = control.locator('input').first();
+	const container = control.locator('.ng-select-container').first();
+	const options = realOptions(optionSelector);
+	const count = async () => options.count().catch(() => 0);
+
+	for (let i = 0; i < attempts; i++) {
+		if (await count()) {
+			return true;
+		}
+		// Keyboard, not a click: ng-select opens on mousedown and the host is often under a backdrop.
+		await input.focus().catch(() => undefined);
+		await page.keyboard.press('ArrowDown').catch(() => undefined);
+		await page.waitForTimeout(700);
+		if (await count()) {
+			return true;
+		}
+		// Still on the placeholder. Waiting does not help (measured: 5s+); a shut/re-open does. Toggle via
+		// the control's OWN container — NEVER Escape, which would close the surrounding nb-dialog.
+		await container.click({ force: true }).catch(() => undefined);
+		await page.waitForTimeout(500);
+	}
+	return (await count()) > 0;
+};
+
+/**
+ * Pick an option and PROVE it committed.
+ *
+ * `target` is either the option text (matched against real options only) or an index INTO THE REAL
+ * options — which is the same index as before whenever the list is populated, because ng-select only
+ * renders a placeholder row when there are no real items at all.
+ *
+ * Commit is confirmed against `div.ng-value` — a new chip appeared, or a chip carrying the option's
+ * text exists — never by reading the control's text back (see the file header). Selection is
+ * re-checked BEFORE every retry so a multi-select is never toggled back off by a second click.
+ *
+ * Best-effort by design (returns false rather than throwing): several of these dropdowns are
+ * optional fields whose list can legitimately be empty, and the callers that DO require a value
+ * assert on the saved record afterwards. What it never does is silently click a placeholder.
+ */
+export const selectNgOption = async (
+	controlSelector: string,
+	optionSelector: string,
+	target: string | number,
+	options: { search?: string; attempts?: number } = {}
+): Promise<boolean> => {
+	const page = getPage();
+	const attempts = options.attempts ?? 3;
+	const values = committedValues(controlSelector);
+	const input = page.locator(controlSelector).first().locator('input').first();
+	const baseline = await values.count().catch(() => 0);
+
+	let wanted = typeof target === 'string' ? target : '';
+	const committed = async (): Promise<boolean> => {
+		const now = await values.count().catch(() => 0);
+		if (now > baseline) {
+			return true; // a new chip/value node appeared
+		}
+		if (wanted) {
+			// Single select replacing an existing value keeps the count at 1 — match on the text instead.
+			return (await values.filter({ hasText: wanted }).count().catch(() => 0)) > 0;
+		}
+		return false;
+	};
+
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		if (await committed()) {
+			return true;
+		}
+		if (!(await openNgSelect(controlSelector, optionSelector))) {
+			continue; // list never populated — re-open and look again rather than clicking a placeholder
+		}
+		if (options.search) {
+			// Typeahead filter. ng-select does NOT re-run its filter against items that arrive later (the
+			// search term is sticky), so this must happen AFTER openNgSelect has proven the list loaded.
+			await input.fill('').catch(() => undefined);
+			await input.pressSequentially(options.search, { delay: 20 }).catch(() => undefined);
+			await page.waitForTimeout(400);
+		}
+		const list = realOptions(optionSelector);
+		const option = typeof target === 'string' ? list.filter({ hasText: target }).first() : list.nth(target);
+		if ((await option.count().catch(() => 0)) === 0) {
+			continue;
+		}
+		if (!wanted) {
+			wanted = ((await option.textContent().catch(() => '')) || '').replace(/\s+/g, ' ').trim();
+		}
+		// DOM-level click for the first try: ng-select binds `(click)="toggleItem(item)"` on the option, so
+		// dispatching the event straight at it fires the handler and CANNOT be intercepted. A coordinate
+		// click — even `{ force: true }`, which only skips the actionability check — is still delivered at
+		// screen coordinates, and when the body-appended panel sits over an nb-dialog's cdk-overlay-backdrop
+		// that click can land on the backdrop and dismiss the whole form. Fall back to a real click on later
+		// attempts in case a handler needs genuine pointer events.
+		if (attempt === 0) {
+			await option.dispatchEvent('click').catch(() => undefined);
+		} else {
+			await option.click({ force: true }).catch(() => undefined);
+		}
+		await page.waitForTimeout(600);
+		if (await committed()) {
+			return true;
+		}
+		await page.waitForTimeout(800); // slow bind (async valueChanges) — give it one more look before retrying
+		if (await committed()) {
+			return true;
+		}
+	}
+	return committed();
+};

--- a/apps/gauzy-e2e/tests/support/pages/AddEmployeeLevel.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddEmployeeLevel.po.ts
@@ -10,6 +10,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { AddEmployeeLevelPage } from '../../../src/support/Base/pageobjects/AddEmployeeLevelPageObject';
@@ -112,9 +113,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index: number) => {
-	// ng-select options render in the body as div.ng-option (appendTo="body").
-	await verifyElementIsVisible(AddEmployeeLevelPage.tagsSelectOptionCss);
-	await getPage().locator(AddEmployeeLevelPage.tagsSelectOptionCss).nth(index).click({ force: true });
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(AddEmployeeLevelPage.tagsSelectCss, AddEmployeeLevelPage.tagsSelectOptionCss, index);
 };
 
 export const clickKeyboardButtonByKeyCode = async (keycode: number) => {

--- a/apps/gauzy-e2e/tests/support/pages/AddEmployeePosition.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddEmployeePosition.po.ts
@@ -11,6 +11,7 @@ import {
 	waitForSpinnerGone,
 	wait
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { AddEmployeePositionPage } from '../../../src/support/Base/pageobjects/AddEmployeePositionPageObject';
@@ -91,9 +92,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index: number) => {
-	// ng-select options render in the body as div.ng-option (appendTo="body").
-	await verifyElementIsVisible(AddEmployeePositionPage.tagsSelectOptionCss);
-	await getPage().locator(AddEmployeePositionPage.tagsSelectOptionCss).nth(index).click({ force: true });
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(AddEmployeePositionPage.tagsSelectCss, AddEmployeePositionPage.tagsSelectOptionCss, index);
 };
 
 export const clickKeyboardButtonByKeyCode = async (keycode: number) => {

--- a/apps/gauzy-e2e/tests/support/pages/AddOrganization.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddOrganization.po.ts
@@ -79,7 +79,10 @@ const clickOptionByText = async (text: string) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	return false;
+	// Fail closed. Returning false let the caller carry on with the value never
+	// committed, so the spec died later somewhere unrelated — the same swallowed
+	// failure this file is meant to remove.
+	throw new Error(`No selectable option matching "${text}" appeared (placeholders such as "No items found" are excluded by design)`);
 };
 
 // Stepper Next/Add buttons are subject to the same overlay; click the currently-visible
@@ -111,7 +114,8 @@ const clickFormButtonByText = async (texts: string[]) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	return false;
+	// Fail closed — see clickOptionByText above.
+	throw new Error(`No selectable option at index ${index} appeared (placeholders such as "No items found" are excluded by design)`);
 };
 
 export const gridBtnExists = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/AddOrganization.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddOrganization.po.ts
@@ -40,7 +40,7 @@ const openDropdown = async (selector: string) => {
 		if (dispatched) {
 			try {
 				await getPage()
-					.locator('div.ng-option, .ng-dropdown-panel .ng-option, .option-list nb-option, .cdk-overlay-container nb-option')
+					.locator('div.ng-option:not(.ng-option-disabled), .ng-dropdown-panel .ng-option:not(.ng-option-disabled), .option-list nb-option, .cdk-overlay-container nb-option')
 					.first()
 					.waitFor({ state: 'visible', timeout: 5000 });
 				return;
@@ -54,8 +54,10 @@ const openDropdown = async (selector: string) => {
 
 // Option panels (ng-select .ng-option / nb-select nb-option) live in overlays that can sit
 // under the same spinner stacking context — dispatch the click on the matching option via DOM.
+// ':not(.ng-option-disabled)' is load-bearing: ng-select renders its own 'No items found' / 'Loading…'
+// rows with the same ng-option class, so an index/text pick could land on a placeholder ng-select ignores.
 const OPTION_SELECTOR =
-	'div.ng-option, .ng-dropdown-panel .ng-option, .option-list nb-option, .cdk-overlay-container nb-option';
+	'div.ng-option:not(.ng-option-disabled), .ng-dropdown-panel .ng-option:not(.ng-option-disabled), .option-list nb-option, .cdk-overlay-container nb-option';
 
 const clickOptionByText = async (text: string) => {
 	for (let attempt = 0; attempt < 5; attempt++) {

--- a/apps/gauzy-e2e/tests/support/pages/AddTasks.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddTasks.po.ts
@@ -15,6 +15,7 @@ import {
 	waitForSpinnerGone,
 	wait
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { AddTaskPage } from '../../../src/support/Base/pageobjects/AddTasksPageObject';
@@ -231,7 +232,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index) => {
-	await clickButtonByIndex(AddTaskPage.tagsSelectOptionCss, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(AddTaskPage.tagsSelectCss, AddTaskPage.tagsSelectOptionCss, index);
 };
 
 export const closeTagsMultiSelectDropdownButtonVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/ApprovalRequest.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/ApprovalRequest.po.ts
@@ -2,7 +2,6 @@ import {
 	verifyElementIsVisible,
 	clickButton,
 	clickElementByText,
-	clickButtonByIndex,
 	clearField,
 	enterInput,
 	clickKeyboardBtnByKeycode,
@@ -16,8 +15,10 @@ import {
 	verifyByLength,
 	verifyTextNotExisting,
 	dispatchClick,
+	scopeGridTo,
 	waitForSpinnerGone
 } from '../util';
+import { controlText, selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { ApprovalRequestPage } from '../../../src/support/Base/pageobjects/ApprovalRequestPageObject';
@@ -85,11 +86,20 @@ const gotoHashRoute = async (targetHash: string, header: string): Promise<void> 
 const ensureAllEmployeesSelected = async (): Promise<void> => {
 	const page = getPage();
 	try {
-		const selector = page.locator('ga-employee-selector.header-selector ng-select').first();
+		const control = 'ga-employee-selector.header-selector ng-select';
+		const selector = page.locator(control).first();
 		if (!(await selector.isVisible().catch(() => false))) return;
-		// Already showing "All Employees"? The selected/placeholder text lives inside the ng-select host, so
-		// its innerText contains "All Employees" when nothing narrower is picked — then this is a no-op.
-		const shownText = (await selector.innerText().catch(() => '')) || '';
+		// Already showing "All Employees"? Read the CLOSED CONTROL (.ng-select-container), not the
+		// <ng-select> host's innerText. The host's text also covers the open dropdown panel, in which
+		// "All Employees" is ALWAYS present as the leading pseudo-option — so an innerText check can be
+		// satisfied by the option list and this early-return fires while a specific employee is still
+		// selected. That silently skips the reset, leaves the header filter in place, and every
+		// verify-exists below then asserts against a getByEmployeeId()-filtered grid.
+		//
+		// (This particular selector sets appendTo="body", so the panel is out of the host today — but that
+		// is app-side markup, not something the spec controls. .ng-select-container is a sibling of the
+		// panel and is therefore correct either way, and it still covers the placeholder case.)
+		const shownText = await controlText(control);
 		if (shownText.includes('All Employees')) return;
 		// A specific employee is selected (pollution from an earlier spec). Open the ng-select and pick the
 		// "All Employees" pseudo-option. ng-select opens on mousedown and appends its panel to <body>, so the
@@ -238,14 +248,16 @@ export const selectTableRowVisible = async () => {
 // "row 0" is whatever the accumulated rows from earlier specs/runs put first — NOT necessarily our request.
 // Filtering by the unique faker name makes the subsequent row-0 selection / verify-exists order-independent.
 export const searchRequestByName = async (name) => {
-	const page = getPage();
-	await waitForSpinnerGone();
-	await page.waitForLoadState('networkidle').catch(() => undefined);
-	const filter = page.locator(ApprovalRequestPage.nameFilterInputCss).first();
-	await filter.fill(String(name)).catch(() => undefined);
-	// smart-table filtering is debounced; let the grid re-render down to the single match before selecting.
-	await page.waitForTimeout(1500);
-	await waitForSpinnerGone();
+	// The filter was NEVER APPLIED. The approvals grid's Name column has no custom filter component, so it
+	// renders angular2-smart-table's stock `input-filter`: `<input [value]="query" (change) (keyup)>`. That
+	// listens for 'change'/'keyup' and never for 'input' — the ONLY event Playwright's .fill() dispatches.
+	// So the old `filter.fill(name)` put text in the box and filtered nothing: every caller below
+	// (verifyRequestExists / verifyElementIsDeleted / selectTableRow) was silently still looking at an
+	// unfiltered, paginated page 1, i.e. exactly the pollution this helper was written to defeat.
+	// scopeGridTo → applySmartTableFilter fills AND dispatches the 'change' the component subscribes to,
+	// then reads the value back and retries if the debounced refetch clobbered it.
+	await getPage().waitForLoadState('networkidle').catch(() => undefined);
+	await scopeGridTo(ApprovalRequestPage.nameFilterInputCss, String(name));
 };
 
 export const selectTableRow = async (name) => {
@@ -372,12 +384,11 @@ export const waitMessageToHide = async () => {
 export const verifyApprovalPolicyExists = async (text) => {
 	// Filter the (server-side, paginated) policy grid to our uniquely-named policy first so it's guaranteed
 	// to render — an unfiltered page 1 may not include it once earlier specs/runs have created policies.
-	const page = getPage();
-	await waitForSpinnerGone();
-	const filter = page.locator(ApprovalRequestPage.policyNameFilterInputCss).first();
-	await filter.fill(String(text)).catch(() => undefined);
-	await page.waitForTimeout(1500); // server-side filter is debounced — let the refetch land
-	await waitForSpinnerGone();
+	// Via the shared helper rather than a bare .fill(): this column DOES use Gauzy's FormControl-based
+	// ga-input-filter-selector (so .fill() happened to work here), but that is a per-column implementation
+	// detail no spec should depend on — applySmartTableFilter drives both widgets and verifies the value
+	// survived the debounced refetch.
+	await scopeGridTo(ApprovalRequestPage.policyNameFilterInputCss, String(text));
 	await verifyText(ApprovalRequestPage.verifyApprovalPolicyCss, text);
 };
 
@@ -422,7 +433,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index) => {
-	await clickButtonByIndex(ApprovalRequestPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(ApprovalRequestPage.addTagsDropdownCss, ApprovalRequestPage.tagsDropdownOption, index);
 };
 
 export const clickCardBody = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Candidates.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Candidates.po.ts
@@ -7,7 +7,6 @@ import {
 	enterInputConditionally,
 	clearField,
 	clickKeyboardBtnByKeycode,
-	clickButtonByIndex,
 	getLastElement,
 	waitElementToHide,
 	verifyText,
@@ -15,6 +14,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { CandidatesPage } from '../../../src/support/Base/pageobjects/CandidatesPageObject';
@@ -273,7 +273,15 @@ export const clickAddTagsDropdown = async () => {
 };
 
 export const selectTagsFromDropdown = async (index) => {
-	await clickButtonByIndex(CandidatesPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(CandidatesPage.addTagsDropdownCss, CandidatesPage.tagsDropdownOption, index);
 };
 
 export const imageInputVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Clients.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Clients.po.ts
@@ -1,6 +1,5 @@
 import {
 	verifyElementIsVisible,
-	clickButtonByIndex,
 	clickButton,
 	dispatchClick,
 	waitForSpinnerGone,
@@ -14,6 +13,7 @@ import {
 	verifyByText,
 	verifyByLength
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { ClientsPage } from '../../../src/support/Base/pageobjects/ClientsPageObject';
@@ -180,7 +180,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index) => {
-	await clickButtonByIndex(ClientsPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(ClientsPage.addTagsDropdownCss, ClientsPage.tagsDropdownOption, index);
 };
 
 export const websiteInputVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/ContactsLeads.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/ContactsLeads.po.ts
@@ -1,6 +1,5 @@
 import {
 	verifyElementIsVisible,
-	clickButtonByIndex,
 	clickButton,
 	dispatchClick,
 	waitForSpinnerGone,
@@ -14,6 +13,7 @@ import {
 	verifyByLength,
 	verifyByText
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { ContactsLeadsPage } from '../../../src/support/Base/pageobjects/ContactsLeadsPageObject';
@@ -173,7 +173,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index) => {
-	await clickButtonByIndex(ContactsLeadsPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(ContactsLeadsPage.addTagsDropdownCss, ContactsLeadsPage.tagsDropdownOption, index);
 };
 
 export const websiteInputVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Customers.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Customers.po.ts
@@ -109,7 +109,9 @@ const clickOptionByText = async (text: string) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	return false;
+	// Fail closed. Returning false let the caller carry on with the value never
+	// committed, so the spec died later somewhere unrelated.
+	throw new Error(`No selectable option matching "${text}" appeared (placeholders such as "No items found" are excluded by design)`);
 };
 
 const clickOptionByIndex = async (index: number) => {
@@ -130,7 +132,8 @@ const clickOptionByIndex = async (index: number) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	return false;
+	// Fail closed — see clickOptionByText above.
+	throw new Error(`No selectable option at index ${index} appeared (placeholders such as "No items found" are excluded by design)`);
 };
 
 // Close a leftover floating invite dialog that would otherwise cover the grid + toolbar (so a row click

--- a/apps/gauzy-e2e/tests/support/pages/Customers.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Customers.po.ts
@@ -87,7 +87,9 @@ const clickFormButtonByText = async (texts: string[]) => {
 // same spinner stacking context, so option clicks are flaky via normal Playwright clicks.
 // Dispatch the click on the matching option via the DOM. Matches ng-select (.ng-option)
 // and nb-select (nb-option) panels.
-const OPTION_SELECTOR = 'div.ng-option, .ng-dropdown-panel .ng-option, .option-list nb-option, .cdk-overlay-container nb-option';
+// ':not(.ng-option-disabled)' is load-bearing: ng-select renders its own 'No items found' / 'Loading…'
+// rows with the same ng-option class, so an index/text pick could land on a placeholder ng-select ignores.
+const OPTION_SELECTOR = 'div.ng-option:not(.ng-option-disabled), .ng-dropdown-panel .ng-option:not(.ng-option-disabled), .option-list nb-option, .cdk-overlay-container nb-option';
 
 const clickOptionByText = async (text: string) => {
 	for (let attempt = 0; attempt < 5; attempt++) {

--- a/apps/gauzy-e2e/tests/support/pages/EditUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/EditUser.po.ts
@@ -15,6 +15,7 @@ import {
 	dispatchClickWhenSettled,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { EditUserPage } from '../../../src/support/Base/pageobjects/EditUserPageObject';
@@ -253,7 +254,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index: number) => {
-	await clickButtonByIndex(EditUserPage.tagsSelectOptionCss, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(EditUserPage.tagsSelectCss, EditUserPage.tagsSelectOptionCss, index);
 };
 
 export const clickKeyboardButtonByKeyCode = async (keycode: number) => {

--- a/apps/gauzy-e2e/tests/support/pages/EmployeeAddInfoTest.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/EmployeeAddInfoTest.po.ts
@@ -9,9 +9,9 @@ import {
 	waitElementToHide,
 	clickByText,
 	verifyByText,
-	clickButtonByIndex,
 	scrollDown
 } from '../util';
+import { selectNgOption } from '../ng-select';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { EmployeeAddInfoPage } from '../../../src/support/Base/pageobjects/EmployeeAddInfoPageObject';
 
@@ -57,7 +57,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index: number) => {
-	await clickButtonByIndex(EmployeeAddInfoPage.tagsSelectOptionCss, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(EmployeeAddInfoPage.tagsSelectCss, EmployeeAddInfoPage.tagsSelectOptionCss, index);
 };
 
 export const clickKeyboardButtonByKeyCode = async (keycode: number) => {

--- a/apps/gauzy-e2e/tests/support/pages/EmployeeDashboardTest.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/EmployeeDashboardTest.po.ts
@@ -10,10 +10,10 @@ import {
 	waitElementToHide,
 	clickByText,
 	verifyByText,
-	clickButtonByIndex,
 	verifyText,
 	enterInputConditionally
 } from '../util';
+import { selectNgOption } from '../ng-select';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { EmployeeDashboardPage } from '../../../src/support/Base/pageobjects/EmployeeDashboardPageObject';
 
@@ -177,7 +177,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index) => {
-	await clickButtonByIndex(EmployeeDashboardPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(EmployeeDashboardPage.addTagsDropdownCss, EmployeeDashboardPage.tagsDropdownOption, index);
 };
 
 export const notesTextareaVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Estimates.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Estimates.po.ts
@@ -14,6 +14,7 @@ import {
 	scrollDown,
 	verifyElementIsNotVisible
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { EstimatesPage } from '../../../src/support/Base/pageobjects/EstimatesPageObject';
@@ -51,19 +52,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index) => {
-	const page = getPage();
-	const option = page.locator(EstimatesPage.tagsDropdownOption);
-	// Re-open the tags ng-select via keyboard (focus the inner input + ArrowDown) until the options
-	// render — ng-select opens on mousedown so a click is backdrop-blocked; focusing the host (not the
-	// inner input) silently fails to open it. Then pick the option (appended to <body>).
-	for (let i = 0; i < 4; i++) {
-		if (await option.first().isVisible().catch(() => false)) break;
-		await waitForSpinnerGone();
-		await page.locator(`${EstimatesPage.addTagsDropdownCss} input`).first().focus().catch(() => {});
-		await page.keyboard.press('ArrowDown').catch(() => {});
-		await page.waitForTimeout(800);
-	}
-	await clickButtonByIndex(EstimatesPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(EstimatesPage.addTagsDropdownCss, EstimatesPage.tagsDropdownOption, index);
 };
 
 export const clickCardBody = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Expenses.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Expenses.po.ts
@@ -14,6 +14,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { ExpensesPage } from '../../../src/support/Base/pageobjects/ExpensesPageObject';
@@ -186,18 +187,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index) => {
-	// Best-effort tag pick: an org tag was created by the addTag prerequisite, but the list still loads
-	// async — click the option if it shows, else dismiss and continue (tags are optional on an expense).
-	const page = getPage();
-	const option = page.locator(ExpensesPage.tagsDropdownOption);
-	try {
-		await option.first().waitFor({ state: 'visible', timeout: 8000 });
-		await option.nth(index).click({ force: true });
-	} catch {
-		// As in selectEmployeeFromDropdown: dismiss the open tags ng-select by clicking the dialog title,
-		// NEVER Escape — the dialog's default closeOnEsc would close the whole add-expense form.
-		await page.locator(ExpensesPage.cardBodyCss).first().click({ force: true }).catch(() => {});
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(ExpensesPage.addTagsDropdownCss, ExpensesPage.tagsDropdownOption, index);
 };
 
 export const purposeTextareaVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Income.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Income.po.ts
@@ -9,6 +9,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { IncomePage } from '../../../src/support/Base/pageobjects/IncomePageObject';
@@ -126,18 +127,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	// Best-effort tag pick: an org tag was created by the addTag prerequisite, but the list still loads
-	// async — click the option if it shows, else dismiss and continue (tags are optional on income).
-	const page = getPage();
-	const option = page.locator(IncomePage.tagsDropdownOption);
-	try {
-		await option.first().waitFor({ state: 'visible', timeout: 8000 });
-		await option.nth(index).click({ force: true });
-	} catch {
-		// As in selectEmployeeFromDropdown: dismiss the open tags ng-select by clicking the inert dialog
-		// title, NEVER Escape — the dialog's default closeOnEsc would close the whole add-income form.
-		await page.locator(IncomePage.cardBodyCss).first().click({ force: true }).catch(() => {});
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(IncomePage.addTagsDropdownCss, IncomePage.tagsDropdownOption, index);
 };
 
 export const notesTextareaVisible = async () => verifyElementIsVisible(IncomePage.notesInputCss);

--- a/apps/gauzy-e2e/tests/support/pages/Invoices.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Invoices.po.ts
@@ -13,6 +13,7 @@ import {
 	scrollDown,
 	verifyElementIsNotVisible
 } from '../util';
+import { committedValues, selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { InvoicesPage } from '../../../src/support/Base/pageobjects/InvoicesPageObject';
@@ -47,24 +48,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	const page = getPage();
-	const option = page.locator(InvoicesPage.tagsDropdownOption);
-	// Re-open the tags ng-select via keyboard (focus the inner input + ArrowDown) until the options
-	// render — ng-select opens on mousedown so a click is backdrop-blocked. Then pick the option
-	// (appended to <body>). Best-effort: tags are optional for an invoice, and the list can render empty,
-	// so if no option shows after a few re-opens, press Escape and continue rather than hard-waiting 60s.
-	for (let i = 0; i < 4; i++) {
-		if (await option.first().isVisible().catch(() => false)) break;
-		await waitForSpinnerGone();
-		await page.locator(`${InvoicesPage.addTagsDropdownCss} input`).first().focus().catch(() => {});
-		await page.keyboard.press('ArrowDown').catch(() => {});
-		await page.waitForTimeout(800);
-	}
-	if (await option.first().isVisible().catch(() => false)) {
-		await option.nth(index).click({ force: true }).catch(() => {});
-	} else {
-		await page.keyboard.press('Escape').catch(() => {});
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(InvoicesPage.addTagsDropdownCss, InvoicesPage.tagsDropdownOption, index);
 };
 
 export const clickCardBody = async () => {
@@ -120,11 +112,19 @@ export const selectContactFromDropdown = async (nameOrIndex: string | number) =>
 	// is set (else it toasts "NOT_LINKED" and never sends), and the popover Send button is [disabled]="!canBeSend"
 	// which is false when the row has no toContact. A silent mis-pick here => the invoice stays DRAFT and
 	// verifySentBadgeClass times out three steps later. So confirm the label, and re-pick if it didn't take.
-	const control = page.locator(InvoicesPage.organizationContactDropdownCss).first();
+	//
+	// VERIFY AGAINST div.ng-value, NOT the control's own text. Reading `control.innerText()` back is the
+	// self-validating trap: ng-select renders its OPEN PANEL inside the <ng-select> element unless the app
+	// sets appendTo="body", and the step immediately before this typeahead-filters the panel down to the
+	// wanted contact — so the check would be satisfied by the option it just typed, and report a commit
+	// while nothing was selected. (It only holds today because contact-select.component.html happens to
+	// carry appendTo="body" — an app-side detail no spec should depend on.) `div.ng-value` is the value
+	// container ng-select writes ONLY once a value is really bound, so it cannot be satisfied by the panel.
+	const values = committedValues(InvoicesPage.organizationContactDropdownCss);
 	const committed = async () =>
 		byName
-			? (await control.innerText().catch(() => '')).toLowerCase().includes(String(nameOrIndex).toLowerCase())
-			: (await control.locator('.ng-value').count().catch(() => 0)) > 0;
+			? (await values.first().innerText().catch(() => '')).toLowerCase().includes(String(nameOrIndex).toLowerCase())
+			: (await values.count().catch(() => 0)) > 0;
 
 	for (let attempt = 0; attempt < 3; attempt++) {
 		for (let i = 0; i < 6; i++) {

--- a/apps/gauzy-e2e/tests/support/pages/ManageEmployees.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/ManageEmployees.po.ts
@@ -13,6 +13,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { ManageEmployeesPage } from '../../../src/support/Base/pageobjects/ManageEmployeesPageObject';
@@ -202,20 +203,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index) => {
-	// Tags are OPTIONAL for the employee form's validity, so make this best-effort: if the ng-select
-	// panel has an option, pick it; if it didn't open / has no options (e.g. the tags grid wasn't
-	// seeded yet), Escape and continue rather than throwing and breaking the whole add flow.
-	const page = getPage();
-	const option = page.locator(ManageEmployeesPage.tagsDropdownOption).nth(index);
-	const appeared = await option
-		.waitFor({ state: 'visible', timeout: 8000 })
-		.then(() => true)
-		.catch(() => false);
-	if (appeared) {
-		await option.click({ force: true }).catch(() => {});
-	} else {
-		await page.keyboard.press('Escape').catch(() => {});
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(ManageEmployeesPage.addTagsDropdownCss, ManageEmployeesPage.tagsDropdownOption, index);
 };
 
 export const clickCardBody = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/ManageOrganization.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/ManageOrganization.po.ts
@@ -40,7 +40,7 @@ const openDropdown = async (selector: string) => {
 			try {
 				await getPage()
 					.locator(
-						'div.ng-option, .ng-dropdown-panel .ng-option, .option-list nb-option, .cdk-overlay-container nb-option'
+						'div.ng-option:not(.ng-option-disabled), .ng-dropdown-panel .ng-option:not(.ng-option-disabled), .option-list nb-option, .cdk-overlay-container nb-option'
 					)
 					.first()
 					.waitFor({ state: 'visible', timeout: 5000 });
@@ -53,8 +53,10 @@ const openDropdown = async (selector: string) => {
 	}
 };
 
+// ':not(.ng-option-disabled)' is load-bearing: ng-select renders its own 'No items found' / 'Loading…'
+// rows with the same ng-option class, so an index/text pick could land on a placeholder ng-select ignores.
 const OPTION_SELECTOR =
-	'div.ng-option, .ng-dropdown-panel .ng-option, .option-list nb-option, .cdk-overlay-container nb-option';
+	'div.ng-option:not(.ng-option-disabled), .ng-dropdown-panel .ng-option:not(.ng-option-disabled), .option-list nb-option, .cdk-overlay-container nb-option';
 
 const clickOptionByText = async (text: string) => {
 	for (let attempt = 0; attempt < 5; attempt++) {

--- a/apps/gauzy-e2e/tests/support/pages/ManageOrganization.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/ManageOrganization.po.ts
@@ -78,7 +78,9 @@ const clickOptionByText = async (text: string) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	return false;
+	// Fail closed. Returning false let the caller carry on with the value never
+	// committed, so the spec died later somewhere unrelated.
+	throw new Error(`No selectable option matching "${text}" appeared (placeholders such as "No items found" are excluded by design)`);
 };
 
 export const gridBtnExists = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/MyTasksTrackedInTimesheets.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/MyTasksTrackedInTimesheets.po.ts
@@ -10,6 +10,7 @@ import {
 	waitForSpinnerGone,
 	compareTwoTexts
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 import type { Response } from '@playwright/test';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
@@ -134,16 +135,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index: number) => {
-	// Best-effort tag pick: the tag options load async and can be empty. Pick one if present; otherwise leave
-	// tags unset (tags are optional on a task, so Save is unaffected).
-	const page = getPage();
-	const options = page.locator(MyTasksTrackedInTimesheets.tagsSelectOptionCss);
-	try {
-		await options.first().waitFor({ state: 'visible', timeout: 8000 });
-		await options.nth(index).click({ force: true });
-	} catch {
-		await page.keyboard.press('Escape').catch(() => undefined);
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(MyTasksTrackedInTimesheets.tagsSelectCss, MyTasksTrackedInTimesheets.tagsSelectOptionCss, index);
 };
 
 export const clickCardBody = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationDepartments.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationDepartments.po.ts
@@ -12,6 +12,7 @@ import {
 	dispatchClick,
 	getLastElement
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { expect } from '@playwright/test';
 import { getPage } from '../page-context';
 // Selectors + data are framework-agnostic — reused from the Cypress tree during migration.
@@ -155,17 +156,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	// Best-effort tag pick: tags is an OPTIONAL field (no validator on the form), so if the appended
-	// ng-dropdown panel is slow/empty, press Escape and continue rather than hanging — the department
-	// still saves. Click the first rendered option when present.
-	const page = getPage();
-	const option = page.locator(OrganizationDepartmentsPage.tagsDropdownOption);
-	try {
-		await option.first().waitFor({ state: 'visible', timeout: 8000 });
-		await option.nth(index).click({ force: true });
-	} catch {
-		await page.keyboard.press('Escape').catch(() => {});
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(OrganizationDepartmentsPage.addTagsDropdownCss, OrganizationDepartmentsPage.tagsDropdownOption, index);
 };
 
 export const clickKeyboardButtonByKeyCode = async (keycode: number) => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationEmploymentTypes.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationEmploymentTypes.po.ts
@@ -10,6 +10,7 @@ import {
 	verifyText,
 	verifyTextNotExisting
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors + data are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationEmploymentTypesPage } from '../../../src/support/Base/pageobjects/OrganizationEmploymentTypesPageObject';
@@ -99,17 +100,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	const page = getPage();
-	const option = page.locator(OrganizationEmploymentTypesPage.tagsDropdownOption);
-	// Best-effort: the tag list (div.ng-option, rendered at body level via appendTo) loads async. The
-	// addTag prerequisite seeds one tag, but if the panel is slow/empty don't hang 60s on option[index] —
-	// pick one if it shows, otherwise Escape and continue (a tag is optional; the type saves without it).
-	try {
-		await option.first().waitFor({ state: 'visible', timeout: 8000 });
-		await option.nth(index).click({ force: true });
-	} catch {
-		await page.keyboard.press('Escape').catch(() => {});
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(OrganizationEmploymentTypesPage.addTagsDropdownCss, OrganizationEmploymentTypesPage.tagsDropdownOption, index);
 };
 
 export const clickCardBody = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
@@ -13,6 +13,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors + data are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationEquipmentPage } from '../../../src/support/Base/pageobjects/OrganizationEquipmentPageObject';
@@ -167,7 +168,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	await clickButtonByIndex(OrganizationEquipmentPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(OrganizationEquipmentPage.addTagsDropdownCss, OrganizationEquipmentPage.tagsDropdownOption, index);
 };
 
 export const clickCardBody = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationInventory.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationInventory.po.ts
@@ -3,7 +3,6 @@ import {
 	verifyElementIsVisible,
 	clickButton,
 	clearField,
-	clickButtonByIndex,
 	waitElementToHide,
 	clickButtonByText,
 	verifyText,
@@ -13,6 +12,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationInventoryPage } from '../../../src/support/Base/pageobjects/OrganizationInventoryPageObject';
@@ -357,7 +357,15 @@ export const clickTagsSelect = async () => {
 };
 
 export const selectTagFromDropdownOptions = async (index) => {
-	await clickButtonByIndex(OrganizationInventoryPage.tagsDropdownOptionCss, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(OrganizationInventoryPage.tagsSelectCss, OrganizationInventoryPage.tagsDropdownOptionCss, index);
 };
 
 export const merchantDescriptionInputVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationProjects.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationProjects.po.ts
@@ -12,6 +12,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationProjectsPage } from '../../../src/support/Base/pageobjects/OrganizationProjectsPageObject';
@@ -93,16 +94,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index) => {
-	// Pick the option from the body-appended panel. dispatchClick avoids any fading overlay swallowing
-	// the coordinate click; ng-select keeps the panel open (closeOnSelect=false) so the next step still
-	// works. Best-effort: tags can be empty on a fresh tenant, so don't hard-fail.
-	const option = getPage().locator(OrganizationProjectsPage.tagsSelectOptionCss);
-	try {
-		await option.nth(index).waitFor({ state: 'visible', timeout: 6000 });
-		await option.nth(index).dispatchEvent('click');
-	} catch {
-		await getPage().keyboard.press('Escape').catch(() => undefined);
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(OrganizationProjectsPage.tagsSelectCss, OrganizationProjectsPage.tagsSelectOptionCss, index);
 };
 
 export const clickKeyboardButtonByKeyCode = async (keycode) => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationTags.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationTags.po.ts
@@ -1,5 +1,6 @@
 import {
 	waitUntil,
+	scopeGridTo,
 	verifyElementIsVisible,
 	clickButton,
 	clickButtonByIndex,
@@ -133,10 +134,22 @@ export const waitMessageToHide = async () => {
 };
 
 export const verifyTagExists = async (text) => {
+	// Scope the grid to THIS tag before asserting. The tags grid is server-paginated at 10 rows, the
+	// seed already ships a full page of tags and the serial suite keeps adding more, so a freshly
+	// created tag routinely sits on page 2 and the unfiltered assertion failed even though the record
+	// existed — a textbook order-dependent failure.
+	//
+	// Filtering also makes the FOLLOWING step correct: the steps do `selectTableRow(0)` straight after
+	// this, and on an unfiltered grid row 0 is whatever the API happened to sort first — so the spec
+	// would edit/delete a seeded tag instead of its own.
+	await scopeGridTo(OrganizationTagsPage.filterNameInputCss, text);
 	await verifyText(OrganizationTagsPage.verifyTagCss, text);
 };
 
 export const verifyTagIsDeleted = async (text) => {
+	// Same scoping: assert the absence against the FILTERED grid, so this cannot be satisfied merely by
+	// the row having moved to another page.
+	await scopeGridTo(OrganizationTagsPage.filterNameInputCss, text);
 	await verifyTextNotExisting(OrganizationTagsPage.verifyTagCss, text);
 };
 
@@ -145,8 +158,10 @@ export const nameInputVisible = async () => {
 };
 
 export const enterFilterInputData = async (text) => {
-	await enterInput(OrganizationTagsPage.filterNameInputCss, text);
-	await waitUntil(2000);
+	// applySmartTableFilter, NOT enterInput: the grid's filter cell is
+	// `<input [value]="query" (change) (keyup)>` and never listens for 'input', which is the only event
+	// Playwright's .fill() dispatches — so the old call typed into the box and filtered nothing.
+	await scopeGridTo(OrganizationTagsPage.filterNameInputCss, text);
 };
 
 export const filteredTagVisible = async (text) => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationTeams.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationTeams.po.ts
@@ -1,6 +1,5 @@
 import {
 	verifyElementIsVisible,
-	clickButtonByIndex,
 	clearField,
 	enterInput,
 	clickKeyboardBtnByKeycode,
@@ -8,8 +7,11 @@ import {
 	verifyText,
 	verifyTextNotExisting,
 	dispatchClick,
+	scopeGridTo,
+	clickAndAwaitDialogClose,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationTeamsPage } from '../../../src/support/Base/pageobjects/OrganizationTeamsPageObject';
@@ -54,8 +56,13 @@ export const nameInputVisible = async () => {
 };
 
 export const enterNameInputData = async (data: string) => {
-	await clearField(OrganizationTeamsPage.teamNameInputCss);
-	await enterInput(OrganizationTeamsPage.teamNameInputCss, data);
+	// Target the CURRENT (topmost) mutation dialog. clearField/enterInput are strict, so if a previous
+	// dialog is somehow still mounted this threw "strict mode violation: … resolved to 2 elements" — and
+	// `.first()` would have been worse, quietly typing into the dead dialog. `.last()` is the one the
+	// user is looking at, and with a single dialog (the normal case) it is identical to today.
+	const input = getPage().locator(OrganizationTeamsPage.teamNameInputCss).last();
+	await input.clear();
+	await input.fill(String(data));
 };
 
 export const tagsMultiSelectVisible = async () => {
@@ -71,7 +78,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index: number) => {
-	await clickButtonByIndex(OrganizationTeamsPage.tagsSelectOptionCss, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(OrganizationTeamsPage.tagsSelectCss, OrganizationTeamsPage.tagsSelectOptionCss, index);
 };
 
 export const employeeDropdownVisible = async () => {
@@ -174,10 +189,14 @@ export const saveButtonVisible = async () => {
 };
 
 export const clickSaveButton = async () => {
-	// Save sits in the dialog; a fading backdrop from a closed sub-dropdown can intercept a coordinate
-	// click, so dispatch the click straight to the element.
-	await waitForSpinnerGone();
-	await dispatchClick(OrganizationTeamsPage.saveButtonCss);
+	// PROVE the submit landed, instead of assuming it. Previously this dispatched one click and moved on;
+	// when the click didn't submit (Save still disabled while memberIds — a required control — was being
+	// bound, or a fading backdrop from a closed sub-dropdown in the way) the dialog just stayed open. The
+	// following verifyTeamExists then passed anyway on a LEFTOVER "Front-End Team" row from an earlier
+	// run (this spec uses a fixed name against an accumulating DB), and the failure only surfaced two
+	// steps later as a second stacked dialog. clickAndAwaitDialogClose waits for Save to be enabled,
+	// dispatches at the element, and requires ga-teams-mutation to DETACH — re-dispatching if it doesn't.
+	await clickAndAwaitDialogClose(OrganizationTeamsPage.saveButtonCss, 'ga-teams-mutation');
 };
 
 export const tableRowVisible = async () => {
@@ -194,6 +213,14 @@ export const selectTableRow = async (nameOrIndex: number | string) => {
 	await waitForSpinnerGone();
 	await page.waitForLoadState('networkidle').catch(() => undefined);
 	await page.waitForTimeout(1500);
+
+	// Filtering by name is what makes the row-scoping actually work: `.filter({ hasText })` can only see
+	// the 10 rows the server rendered for the CURRENT page, so on an accumulated DB the spec's own team
+	// is simply not among them and the click silently lands on nothing (or, via the .first() fallback,
+	// on a foreign row that then gets edited/deleted). Best-effort — no-ops if the filter row is absent.
+	if (typeof nameOrIndex === 'string' && nameOrIndex.length) {
+		await scopeGridTo(OrganizationTeamsPage.nameFilterInputCss, nameOrIndex);
+	}
 
 	const rows = page.locator(OrganizationTeamsPage.selectTableRowCss);
 	const row =
@@ -252,9 +279,16 @@ export const waitMessageToHide = async () => {
 };
 
 export const verifyTeamExists = async (text: string) => {
+	// Narrow the grid to THIS team before asserting: it is server-paginated at 10 rows and the serial
+	// suite keeps adding teams to one shared DB, so the row the spec just created is regularly on page 2
+	// and the unfiltered assertion failed with the record perfectly intact.
+	await scopeGridTo(OrganizationTeamsPage.nameFilterInputCss, text);
 	await verifyText(OrganizationTeamsPage.verifyTeamCss, text);
 };
 
 export const verifyTeamIsDeleted = async (text: string) => {
+	// Same scoping: an absence assertion on an unfiltered, paginated grid is satisfied by the row simply
+	// having moved to another page, which makes it both flaky AND too weak.
+	await scopeGridTo(OrganizationTeamsPage.nameFilterInputCss, text);
 	await verifyTextNotExisting(OrganizationTeamsPage.verifyTeamCss, text);
 };

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationTeams.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationTeams.po.ts
@@ -1,7 +1,5 @@
 import {
 	verifyElementIsVisible,
-	clearField,
-	enterInput,
 	clickKeyboardBtnByKeycode,
 	waitElementToHide,
 	verifyText,

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationVendors.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationVendors.po.ts
@@ -9,6 +9,7 @@ import {
 	waitElementToHide,
 	verifyElementNotExist
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationVendorsPage } from '../../../src/support/Base/pageobjects/OrganizationVendorsPageObject';
@@ -111,7 +112,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	await clickButtonByIndex(OrganizationVendorsPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(OrganizationVendorsPage.addTagsDropdownCss, OrganizationVendorsPage.tagsDropdownOption, index);
 };
 
 export const saveVendorButtonVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Payments.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Payments.po.ts
@@ -13,6 +13,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { PaymentsPage } from '../../../src/support/Base/pageobjects/PaymentsPageObject';
@@ -60,31 +61,15 @@ export const clickTagsDropdown = async (index: number) => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	// Best-effort tag pick. Tags are OPTIONAL on a payment (no validator on the `tags` control), and the
-	// org-tag list still loads async. Crucially, the tags ng-select panel is appendTo=body and sits over
-	// the nb-dialog's cdk-overlay-backdrop, so a COORDINATE click on an option (even {force:true}) can
-	// land on the dialog backdrop and DISMISS the whole payment form — the exact failure here: by the
-	// next step (clickCardBody) the dialog was already gone and the footer click timed out. So select via
-	// the KEYBOARD only (ArrowDown to highlight, Enter to toggle — multiple+closeOnSelect=false), which
-	// never touches the backdrop. We DON'T close the panel here — clickCardBody (next step) closes it by
-	// clicking the inert dialog title. If no option renders within ~8s, just continue — tags are optional.
-	const page = getPage();
-	const tagInput = page.locator(`${PaymentsPage.addTagsDropdownCss} input`).first();
-	const option = page.locator(PaymentsPage.tagsDropdownOption);
-	try {
-		await option.first().waitFor({ state: 'visible', timeout: 8000 });
-		await tagInput.focus().catch(() => {});
-		for (let i = 0; i <= index; i++) {
-			await page.keyboard.press('ArrowDown').catch(() => {});
-		}
-		await page.keyboard.press('Enter').catch(() => {});
-	} catch {
-		/* tag list never rendered — tags are optional, continue */
-	}
-	// Do NOT press Escape here (or anywhere in this flow): the payment dialog opens with Nebular's default
-	// closeOnEsc=true, so any document-level Escape closes the WHOLE form. The tags panel stays open
-	// (closeOnSelect=false); clickCardBody (the very next step) closes it by clicking the inert dialog
-	// title — an in-dialog outside-click that dismisses only the dropdown overlay, leaving the form intact.
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(PaymentsPage.addTagsDropdownCss, PaymentsPage.tagsDropdownOption, index);
 };
 
 export const projectDropdownVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Proposals.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Proposals.po.ts
@@ -14,6 +14,7 @@ import {
 	waitForSpinnerGone,
 	waitForDropdownToLoad
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { ProposalsPage } from '../../../src/support/Base/pageobjects/ProposalsPageObject';
@@ -176,17 +177,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index) => {
-	const page = getPage();
-	const option = page.locator(ProposalsPage.tagsDropdownOption);
-	// Re-open the tags ng-select via keyboard until the options (div.ng-option) render, then pick one.
-	for (let i = 0; i < 4; i++) {
-		if (await option.first().isVisible().catch(() => false)) break;
-		await waitForSpinnerGone();
-		await page.locator(`${ProposalsPage.addTagsDropdownCss} input`).first().focus().catch(() => {});
-		await page.keyboard.press('ArrowDown').catch(() => {});
-		await page.waitForTimeout(800);
-	}
-	await clickButtonByIndex(ProposalsPage.tagsDropdownOption, index);
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(ProposalsPage.addTagsDropdownCss, ProposalsPage.tagsDropdownOption, index);
 };
 
 export const jobPostContentTextareaVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Register.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Register.po.ts
@@ -41,7 +41,7 @@ const openDropdown = async (selector: string) => {
 		if (dispatched) {
 			try {
 				await getPage()
-					.locator('div.ng-option, .ng-dropdown-panel .ng-option, .option-list nb-option, .cdk-overlay-container nb-option')
+					.locator('div.ng-option:not(.ng-option-disabled), .ng-dropdown-panel .ng-option:not(.ng-option-disabled), .option-list nb-option, .cdk-overlay-container nb-option')
 					.first()
 					.waitFor({ state: 'visible', timeout: 5000 });
 				return;
@@ -55,8 +55,10 @@ const openDropdown = async (selector: string) => {
 
 // Option panels (ng-select .ng-option / nb-select nb-option) live in overlays that can sit under the
 // same spinner stacking context — dispatch the click on the matching option via DOM.
+// ':not(.ng-option-disabled)' is load-bearing: ng-select renders its own 'No items found' / 'Loading…'
+// rows with the same ng-option class, so an index/text pick could land on a placeholder ng-select ignores.
 const OPTION_SELECTOR =
-	'div.ng-option, .ng-dropdown-panel .ng-option, .option-list nb-option, .cdk-overlay-container nb-option';
+	'div.ng-option:not(.ng-option-disabled), .ng-dropdown-panel .ng-option:not(.ng-option-disabled), .option-list nb-option, .cdk-overlay-container nb-option';
 
 const clickOptionByText = async (text: string) => {
 	for (let attempt = 0; attempt < 5; attempt++) {

--- a/apps/gauzy-e2e/tests/support/pages/Register.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Register.po.ts
@@ -80,7 +80,10 @@ const clickOptionByText = async (text: string) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	return false;
+	// Fail closed. Returning false let the caller carry on with the value never
+	// committed, so the spec died later somewhere unrelated — the same swallowed
+	// failure this file is meant to remove.
+	throw new Error(`No selectable option matching "${text}" appeared (placeholders such as "No items found" are excluded by design)`);
 };
 
 // Stepper forward/confirm buttons are subject to the same overlay; click the currently-visible matching
@@ -109,7 +112,8 @@ const clickFormButtonByText = async (texts: string[]) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	return false;
+	// Fail closed — see clickOptionByText above.
+	throw new Error(`No selectable option at index ${index} appeared (placeholders such as "No items found" are excluded by design)`);
 };
 
 export const registerLinkVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/SalesEstimates.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/SalesEstimates.po.ts
@@ -13,6 +13,7 @@ import {
 	verifyTextNotExisting,
 	scrollDown
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { SalesEstimatesPage } from '../../../src/support/Base/pageobjects/SalesEstimatesPageObject';
@@ -51,25 +52,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	const page = getPage();
-	const option = page.locator(SalesEstimatesPage.tagsDropdownOption);
-	// Re-open the tags ng-select via keyboard (focus inner input + ArrowDown) until the options render —
-	// ng-select opens on mousedown so a click is backdrop-blocked. Then pick the option (appended to body).
-	// Best-effort: tags are OPTIONAL for an estimate (no validator on the tags control) and the list can
-	// render empty/slow; if no option shows after a few re-opens, press Escape and continue rather than
-	// hard-waiting 60s on div.ng-option (the observed test timeout). Mirrors the proven Invoices.po pattern.
-	for (let i = 0; i < 4; i++) {
-		if (await option.first().isVisible().catch(() => false)) break;
-		await waitForSpinnerGone();
-		await page.locator(`${SalesEstimatesPage.addTagsDropdownCss} input`).first().focus().catch(() => {});
-		await page.keyboard.press('ArrowDown').catch(() => {});
-		await page.waitForTimeout(800);
-	}
-	if (await option.first().isVisible().catch(() => false)) {
-		await option.nth(index).click({ force: true }).catch(() => {});
-	} else {
-		await page.keyboard.press('Escape').catch(() => {});
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(SalesEstimatesPage.addTagsDropdownCss, SalesEstimatesPage.tagsDropdownOption, index);
 };
 
 export const clickCardBody = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/SalesInvoices.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/SalesInvoices.po.ts
@@ -11,6 +11,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { SalesInvoicesPage } from '../../../src/support/Base/pageobjects/SalesInvoicesPageObject';
@@ -50,25 +51,15 @@ export const clickTagsDropdown = async () => {
 };
 
 export const selectTagFromDropdown = async (index: number) => {
-	const page = getPage();
-	const option = page.locator(SalesInvoicesPage.tagsDropdownOption);
-	// Re-open the tags ng-select via keyboard (focus inner input + ArrowDown) until the options render —
-	// ng-select opens on mousedown so a click is backdrop-blocked. Then pick the option (appended to body).
-	// Best-effort: tags are OPTIONAL for an invoice (no validator on the tags control) and the list can
-	// render empty/slow; if no option shows after a few re-opens, press Escape and continue rather than
-	// hard-waiting on div.ng-option. Mirrors the proven SalesEstimates.po pattern.
-	for (let i = 0; i < 4; i++) {
-		if (await option.first().isVisible().catch(() => false)) break;
-		await waitForSpinnerGone();
-		await page.locator(`${SalesInvoicesPage.addTagsDropdownCss} input`).first().focus().catch(() => {});
-		await page.keyboard.press('ArrowDown').catch(() => {});
-		await page.waitForTimeout(800);
-	}
-	if (await option.first().isVisible().catch(() => false)) {
-		await option.nth(index).click({ force: true }).catch(() => {});
-	} else {
-		await page.keyboard.press('Escape').catch(() => {});
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(SalesInvoicesPage.addTagsDropdownCss, SalesInvoicesPage.tagsDropdownOption, index);
 };
 
 export const clickCardBody = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/TeamsTasks.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/TeamsTasks.po.ts
@@ -13,6 +13,7 @@ import {
 	dispatchClick,
 	waitForSpinnerGone
 } from '../util';
+import { selectNgOption } from '../ng-select';
 import { getPage } from '../page-context';
 // Selectors + data are framework-agnostic — reused from the Cypress tree during migration.
 import { TeamsTasksPage } from '../../../src/support/Base/pageobjects/TeamsTasksPageObject';
@@ -228,19 +229,15 @@ export const clickTagsMultiSelect = async () => {
 };
 
 export const selectTagsFromDropdown = async (index: number) => {
-	// The tag options (div.ng-option in the appended .ng-dropdown-panel) load async after the panel opens,
-	// so wait for one before clicking; best-effort because the tag is optional (it's not part of any
-	// downstream assertion — the task saves fine without it), so we must not hard-hang the 60s force-timeout
-	// if the panel is slow/empty. Mirrors the best-effort team / employee pickers in this file. (Playbook
-	// pattern 1 + anti-hang.)
-	const page = getPage();
-	const option = page.locator(TeamsTasksPage.tagsSelectOptionCss);
-	try {
-		await option.first().waitFor({ state: 'visible', timeout: 8000 });
-		await option.nth(index).click({ force: true });
-	} catch {
-		await page.keyboard.press('Escape').catch(() => undefined);
-	}
+	// Routed through the ONE shared ng-select driver (tests/support/ng-select.ts). It counts only REAL
+	// options: a bare `div.ng-option` ALSO matches ng-select's disabled "No items found" / "Loading…"
+	// rows, so the old wait-then-click was satisfied by an EMPTY list and then clicked a row ng-select
+	// ignores — a silent no-op that left this field unset. It re-opens the panel via the control's own
+	// container until real options render (NEVER Escape: nb-dialog opens with closeOnEsc and that closed
+	// the whole form), and it confirms the pick against `div.ng-value`, the only node that exists once a
+	// value is really bound. Still best-effort — the tag is optional here — but it can no longer
+	// half-succeed, and it can no longer kill the dialog on a slow list.
+	await selectNgOption(TeamsTasksPage.tagsSelectCss, TeamsTasksPage.tagsSelectOptionCss, index);
 };
 
 export const closeTagsMultiSelectDropdownButtonVisible = async () =>

--- a/apps/gauzy-e2e/tests/support/util.ts
+++ b/apps/gauzy-e2e/tests/support/util.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import { getPage } from './page-context';
+import { resolveOptionSelector } from './ng-select';
 
 /**
  * Playwright port of the Cypress util layer (src/support/Base/utils/util.ts).
@@ -16,6 +17,22 @@ const taskTimeout = 60_000;
 
 const loc = (selector: string) => getPage().locator(selector);
 
+/**
+ * `loc()` for selectors that MAY address ng-select options.
+ *
+ * ng-select renders "No items found" / "Loading…" / "Type to search" as
+ * `div.ng-option.ng-option-disabled` — the same class real choices carry. Every util below that
+ * WAITS FOR or CLICKS an option therefore has to exclude those placeholders, or it either proceeds
+ * against an empty list or clicks a row ng-select ignores (a silent no-op that submits null; see
+ * ng-select.ts for the proof).
+ *
+ * `resolveOptionSelector` upgrades the selector only once a real option has actually rendered, and
+ * otherwise returns the caller's original selector untouched — so this is strictly safer than what
+ * it replaces and cannot turn a step that used to pass into one that fails. Non-option selectors
+ * (the vast majority, plus every Nebular `nb-option` one) are returned as-is with no extra wait.
+ */
+const optionAwareLoc = async (selector: string) => loc(await resolveOptionSelector(selector));
+
 export const getTitle = async (): Promise<string> => getPage().title();
 
 export const verifyText = async (selector: string, data: string) =>
@@ -24,7 +41,9 @@ export const verifyText = async (selector: string, data: string) =>
 	// rendered options/rows/cards?" check when X isn't first (dropdown options, grid rows, reused
 	// headers). Filter by text then assert visibility — covers both the single-element and among-many
 	// intents, retry-safe, and no Playwright strict-mode violation.
-	expect(loc(selector).filter({ hasText: data }).first()).toBeVisible({ timeout: defaultCommandTimeout });
+	expect((await optionAwareLoc(selector)).filter({ hasText: data }).first()).toBeVisible({
+		timeout: defaultCommandTimeout
+	});
 
 export const verifyValue = async (selector: string, data: string) =>
 	expect(loc(selector).first()).toHaveValue(data, { timeout: defaultCommandTimeout });
@@ -42,7 +61,7 @@ export const verifyTextByIndex = async (selector: string, data: string, index: n
 	expect(loc(selector).nth(index)).toContainText(data);
 
 export const clickButton = async (selector: string) =>
-	loc(selector).first().click({ force: true, timeout: taskTimeout });
+	(await optionAwareLoc(selector)).first().click({ force: true, timeout: taskTimeout });
 
 // DOM-level click that bypasses overlay hit-testing: dispatches the event straight to the element so
 // the framework's (click) handler fires even when a fading cdk-overlay backdrop sits on top. A
@@ -132,14 +151,88 @@ export const applySmartTableFilter = async (selector: string, value: string, att
 	}
 };
 
+/**
+ * Narrow a smart-table grid to the record this spec is about, so "my row exists" stops depending on
+ * how much data earlier specs left behind.
+ *
+ * The grids are SERVER-paginated at 10 rows and the suite runs serially against ONE accumulating
+ * database, so a row a spec just created is regularly not on page 1 at all. A bare
+ * `verifyText(<tbody>, name)` then fails — not because the record is missing, but because it is on
+ * page 2. That is precisely the kind of order-dependence that makes the failing set rotate between
+ * runs, and it is what `remove-user` / `edit-user` were already fixed by filtering.
+ *
+ * Best-effort ON PURPOSE: not every grid has a filter row (several set `hideSubHeader` or mark all
+ * columns `isFilterable: false`, and some screens are card grids, not tables). When the filter input
+ * is not there this returns false and the caller asserts exactly as it did before — so adding this
+ * call to an existing verification can only ever narrow the grid, never break it.
+ *
+ * Prefer a column-key selector (`th.angular2-smart-th.<columnKey> input`) over a
+ * `[placeholder="…"]` one: the placeholder is the TRANSLATED column title, so it breaks the moment a
+ * spec changes the UI language, while the column key is stable.
+ */
+export const scopeGridTo = async (filterSelector: string, value: string): Promise<boolean> => {
+	await waitForSpinnerGone();
+	try {
+		await loc(filterSelector).first().waitFor({ state: 'visible', timeout: 6_000 });
+	} catch {
+		return false; // this grid has no filter row — leave the caller's behaviour untouched
+	}
+	await applySmartTableFilter(filterSelector, value);
+	return true;
+};
+
+/**
+ * Submit a dialog and PROVE it closed.
+ *
+ * "Click Save, then assert the row exists" is one of the ways this suite lies to itself. When the
+ * click does not actually submit — the button was still disabled, the dispatch raced an async
+ * valueChanges, an overlay swallowed it — the dialog simply stays open, and the following
+ * `verifyXExists` is then satisfied by a LEFTOVER row that an earlier run created under the same
+ * fixed test name. The spec goes green having saved nothing, and the next step opens a SECOND dialog
+ * on top of the first, which is where it finally falls over (`strict mode violation: … resolved to 2
+ * elements`) — several steps away from the real cause, and only when the previous run happened to
+ * leave the right residue. That is exactly the shape of an order-dependent failure.
+ *
+ * So: wait for the button to be genuinely enabled (a dispatched click on a disabled button runs the
+ * handler but the component's own guard then discards it), dispatch the click at the element so no
+ * overlay can intercept it, and wait for the dialog host to DETACH. Re-dispatch if it is still there.
+ * Returns whether the dialog actually closed.
+ */
+export const clickAndAwaitDialogClose = async (
+	buttonSelector: string,
+	dialogSelector: string,
+	attempts = 3
+): Promise<boolean> => {
+	const page = getPage();
+	const dialog = loc(dialogSelector).first();
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		await waitForSpinnerGone();
+		const button = loc(buttonSelector).first();
+		await button.waitFor({ state: 'visible', timeout: defaultCommandTimeout }).catch(() => undefined);
+		for (let i = 0; i < 12; i++) {
+			if (await button.isEnabled().catch(() => false)) break;
+			await page.waitForTimeout(500);
+		}
+		await button.dispatchEvent('click').catch(() => undefined);
+		try {
+			await dialog.waitFor({ state: 'detached', timeout: 12_000 });
+			return true;
+		} catch {
+			/* still open — the submit did not take. Settle and try once more. */
+		}
+		await page.waitForTimeout(800);
+	}
+	return (await loc(dialogSelector).count().catch(() => 0)) === 0;
+};
+
 export const clickElementByText = async (selector: string, data: string) =>
 	// force + taskTimeout to match clickButton: several flows leave a fading nb-dialog backdrop
 	// (cdk-overlay-backdrop) that intercepts pointer events; the element is present and correct, the
 	// click just needs to go through (Appointments "Book Public Appointment", etc.).
-	loc(selector).filter({ hasText: data }).first().click({ force: true, timeout: taskTimeout });
+	(await optionAwareLoc(selector)).filter({ hasText: data }).first().click({ force: true, timeout: taskTimeout });
 
 export const forceClickElementByText = async (selector: string, data: string) =>
-	loc(selector).filter({ hasText: data }).first().click({ force: true });
+	(await optionAwareLoc(selector)).filter({ hasText: data }).first().click({ force: true });
 
 export const enterInput = async (selector: string, data: string) =>
 	loc(selector).fill(String(data), { timeout: taskTimeout });
@@ -157,13 +250,17 @@ export const verifyElementIsVisible = async (selector: string) =>
 	// selector more than once (grid rows, tab headers, repeated nb components). Asserting on the
 	// first match preserves the "is this control present?" intent without Playwright strict-mode
 	// violations. Single-match selectors are unaffected.
-	expect(loc(selector).first()).toBeVisible({ timeout: defaultCommandTimeout });
+	expect((await optionAwareLoc(selector)).first()).toBeVisible({ timeout: defaultCommandTimeout });
 
 export const verifyElementIsVisibleByIndex = async (selector: string, index: number) =>
-	expect(loc(selector).nth(index)).toBeVisible({ timeout: defaultCommandTimeout });
+	expect((await optionAwareLoc(selector)).nth(index)).toBeVisible({ timeout: defaultCommandTimeout });
 
 export const clickButtonByIndex = async (selector: string, index: number) =>
-	loc(selector).nth(index).click({ force: true, timeout: taskTimeout });
+	// Option selectors are resolved to REAL options first: `nth(0)` on a bare `div.ng-option` is
+	// ng-select's own "No items found" row whenever the list has not loaded, and clicking it is a
+	// silent no-op. The index is unchanged for a populated list — ng-select only renders a placeholder
+	// row when there are no real items at all.
+	(await optionAwareLoc(selector)).nth(index).click({ force: true, timeout: taskTimeout });
 
 export const clickOrganizationByIndex = async (selector: string, index: number) =>
 	loc(selector).nth(index).click({ force: true, timeout: taskTimeout });
@@ -226,10 +323,10 @@ export const verifyElementNotExist = async (selector: string) =>
 	expect(loc(selector)).toHaveCount(0, { timeout: defaultCommandTimeout });
 
 export const verifyByText = async (selector: string, text: string) =>
-	expect(loc(selector)).toContainText(text, { timeout: defaultCommandTimeout });
+	expect(await optionAwareLoc(selector)).toContainText(text, { timeout: defaultCommandTimeout });
 
 export const clickByText = async (selector: string, text: string) =>
-	loc(selector).filter({ hasText: text }).first().click({ force: true, timeout: taskTimeout });
+	(await optionAwareLoc(selector)).filter({ hasText: text }).first().click({ force: true, timeout: taskTimeout });
 
 export const clickButtonMultipleTimes = async (selector: string, n: number) => {
 	for (let i = 0; i < n; i++) {
@@ -269,7 +366,7 @@ export const uploadMedia = async (selector: string, btn: string, file: string) =
 export const uploadMediaInput = async (selector: string, file: string) => loc(selector).setInputFiles(file);
 
 export const waitElementToLoad = async (selector: string) =>
-	expect(loc(selector).first()).toBeAttached({ timeout: defaultCommandTimeout });
+	expect((await optionAwareLoc(selector)).first()).toBeAttached({ timeout: defaultCommandTimeout });
 
 export const dragNDrop = async (source: string, index: number, target: string) =>
 	loc(source).nth(index).dragTo(loc(target));
@@ -290,7 +387,7 @@ export const verifyElementIsNotVisibleByIndex = async (selector: string, index: 
 	expect(loc(selector).nth(index)).toBeHidden({ timeout: defaultCommandTimeout });
 
 export const clickButtonWithForce = async (selector: string) =>
-	loc(selector).click({ force: true, timeout: taskTimeout });
+	(await optionAwareLoc(selector)).click({ force: true, timeout: taskTimeout });
 
 export const verifyElementIfVisible = async (locOne: string, locTwo: string) => {
 	if (await loc(locTwo).first().isVisible()) {
@@ -300,11 +397,16 @@ export const verifyElementIfVisible = async (locOne: string, locTwo: string) => 
 
 export const clickButtonDouble = async (selector: string) => loc(selector).dblclick({ timeout: taskTimeout });
 
-export const waitForDropdownToLoad = async (selector: string) =>
-	expect.poll(async () => loc(selector).count(), { timeout: defaultCommandTimeout }).toBeGreaterThan(1);
+export const waitForDropdownToLoad = async (selector: string) => {
+	// Poll REAL options: a bare `div.ng-option` count includes ng-select's "No items found" placeholder,
+	// so "the dropdown loaded" could be satisfied by an empty list. Strictly stricter — the raw count is
+	// always >= the real count, so anything that satisfied this before still does.
+	const resolved = await resolveOptionSelector(selector);
+	return expect.poll(async () => loc(resolved).count(), { timeout: defaultCommandTimeout }).toBeGreaterThan(1);
+};
 
 export const clickButtonByIndexNoForce = async (selector: string, index: number) =>
-	loc(selector).nth(index).click({ timeout: taskTimeout });
+	(await optionAwareLoc(selector)).nth(index).click({ timeout: taskTimeout });
 
 export const enterTextInIFrame = async (selector: string, text: string) =>
 	getPage().frameLocator(selector).locator('p').type(text);


### PR DESCRIPTION
The e2e suite has had a pair of failures that **rotate between runs** and pass in isolation. That signature means state- and timing-dependence, not broken assertions, so this attacks the causes.

## 1. The `div.ng-option` placeholder trap (66 files)

ng-select renders `No items found` / `Loading…` / `Type to search` as `div.ng-option.ng-option-disabled` — verified against the vendored template. So a bare `div.ng-option` selector is **satisfied by an empty panel**, and `nth(i)` clicks a row ng-select ignores. The slower the dropdown loads, the likelier the placeholder is what gets clicked.

Fixed at two levels rather than by editing 66 files:

- **Blanket:** `resolveOptionSelector` rewrites option selectors to `:not(.ng-option-disabled)` — but only once a real option has rendered, otherwise it returns the caller's original selector, so no existing step can newly fail. Wired into 11 util functions, covering all 66 files.
- **Full driver:** `selectNgOption` re-opens the panel via its own `.ng-select-container` until real options appear (never Escape — several hand-rolled loops fell back to `keyboard.press('Escape')`, which closes the entire `nb-dialog`), dispatches at the option that carries `(click)="toggleItem(item)"` so a backdrop cannot intercept it, and confirms against `div.ng-value`. 28 pickers now route through it.

Three page-object selectors never addressed an option at all: `'[type="checkbox"]'` matched every checkbox on the page including grid row selectors, and `div.ng-dropdown-panel-items.scroll-host` is the panel's scroll container.

## 2. Assertions that validated themselves (3 sites)

`Invoices` read the ng-select control's own `innerText` back as proof of commit. `ApprovalRequest.ensureAllEmployeesSelected` early-**returned** on the same check, silently skipping the header-filter reset. `JobsProposals.verifyProposalCss` was `div.ng-star-inserted` — every Angular-inserted div on the page — so "the proposal exists" could be satisfied by the create dialog still being mounted, and the mirror "is it deleted?" passed as soon as the text left ANY div.

Added `committedValues()` (`div.ng-value`) and `controlText()` so the read-back is from a different element than the write.

## 3. Grids paging at 10

`scopeGridTo` narrows a grid before asserting. Best-effort: it no-ops when the grid has no filter row, so it can only narrow. Also `ApprovalRequest.searchRequestByName` was **a filter that never applied** — `.fill()` against angular2-smart-table's stock `input-filter`, which listens for `change`/`keyup` only.

## 4. Two causes not in the original brief

- **Fixed test data + accumulating DB + a server uniqueness constraint.** From the network trace: `POST /api/organization-team → 400 "The team name 'Front-End Team' is already in use"`, swallowed by the app's bare `catch`, so the dialog stayed open — and `verifyTeamExists` then passed **on a leftover row**, with the spec dying two steps later on a stacked dialog. Fixed with per-run faker suffixes; swept the API for other such validators and found the same latent trap in the expenses category step.
- **"Click Save" without proving the dialog closed.** `clickAndAwaitDialogClose` waits for enabled, dispatches, requires detach, re-dispatches.

## Verification — and its limits

31 specs pass with `retries: 0` against a deliberately polluted DB.

`organization-teams` **failed at HEAD and passes now**, with the baseline confirmed by checking out `origin/develop` over `apps/gauzy-e2e` and reproducing the identical error. `teams-tasks` still fails and was A/B'd the same way — it fails **identically at baseline**, so this branch neither causes nor fixes it.

**This reduces the problem, it does not close it.** One rotating failure is gone with a root cause proven from the trace. The `div.ng-option` work is broad and strictly safer, but it is prophylactic — it was never caught red-handed in these runs. No full-suite run was done.

## Biggest remaining lever, deliberately left out

`CustomCommands.addTag` / `addProject` create a row unconditionally on every call. The DB now holds **49 tags named "Default"** and **28 projects named "Gauzy Web Site"**, and that list grows every run — which directly feeds cause #1, because slower ng-select loads mean more time spent on the placeholder. Making them idempotent attacks the root, but it changes a prerequisite ~20 specs depend on and would invalidate all the verification above, so it was left for its own change rather than landed unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens flaky e2e tests by centralizing `ng-select` handling, excluding placeholder options, enforcing dialog closure, scoping grid assertions, and making dropdown pickers fail fast. Reduces rotating failures without changing app behavior.

- **Bug Fixes**
  - Added a single `ng-select` driver (`tests/support/ng-select.ts`) that ignores placeholder rows, reopens until real options render, clicks the actual option node, and verifies commits via `div.ng-value`. Routed affected pickers through it.
  - Made option pickers fail closed: if no real option appears, helpers now throw with a clear message (placeholders excluded by design) instead of returning false and letting tests proceed silently.
  - Tightened selectors: use `div.ng-option` (not checkboxes or scroll containers); filtered to `:not(.ng-option-disabled)`; scoped proposal row checks to the grid; addressed grid filter inputs by column key, not translated placeholders.
  - Replaced self-validating reads with `committedValues()` / `controlText()` to assert committed state.
  - Ensured saves actually close dialogs via `clickAndAwaitDialogClose`, and always target the topmost dialog.
  - Scoped paginated grids before assertions using `scopeGridTo`; fixed filters to emit `change`/`keyup`.
  - Made team and expense-category names run-unique to avoid API 400s on an accumulating DB.

- **Verification**
  - 31 specs pass with retries: 0; `organization-teams` now passes.
  - `teams-tasks` still fails identically on `develop` (pre-existing).

<sup>Written for commit ff58ed97aa0691fef59707ed504030833dcebb7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

