### PR TITLE
fix(product): time logs vanishing across a timezone boundary, and a statistic page with no empty state

### DIFF
--- a/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic.component.html
+++ b/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic.component.html
@@ -17,6 +17,8 @@
           @if (candidates$ | async; as candidates) {
             @if (candidates.length > 0) {
               <ga-overall-rating-chart [candidates]="candidates"></ga-overall-rating-chart>
+            } @else {
+              <ng-container *ngTemplateOutlet="noCandidates"></ng-container>
             }
           }
         </nb-accordion-item-body>
@@ -32,6 +34,8 @@
                 [candidates]="candidates"
                 [employees]="employees$ | async"
               ></ga-interview-rating-chart>
+            } @else {
+              <ng-container *ngTemplateOutlet="noCandidates"></ng-container>
             }
           }
         </nb-accordion-item-body>
@@ -48,6 +52,8 @@
                 [interviews]="interviews$ | async"
                 [employees]="employees$ | async"
               ></ga-criterions-rating-chart>
+            } @else {
+              <ng-container *ngTemplateOutlet="noCandidates"></ng-container>
             }
           }
         </nb-accordion-item-body>
@@ -63,6 +69,8 @@
                 [candidates]="candidates"
                 [interviews]="interviews$ | async"
               ></ga-average-criterions-rating-chart>
+            } @else {
+              <ng-container *ngTemplateOutlet="noCandidates"></ng-container>
             }
           }
         </nb-accordion-item-body>
@@ -70,3 +78,17 @@
     </nb-accordion>
   </nb-card-body>
 </nb-card>
+
+<!--
+  Shown when the organization has NO candidates at all. Without it each accordion body
+  renders completely empty: the "no data" markup lives INSIDE the chart components, which
+  are themselves behind the `candidates.length > 0` gate, so zero candidates meant four
+  expanded, blank panels rather than an empty state. Same class names as the charts use,
+  so it reads identically and existing selectors still match.
+-->
+<ng-template #noCandidates>
+  <div class="no-data">
+    <nb-icon icon="info-outline" class="no-data-icon"></nb-icon>
+    <span class="no-data-text">{{ 'CANDIDATES_PAGE.STATISTIC.NO_DATA' | translate }}</span>
+  </div>
+</ng-template>

--- a/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic.component.scss
@@ -10,6 +10,29 @@
   nb-accordion {
     box-shadow: unset;
   }
+
+  // Empty state for "this organization has no candidates at all". Mirrors the layout the
+  // chart components use for "no rating data", but from theme tokens rather than the
+  // hardcoded `#e5e5e5` / `#909cb4` those carry — a fixed light border and grey text read
+  // wrong on the dark canvas.
+  .no-data {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    height: 150px;
+    border: 1px solid nb-theme(border-basic-color-3);
+    border-radius: nb-theme(border-radius);
+
+    &-text {
+      color: nb-theme(text-hint-color);
+    }
+
+    &-icon {
+      color: nb-theme(text-hint-color);
+    }
+  }
   nb-accordion-item-header {
     padding: 1.5rem;
   }

--- a/packages/ui-core/shared/src/lib/timer-picker/timer-range-picker/timer-range-picker.component.ts
+++ b/packages/ui-core/shared/src/lib/timer-picker/timer-range-picker/timer-range-picker.component.ts
@@ -5,6 +5,7 @@ import { NG_VALUE_ACCESSOR, NgModel } from '@angular/forms';
 import { IDateRange } from '@gauzy/contracts';
 import { merge } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
