### PR TITLE
fix(e2e): repair a bad throw I merged, and settle the tags "Add" click that breaks four specs

### DIFF
--- a/apps/gauzy-e2e/tests/support/pages/AddOrganization.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddOrganization.po.ts
@@ -114,8 +114,10 @@ const clickFormButtonByText = async (texts: string[]) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	// Fail closed — see clickOptionByText above.
-	throw new Error(`No selectable option at index ${index} appeared (placeholders such as "No items found" are excluded by design)`);
+	// Deliberately returns a boolean rather than throwing: unlike a dropdown value that
+	// never committed, an absent form button is a legitimate branch for the callers here
+	// (they fall back to another submit path).
+	return false;
 };
 
 export const gridBtnExists = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationTags.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationTags.po.ts
@@ -4,6 +4,7 @@ import {
 	verifyElementIsVisible,
 	clickButton,
 	clickButtonByIndex,
+	dispatchClickWhenSettled,
 	clearField,
 	enterInput,
 	waitElementToHide,
@@ -27,7 +28,26 @@ export const addTagButtonVisible = async () => {
 };
 
 export const clickAddTagButton = async () => {
-	await clickButton(OrganizationTagsPage.addTagButtonCss);
+	// `CustomCommands.addTag` is a prerequisite of ~4 specs (invoices, estimates,
+	// sales-estimates, teams-tasks) and all four have died here: the click is
+	// delivered, `TagsComponent.add()` never runs, and the scenario then times out
+	// waiting for the dialog's `#inputName`.
+	//
+	// `clickButton` is `.click({ force: true })`, and `force` only skips the
+	// actionability CHECK — the click is still dispatched at screen coordinates, so
+	// it is lost to whatever occupies that point. The exact mechanism is still open
+	// (an `[nbSpinner]` overlay on the card, the action row's slide-in transform,
+	// and `ngxPermissions` re-creating the embedded view have each been argued from
+	// the traces, and at least one trace contradicts the overlay theory by showing
+	// the button take `:hover` at the moment of the click).
+	//
+	// The fix is deliberately mechanism-independent: `dispatchClickWhenSettled`
+	// dispatches the event AT the element (immune to hit-testing and to the node
+	// under the cursor changing) and then confirms the dialog actually opened,
+	// re-dispatching if not. Do not reduce it to "settle, then click" — the
+	// confirm-and-retry is the load-bearing part. Same treatment as
+	// AddUser/EditUser/InviteUser/OrganizationProjects.
+	await dispatchClickWhenSettled(OrganizationTagsPage.addTagButtonCss, OrganizationTagsPage.tagNameInputCss);
 };
 
 export const closeDialogButtonVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Register.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Register.po.ts
@@ -112,8 +112,10 @@ const clickFormButtonByText = async (texts: string[]) => {
 		if (clicked) return true;
 		await getPage().waitForTimeout(500);
 	}
-	// Fail closed — see clickOptionByText above.
-	throw new Error(`No selectable option at index ${index} appeared (placeholders such as "No items found" are excluded by design)`);
+	// Deliberately returns a boolean rather than throwing: unlike a dropdown value that
+	// never committed, an absent form button is a legitimate branch for the callers here
+	// (they fall back to another submit path).
+	return false;
 };
 
 export const registerLinkVisible = async () => {


### PR DESCRIPTION
Two fixes. The first is a regression I introduced in #9864 and merged; the second is the single highest-leverage item from a root-cause pass over the first CI e2e run that ever reached the test step.

## 1. `clickFormButtonByText` threw a message referencing an undefined `index`

The "fail closed" change in #9864 was applied by a script that assumed the second retry-loop in each file was `clickOptionByIndex`. In `Register.po.ts` and `AddOrganization.po.ts` it was `clickFormButtonByText(texts: string[])`, which has no `index` parameter — so the throw was a `ReferenceError` waiting to fire.

It would also have been a `TS2304` had the e2e project type-checked cleanly. It does not: `@playwright/test` types fail to resolve there, so `tsc --noEmit -p apps/gauzy-e2e/tsconfig.json` stops before it reaches this. Worth fixing separately — it is why a whole class of error gets through.

Both are restored to returning a boolean, which is the right behaviour regardless: unlike a dropdown value that never committed, **an absent form button is a legitimate branch** for these callers — exactly as the equivalent helper in `Customers.po.ts` already documents. The two genuine option pickers keep throwing.

## 2. `clickAddTagButton` now settles, dispatches and confirms

`CustomCommands.addTag` is a prerequisite of **invoices, estimates, sales-estimates and teams-tasks**, and all four died on it in run 30646106163. The pattern is identical each time: the click is delivered, `TagsComponent.add()` never runs, `ngx-tags-mutation` never opens, and the scenario times out waiting for `#inputName`.

`clickButton` is `.click({ force: true })`. `force` only skips the actionability **check** — the click is still dispatched at screen coordinates, so it is lost to whatever occupies that point.

**The mechanism is deliberately not asserted.** Three incompatible explanations were argued from the traces:
- an `[nbSpinner]` overlay on the `<nb-card>` (the spinner is `position:absolute; inset:0; z-index:9999` and wraps the header toolbar, not just the body),
- the action row's slide-in transform still animating,
- `ngxPermissions` clearing and re-creating the embedded view, so `mousedown`/`mouseup` land on different nodes.

And one trace **contradicts the overlay theory outright**: the Add button takes its `:hover` state at the moment of the click, and hover only goes to the topmost hit element.

So the fix is mechanism-independent. `dispatchClickWhenSettled` dispatches the event **at** the element — immune both to hit-testing and to the node under the cursor changing — and then **confirms the dialog actually opened**, re-dispatching if not. It already exists (`util.ts:100`) and is already used by `AddUser`, `EditUser`, `InviteUser` and `OrganizationProjects`; it was simply never wired into the tags path.

⚠️ Do not later "simplify" this to a settle followed by a click. The confirm-and-re-dispatch loop is the load-bearing part.

## Not in this PR — filed for follow-up

Two real **product** bugs were found by the same pass and deserve their own change:

- **Time logs vanish across a timezone boundary.** The create path uses the browser zone (`timer-range-picker.component.ts:104`, `timezone.tz.guess()`), the read path uses the configured Gauzy zone (`base-selector-filter.component.ts:86`). A log created near a day boundary is filed on a different day than the grid that created it. Any user whose browser TZ differs from their configured TZ is affected.
- **Candidate statistic page renders four empty expanded panels** instead of an empty state: `candidate-statistic.component.html:16-22` gates on `@if (candidates.length > 0)` with no `@else`, and the "no data" markup lives *inside* the gated components.

Also noted: `[nbSpinner]` is bound to `<nb-card>` rather than `<nb-card-body>` in ~57 templates, which puts a click-eating overlay over each page's primary action button during every refresh — real users' clicks are discarded too, not just the suite's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two e2e issues: a bad throw in the form button helper and a flaky Tags “Add” click. This stabilizes tag creation and unblocks invoices, estimates, sales-estimates, and teams-tasks specs in CI.

- **Bug Fixes**
  - `clickFormButtonByText` in Register and Add Organization now returns `boolean` instead of throwing; removes the undefined `index` error and matches callers that branch on absence.
  - `clickAddTagButton` now uses `dispatchClickWhenSettled` to fire the event at the element and confirm the dialog opened; avoids lost clicks under overlays/animations and stabilizes `CustomCommands.addTag`.

<sup>Written for commit f4ac71790a99140644e2dc242fbbd058c5cddaf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

