### PR TITLE
fix: the last e2e failure, plus the two product defects behind the remaining flakes

### DIFF
--- a/apps/gauzy-e2e/src/support/Base/pageobjects/ManageEmployeesPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/ManageEmployeesPageObject.ts
@@ -31,7 +31,21 @@ export const ManageEmployeesPage = {
 	// ngx-password-form-field reflects id onto BOTH its host element and the inner input; scope to
 	// input# so enterInput's fill() (no .first()) doesn't hit a strict-mode violation.
 	passwordInputCss: 'input#password',
-	addTagsDropdownCss: '#addTags',
+	// MUST stay scoped to the Add-Employee dialog. The employees grid's Tags column filter is a
+	// TagsColorFilterComponent -> <ga-tags-color-input> -> <ng-select id="addTags">, i.e. a SECOND
+	// #addTags that sits EARLIER in the DOM than the dialog's (the dialog lives in the cdk-overlay
+	// container appended at the end of <body>), so a bare '#addTags' + .first() drove the GRID filter
+	// while the dialog was open. That is not merely "the tag went to the wrong control": when no tag
+	// exists yet in the org (edit-employee is the first spec in its shard and seeds its tag only AFTER
+	// this call), the option list stays empty and the ng-select driver falls into its re-open branch,
+	// `.ng-select-container.click({ force: true })`. force only skips the actionability CHECK — the
+	// click is still delivered at screen coordinates, which for a control BEHIND the modal means the
+	// dialog's cdk-overlay-backdrop; NbDialogService.open(EmployeeMutationComponent) takes the default
+	// closeOnBackdropClick: true, so the whole Add Employee form was dismissed mid-fill. The visible
+	// symptom was several steps later ("#inputImageUrl input[type=text]" not found), because the
+	// clickCardBody() in between is wrapped in .catch(). Same fix already applied to the candidates,
+	// payments, departments, income and teams page objects for this exact clash.
+	addTagsDropdownCss: 'ga-employee-mutation #addTags',
 	tagsDropdownOption: 'div.ng-option',
 	// ngx-file-uploader-input renders TWO inputs (text URL + hidden file); target the text one only,
 	// else enterInput's fill() (no .first()) hits a strict-mode violation.

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/RegisterPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/RegisterPageObject.ts
@@ -8,6 +8,10 @@ export const RegisterPage = {
 	confirmPassFieldCss: '#input-re-password',
 	// nb-checkbox renders its visual box as span.custom-checkbox (the terms checkbox).
 	termAndConditionCheckboxCss: 'span.custom-checkbox',
+	// ...but the CHECKED STATE lives on nb-checkbox's real control: a visually-hidden native input
+	// inside the same <label>. Assert against this one — the span above is only the click target.
+	// Scoped to ngx-register so it can never resolve to a checkbox from another mounted component.
+	termAndConditionInputCss: 'ngx-register nb-checkbox input[type="checkbox"]',
 	registerButtonCss: 'ngx-register form button.submit-btn',
 
 	// --- First-organization onboarding stepper (organizations-step-form, isOnboarding=true) ---

--- a/apps/gauzy-e2e/tests/support/commands.ts
+++ b/apps/gauzy-e2e/tests/support/commands.ts
@@ -292,6 +292,13 @@ export const CustomCommands = {
 		} catch {
 			/* no tag seeded — employee tags are optional */
 		}
+		// The tag itself is optional, but the DIALOG is not: driving an ng-select that turns out to sit
+		// BEHIND the modal delivers its coordinate clicks onto the cdk-overlay-backdrop, and NbDialog's
+		// closeOnBackdropClick (default true) then dismisses the whole form. Assert the dialog survived
+		// so that failure is reported HERE, with its real cause, instead of being swallowed by the
+		// clickCardBody() catch below and resurfacing 60s later as "#inputImageUrl not found". This can
+		// only ever fire on a run that was already doomed — every line after it needs this same dialog.
+		await getPage().locator('ga-employee-mutation').first().waitFor({ state: 'visible', timeout: 10_000 });
 		await manageEmployeesPage.clickCardBody().catch(() => undefined);
 		await manageEmployeesPage.imageInputVisible();
 		await manageEmployeesPage.enterImageDataUrl(validImg);

--- a/apps/gauzy-e2e/tests/support/pages/Login.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Login.po.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { clearField, enterInput, clickButton, verifyElementIsVisible, getTitle } from '../util';
+import { clearField, enterInput, clickWhenEnabled, verifyElementIsVisible, getTitle } from '../util';
 // Selectors + data are framework-agnostic — reused from the Cypress tree during migration.
 import { LoginPage } from '../../../src/support/Base/pageobjects/LoginPageObject';
 import { LoginPageData } from '../../../src/support/Base/pagedata/LoginPageData';
@@ -9,6 +9,10 @@ export const enterEmail = async (data: string) => enterInput(LoginPage.emailInpu
 export const verifyTitle = async () => expect(await getTitle()).toBe(LoginPageData.TitleText);
 export const clearPasswordField = async () => clearField(LoginPage.passwordInputFieldCss);
 export const enterPassword = async (data: string) => enterInput(LoginPage.passwordInputFieldCss, data);
-export const clickLoginButton = async () => clickButton(LoginPage.loginButton);
+// login.component.html: `[disabled]="submitted || !form.valid"`, and the password is filled a few ms
+// earlier — the same disabled-race the register submit hit, and a forced click on a still-disabled
+// button is dropped silently. Gate on enabled first. `force` is kept so the click behaviour is
+// otherwise byte-identical for the many features whose Background logs in through here.
+export const clickLoginButton = async () => clickWhenEnabled(LoginPage.loginButton, { force: true });
 export const verifyLoginText = async () => verifyElementIsVisible(LoginPage.loginHeadingCss);
 export const verifyLoginButton = async () => verifyElementIsVisible(LoginPage.loginButton);

--- a/apps/gauzy-e2e/tests/support/pages/Register.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Register.po.ts
@@ -1,7 +1,9 @@
 import dayjs from 'dayjs';
+import { expect } from '@playwright/test';
 import {
 	clickButton,
 	clickButtonByIndex,
+	clickWhenEnabled,
 	enterInput,
 	getLastElement,
 	verifyElementIsVisible,
@@ -144,10 +146,33 @@ export const enterConfirmPass = async (data) => {
 
 export const clickTermAndConditionCheckBox = async () => {
 	await clickButton(RegisterPage.termAndConditionCheckboxCss);
+	// Prove the toggle landed. The submit button's `[disabled]` reads `user.terms`, so a swallowed
+	// checkbox click would otherwise only ever show up as a submit that quietly never fires.
+	await expect(getPage().locator(RegisterPage.termAndConditionInputCss).first()).toBeChecked({
+		timeout: 24_000
+	});
 };
 
 export const clickRegisterButton = async () => {
-	await clickButton(RegisterPage.registerButtonCss);
+	// register.component.html: `[disabled]="submitted || !form.valid || !user.terms"`. The terms
+	// checkbox is clicked immediately before this, and `user.terms` only reaches the binding on
+	// Angular's next change-detection pass — so the button is still `disabled` for a few frames. A
+	// {force:true} click is DROPPED outright on a disabled button (force skips the actionability
+	// check, not the browser's own rule), which is why the run then died 60s later in the NEXT step
+	// on `locator.fill … waiting for locator('#nameInput')`. Wait for it to be genuinely enabled and
+	// click for real.
+	await clickWhenEnabled(RegisterPage.registerButtonCss);
+	// ...then prove the submit took. AuthStrategy.register() chains into login() and redirects to '/',
+	// which pages.component forwards to /onboarding/tenant — either way we leave /auth/register. Poll
+	// the URL directly rather than waitForURL so this does not depend on hash-router navigations being
+	// reported as navigation events. Without this assertion a dropped click stays invisible here and
+	// surfaces a minute later somewhere unrelated.
+	await expect
+		.poll(() => getPage().url().includes('/auth/register'), {
+			timeout: 60_000,
+			message: 'Register submit did not take — still on /auth/register after clicking Register'
+		})
+		.toBe(false);
 };
 
 export const verifyOrganisationNameField = async () => {

--- a/apps/gauzy-e2e/tests/support/util.ts
+++ b/apps/gauzy-e2e/tests/support/util.ts
@@ -63,6 +63,31 @@ export const verifyTextByIndex = async (selector: string, data: string, index: n
 export const clickButton = async (selector: string) =>
 	(await optionAwareLoc(selector)).first().click({ force: true, timeout: taskTimeout });
 
+/**
+ * Click a control only once it is genuinely INTERACTIVE (not `disabled`).
+ *
+ * `clickButton` above passes `force: true`, and **force does not bypass `disabled`**. It skips
+ * Playwright's actionability CHECK, but the click is still delivered as a real mouse event at the
+ * element's coordinates — and the HTML spec has the browser drop click events queued on a *disabled*
+ * form control instead of dispatching them. So a forced click on a button whose `[disabled]` binding
+ * Angular has not re-evaluated yet is a SILENT no-op: nothing is clicked, no error is raised, and the
+ * spec dies many seconds later on whatever that click was supposed to produce.
+ *
+ * That is exactly how the register submit was being lost: the terms checkbox is clicked ~40ms earlier
+ * and `[disabled]="submitted || !form.valid || !user.terms"` only clears on Angular's next
+ * change-detection pass, so the run failed a minute later in the NEXT step with
+ * `locator.fill: Timeout 60000ms exceeded … waiting for locator('#nameInput')`.
+ *
+ * Gating on `toBeEnabled` waits for the state that actually matters and retries until it holds, so no
+ * sleep is needed. `force` defaults to OFF because the point is that the control must be interactive;
+ * callers that also have to survive a fading overlay can opt back in.
+ */
+export const clickWhenEnabled = async (selector: string, options: { force?: boolean } = {}) => {
+	const target = loc(selector).first();
+	await expect(target).toBeEnabled({ timeout: defaultCommandTimeout });
+	await target.click({ force: options.force ?? false, timeout: taskTimeout });
+};
+
 // DOM-level click that bypasses overlay hit-testing: dispatches the event straight to the element so
 // the framework's (click) handler fires even when a fading cdk-overlay backdrop sits on top. A
 // coordinate click — even {force:true} — lands on the backdrop instead, because force only skips the

--- a/apps/gauzy/src/app/pages/approval-policy/approval-policy.component.html
+++ b/apps/gauzy/src/app/pages/approval-policy/approval-policy.component.html
@@ -1,8 +1,5 @@
 <ng-template ngxPermissionsOnly="APPROVALS_POLICY_VIEW">
   <nb-card
-    [nbSpinner]="loading"
-    nbSpinnerStatus="primary"
-    nbSpinnerSize="large"
     class="card-scroll"
     >
     <nb-card-header class="d-flex flex-column pb-0">
@@ -23,7 +20,7 @@
         ></ngx-gauzy-button-action>
       </div>
     </nb-card-header>
-    <nb-card-body>
+    <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
       @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
         <div class="table-scroll-container custom-table">
           <angular2-smart-table

--- a/apps/gauzy/src/app/pages/approvals/approvals.component.html
+++ b/apps/gauzy/src/app/pages/approvals/approvals.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <h4>
@@ -33,7 +33,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/approvals/approvals.component.ts
+++ b/apps/gauzy/src/app/pages/approvals/approvals.component.ts
@@ -145,56 +145,62 @@ export class ApprovalsComponent extends PaginationFilterBaseComponent implements
 			return;
 		}
 		this.loading = true;
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.organization;
-		const { activePage, itemsPerPage } = this.getPagination();
-		const buffersItems: any[] = [];
-		let items: any = [];
-		if (this.selectedEmployeeId) {
-			items = (
-				await this.approvalRequestService.getByEmployeeId(this.selectedEmployeeId, ['requestApprovals'], {
-					organizationId,
-					tenantId
-				})
-			).items;
-		} else {
-			items = (
-				await this.approvalRequestService.getAll(
-					[
-						'employeeApprovals',
-						'employeeApprovals.employee',
-						'employeeApprovals.employee.user',
-						'teamApprovals',
-						'teamApprovals.team',
-						'tags',
-						'createdByUser'
-					],
-					{ organizationId, tenantId }
-				)
-			).items;
+		try {
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.organization;
+			const { activePage, itemsPerPage } = this.getPagination();
+			const buffersItems: any[] = [];
+			let items: any = [];
+			if (this.selectedEmployeeId) {
+				items = (
+					await this.approvalRequestService.getByEmployeeId(this.selectedEmployeeId, ['requestApprovals'], {
+						organizationId,
+						tenantId
+					})
+				).items;
+			} else {
+				items = (
+					await this.approvalRequestService.getAll(
+						[
+							'employeeApprovals',
+							'employeeApprovals.employee',
+							'employeeApprovals.employee.user',
+							'teamApprovals',
+							'teamApprovals.team',
+							'tags',
+							'createdByUser'
+						],
+						{ organizationId, tenantId }
+					)
+				).items;
 
-			if (items.length > 0) {
-				items.filter((item) => {
-					item.employees = pluck(item.employeeApprovals, 'employee');
-					item.teams = pluck(item.teamApprovals, 'team');
-					return item;
-				});
+				if (items.length > 0) {
+					items.filter((item) => {
+						item.employees = pluck(item.employeeApprovals, 'employee');
+						item.teams = pluck(item.teamApprovals, 'team');
+						return item;
+					});
+				}
 			}
-		}
-		items.map((item: any) => {
-			buffersItems.push({
-				...item,
-				status: this.statusMapper(item)
+			items.map((item: any) => {
+				buffersItems.push({
+					...item,
+					status: this.statusMapper(item)
+				});
 			});
-		});
-		this.smartTableSource.setPaging(activePage, itemsPerPage, false);
-		this.smartTableSource.load(buffersItems);
-		if (this.isGridLayout) this._loadGridLayoutData();
-		this.setPagination({
-			...this.getPagination(),
-			totalItems: this.smartTableSource.count()
-		});
-		this.loading = false;
+			this.smartTableSource.setPaging(activePage, itemsPerPage, false);
+			this.smartTableSource.load(buffersItems);
+			if (this.isGridLayout) this._loadGridLayoutData();
+			this.setPagination({
+				...this.getPagination(),
+				totalItems: this.smartTableSource.count()
+			});
+		} catch (error) {
+			console.error('Error while retrieving approvals', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
+		}
 	}
 
 	private get isGridLayout(): boolean {

--- a/apps/gauzy/src/app/pages/candidates/candidates.component.html
+++ b/apps/gauzy/src/app/pages/candidates/candidates.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <h4>
@@ -61,7 +61,7 @@
       <ga-layout-selector [componentName]="viewComponentName"></ga-layout-selector>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container custom-table">
         <div>

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-experience/edit-candidate-education/edit-candidate-education.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-experience/edit-candidate-education/edit-candidate-education.component.ts
@@ -96,19 +96,25 @@ export class EditCandidateEducationComponent extends PaginationFilterBaseCompone
 	}
 	private async loadEducations() {
 		this.loading = true;
-		const { id: organizationId, tenantId } = this.selectedOrganization;
-		const { items = [] } = await this.candidateEducationsService.getAll({
-			candidateId: this.candidateId,
-			organizationId,
-			tenantId
-		});
-		this.educationList = items;
-		this.sourceSmartTable.load(items);
-		this.setPagination({
-			...this.getPagination(),
-			totalItems: this.sourceSmartTable.count()
-		});
-		this.loading = false;
+		try {
+			const { id: organizationId, tenantId } = this.selectedOrganization;
+			const { items = [] } = await this.candidateEducationsService.getAll({
+				candidateId: this.candidateId,
+				organizationId,
+				tenantId
+			});
+			this.educationList = items;
+			this.sourceSmartTable.load(items);
+			this.setPagination({
+				...this.getPagination(),
+				totalItems: this.sourceSmartTable.count()
+			});
+		} catch (error) {
+			console.error('Error while retrieving candidate educations', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
+		}
 	}
 	async loadSmartTable() {
 		this.settingsSmartTable = {

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-experience/edit-candidate-experience/edit-candidate-experience-form.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-experience/edit-candidate-experience/edit-candidate-experience-form.component.ts
@@ -74,22 +74,28 @@ export class EditCandidateExperienceFormComponent extends PaginationFilterBaseCo
 
 	private async loadExperience() {
 		this.loading = true;
-		const { id: organizationId, tenantId } = this.selectedOrganization;
-		const { items = [] } = await this.candidateExperienceService.getAll(
-			{
-				candidateId: this.candidateId,
-				organizationId,
-				tenantId
-			},
-			['organization']
-		);
-		this.experienceList = items;
-		this.sourceSmartTable.load(items);
-		this.setPagination({
-			...this.getPagination(),
-			totalItems: this.sourceSmartTable.count()
-		});
-		this.loading = false;
+		try {
+			const { id: organizationId, tenantId } = this.selectedOrganization;
+			const { items = [] } = await this.candidateExperienceService.getAll(
+				{
+					candidateId: this.candidateId,
+					organizationId,
+					tenantId
+				},
+				['organization']
+			);
+			this.experienceList = items;
+			this.sourceSmartTable.load(items);
+			this.setPagination({
+				...this.getPagination(),
+				totalItems: this.sourceSmartTable.count()
+			});
+		} catch (error) {
+			console.error('Error while retrieving candidate experience', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
+		}
 	}
 
 	editExperience(experience: ICandidateExperience) {

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.ts
@@ -106,17 +106,23 @@ export class EditCandidateFeedbacksComponent extends PaginationFilterBaseCompone
 	async getEmployees() {
 		this.loading = true;
 
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.selectedOrganization;
+		try {
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.selectedOrganization;
 
-		const { items } = await firstValueFrom(
-			this.employeesService.getAll(['user'], {
-				organizationId,
-				tenantId
-			})
-		);
-		this.employeeList = items;
-		this.loading = false;
+			const { items } = await firstValueFrom(
+				this.employeesService.getAll(['user'], {
+					organizationId,
+					tenantId
+				})
+			);
+			this.employeeList = items;
+		} catch (error) {
+			console.error('Error while retrieving employees', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
+		}
 	}
 	setView() {
 		this.viewComponentName = ComponentEnum.FEEDBACKS;
@@ -273,53 +279,62 @@ export class EditCandidateFeedbacksComponent extends PaginationFilterBaseCompone
 		return res;
 	}
 	async loadInterviews() {
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.selectedOrganization;
+		try {
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.selectedOrganization;
 
-		const result = await firstValueFrom(
-			this.candidateInterviewService.getAll(['feedbacks', 'interviewers', 'technologies', 'personalQualities'], {
-				candidateId: this.candidateId,
-				organizationId,
-				tenantId
-			})
-		);
-		const { items } = await firstValueFrom(
-			this.candidatesService.getAll(['user', 'interview', 'feedbacks'], {
-				organizationId,
-				tenantId
-			})
-		);
-
-		if (result) {
-			this.interviewList = result.items;
-			this.interviewList.forEach((interview) => {
-				items.forEach((candidate) => {
-					if (interview.candidateId === candidate.id) {
-						interview.candidate = candidate;
+			const result = await firstValueFrom(
+				this.candidateInterviewService.getAll(
+					['feedbacks', 'interviewers', 'technologies', 'personalQualities'],
+					{
+						candidateId: this.candidateId,
+						organizationId,
+						tenantId
 					}
-				});
-			});
-			this.loading = true;
-			const feedbackList = await this.loadFeedbacks();
-			feedbackList.forEach((fb) => {
-				const currentInterview = this.interviewList.find(
-					(interview) => fb.interviewId && interview.id === fb.interviewId
-				);
-				fb.interviewTitle = currentInterview ? currentInterview.title : '';
+				)
+			);
+			const { items } = await firstValueFrom(
+				this.candidatesService.getAll(['user', 'interview', 'feedbacks'], {
+					organizationId,
+					tenantId
+				})
+			);
 
-				if (fb.interviewer) {
-					this.employeeList.forEach((item) => {
-						if (fb.interviewId && fb.interviewer.employeeId === item.id) {
-							fb.interviewer.employeeImageUrl = item.user.imageUrl;
-							fb.interviewer.employeeName = item.user.name;
+			if (result) {
+				this.interviewList = result.items;
+				this.interviewList.forEach((interview) => {
+					items.forEach((candidate) => {
+						if (interview.candidateId === candidate.id) {
+							interview.candidate = candidate;
 						}
 					});
-				}
-			});
-			const uniq = {};
-			this.interviewList = this.interviewList.filter((obj) => !uniq[obj.id] && (uniq[obj.id] = true));
+				});
+				this.loading = true;
+				const feedbackList = await this.loadFeedbacks();
+				feedbackList.forEach((fb) => {
+					const currentInterview = this.interviewList.find(
+						(interview) => fb.interviewId && interview.id === fb.interviewId
+					);
+					fb.interviewTitle = currentInterview ? currentInterview.title : '';
+
+					if (fb.interviewer) {
+						this.employeeList.forEach((item) => {
+							if (fb.interviewId && fb.interviewer.employeeId === item.id) {
+								fb.interviewer.employeeImageUrl = item.user.imageUrl;
+								fb.interviewer.employeeName = item.user.name;
+							}
+						});
+					}
+				});
+				const uniq = {};
+				this.interviewList = this.interviewList.filter((obj) => !uniq[obj.id] && (uniq[obj.id] = true));
+			}
+		} catch (error) {
+			console.error('Error while retrieving candidate interviews', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
 		}
-		this.loading = false;
 	}
 	editFeedback(feedback?: ICandidateFeedback) {
 		this.cancel();

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.ts
@@ -237,86 +237,94 @@ export class EditCandidateInterviewComponent extends PaginationFilterBaseCompone
 		}
 		this.loading = true;
 
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.selectedOrganization;
+		try {
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.selectedOrganization;
 
-		const { items: allFeedbacks = [] } = await this.candidateFeedbacksService.getAll(['interviewer'], {
-			organizationId,
-			tenantId
-		});
-		this.allFeedbacks = allFeedbacks;
-
-		const { items } = await firstValueFrom(
-			this.employeesService.getAll(['user'], {
+			const { items: allFeedbacks = [] } = await this.candidateFeedbacksService.getAll(['interviewer'], {
 				organizationId,
 				tenantId
-			})
-		);
-		this.employeeList = items;
+			});
+			this.allFeedbacks = allFeedbacks;
 
-		const interviews = await firstValueFrom(
-			this.candidateInterviewService.getAll(
-				['feedbacks', 'interviewers', 'technologies', 'personalQualities', 'candidate'],
-				{ candidateId: this.candidateId, organizationId, tenantId }
-			)
-		);
+			const { items } = await firstValueFrom(
+				this.employeesService.getAll(['user'], {
+					organizationId,
+					tenantId
+				})
+			);
+			this.employeeList = items;
 
-		if (interviews) {
-			this.interviewList = interviews.items;
-			this.allInterviews = interviews.items;
-			this.tableInterviewList = [];
+			const interviews = await firstValueFrom(
+				this.candidateInterviewService.getAll(
+					['feedbacks', 'interviewers', 'technologies', 'personalQualities', 'candidate'],
+					{ candidateId: this.candidateId, organizationId, tenantId }
+				)
+			);
 
-			if (isNotEmpty(this.interviewList)) {
-				this.interviewList.forEach((interview) => {
-					const employees = [];
-					interview.interviewers.forEach((interviewer: ICandidateInterviewers) => {
-						this.employeeList.forEach((employee: IEmployee) => {
-							if (interviewer.employeeId === employee.id) {
-								interviewer.employeeImageUrl = employee.user.imageUrl;
-								interviewer.employeeName = employee.user.name;
-								employees.push(employee);
+			if (interviews) {
+				this.interviewList = interviews.items;
+				this.allInterviews = interviews.items;
+				this.tableInterviewList = [];
+
+				if (isNotEmpty(this.interviewList)) {
+					this.interviewList.forEach((interview) => {
+						const employees = [];
+						interview.interviewers.forEach((interviewer: ICandidateInterviewers) => {
+							this.employeeList.forEach((employee: IEmployee) => {
+								if (interviewer.employeeId === employee.id) {
+									interviewer.employeeImageUrl = employee.user.imageUrl;
+									interviewer.employeeName = employee.user.name;
+									employees.push(employee);
+								}
+							});
+						});
+						this.candidates.forEach((item) => {
+							if (item.id === interview.candidate.id) {
+								interview.candidate.user = item.user;
 							}
 						});
-					});
-					this.candidates.forEach((item) => {
-						if (item.id === interview.candidate.id) {
-							interview.candidate.user = item.user;
-						}
-					});
 
-					interview.employees = employees;
-					this.tableInterviewList.push({
-						...interview,
-						fullName: this.selectedCandidate.user.name,
-						imageUrl: this.selectedCandidate.user.imageUrl,
-						showArchive: false,
-						employees: employees,
-						allFeedbacks: this.allFeedbacks,
-						hideActions: true
+						interview.employees = employees;
+						this.tableInterviewList.push({
+							...interview,
+							fullName: this.selectedCandidate.user.name,
+							imageUrl: this.selectedCandidate.user.imageUrl,
+							showArchive: false,
+							employees: employees,
+							allFeedbacks: this.allFeedbacks,
+							hideActions: true
+						});
 					});
-				});
+				}
 			}
+			this.interviewList = this.onlyPast
+				? this.filterInterviewByTime(this.interviewList, true)
+				: this.interviewList;
+
+			this.interviewList = this.onlyFuture
+				? this.filterInterviewByTime(this.interviewList, false)
+				: this.interviewList;
+
+			this.tableInterviewList = this.onlyPast
+				? this.filterInterviewByTime(this.tableInterviewList, true)
+				: this.tableInterviewList;
+
+			this.tableInterviewList = this.onlyFuture
+				? this.filterInterviewByTime(this.tableInterviewList, false)
+				: this.tableInterviewList;
+
+			this.sourceSmartTable.load(this.tableInterviewList);
+			this.setPagination({
+				...this.getPagination(),
+				totalItems: this.sourceSmartTable.count()
+			});
+		} catch (error) {
+			console.error('Error while retrieving candidate interviews', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
 		}
-		this.interviewList = this.onlyPast ? this.filterInterviewByTime(this.interviewList, true) : this.interviewList;
-
-		this.interviewList = this.onlyFuture
-			? this.filterInterviewByTime(this.interviewList, false)
-			: this.interviewList;
-
-		this.tableInterviewList = this.onlyPast
-			? this.filterInterviewByTime(this.tableInterviewList, true)
-			: this.tableInterviewList;
-
-		this.tableInterviewList = this.onlyFuture
-			? this.filterInterviewByTime(this.tableInterviewList, false)
-			: this.tableInterviewList;
-
-		this.sourceSmartTable.load(this.tableInterviewList);
-		this.setPagination({
-			...this.getPagination(),
-			totalItems: this.sourceSmartTable.count()
-		});
-		this.loading = false;
 	}
 
 	async addInterviewFeedback(id: string) {

--- a/apps/gauzy/src/app/pages/contacts/contacts.component.ts
+++ b/apps/gauzy/src/app/pages/contacts/contacts.component.ts
@@ -187,8 +187,8 @@ export class ContactsComponent extends PaginationFilterBaseComponent implements 
 	private async _initEditMethod(id: string) {
 		if (id) {
 			this.loading = true;
-			const { tenantId } = this.store.user;
 			try {
+				const { tenantId } = this.store.user;
 				const items = await this.organizationContactService.getById(id, tenantId, [
 					'projects',
 					'members',
@@ -202,8 +202,9 @@ export class ContactsComponent extends PaginationFilterBaseComponent implements 
 				}
 			} catch (error) {
 				this.toastrService.danger(this.getTranslation('TOASTR.TITLE.ERROR'));
+			} finally {
+				this.loading = false;
 			}
-			this.loading = false;
 			this.cd.detectChanges();
 		}
 	}

--- a/apps/gauzy/src/app/pages/dashboard/accounting/accounting.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/accounting/accounting.component.ts
@@ -152,13 +152,13 @@ export class AccountingComponent extends TranslationBaseComponent implements Aft
 			do {
 				this.generateCharts();
 			} while (!this.aggregatedEmployeeStatistics.chart.length);
-
-			// Set loading state to false
-			this.loading = false;
 		} catch (error) {
 			// Handle errors
 			console.log('Error while retrieving employee aggregate statistics', error);
 			this.toastrService.danger(error);
+		} finally {
+			// Always drop the spinner, otherwise a failed request leaves the card covered forever
+			this.loading = false;
 		}
 	}
 

--- a/apps/gauzy/src/app/pages/dashboard/human-resources/human-resources.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/human-resources/human-resources.component.ts
@@ -14,7 +14,7 @@ import { debounceTime, filter, tap } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { distinctUntilChange, toUTC } from '@gauzy/ui-core/common';
-import { DateRangePickerBuilderService, EmployeeStatisticsService, Store } from '@gauzy/ui-core/core';
+import { DateRangePickerBuilderService, EmployeeStatisticsService, Store, ToastrService } from '@gauzy/ui-core/core';
 import { ProfitHistoryComponent, RecordsHistoryComponent } from '@gauzy/ui-core/shared';
 
 @UntilDestroy({ checkProperties: true })
@@ -57,7 +57,8 @@ export class HumanResourcesComponent implements OnInit, OnDestroy {
 		private readonly dialogService: NbDialogService,
 		private readonly router: Router,
 		private readonly employeeStatisticsService: EmployeeStatisticsService,
-		private readonly dateRangePickerBuilderService: DateRangePickerBuilderService
+		private readonly dateRangePickerBuilderService: DateRangePickerBuilderService,
+		private readonly toastrService: ToastrService
 	) {}
 
 	async ngOnInit() {
@@ -108,24 +109,29 @@ export class HumanResourcesComponent implements OnInit, OnDestroy {
 
 		this.loading = true;
 
-		this.employeeStatistics = await this.employeeStatisticsService.getAggregatedStatisticsByEmployeeId({
-			employeeId: this.selectedEmployee.id,
-			startDate: toUTC(startDate).format('YYYY-MM-DD HH:mm:ss'),
-			endDate: toUTC(endDate).format('YYYY-MM-DD HH:mm:ss'),
-			organizationId,
-			tenantId
-		});
-		this.income = this._statsSum(this.employeeStatistics, 'income');
-		this.expenseWithoutSalary = this._statsSum(this.employeeStatistics, 'expenseWithoutSalary');
-		this.expense = this._statsSum(this.employeeStatistics, 'expense');
-		this.directIncomeBonus = this._statsSum(this.employeeStatistics, 'directIncomeBonus');
-		this.nonBonusIncome = this.income - this.directIncomeBonus;
-		this.profit = this._statsSum(this.employeeStatistics, 'profit');
-		this.bonus = this._statsSum(this.employeeStatistics, 'bonus');
-		this.calculatedBonus = +(this.bonus - this.directIncomeBonus).toFixed(2);
-		this.salary = +(this.expense - this.expenseWithoutSalary).toFixed(2);
-
-		this.loading = false;
+		try {
+			this.employeeStatistics = await this.employeeStatisticsService.getAggregatedStatisticsByEmployeeId({
+				employeeId: this.selectedEmployee.id,
+				startDate: toUTC(startDate).format('YYYY-MM-DD HH:mm:ss'),
+				endDate: toUTC(endDate).format('YYYY-MM-DD HH:mm:ss'),
+				organizationId,
+				tenantId
+			});
+			this.income = this._statsSum(this.employeeStatistics, 'income');
+			this.expenseWithoutSalary = this._statsSum(this.employeeStatistics, 'expenseWithoutSalary');
+			this.expense = this._statsSum(this.employeeStatistics, 'expense');
+			this.directIncomeBonus = this._statsSum(this.employeeStatistics, 'directIncomeBonus');
+			this.nonBonusIncome = this.income - this.directIncomeBonus;
+			this.profit = this._statsSum(this.employeeStatistics, 'profit');
+			this.bonus = this._statsSum(this.employeeStatistics, 'bonus');
+			this.calculatedBonus = +(this.bonus - this.directIncomeBonus).toFixed(2);
+			this.salary = +(this.expense - this.expenseWithoutSalary).toFixed(2);
+		} catch (error) {
+			console.error('Error while retrieving employee aggregated statistics', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
+		}
 	}
 
 	async openHistoryDialog(type: EmployeeStatisticsHistoryEnum) {

--- a/apps/gauzy/src/app/pages/departments/departments.component.html
+++ b/apps/gauzy/src/app/pages/departments/departments.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="card-custom-header">
     <div class="card-header-title">
       <h4>
@@ -16,7 +16,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (
       dataLayoutStyle === componentLayoutStyleEnum.TABLE && !loading
       ) {

--- a/apps/gauzy/src/app/pages/documents/documents.component.html
+++ b/apps/gauzy/src/app/pages/documents/documents.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" class="card-scroll">
+<nb-card class="card-scroll">
 	<nb-card-header class="pb-0">
 		<div class="main-header">
 			<h4>
@@ -16,7 +16,7 @@
 			></ngx-gauzy-button-action>
 		</div>
 	</nb-card-header>
-	<nb-card-body>
+	<nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary">
 		@if (dataLayoutStyle === componentLayoutStyleEnum.TABLE && documentList?.length) {
 		<div class="table-scroll-container">
 			@for (document of documentList; track document.id) {

--- a/apps/gauzy/src/app/pages/employee-levels/employee-level.component.ts
+++ b/apps/gauzy/src/app/pages/employee-levels/employee-level.component.ts
@@ -100,27 +100,33 @@ export class EmployeeLevelComponent extends PaginationFilterBaseComponent implem
 			return;
 		}
 		this.loading = true;
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.organization;
-		const { activePage, itemsPerPage } = this.getPagination();
+		try {
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.organization;
+			const { activePage, itemsPerPage } = this.getPagination();
 
-		const { items } = await this.employeeLevelService.getAll(['tags'], {
-			tenantId,
-			organizationId
-		});
-		if (items) {
-			this.smartTableSource.setPaging(activePage, itemsPerPage, false);
-			this.smartTableSource.load(items);
-			if (this._isGridLayout) {
-				this._loadGridLayoutData();
-			} else this.employeeLevels = items;
-			this.setPagination({
-				...this.getPagination(),
-				totalItems: this.smartTableSource.count()
+			const { items } = await this.employeeLevelService.getAll(['tags'], {
+				tenantId,
+				organizationId
 			});
+			if (items) {
+				this.smartTableSource.setPaging(activePage, itemsPerPage, false);
+				this.smartTableSource.load(items);
+				if (this._isGridLayout) {
+					this._loadGridLayoutData();
+				} else this.employeeLevels = items;
+				this.setPagination({
+					...this.getPagination(),
+					totalItems: this.smartTableSource.count()
+				});
+			}
+			await this.emptyListInvoke();
+		} catch (error) {
+			console.error('Error while retrieving employee levels', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
 		}
-		await this.emptyListInvoke();
-		this.loading = false;
 	}
 
 	private async _loadGridLayoutData() {

--- a/apps/gauzy/src/app/pages/employees/employees.component.html
+++ b/apps/gauzy/src/app/pages/employees/employees.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <div class="card-header-title">
@@ -43,7 +43,7 @@
       <ga-layout-selector [componentName]="viewComponentName"></ga-layout-selector>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     <ng-template [ngxPermissionsOnly]="[PermissionsEnum.ALL_ORG_VIEW, PermissionsEnum.ORG_EMPLOYEES_VIEW]">
       @switch (dataLayoutStyle) {
         <!-- Table View -->

--- a/apps/gauzy/src/app/pages/employees/event-types/event-type.component.html
+++ b/apps/gauzy/src/app/pages/employees/event-types/event-type.component.html
@@ -1,7 +1,4 @@
 <nb-card
-  [nbSpinner]="loading"
-  nbSpinnerStatus="primary"
-  nbSpinnerSize="large"
   class="card-scroll"
   >
   <nb-card-header class="d-flex flex-column pb-0">
@@ -22,7 +19,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container custom-table">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/equipment-sharing-policy/equipment-sharing-policy.component.html
+++ b/apps/gauzy/src/app/pages/equipment-sharing-policy/equipment-sharing-policy.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="card-custom-header">
     <div class="card-header-title">
       <h4>
@@ -17,7 +17,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/equipment-sharing/equipment-sharing.component.html
+++ b/apps/gauzy/src/app/pages/equipment-sharing/equipment-sharing.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <div class="card-header-title">
@@ -37,7 +37,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     <ng-template [ngxPermissionsOnly]="[PermissionsEnum.ALL_ORG_VIEW, PermissionsEnum.ORG_EQUIPMENT_SHARING_VIEW]">
       @switch (dataLayoutStyle) {
         <!-- Table View -->

--- a/apps/gauzy/src/app/pages/equipment/equipment.component.html
+++ b/apps/gauzy/src/app/pages/equipment/equipment.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <h4>
@@ -26,7 +26,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/expense-recurring/expense-recurring.component.html
+++ b/apps/gauzy/src/app/pages/expense-recurring/expense-recurring.component.html
@@ -1,8 +1,4 @@
-<nb-card
-  [nbSpinner]="loading"
-  [nbSpinnerStatus]="'primary'"
-  [nbSpinnerSize]="'large'"
-  >
+<nb-card>
   <nb-card-header class="flex flex-column">
     <div class="card-header-title">
       <h4>
@@ -20,7 +16,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body class="settings-body">
+  <nb-card-body class="settings-body" [nbSpinner]="loading" [nbSpinnerStatus]="'primary'" [nbSpinnerSize]="'large'">
     <div class="container">
       @if (expenses?.length) {
         <div

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.html
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.html
@@ -1,8 +1,4 @@
-<nb-card
-  [nbSpinner]="loading"
-  nbSpinnerStatus="primary"
-  nbSpinnerSize="large"
-  >
+<nb-card>
   <nb-card-header class="card-custom-header">
     <div class="card-header-title">
       <h4>
@@ -29,7 +25,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/goal-settings/goal-settings.component.ts
+++ b/apps/gauzy/src/app/pages/goal-settings/goal-settings.component.ts
@@ -162,53 +162,59 @@ export class GoalSettingsComponent extends PaginationFilterBaseComponent impleme
 
 	private async _loadTableData(tab) {
 		this.loading = true;
-		if (!this.organization) {
-			return;
-		}
+		try {
+			if (!this.organization) {
+				return;
+			}
 
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.organization;
-		const findObj = {
-			organization: {
-				id: organizationId
-			},
-			tenantId
-		};
-		const { activePage, itemsPerPage } = this.getPagination();
-		this.smartTableData.setPaging(activePage, itemsPerPage, false);
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.organization;
+			const findObj = {
+				organization: {
+					id: organizationId
+				},
+				tenantId
+			};
+			const { activePage, itemsPerPage } = this.getPagination();
+			this.smartTableData.setPaging(activePage, itemsPerPage, false);
 
-		if (tab === 'kpi') {
-			await this.goalSettingService.getAllKPI(findObj).then((res) => {
-				this.smartTableData.load(res.items);
-			});
-		} else if (tab === 'timeframe') {
-			await this.goalSettingService.getAllTimeFrames(findObj).then((res) => {
-				if (!!res) {
-					const mappedItems = [];
-					res.items.map((item) => {
-						item = Object.assign({}, item, {
-							status: this.statusMapper(item.status)
-						});
-						mappedItems.push(item);
-					});
-					this.smartTableData.load(mappedItems);
-				}
-			});
-		} else {
-			await this.goalSettingService.getAllGeneralSettings(findObj).then((generalSettings) => {
-				const { items } = generalSettings;
-				this.goalGeneralSettings = items.pop();
-				this.generalSettingsForm.patchValue({
-					...this.goalGeneralSettings
+			if (tab === 'kpi') {
+				await this.goalSettingService.getAllKPI(findObj).then((res) => {
+					this.smartTableData.load(res.items);
 				});
+			} else if (tab === 'timeframe') {
+				await this.goalSettingService.getAllTimeFrames(findObj).then((res) => {
+					if (!!res) {
+						const mappedItems = [];
+						res.items.map((item) => {
+							item = Object.assign({}, item, {
+								status: this.statusMapper(item.status)
+							});
+							mappedItems.push(item);
+						});
+						this.smartTableData.load(mappedItems);
+					}
+				});
+			} else {
+				await this.goalSettingService.getAllGeneralSettings(findObj).then((generalSettings) => {
+					const { items } = generalSettings;
+					this.goalGeneralSettings = items.pop();
+					this.generalSettingsForm.patchValue({
+						...this.goalGeneralSettings
+					});
+				});
+			}
+			this._loadGridLayoutData();
+			this.setPagination({
+				...this.getPagination(),
+				totalItems: this.smartTableData.count()
 			});
+		} catch (error) {
+			console.error('Error while retrieving goal settings', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
 		}
-		this._loadGridLayoutData();
-		this.setPagination({
-			...this.getPagination(),
-			totalItems: this.smartTableData.count()
-		});
-		this.loading = false;
 	}
 
 	private async _loadGridLayoutData() {

--- a/apps/gauzy/src/app/pages/goals/goals.component.ts
+++ b/apps/gauzy/src/app/pages/goals/goals.component.ts
@@ -216,49 +216,55 @@ export class GoalsComponent extends TranslationBaseComponent implements OnInit, 
 		}
 		this.loading = true;
 
-		const { tenantId } = this.store.user;
-		const findObj = {
-			organizationId: this.selectedOrganizationId,
-			tenantId
-		};
-		await this.getGoalSettings(findObj);
-		await this.goalService
-			.getAllGoals(
-				[
-					'keyResults',
-					'keyResults.updates',
-					'keyResults.goal',
-					'ownerEmployee',
-					'ownerEmployee.user',
-					'organization',
-					'ownerTeam',
-					'lead',
-					'lead.user',
-					'keyResults.owner',
-					'keyResults.lead',
-					'alignedKeyResult',
-					'alignedKeyResult.goal',
-					'alignedKeyResult.goal.ownerEmployee',
-					'alignedKeyResult.goal.ownerEmployee.user',
-					'alignedKeyResult.goal.organization',
-					'alignedKeyResult.goal.ownerTeam',
-					'alignedKeyResult.owner',
-					'alignedKeyResult.lead',
-					'alignedKeyResult.updates'
-				],
-				findObj
-			)
-			.then((goals) => {
-				if (goals) {
-					this.noGoals = goals.items.length > 0 ? false : true;
-					this.goals = goals.items;
-					this.allGoals = goals.items;
-					if (!!this.selectedFilter) {
-						this.filterGoals(this.selectedFilter, this.allGoals);
+		try {
+			const { tenantId } = this.store.user;
+			const findObj = {
+				organizationId: this.selectedOrganizationId,
+				tenantId
+			};
+			await this.getGoalSettings(findObj);
+			await this.goalService
+				.getAllGoals(
+					[
+						'keyResults',
+						'keyResults.updates',
+						'keyResults.goal',
+						'ownerEmployee',
+						'ownerEmployee.user',
+						'organization',
+						'ownerTeam',
+						'lead',
+						'lead.user',
+						'keyResults.owner',
+						'keyResults.lead',
+						'alignedKeyResult',
+						'alignedKeyResult.goal',
+						'alignedKeyResult.goal.ownerEmployee',
+						'alignedKeyResult.goal.ownerEmployee.user',
+						'alignedKeyResult.goal.organization',
+						'alignedKeyResult.goal.ownerTeam',
+						'alignedKeyResult.owner',
+						'alignedKeyResult.lead',
+						'alignedKeyResult.updates'
+					],
+					findObj
+				)
+				.then((goals) => {
+					if (goals) {
+						this.noGoals = goals.items.length > 0 ? false : true;
+						this.goals = goals.items;
+						this.allGoals = goals.items;
+						if (!!this.selectedFilter) {
+							this.filterGoals(this.selectedFilter, this.allGoals);
+						}
 					}
-					this.loading = false;
-				}
-			});
+				});
+		} catch (error) {
+			console.error('Error while retrieving goals', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
+		}
 	}
 
 	async openKeyResultParameters() {

--- a/apps/gauzy/src/app/pages/help-center/help-center.component.ts
+++ b/apps/gauzy/src/app/pages/help-center/help-center.component.ts
@@ -132,35 +132,41 @@ export class HelpCenterComponent extends TranslationBaseComponent implements OnD
 
 	async loadArticles(id) {
 		this.loading = true;
-		this.expandedArticles.clear();
-		this.articleContent.clear();
-		const result = await this.helpCenterArticleService.findByCategoryId(id);
-		if (result) {
-			this.articleList = result;
-			for (const article of this.articleList) {
-				if (article.data) {
-					this.articleContent.set(article.id, this.sanitizer.bypassSecurityTrustHtml(article.data));
+		try {
+			this.expandedArticles.clear();
+			this.articleContent.clear();
+			const result = await this.helpCenterArticleService.findByCategoryId(id);
+			if (result) {
+				this.articleList = result;
+				for (const article of this.articleList) {
+					if (article.data) {
+						this.articleContent.set(article.id, this.sanitizer.bypassSecurityTrustHtml(article.data));
+					}
 				}
 			}
-		}
-		this.filteredArticles = this.articleList;
-		const { id: organizationId, tenantId } = this.organization;
-		const res = await this.helpCenterAuthorService.getAll([], {
-			organizationId,
-			tenantId
-		});
-		if (res) {
-			this.authors = res.items;
-			for (const article of this.articleList) {
-				const employeesList = [];
-				this.authors.forEach((author) => {
-					this.employees.forEach((employee) => {
-						if (employee.id === author.employeeId && author.articleId === article.id)
-							employeesList.push(employee);
+			this.filteredArticles = this.articleList;
+			const { id: organizationId, tenantId } = this.organization;
+			const res = await this.helpCenterAuthorService.getAll([], {
+				organizationId,
+				tenantId
+			});
+			if (res) {
+				this.authors = res.items;
+				for (const article of this.articleList) {
+					const employeesList = [];
+					this.authors.forEach((author) => {
+						this.employees.forEach((employee) => {
+							if (employee.id === author.employeeId && author.articleId === article.id)
+								employeesList.push(employee);
+						});
 					});
-				});
-				article.employees = employeesList;
+					article.employees = employeesList;
+				}
 			}
+		} catch (error) {
+			console.error('Error while retrieving help center articles', error);
+			this.toastrService.danger(error);
+		} finally {
 			this.loading = false;
 		}
 	}

--- a/apps/gauzy/src/app/pages/income/income.component.html
+++ b/apps/gauzy/src/app/pages/income/income.component.html
@@ -1,8 +1,4 @@
-<nb-card
-  [nbSpinner]="loading"
-  nbSpinnerStatus="primary"
-  nbSpinnerSize="large"
-  >
+<nb-card>
   <nb-card-header class="card-custom-header">
     <div class="col-auto">
       <h4>
@@ -20,7 +16,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body class="custom-card">
+  <nb-card-body class="custom-card" [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/integrations/components/integration-list/list.component.html
+++ b/apps/gauzy/src/app/pages/integrations/components/integration-list/list.component.html
@@ -1,4 +1,4 @@
-<nb-card class="card-scroll" [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card class="card-scroll">
 	<nb-card-header class="d-flex flex-column pb-0">
 		<div class="card-header-title">
 			<h4>
@@ -32,7 +32,7 @@
 			</ng-template>
 		</ng-template>
 	</nb-card-header>
-	<nb-card-body>
+	<nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 		<div class="table-scroll-container">
 			<ng-template [ngxPermissionsOnly]="['INTEGRATION_ADD', 'INTEGRATION_EDIT']">
 				<ng-template [ngxPermissionsOnly]="['INTEGRATION_VIEW']">

--- a/apps/gauzy/src/app/pages/inventory/components/manage-merchants/merchant-table/merchant-table.component.html
+++ b/apps/gauzy/src/app/pages/inventory/components/manage-merchants/merchant-table/merchant-table.component.html
@@ -1,8 +1,4 @@
-<nb-card
-  [nbSpinner]="loading"
-  nbSpinnerStatus="primary"
-  nbSpinnerSize="large"
-  >
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <h4>
@@ -21,7 +17,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     <ng-template ngxPermissionsOnly="ORG_INVENTORY_VIEW">
       @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
         <div class="table-scroll-container">

--- a/apps/gauzy/src/app/pages/inventory/components/manage-product-categories/product-categories.component.html
+++ b/apps/gauzy/src/app/pages/inventory/components/manage-product-categories/product-categories.component.html
@@ -1,8 +1,4 @@
-<nb-card
-  [nbSpinner]="loading"
-  [nbSpinnerStatus]="'primary'"
-  [nbSpinnerSize]="'large'"
-  >
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <h4>
@@ -22,7 +18,7 @@
       </ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" [nbSpinnerStatus]="'primary'" [nbSpinnerSize]="'large'">
     <ng-template ngxPermissionsOnly="ORG_PRODUCT_CATEGORIES_VIEW">
       @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
         <div class="table-scroll-container">

--- a/apps/gauzy/src/app/pages/inventory/components/manage-product-types/product-types.component.html
+++ b/apps/gauzy/src/app/pages/inventory/components/manage-product-types/product-types.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <h4>
@@ -18,7 +18,7 @@
       </ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     <ng-template ngxPermissionsOnly="ORG_PRODUCT_TYPES_VIEW">
       @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
         <div class="table-scroll-container">

--- a/apps/gauzy/src/app/pages/inventory/components/manage-warehouses/select-product-form/select-product-form.component.ts
+++ b/apps/gauzy/src/app/pages/inventory/components/manage-warehouses/select-product-form/select-product-form.component.ts
@@ -12,7 +12,7 @@ import { SelectedRowComponent } from '../../inventory-table-components/selected-
 import { tap } from 'rxjs/operators';
 import { debounceTime } from 'rxjs';
 import { IPaginationBase, PaginationFilterBaseComponent } from '@gauzy/ui-core/shared';
-import { Store } from '@gauzy/ui-core/core';
+import { Store, ToastrService } from '@gauzy/ui-core/core';
 
 export interface SelectedRowEvent {
 	data: IProductTranslated;
@@ -45,7 +45,8 @@ export class SelectProductComponent extends PaginationFilterBaseComponent implem
 		public dialogRef: NbDialogRef<any>,
 		private store: Store,
 		readonly translateService: TranslateService,
-		private http: HttpClient
+		private http: HttpClient,
+		private readonly toastrService: ToastrService
 	) {
 		super(translateService);
 	}
@@ -83,27 +84,33 @@ export class SelectProductComponent extends PaginationFilterBaseComponent implem
 
 	async loadSettings() {
 		this.loading = true;
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.organization || { id: '' };
+		try {
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.organization || { id: '' };
 
-		const data =
-			'data=' +
-			JSON.stringify({
-				relations: ['productType', 'productCategory', 'featuredImage', 'variants'],
-				findInput: { organizationId, tenantId }
+			const data =
+				'data=' +
+				JSON.stringify({
+					relations: ['productType', 'productCategory', 'featuredImage', 'variants'],
+					findInput: { organizationId, tenantId }
+				});
+			const { activePage, itemsPerPage } = this.getPagination();
+			this.smartTableSource = new ServerDataSource(this.http, {
+				endPoint: this.PRODUCTS_URL + data,
+				dataKey: 'items',
+				totalKey: 'total',
+				perPage: 'per_page',
+				pagerPageKey: 'page'
 			});
-		const { activePage, itemsPerPage } = this.getPagination();
-		this.smartTableSource = new ServerDataSource(this.http, {
-			endPoint: this.PRODUCTS_URL + data,
-			dataKey: 'items',
-			totalKey: 'total',
-			perPage: 'per_page',
-			pagerPageKey: 'page'
-		});
-		this.smartTableSource.setPaging(activePage, itemsPerPage, false);
-		await this.smartTableSource.getElements();
-		this.setPagination({ ...this.getPagination(), totalItems: this.smartTableSource.count() });
-		this.loading = false;
+			this.smartTableSource.setPaging(activePage, itemsPerPage, false);
+			await this.smartTableSource.getElements();
+			this.setPagination({ ...this.getPagination(), totalItems: this.smartTableSource.count() });
+		} catch (error) {
+			console.error('Error while retrieving products', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
+		}
 	}
 
 	async loadSmartTable() {

--- a/apps/gauzy/src/app/pages/inventory/components/manage-warehouses/warehouses-table/warehouses-table.component.html
+++ b/apps/gauzy/src/app/pages/inventory/components/manage-warehouses/warehouses-table/warehouses-table.component.html
@@ -1,8 +1,4 @@
-<nb-card
-  [nbSpinner]="loading"
-  nbSpinnerStatus="primary"
-  nbSpinnerSize="large"
-  >
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title">
       <h4>
@@ -21,7 +17,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/inventory/components/table-inventory-items/table-inventory.component.html
+++ b/apps/gauzy/src/app/pages/inventory/components/table-inventory-items/table-inventory.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
 	<nb-card-header class="d-flex flex-column pb-0">
 		<div class="card-header-title">
 			<div class="card-header-title">
@@ -24,7 +24,7 @@
 		</div>
 	</nb-card-header>
 
-	<nb-card-body>
+	<nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 		@if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
 			<div class="table-scroll-container">
 				<angular2-smart-table

--- a/apps/gauzy/src/app/pages/invoices/invoices-received/invoices-received.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoices-received/invoices-received.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="card-custom-header">
     <div class="col-auto">
       <h4>
@@ -16,7 +16,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
 	<nb-card-header class="card-header-title">
 		<div class="col-auto">
 			<h4>
@@ -22,7 +22,7 @@
 			</div>
 		</div>
 	</nb-card-header>
-	<nb-card-body class="card-body">
+	<nb-card-body class="card-body" [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 		<ng-template [ngxPermissionsOnly]="['INVOICES_EDIT', 'INVOICES_VIEW']">
 			<div class="actions-container">
 				<ng-template ngxPermissionsOnly="INVOICES_EDIT">

--- a/apps/gauzy/src/app/pages/payments/payments.component.html
+++ b/apps/gauzy/src/app/pages/payments/payments.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="card-custom-header">
     <div class="card-header-title">
       <h4>
@@ -16,7 +16,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
       <div class="table-scroll-container">
         <angular2-smart-table

--- a/apps/gauzy/src/app/pages/positions/positions.component.ts
+++ b/apps/gauzy/src/app/pages/positions/positions.component.ts
@@ -263,33 +263,39 @@ export class PositionsComponent extends PaginationFilterBaseComponent implements
 			return;
 		}
 		this.loading = true;
-		const { id: organizationId } = this.organization;
-		const { tenantId } = this.store.user;
-		const { activePage, itemsPerPage } = this.getPagination();
+		try {
+			const { id: organizationId } = this.organization;
+			const { tenantId } = this.store.user;
+			const { activePage, itemsPerPage } = this.getPagination();
 
-		const res = await this.organizationPositionsService.getAll(
-			{
-				organizationId,
-				tenantId
-			},
-			['tags']
-		);
-		if (res) {
-			this.smartTableSource.setPaging(activePage, itemsPerPage, false);
-			this.smartTableSource.load(res.items);
-			if (this._isGridLayout) {
-				this._loadGridLayoutData();
-			} else this.positions = res.items;
-			this.setPagination({
-				...this.getPagination(),
-				totalItems: this.smartTableSource.count()
-			});
-			if (this.positions.length <= 0) {
-				this.positionsExist = false;
-			} else {
-				this.positionsExist = true;
+			const res = await this.organizationPositionsService.getAll(
+				{
+					organizationId,
+					tenantId
+				},
+				['tags']
+			);
+			if (res) {
+				this.smartTableSource.setPaging(activePage, itemsPerPage, false);
+				this.smartTableSource.load(res.items);
+				if (this._isGridLayout) {
+					this._loadGridLayoutData();
+				} else this.positions = res.items;
+				this.setPagination({
+					...this.getPagination(),
+					totalItems: this.smartTableSource.count()
+				});
+				if (this.positions.length <= 0) {
+					this.positionsExist = false;
+				} else {
+					this.positionsExist = true;
+				}
+				this.emptyListInvoke();
 			}
-			this.emptyListInvoke();
+		} catch (error) {
+			console.error('Error while retrieving organization positions', error);
+			this.toastrService.danger(error);
+		} finally {
 			this.loading = false;
 		}
 	}

--- a/apps/gauzy/src/app/pages/projects/components/project-list/list.component.html
+++ b/apps/gauzy/src/app/pages/projects/components/project-list/list.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="main-header pb-0">
     <div class="main-header">
       <h4>
@@ -16,7 +16,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     <ng-template [ngxPermissionsOnly]="[PermissionsEnum.ORG_PROJECT_VIEW]">
       @switch (dataLayoutStyle) {
         <!-- Table View -->

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.html
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="flex flex-column">
     <h4>
       <ngx-header-title [allowEmployee]="false">
@@ -14,7 +14,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body class="settings-body">
+  <nb-card-body class="settings-body" [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     <div class="container">
       @if (recurringExpenses?.length) {
         <div

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.ts
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.ts
@@ -277,29 +277,34 @@ export class RecurringExpensesEmployeeComponent extends TranslationBaseComponent
 
 		this.loading = true;
 
-		this.fetchedHistories = {};
-		if (this.selectedEmployeeId) {
-			this.recurringExpenses = (
-				await this.employeeRecurringExpenseService.getAllByRange(['employee', 'employee.user'], {
-					employeeId: this.selectedEmployeeId,
-					startDate: toUTC(startDate).format('YYYY-MM-DD HH:mm'),
-					endDate: toUTC(endDate).format('YYYY-MM-DD HH:mm'),
-					organizationId,
-					tenantId
-				})
-			).items;
-			this.loading = false;
-		} else {
-			this.recurringExpenses = (
-				await this.employeeRecurringExpenseService.getAll(
-					['employee', 'employee.user'],
-					{
+		try {
+			this.fetchedHistories = {};
+			if (this.selectedEmployeeId) {
+				this.recurringExpenses = (
+					await this.employeeRecurringExpenseService.getAllByRange(['employee', 'employee.user'], {
+						employeeId: this.selectedEmployeeId,
+						startDate: toUTC(startDate).format('YYYY-MM-DD HH:mm'),
+						endDate: toUTC(endDate).format('YYYY-MM-DD HH:mm'),
 						organizationId,
 						tenantId
-					},
-					{}
-				)
-			).items;
+					})
+				).items;
+			} else {
+				this.recurringExpenses = (
+					await this.employeeRecurringExpenseService.getAll(
+						['employee', 'employee.user'],
+						{
+							organizationId,
+							tenantId
+						},
+						{}
+					)
+				).items;
+			}
+		} catch (error) {
+			console.error('Error while retrieving employee recurring expenses', error);
+			this.toastrService.danger(error);
+		} finally {
 			this.loading = false;
 		}
 	}

--- a/apps/gauzy/src/app/pages/settings/email-history/email-history.component.html
+++ b/apps/gauzy/src/app/pages/settings/email-history/email-history.component.html
@@ -1,4 +1,4 @@
-<nb-card class="card-scroll" [nbSpinner]="loading" nbSpinnerStatus="primary">
+<nb-card class="card-scroll">
 	<nb-card-header class="d-flex justify-content-between">
 		<h4 class="email-history-header">
 			<ngx-header-title>
@@ -17,7 +17,7 @@
 			</button>
 		</div>
 	</nb-card-header>
-	<nb-card-body>
+	<nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary">
 		<div class="content-container">
 			<aside class="email-list">
 				<nb-list nbInfiniteList [threshold]="20" (bottomThreshold)="loadNext()">

--- a/apps/gauzy/src/app/pages/tags/tags.component.html
+++ b/apps/gauzy/src/app/pages/tags/tags.component.html
@@ -22,7 +22,7 @@
     </nb-card>
   </div>
   <div class="col-10 h-100">
-    <nb-card class="tags-component h-100" [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+    <nb-card class="tags-component h-100">
       <nb-card-header class="flex flex-column pb-0">
         <h4 class="card-header-title">
           <ngx-header-title>
@@ -38,7 +38,7 @@
           ></ngx-gauzy-button-action>
         </div>
       </nb-card-header>
-      <nb-card-body>
+      <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
         @if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
           <div class="table-scroll-container">
             <angular2-smart-table

--- a/apps/gauzy/src/app/pages/tags/tags.component.ts
+++ b/apps/gauzy/src/app/pages/tags/tags.component.ts
@@ -290,10 +290,11 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 
 	async getTagTypes() {
 		this.loading = true;
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.organization;
 
 		try {
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.organization;
+
 			const { items } = await this.tagTypesService.getTagTypes({
 				tenantId,
 				organizationId
@@ -309,10 +310,11 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 					};
 				})
 			);
-			this.loading = false;
 		} catch (error) {
-			this.loading = false;
+			console.error('Error while retrieving tag types', error);
 			this.toastrService.danger('TAGS_PAGE.TAGS_FETCH_FAILED', 'Error fetching tag types');
+		} finally {
+			this.loading = false;
 		}
 	}
 
@@ -320,33 +322,39 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 		this.allTags = [];
 		this.filterOptions = [{ value: '', displayName: 'All' }];
 
-		const { tenantId } = this.store.user;
-		const { id: organizationId } = this.organization;
+		try {
+			const { tenantId } = this.store.user;
+			const { id: organizationId } = this.organization;
 
-		const { items } = await this.tagsService.getTags(
-			{
-				tenantId,
-				organizationId
-			},
-			['tagType']
-		);
+			const { items } = await this.tagsService.getTags(
+				{
+					tenantId,
+					organizationId
+				},
+				['tagType']
+			);
 
-		const { activePage, itemsPerPage } = this.getPagination();
+			const { activePage, itemsPerPage } = this.getPagination();
 
-		this.allTags = items;
+			this.allTags = items;
 
-		this.smartTableSource.setPaging(activePage, itemsPerPage, false);
-		if (!this._isFiltered) {
-			this.smartTableSource.load(this.allTags);
-		} else {
-			if (!this._isGridLayout) await this.smartTableSource.getElements();
+			this.smartTableSource.setPaging(activePage, itemsPerPage, false);
+			if (!this._isFiltered) {
+				this.smartTableSource.load(this.allTags);
+			} else {
+				if (!this._isGridLayout) await this.smartTableSource.getElements();
+			}
+			this._loadDataLayoutCard();
+			this.setPagination({
+				...this.getPagination(),
+				totalItems: this.smartTableSource.count()
+			});
+		} catch (error) {
+			console.error('Error while retrieving tags', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
 		}
-		this._loadDataLayoutCard();
-		this.setPagination({
-			...this.getPagination(),
-			totalItems: this.smartTableSource.count()
-		});
-		this.loading = false;
 	}
 
 	private async _loadDataLayoutCard() {

--- a/apps/gauzy/src/app/pages/tasks/components/task/task.component.html
+++ b/apps/gauzy/src/app/pages/tasks/components/task/task.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
 	<nb-card-header class="card-customer-header pb-0">
 		<div class="card-header-title">
 			<h4>
@@ -31,7 +31,7 @@
 			</div>
 		</div>
 	</nb-card-header>
-	<nb-card-body [class.project]="selectedProject">
+	<nb-card-body [class.project]="selectedProject" [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 		<ng-template [ngxPermissionsOnly]="['ALL_ORG_VIEW', 'ORG_TASK_VIEW']">
 			@switch (viewMode) {
 				@case (taskListTypeEnum.GRID) {

--- a/apps/gauzy/src/app/pages/teams/teams.component.html
+++ b/apps/gauzy/src/app/pages/teams/teams.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
 	<nb-card-header class="card-custom-header">
 		<div class="card-header-title">
 			<h4>
@@ -16,7 +16,7 @@
 			></ngx-gauzy-button-action>
 		</div>
 	</nb-card-header>
-	<nb-card-body>
+	<nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 		@if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
 		<div class="table-scroll-container">
 			<angular2-smart-table

--- a/apps/gauzy/src/app/pages/time-off/time-off-settings/time-off-settings.component.html
+++ b/apps/gauzy/src/app/pages/time-off/time-off-settings/time-off-settings.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="card-header-title d-flex justify-content-start">
       <ngx-back-navigation></ngx-back-navigation>
@@ -17,7 +17,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     <!-- Check if the user has the 'TIME_OFF_POLICY_VIEW' permission -->
     <ng-template [ngxPermissionsOnly]="[PermissionsEnum.ALL_ORG_VIEW, PermissionsEnum.TIME_OFF_POLICY_VIEW]">
       @switch (dataLayoutStyle) {

--- a/apps/gauzy/src/app/pages/time-off/time-off.component.html
+++ b/apps/gauzy/src/app/pages/time-off/time-off.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
 	<nb-card-header class="d-flex flex-column pb-0">
 		<div class="card-header-title">
 			<h4>
@@ -44,7 +44,7 @@
 			<ga-layout-selector [componentName]="viewComponentName"></ga-layout-selector>
 		</div>
 	</nb-card-header>
-	<nb-card-body>
+	<nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 		@if (showFilter) {
 		<div class="row mb-3 justify-content-end">
 			<div class="filter">

--- a/apps/gauzy/src/app/pages/users/edit-user-profile/edit-user-organizations/edit-user-organizations.component.ts
+++ b/apps/gauzy/src/app/pages/users/edit-user-profile/edit-user-organizations/edit-user-organizations.component.ts
@@ -154,29 +154,35 @@ export class EditUserOrganizationsComponent extends TranslationBaseComponent imp
 	}
 
 	private async loadOrganizations() {
-		const { tenantId } = this.store.user;
-		const users = await this.userOrganizationsService.getAll(['user', 'user.role'], { tenantId });
+		try {
+			const { tenantId } = this.store.user;
+			const users = await this.userOrganizationsService.getAll(['user', 'user.role'], { tenantId });
 
-		const { items } = await this.userOrganizationsService.getAll(['user'], {
-			userId: this.paramId,
-			tenantId
-		});
+			const { items } = await this.userOrganizationsService.getAll(['user'], {
+				userId: this.paramId,
+				tenantId
+			});
 
-		this.selectedUserId = items[0].userId;
+			this.selectedUserId = items[0].userId;
 
-		const user = items[0]['user'];
-		this.selectedUserName = user.name || '';
+			const user = items[0]['user'];
+			this.selectedUserName = user.name || '';
 
-		const { items: organizations } = await this.organizationsService.getAll({
-			tenantId
-		});
+			const { items: organizations } = await this.organizationsService.getAll({
+				tenantId
+			});
 
-		const includedOrgs = users.items.filter((item) => item.user.id === items[0].userId);
+			const includedOrgs = users.items.filter((item) => item.user.id === items[0].userId);
 
-		const filtered = organizations.filter((a) => includedOrgs.filter((b) => b.organizationId === a.id).length);
+			const filtered = organizations.filter((a) => includedOrgs.filter((b) => b.organizationId === a.id).length);
 
-		this.organizations = filtered;
-		this.loading = false;
+			this.organizations = filtered;
+		} catch (error) {
+			console.error('Error while retrieving user organizations', error);
+			this.toastrService.danger(error);
+		} finally {
+			this.loading = false;
+		}
 	}
 
 	cancel() {

--- a/apps/gauzy/src/app/pages/users/users.component.html
+++ b/apps/gauzy/src/app/pages/users/users.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
 	<nb-card-header class="d-flex flex-column pb-0">
 		<div class="card-header-title">
 			<h4>
@@ -27,7 +27,7 @@
 			</ng-template>
 		</div>
 	</nb-card-header>
-	<nb-card-body>
+	<nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 		<ng-template ngxPermissionsOnly="ORG_USERS_EDIT">
 			@if (showAddCard) {
 				<div class="edit-user-mutation">

--- a/apps/gauzy/src/app/pages/vendors/vendors.component.ts
+++ b/apps/gauzy/src/app/pages/vendors/vendors.component.ts
@@ -424,12 +424,12 @@ export class VendorsComponent extends PaginationFilterBaseComponent implements O
 				...this.getPagination(),
 				totalItems: this.smartTableSource.count()
 			});
-
-			// Set loading indicator back to false
-			this.loading = false;
 		} catch (error) {
 			// Handle errors using the errorHandlingService
 			this.errorHandlingService.handleError(error);
+		} finally {
+			// Always drop the spinner, otherwise a failed request leaves the card covered forever
+			this.loading = false;
 		}
 	}
 

--- a/packages/plugins/job-proposal-ui/src/lib/proposal/components/proposal/proposal.component.html
+++ b/packages/plugins/job-proposal-ui/src/lib/proposal/components/proposal/proposal.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
 	<nb-card-header class="card-custom-header">
 		<div class="card-header-title">
 			<h4>
@@ -33,7 +33,7 @@
 			></ngx-gauzy-button-action>
 		</div>
 	</nb-card-header>
-	<nb-card-body class="content">
+	<nb-card-body class="content" [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 		@if (dataLayoutStyle === componentLayoutStyleEnum.TABLE) {
 			<div class="table-scroll-container custom-table">
 				<angular2-smart-table

--- a/packages/ui-core/shared/src/lib/invite/invites/invites.component.html
+++ b/packages/ui-core/shared/src/lib/invite/invites/invites.component.html
@@ -1,4 +1,4 @@
-<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+<nb-card>
   <nb-card-header class="d-flex flex-column pb-0">
     <div class="header-title-with-back">
       <ngx-back-navigation></ngx-back-navigation>
@@ -17,7 +17,7 @@
       ></ngx-gauzy-button-action>
     </div>
   </nb-card-header>
-  <nb-card-body>
+  <nb-card-body [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
     <!-- Check if the user has the 'ORG_INVITE_VIEW' permission -->
     <ng-template [ngxPermissionsOnly]="[PermissionsEnum.ALL_ORG_VIEW, PermissionsEnum.ORG_INVITE_VIEW]">
       @switch (dataLayoutStyle) {


### PR DESCRIPTION
Four independent fixes, integrated and verified together. Two are **product** bugs that affect real users; two are test fixes for the last failing specs.

## 1. `[nbSpinner]` moved from `<nb-card>` to `<nb-card-body>` — 33 templates

Nebular's spinner is `position: absolute; inset: 0; z-index: 9999`. Bound to the whole card, it covers the **header** — which is where every page's Add / Edit / Delete buttons live. So during each list refresh a real user's click on a primary action was silently discarded. It is also the leading suspect behind several e2e flakes.

**The obvious objection — that this removes an accidental double-submit guard — was raised in review and does not hold. I audited all 33 rather than assuming:**

- **32 of 33** already gate their header actions on `[isDisable]` / `[disabled]`, i.e. on selection state. The overlay was never the guard.
- The one exception, `email-history`, has only a non-destructive "filters" button in its header; its `resend()` / `archive()` sit **inside** `nb-card-body` and remain covered.

Four pages were deliberately excluded where the whole-card spinner is intentional (`import-export/export`, `employees/timesheet/calendar`, `organizations`, `integration-hubstaff-ui/hubstaff`).

## 2. A failed request no longer strands the loading overlay — 19 call sites, 18 components

`loading = true` … `await` … `loading = false` with no `try/finally`. One rejected request left `loading` true forever, and with a `z-index: 9999` overlay that means **the card is permanently covered and unclickable, with no error shown**. `tags.component.ts` was worse: it destructured `this.organization` *before* the try, so a lifecycle race rejected before the flag could ever clear.

Now wrapped in `try/catch/finally` — flag cleared in `finally`, error surfaced to the user.

## 3. `edit-employee` — the last real e2e failure

A **duplicate DOM id**. `ga-tags-color-input` hardcodes `id="addTags"`, so the employees grid's tag *filter* and the Add-Employee dialog's tag *field* both render `#addTags`. The dialog lives in a `cdk-overlay` appended at end of `<body>`, so `.first()` resolved to the **grid's** control.

This spec runs first in its shard, so no tags existed yet — the ng-select driver fell into its re-open branch and force-clicked 15 times. `force` skips the actionability check but still delivers at screen coordinates, so those clicks landed on the dialog's **backdrop** — and the dialog opens with NbDialog's default `closeOnBackdropClick: true`. It dismissed itself mid-fill.

Screencast frames pin it exactly: dialog open and filled at t=189731, gone at t=190883 — 355 ms after the first force-click. The 60-second stall that followed was swallowed by a `.catch(() => undefined)`.

Fixed by scoping the selector to `ga-employee-mutation #addTags`, plus an explicit wait so a dismissed dialog is reported where it happens.

## 4. `register` submit was dropped on a still-disabled button

`force: true` does **not** bypass `disabled` — the browser drops the click entirely. The terms checkbox and the submit were clicked ~41 ms apart, before Angular propagated `[(ngModel)]` into `[disabled]`. New `clickWhenEnabled()` gates on `toBeEnabled` and clicks without `force`, since the point is that the control must genuinely be interactive.

## Verification

Built and verified **together**, not in isolation — #1 and #2 touch the same components from different sides.

```
nx build gauzy … Successfully ran target build for project gauzy and 23 tasks

DI / runtime check across all 13 affected pages:
  13/13 pages clean — no NG0201, no spurious danger toasts, no stuck spinners
```

That runtime check matters: two components gained **new `ToastrService` injections**, and a missing provider is an `NG0201` at page open — invisible to the build. The review correctly flagged that "syntax-checked, zero parse diagnostics" establishes only that files parse.

## Known-not-fixed

- **`ga-tags-color-input` hardcodes `id="addTags"` on ~86 instances**, so any page with both a grid tag filter and a form emits duplicate ids and the dialog's `<label for="addTags">` targets the wrong control. A unique-id migration invalidates ~25 e2e selectors at once, so it needs its own change.
- `register.feature` also fails later at `verifyHeadingOnCompletePage` — a separate, unrelated root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two user-facing UI bugs and stabilizes the last flaky e2e specs. Header actions stay clickable during loads, spinners no longer get stuck, and register/login and employee edit flows are reliable.

- **Bug Fixes**
  - Moved `[nbSpinner]` from `nb-card` to `nb-card-body` in 33 templates so headers (Add/Edit/Delete) remain clickable during data loads; left full-card overlays where intentional.
  - Ensured loading overlays always clear and errors surface: wrapped 19 async code paths across 18 components in try/catch/finally.
  - Stopped the Add‑Employee dialog from dismissing mid‑fill by scoping the `#addTags` selector to `ga-employee-mutation`.
  - Added `clickWhenEnabled()` and used it for Register and Login submits to avoid dropped clicks on still‑disabled buttons; also asserted navigation off `/auth/register`.

<sup>Written for commit 29928445385ac06fafee37a7a4b2685b6dc6631f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

