### PR TITLE
fix(build): actually rebuild native modules, and fail the build when a required binary is missing

### DIFF
--- a/.scripts/postinstall.js
+++ b/.scripts/postinstall.js
@@ -38,7 +38,7 @@ const nativePackages = ['@sentry/profiling-node', 'bcrypt', 'better-sqlite3', 'a
  * Not required, and why:
  * - `@sentry/profiling-node` — from v10 it has no `install` script and ships no binary
  *   of its own; the native part moved to `@sentry-internal/node-cpu-profiler`, which
- *   carries prebuilds. Demanding a binary here would fail every build.
+ *   carries prebuilt binaries. Demanding a binary here would fail every build.
  * - `active-win` — desktop-only, and pruned by `--production` in the API image.
  */
 const packagesRequiringBinary = new Set(['better-sqlite3', 'bcrypt']);
@@ -100,7 +100,7 @@ function runScriptsSequentially() {
 /**
  * Whether a native package has produced a loadable binary.
  *
- * `prebuild-install` drops it in `prebuilds/`, `node-gyp` in `build/Release`, and a
+ * `prebuild-install` drops it in a `prebuilds` folder, `node-gyp` in `build/Release`, and a
  * few packages keep it elsewhere — so this looks for any `.node` anywhere under the
  * package rather than assuming one layout.
  *

--- a/.scripts/postinstall.js
+++ b/.scripts/postinstall.js
@@ -100,7 +100,7 @@ function runScriptsSequentially() {
 /**
  * Whether a native package has produced a loadable binary.
  *
- * `prebuild-install` drops it in a `prebuilds` folder, `node-gyp` in `build/Release`, and a
+ * `prebuild-install` drops it under a prebuilt-binaries folder, `node-gyp` in `build/Release`, and a
  * few packages keep it elsewhere — so this looks for any `.node` anywhere under the
  * package rather than assuming one layout.
  *

--- a/.scripts/postinstall.js
+++ b/.scripts/postinstall.js
@@ -25,6 +25,24 @@ const foundScripts = [];
 // List of native packages to always handle
 const nativePackages = ['@sentry/profiling-node', 'bcrypt', 'better-sqlite3', 'active-win'];
 
+/**
+ * Packages that MUST end up with a loadable `.node` binary, or the build is wrong.
+ *
+ * Deliberately narrower than `nativePackages`, because "we rebuild it" and "it owns a
+ * binary" are not the same thing:
+ *
+ * - `better-sqlite3` — the API image sets `ENV DB_TYPE=better-sqlite3`, so without this
+ *   binary the container cannot open its database at all.
+ * - `bcrypt` — password hashing; every login path needs it.
+ *
+ * Not required, and why:
+ * - `@sentry/profiling-node` — from v10 it has no `install` script and ships no binary
+ *   of its own; the native part moved to `@sentry-internal/node-cpu-profiler`, which
+ *   carries prebuilds. Demanding a binary here would fail every build.
+ * - `active-win` — desktop-only, and pruned by `--production` in the API image.
+ */
+const packagesRequiringBinary = new Set(['better-sqlite3', 'bcrypt']);
+
 // Function to check for postinstall scripts in a package.json
 function checkPackageScripts(dir) {
 	const packageJsonPath = path.join(dir, 'package.json');
@@ -79,30 +97,110 @@ function runScriptsSequentially() {
 }
 
 // Rebuild or force install native packages
+/**
+ * Whether a native package has produced a loadable binary.
+ *
+ * `prebuild-install` drops it in `prebuilds/`, `node-gyp` in `build/Release`, and a
+ * few packages keep it elsewhere — so this looks for any `.node` anywhere under the
+ * package rather than assuming one layout.
+ *
+ * @param {string} packagePath - Absolute path of the installed package.
+ * @returns {string|null} Path of the first binary found, or `null`.
+ */
+function findNativeBinary(packagePath) {
+	const stack = [packagePath];
+	while (stack.length) {
+		const dir = stack.pop();
+		let entries;
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			// Nested node_modules would report a DEPENDENCY's binary as ours.
+			if (entry.isDirectory() && entry.name !== 'node_modules') {
+				stack.push(path.join(dir, entry.name));
+			} else if (entry.isFile() && entry.name.endsWith('.node')) {
+				return path.join(dir, entry.name);
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Builds the native packages that `--ignore-scripts` skipped, and FAILS if one of
+ * them ends up without a binary.
+ *
+ * Why this is not `yarn add <pkg> --force` any more: that ran with `cwd` set to the
+ * package's own directory, so yarn treated `node_modules/better-sqlite3` as a project
+ * root and tried to add the package as a dependency of itself. It never invoked
+ * node-gyp, and every failure was caught and logged, so the build went green either
+ * way. The result was images that shipped without `better_sqlite3.node` — and since
+ * the API image sets `ENV DB_TYPE=better-sqlite3`, such an image cannot open its
+ * database at all unless the deployment overrides `DB_TYPE`.
+ *
+ * `npm rebuild` from the workspace root is the supported way: it runs each package's
+ * own `install`/`rebuild` lifecycle. That matters because these packages hang their
+ * build off `install`, not `postinstall` — better-sqlite3's is
+ * `prebuild-install || node-gyp rebuild --release` — which is why the
+ * postinstall-only scan above never sees them.
+ */
 function handleNativePackages() {
 	console.log('Handling native packages...');
+
+	const installed = [];
 	for (const packageName of nativePackages) {
 		const packagePath = path.join(nodeModulesPath, packageName);
-
-		console.log(`Checking path for ${packageName}: ${packagePath}`);
-
-		if (fs.existsSync(packagePath)) {
-			const packageJsonPath = path.join(packagePath, 'package.json');
-			console.log(`Checking package.json for ${packageName}: ${packageJsonPath}`);
-
-			if (fs.existsSync(packageJsonPath)) {
-				console.log(`Rebuilding native package: ${packageName} in ${packagePath}`);
-				try {
-					execSync(`yarn add ${packageName} --force`, { stdio: 'inherit', cwd: packagePath });
-				} catch (error) {
-					console.error(`Failed to rebuild native package ${packageName}:`, error);
-				}
-			} else {
-				console.warn(`Native package ${packageName} does not have a package.json at ${packageJsonPath}. Skipping.`);
-			}
-		} else {
-			console.warn(`Native package ${packageName} is not installed in ${packagePath}. Skipping.`);
+		if (!fs.existsSync(path.join(packagePath, 'package.json'))) {
+			// Legitimately absent: `--production` prunes some of these.
+			console.warn(`Native package ${packageName} is not installed. Skipping.`);
+			continue;
 		}
+		installed.push({ packageName, packagePath });
+	}
+
+	if (!installed.length) {
+		console.log('No native packages present.');
+		return;
+	}
+
+	const names = installed.map((p) => p.packageName);
+	console.log(`Rebuilding native packages: ${names.join(', ')}`);
+	try {
+		// Root cwd, not the package's own directory.
+		execSync(`npm rebuild ${names.join(' ')}`, { stdio: 'inherit' });
+	} catch (error) {
+		// Not fatal on its own — the verification below decides. A package that
+		// already carries a valid prebuilt binary can fail `npm rebuild` (no
+		// toolchain present) and still be perfectly usable.
+		console.error('npm rebuild reported a failure; verifying binaries anyway:', error.message);
+	}
+
+	const missing = [];
+	for (const { packageName, packagePath } of installed) {
+		const binary = findNativeBinary(packagePath);
+		const required = packagesRequiringBinary.has(packageName);
+		if (binary) {
+			console.log(`  ✔ ${packageName} → ${path.relative(nodeModulesPath, binary)}`);
+		} else if (required) {
+			console.error(`  ✖ ${packageName} produced NO native binary`);
+			missing.push(packageName);
+		} else {
+			// Expected for packages whose native half lives in a sibling package.
+			console.log(`  – ${packageName} has no binary of its own (not required)`);
+		}
+	}
+
+	if (missing.length) {
+		// Fail loudly. This used to be swallowed, which is precisely how a broken
+		// image reached an environment: the build was green and the fault only
+		// surfaced later as a runtime failure to open the database.
+		throw new Error(
+			`Native package(s) built no binary: ${missing.join(', ')}. ` +
+				`The image would start without them and fail at runtime, so the build is stopped here.`
+		);
 	}
 }
 


### PR DESCRIPTION
Root cause of the missing `better-sqlite3` binary on the dev/demo image. The build that produced it was **green** — that is the important part.

## Why the image shipped without the binary

Three things had to line up, and they did:

**1. `--ignore-scripts` skips the native build.** Both `yarn install` steps in `.deploy/api/Dockerfile` (lines 127 and 227) pass it. That is deliberate — `yarn postinstall.manual` is meant to do the work afterwards.

**2. `postinstall.manual` never actually built it.**

- `findPostInstallScripts()` only collects packages that declare `scripts.postinstall`. better-sqlite3 declares an **`install`** script, not a `postinstall`:
  ```json
  "install": "prebuild-install || node-gyp rebuild --release"
  ```
  so it was never in the list.
- `handleNativePackages()` did name it, but ran `yarn add <pkg> --force` with **`cwd` set to the package's own directory**. That makes yarn treat `node_modules/better-sqlite3` as a project root and try to add the package as a dependency of itself. node-gyp is never invoked.

**3. Every failure was swallowed** — both paths sat inside `catch { console.error(...) }`. Neither problem could turn the build red, so the fault surfaced later, at runtime, in whichever environment received the image.

That also explains why prod has the binary and demo does not, from the same Dockerfile: whether it exists depended on a path that could fail silently.

**Severity:** the API image sets `ENV DB_TYPE=better-sqlite3` (line 418). An image without the binary cannot open its database at all unless the deployment overrides `DB_TYPE`.

## The fix

`npm rebuild <pkgs>` from the workspace **root**, which runs each package's own `install`/`rebuild` lifecycle — the supported path, and the one that actually reaches `prebuild-install || node-gyp`.

Then every package is checked for a loadable `.node`, and a missing **required** binary throws, failing the Docker build at the point of the fault rather than shipping it.

An `npm rebuild` failure is logged but not fatal by itself — the binary check decides. A package that already carries a valid prebuilt binary can fail to rebuild for want of a toolchain and still be perfectly usable.

## The requirement is per package, deliberately

"We rebuild it" and "it owns a binary" are not the same set, and conflating them would fail every build:

| Package | Binary required | Why |
|---|---|---|
| `better-sqlite3` | **yes** | the image's default DB driver |
| `bcrypt` | **yes** | every login path |
| `@sentry/profiling-node` | no | since v10 it has no `install` script and ships no binary; the native half moved to `@sentry-internal/node-cpu-profiler`, which carries prebuilds |
| `active-win` | no | desktop-only, pruned by `--production` |

I checked `@sentry/profiling-node` specifically because a blanket check would have made this change break every build — it has **no** `.node` of its own in a perfectly healthy tree.

## Verification

Detection scans for any `.node` under the package rather than assuming one layout, since `prebuild-install` writes to `prebuilds/`, node-gyp to `build/Release`, and bcrypt to `lib/binding/napi-v3/`. Nested `node_modules` are skipped so a dependency's binary is never mistaken for the package's own.

Dry-run against the real tree:

```
– @sentry/profiling-node (no binary, not required)
✔ bcrypt              → bcrypt/lib/binding/napi-v3/bcrypt_lib.node
✔ better-sqlite3      → better-sqlite3/build/Release/better_sqlite3.node
  (absent) active-win
WOULD PASS
```

Negative control: a non-native package (`rxjs`) correctly reports no binary, so the scan does not produce false positives.

## Follow-up worth considering separately

`ENV DB_TYPE=better-sqlite3` as an image default means any deployment that forgets to set `DB_TYPE` silently runs on sqlite. That is a sharp edge independent of this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker builds to reliably produce native binaries and fail fast when a required binary is missing. Prevents shipping images that can’t start with `better-sqlite3`.

- **Bug Fixes**
  - Rebuild native packages via `npm rebuild` from the workspace root to run each package’s `install`/`rebuild` lifecycle.
  - Verify a loadable `.node` exists after rebuild; fail the build if missing for required packages (`better-sqlite3`, `bcrypt`).
  - Treat `@sentry/profiling-node` and `active-win` as not required; skip if pruned by `--production`.
  - Scan avoids nested `node_modules`; log rebuild errors but gate success on binary presence.
  - Stop swallowing errors so the Docker build fails at the point of fault instead of at runtime.

<sup>Written for commit 519dd8534a57c919fa19ed79178e84dd74b57e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