+import { TimeZoneService } from '../../timesheet/gauzy-filters/timezone-filter';
 
 @Component({
 	selector: 'ngx-timer-range-picker',
@@ -82,7 +83,41 @@ export class TimerRangePickerComponent implements OnInit, AfterViewInit {
 	maxSlotEndTime: string;
 	minSlotEndTime: string;
 
-	constructor(private cd: ChangeDetectorRef) {}
+	/**
+	 * True when the host bound `[timezoneOffset]` explicitly (manage-appointment does,
+	 * from the appointment's own timezone). Recorded before the default is applied so
+	 * a supplied offset is never mistaken for a derived one.
+	 */
+	private hasExplicitTimezoneOffset = false;
+
+	constructor(private cd: ChangeDetectorRef, private readonly timeZoneService: TimeZoneService) {}
+
+	/**
+	 * The UTC offset used to turn the picked wall-clock time into an instant.
+	 *
+	 * This used to be the BROWSER's offset (`timezone.tz.guess()`), while every read of
+	 * time logs filters by the configured Gauzy timezone (`TimeZoneService`, consumed in
+	 * `BaseSelectorFilterComponent`). When the two differ, a log created near a day
+	 * boundary is written at an instant that falls outside the day the grid asks for, and
+	 * it silently disappears: the POST returns 201, and the GET that follows comes back
+	 * empty. Deriving from the same service the read path uses keeps write and read on
+	 * one clock.
+	 *
+	 * Resolved per call rather than once, and against the date being edited rather than
+	 * "now", because a zone's offset changes across a DST boundary — asking for today's
+	 * offset while entering time for the other side of that boundary files the log an
+	 * hour out.
+	 *
+	 * @param date - The date the entry is being made for.
+	 * @returns A `±HH:mm` offset string.
+	 */
+	private resolveTimezoneOffset(date: Date | string): string {
+		if (this.hasExplicitTimezoneOffset && this.timezoneOffset) {
+			return this.timezoneOffset;
+		}
+		const on = moment(date ?? new Date()).format('YYYY-MM-DD');
+		return timezone.tz(on, this.timeZoneService.currentTimeZone).format('Z');
+	}
 
 	onChange: any = () => {};
 	onTouched: any = () => {};
@@ -101,14 +136,14 @@ export class TimerRangePickerComponent implements OnInit, AfterViewInit {
 	}
 
 	ngAfterViewInit() {
-		this.timezoneOffset = this.timezoneOffset || timezone.tz(timezone.tz.guess()).format('Z');
+		this.hasExplicitTimezoneOffset = !!this.timezoneOffset;
 		merge(this.dateModel.valueChanges, this.startTimeModel.valueChanges, this.endTimeModel.valueChanges)
 			.pipe(debounceTime(10))
 			.subscribe((data) => {
-				const start = new Date(
-					moment(this.date).format('YYYY-MM-DD') + ' ' + this.startTime + this.timezoneOffset
-				);
-				const end = new Date(moment(this.date).format('YYYY-MM-DD') + ' ' + this.endTime + this.timezoneOffset);
+				const day = moment(this.date).format('YYYY-MM-DD');
+				const offset = this.resolveTimezoneOffset(this.date);
+				const start = new Date(day + ' ' + this.startTime + offset);
+				const end = new Date(day + ' ' + this.endTime + offset);
 
 				if (this.slotStartTime && this.slotEndTime && this.allowedDuration) {
 					this.minSlotStartTime = moment(this.slotStartTime).clone().format('HH:mm');


### PR DESCRIPTION
Two user-facing bugs, both surfaced while root-causing e2e failures. Neither is a test problem.

## 1. A time log created near a day boundary could silently disappear

The **create** path used the browser's offset — `timezone.tz(timezone.tz.guess()).format('Z')` in `timer-range-picker` — while every **read** of time logs filters by the *configured* Gauzy timezone (`TimeZoneService`, consumed in `BaseSelectorFilterComponent`).

When the two differ, the entry is written at an instant outside the day the grid asks for. The trace shows it exactly:

```
POST /api/timesheet/time-log  →  201   startedAt: 2026-07-31T00:00:00.000Z
GET  …?startDate=…04:00:00&endDate=…03:59:59  →  []     (×3)
```

The user watches a save succeed and the row never appear. This hits **anyone whose browser timezone differs from their configured one** — the normal case for a remote team, and the entire reason the setting exists.

The offset now derives from the same service the read path uses, so write and read share one clock. Two details that matter beyond the one-line swap:

- **Resolved per use, against the date being edited** — not once in `ngAfterViewInit` against "now". A zone's offset changes across a DST boundary, so asking for today's offset while entering time for the other side of it files the log an hour out. The original code had that flaw too.
- **An explicitly bound `[timezoneOffset]` still wins.** `manage-appointment` passes one derived from the appointment's own timezone, which is a genuinely different concept. `hasExplicitTimezoneOffset` records that *before* the default is applied, so a supplied value is never mistaken for a derived one.

## 2. The candidate statistic page rendered four blank panels

All four accordion bodies gate on `@if (candidates.length > 0)` with no `@else` — and the "no data yet" markup lives **inside** the chart components, i.e. behind the same gate. An organization with no candidates got four expanded, completely empty panels and no explanation.

Each body now has an `@else` rendering one shared `<ng-template>`, reusing the markup shape the charts already use so it reads identically and existing selectors still match.

The **styles are new rather than borrowed**: the charts hardcode `#e5e5e5` and `#909cb4`, and a fixed light border with grey text reads wrong on the near-black canvas, so the parent's copy uses theme tokens.

## Verification

`nx build gauzy` clean, and checked in a browser against a running API on a non-demo seed (which is the zero-candidate case):

```
PASS  page host rendered
PASS  empty state present in the DOM        — 4 .no-data node(s)
PASS  at least one is visible (open accordion)
PASS  no blank expanded panel remains       — 0 blank body(ies)
PASS  dark border is not an opaque light colour
5/5 passed        firstText: "No data yet"
```

Worth noting how that verification went, because it nearly produced a false negative: the accordions start **collapsed**, Nebular keeps a collapsed body in the DOM with `visibility: hidden`, and `innerText` returns `''` for hidden elements — so the first run reported four "blank" bodies and no text. The markup was correct all along; the check had to open an accordion and judge only `nb-accordion-item:not(.collapsed)`, which is exactly what the e2e page object already does.

The timezone fix is not directly verifiable by screenshot. The `timesheets` spec is its real test — it currently fails 3/3 on precisely this path, so the next CI run is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes time logs disappearing across timezone boundaries and adds a clear empty state to Candidate Statistics. This aligns create/read timezone logic and prevents blank panels when there are no candidates.

- **Bug Fixes**
  - Time logs: Create path now uses the configured timezone (same as reads). Offset resolves per edited date to handle DST. An explicit `[timezoneOffset]` still overrides.
  - Candidate Statistics: Added an `@else` with a shared empty-state template when there are zero candidates. Styles use theme tokens for better contrast on dark backgrounds, while keeping the same markup shape as the charts.

<sup>Written for commit 4979dfe217abcda7e2d6ecd41e2081c973c8afc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

