### PR TITLE
fix(ui): visual sweep of accounting, employees, organization, settings and reports (wave 4)

### DIFF
--- a/apps/gauzy-e2e/tests/support/pages/TimeOff.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/TimeOff.po.ts
@@ -547,7 +547,8 @@ export const waitMessageToHide = async () => waitElementToHide(TimeOffPage.toast
 
 export const verifyPolicyExists = async (text: string) => {
 	// Assert the policy name renders in a grid cell. Used for BOTH the request grid (Policy column, a
-	// custom ApprovalPolicyComponent that renders <div>{{ value.name }}</div>) and the settings grid
+	// custom ApprovalPolicyComponent that renders <div class="policy">{{ value.name }}</div>, or an
+	// em-dash in a <span class="empty"> when the request has no policy) and the settings grid
 	// (Name column, a type:'string' cell). The old 'div.ng-star-inserted' worked for the custom-render
 	// request cell but a plain string cell has no such wrapper div — so scope the verify to the smart-table
 	// CELL element (present in both grids) filtered by the exact name. This is pollution-safe (matches the

--- a/apps/gauzy/src/app/pages/accounting-templates/accounting-templates.component.scss
+++ b/apps/gauzy/src/app/pages/accounting-templates/accounting-templates.component.scss
@@ -1,3 +1,11 @@
+// The email-templates sheet `@use`s the theme module, which keeps it private to
+// that file — loading it here brings in `$height` but not `nb-theme`. Sass passes
+// an unknown function through as plain CSS, so the two rules at the bottom of this
+// file shipped as the literal text `nb-theme(...)` and the browser dropped them:
+// the language/template selects lost their background, and — the visible one —
+// the rendered template preview never had `color: text-basic-color` applied, so
+// it kept the seeded HTML's own near-black text on the dark themes' dark panel.
+@use 'themes' as *;
 @use '../email-templates/email-templates.component' as *;
 
 :host {

--- a/apps/gauzy/src/app/pages/approvals/approvals.component.scss
+++ b/apps/gauzy/src/app/pages/approvals/approvals.component.scss
@@ -1,4 +1,7 @@
 @forward '@shared/_pg-card';
+// `@forward` re-exports to importers but does NOT bring members into this file,
+// so `nb-theme()` needs its own `@use`.
+@use 'themes' as *;
 
 :host {
   nb-card-body {

--- a/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.html
+++ b/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.html
@@ -1,3 +1,8 @@
-<div>
-	{{ value ? value.name : null }}
-</div>
+<!-- The chip used to render whether or not there was a policy, so a request with
+     none showed an empty grey pill. An em-dash reads as "not set"; the pill is
+     kept for the case where there is something to put in it. -->
+@if (value?.name) {
+	<div class="policy">{{ value.name }}</div>
+} @else {
+	<span class="empty">&mdash;</span>
+}

--- a/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.scss
+++ b/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.scss
@@ -13,7 +13,7 @@
 // `tag-border-radius` was taken off across the app — and the background was a
 // hand-copy of `gauzy-sidebar-background-3`. The `margin: 0 10px` is gone too:
 // the cell already has its own horizontal padding, so the chip was indented
-// 10px further than the text in every neighbouring column.
+// 10px further than the text in every adjacent column.
 .policy {
   display: flex;
   flex-direction: row;

--- a/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.scss
+++ b/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.scss
@@ -1,29 +1,38 @@
 @use 'themes' as *;
 
-div {
+// The approval-policy chip in a smart-table cell.
+//
+// The selector was a bare `div`, which is why the template could not grow a
+// second branch without the empty state inheriting the pill; it is `.policy`
+// now (a new class, nothing was renamed — no template or page object referred
+// to this element by name).
+//
+// Sized from the shared table-density tokens (`$gauzy-density` in `themes.scss`)
+// like every other in-cell chip; the literals are CSS-var fallbacks only. The
+// radius was `12px`, i.e. a full stadium pill on a ~19px chip — the same thing
+// `tag-border-radius` was taken off across the app — and the background was a
+// hand-copy of `gauzy-sidebar-background-3`. The `margin: 0 10px` is gone too:
+// the cell already has its own horizontal padding, so the chip was indented
+// 10px further than the text in every neighbouring column.
+.policy {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  padding: 3px 8px;
-
   width: fit-content;
-
-  background: rgba(126, 126, 143, 0.1);
-  border-radius: 12px;
-
-  /* Inside auto layout */
-
-  flex: none;
-  order: 0;
-  flex-grow: 0;
-  margin: 0px 10px;
-
-  /* Typography */
-
-  font-size: 12px;
+  padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
+  background: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+  border-radius: var(--gauzy-radius-sm, 0.375rem);
+  font-size: var(--gauzy-table-header-font-size, 0.75rem);
   font-weight: 600;
-  line-height: 15px;
+  line-height: var(--gauzy-table-header-line-height, 0.9375rem);
   letter-spacing: 0em;
   text-align: left;
+  white-space: nowrap;
+}
+
+// "No policy set". Muted, and deliberately WITHOUT the chip box, so an unset
+// value does not read as a value.
+.empty {
+  color: nb-theme(text-hint-color);
 }

--- a/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/average-criterions-rating-chart/average-criterions-rating-chart.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/average-criterions-rating-chart/average-criterions-rating-chart.component.scss
@@ -1,22 +1,31 @@
+@use 'themes' as *;
+
 .select {
   width: 20rem;
   margin: 0 0 1.25rem 0;
 }
 
+// Same empty state as the page-level one in `candidate-statistic.component.scss`
+// and now from the same tokens. `#e5e5e5` is a fixed light hairline and
+// `#909cb4` a fixed blue-grey: on the near-black canvas the border vanished and
+// the caption fought the neutral text ramp. The radius and gap were missing
+// here too, so the two empty states did not match even on the light themes.
 .no-data {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: 1px #e5e5e5 solid;
+  gap: 0.5rem;
   height: 150px;
+  border: 1px solid nb-theme(border-basic-color-3);
+  border-radius: nb-theme(border-radius);
 
   &-text {
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 
   &-icon {
     font-size: 1.5rem !important;
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 }

--- a/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/criterions-rating-chart/criterions-rating-chart.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/criterions-rating-chart/criterions-rating-chart.component.scss
@@ -22,20 +22,27 @@
   @include nb-rtl(padding-right, 1rem);
 }
 
+// Same empty state as the page-level one in `candidate-statistic.component.scss`
+// and now from the same tokens. `#e5e5e5` is a fixed light hairline and
+// `#909cb4` a fixed blue-grey: on the near-black canvas the border vanished and
+// the caption fought the neutral text ramp. The radius and gap were missing
+// here too, so the two empty states did not match even on the light themes.
 .no-data {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: 1px #e5e5e5 solid;
+  gap: 0.5rem;
   height: 150px;
+  border: 1px solid nb-theme(border-basic-color-3);
+  border-radius: nb-theme(border-radius);
 
   &-text {
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 
   &-icon {
     font-size: 1.5rem !important;
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 }

--- a/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/interview-rating-chart/interview-rating-chart.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/interview-rating-chart/interview-rating-chart.component.scss
@@ -1,22 +1,31 @@
+@use 'themes' as *;
+
 .select {
   width: 100%;
   margin: 0 0 1.25rem 0;
 }
 
+// Same empty state as the page-level one in `candidate-statistic.component.scss`
+// and now from the same tokens. `#e5e5e5` is a fixed light hairline and
+// `#909cb4` a fixed blue-grey: on the near-black canvas the border vanished and
+// the caption fought the neutral text ramp. The radius and gap were missing
+// here too, so the two empty states did not match even on the light themes.
 .no-data {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: 1px #e5e5e5 solid;
+  gap: 0.5rem;
   height: 150px;
+  border: 1px solid nb-theme(border-basic-color-3);
+  border-radius: nb-theme(border-radius);
 
   &-text {
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 
   &-icon {
     font-size: 1.5rem !important;
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 }

--- a/apps/gauzy/src/app/pages/candidates/candidates.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidates.component.scss
@@ -9,100 +9,13 @@
   justify-content: space-between;
 }
 
-:host .grid-scroll-container {
-  .flex-container {
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: flex-start;
-    padding: 0;
-    margin: 0;
-    list-style: none;
-
-    .flex-item {
-      border: 0.0625rem solid #e4e9f2;
-      border-radius: 0.25rem;
-      width: 23%;
-      margin: 10px;
-
-      .fullName {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        padding: 1rem 1.5rem;
-        line-height: 40px;
-        font-size: 1.5em;
-      }
-
-      .avatar {
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-      }
-
-      .email {
-        @include nb-ltr(text-align, right);
-        @include nb-rtl(text-align, left);
-        padding-right: 1.5rem;
-        bottom: 36px;
-        position: relative;
-      }
-
-      .info-line {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 0.8em;
-        color: darkgray;
-        line-height: 0px;
-        padding: 0.7rem 1.5rem;
-
-        .info-meta {
-          margin-right: 10px;
-          @include nb-ltr(margin-right, 10px);
-          @include nb-rtl(margin-left, 10px);
-        }
-
-        .info-value {
-          display: flex;
-          justify-content: flex-end;
-          text-align: end;
-          color: black;
-          font-size: 1em;
-        }
-
-        .status-badge {
-          text-align: center;
-          padding: 10px 30px;
-          border-radius: 0.25rem;
-          color: #fff;
-        }
-
-        /* Status */
-        .badge-danger {
-          background-color: #ff3d71;
-        }
-
-        .badge-success {
-          background-color: #00d68f;
-        }
-
-        .badge-primary {
-          background-color: #0095ff;
-        }
-
-        .badge-warning {
-          background-color: #fa0;
-        }
-      }
-
-      .card-footer {
-        justify-content: space-around;
-        display: flex;
-      }
-    }
-  }
-}
+// REMOVED: a `:host .grid-scroll-container .flex-container .flex-item` block
+// describing a hand-rolled candidate card — `.avatar`, `.fullName`, `.email`,
+// `.status-badge` and four `.badge-*` fills. No template in the repo renders
+// `.flex-container`; the grid view goes through `<ga-card-grid>`, whose own
+// stylesheet is already token-based. So none of it ever applied, and what it
+// carried was `#e4e9f2` / `darkgray` / `color: black` / four literal status
+// fills — exactly the values a later theme sweep would waste time "fixing".
 
 :host {
   nb-card-body {

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.scss
@@ -46,24 +46,29 @@ input {
   margin: 0 0 8px;
 }
 
+// Secondary caption under a document name. `grey` (#808080) measures 3.5:1 on
+// the light card and is the wrong hue on the neutral dark ramp; `text-hint-color`
+// is the app's own muted step and is tuned per theme.
 .document-data {
   font-size: 12px;
-  color: grey;
+  color: nb-theme(text-hint-color);
 }
 
+// The download glyph — the theme's link colour rather than a literal blue.
 .doc-icon {
-  color: #3365ff !important;
+  color: nb-theme(text-primary-color) !important;
 }
 
 .header {
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  border-color: 1px solid black;
+  // (dropped `border-color: 1px solid black` — `border-color` takes a colour,
+  // not a border shorthand, so the declaration was invalid and discarded.)
 }
 
 .documents-card-container {
-  background-color: rgba(126, 126, 143, 0.05);
+  background-color: var(--gauzy-sidebar-background-4);
   border-radius: nb-theme(border-radius);
   padding: 1rem;
 }

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-employment/edit-candidate-employment.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-employment/edit-candidate-employment.component.scss
@@ -1,16 +1,8 @@
-.notes {
-  margin-top: 16px;
-  padding: 10px;
-  border-radius: 5px;
-  text-indent: 1em;
-}
-
-.notes p {
-  margin: 0;
-  color: #eac72d;
-  font-size: 0.75rem;
-  font-weight: 700;
-}
+// REMOVED: a `.notes` / `.notes p { color: #eac72d }` pair. This template has no
+// `.notes` element — the sibling employee tab is the one that renders a note,
+// and its own stylesheet already paints it from
+// `--color-warning-transparent-100` / `--color-warning-default`. What was here
+// was a stale copy carrying a literal mustard `#eac72d` and no background at all.
 :host {
   overflow-y: auto;
   max-height: calc(100vh - 28rem);

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.html
@@ -5,10 +5,14 @@
 				@if (allFeedbacks?.length > 0) {
 					<div class="filters">
 						@if (dataLayoutStyle === 'CARDS_GRID') {
+							<!-- Was a hardcoded English `placeholder="Select interview"`:
+							     untranslated in every other locale, and still carrying the
+							     "Select …" prefix that was dropped from the app's other
+							     comboboxes. -->
 							<nb-select
 								[formControl]="selectInterview"
 								class="select mr-3 show"
-								placeholder="Select interview"
+								[placeholder]="'CANDIDATES_PAGE.EDIT_CANDIDATE.INTERVIEW.INTERVIEW' | translate"
 								(selectedChange)="onInterviewSelected($event)"
 							>
 								<nb-option [value]="all">

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.scss
@@ -34,7 +34,9 @@
 }
 
 .block {
-  border: 0.0625rem solid #e4e9f2;
+  // `#e4e9f2` is a fixed pale-blue hairline: on the near-black canvas it draws a
+  // light box, and it ignores the theme everywhere else too.
+  border: 0.0625rem solid nb-theme(gauzy-border-default-color);
   padding: 0.5rem;
   width: 12rem;
   border-radius: 5px;
@@ -130,12 +132,14 @@
   font-size: 15px;
 }
 
+// The thumbs-up / thumbs-down glyphs beside the Hire / Reject radios. Literal
+// eva-palette values before, so they stayed put whichever theme was active.
 .success {
-  color: #00d68f;
+  color: nb-theme(color-success-default);
 }
 
 .error {
-  color: #ff3d71;
+  color: nb-theme(color-danger-default);
 }
 
 .image-small {
@@ -258,7 +262,8 @@
           flex-direction: row;
           justify-content: space-between;
           align-items: center;
-          border: 1px #e4e9f2 solid;
+          // See `.block` above — `#e4e9f2` is a fixed pale-blue hairline.
+          border: 1px solid nb-theme(gauzy-border-default-color);
           @include nb-ltr(margin, 0.15rem 0.15rem 0.15rem 0);
           @include nb-rtl(margin, 0.15rem 0 0.15rem 0.15rem);
           padding: 0.2rem 0.5rem;

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.scss
@@ -1,153 +1,23 @@
 @use 'gauzy/_gauzy-table' as *;
 @use 'gauzy/_gauzy-overrides' as *;
 
-.right-block {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
 .checkboxes {
   display: flex;
   justify-content: flex-end;
   align-items: center;
 }
 
-:host .card-container {
-  display: flex;
-  flex-wrap: wrap;
-
-  .card-body {
-    width: 100%;
-    max-width: 300px;
-    margin: 20px;
-
-    .card-header {
-      padding: 0.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-
-      &-badge {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-      }
-
-      .header-container {
-        text-align: center;
-      }
-    }
-
-    .interview-card {
-      display: flex;
-      flex-direction: column;
-      padding: 0.5rem;
-
-      .name-container {
-        display: flex;
-        align-items: center;
-        margin-bottom: 10px;
-
-        &:hover {
-          cursor: pointer;
-          color: #3366ff;
-        }
-
-        .image-container {
-          width: 70px;
-          height: 50px;
-          display: flex;
-          justify-content: center;
-          margin-right: 10px;
-          @include nb-ltr(margin-right, 10px);
-          @include nb-rtl(margin-left, 10px);
-
-          img {
-            height: 100%;
-            max-width: 70px;
-          }
-        }
-      }
-
-      .team-members {
-        margin-bottom: 0.5rem;
-      }
-    }
-
-    .button-container {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin-top: auto;
-      flex-wrap: wrap;
-    }
-  }
-}
-
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  .btn {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-  }
-}
-
-:host .badge {
-  text-align: center;
-  padding: 5px;
-  @include nb-ltr(margin-left, 0.2rem);
-  @include nb-rtl(margin-right, 0.2rem);
-}
-
-:host .client-info {
-  padding: 0px 12px;
-  display: flex;
-  flex-direction: column;
-
-  .info-line {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    font-size: 0.7em;
-    color: darkgray;
-
-    .info-value {
-      display: flex;
-      justify-content: flex-end;
-      text-align: end;
-
-      .info-list-item:not(:last-child)::after {
-        content: ',';
-        @include nb-ltr(margin-right, 5px);
-        @include nb-rtl(margin-left, 5px);
-      }
-    }
-
-    .criterions {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      text-align: end;
-    }
-  }
-}
-
-.btn {
-  margin: 0.2rem;
-}
-
-.badge-warning {
-  background-color: #fa0;
-}
-
-.badge-primary {
-  background-color: #0095ff;
-}
+// REMOVED with the visual sweep, all of it dead against this template (which
+// renders `.checkboxes`, `.table-scroll-container`, `.custom-card-body` and the
+// action buttons, and nothing else):
+//   * `.right-block`, `.header`, `.btn`;
+//   * `.card-container` / `.interview-card` / `.image-container`, a hand-rolled
+//     interview card replaced by `<ga-card-grid>` — it carried
+//     `.name-container:hover { color: #3366ff }`;
+//   * `.client-info .info-line { color: darkgray }`;
+//   * `.badge`, plus `.badge-warning { #fa0 }` and `.badge-primary { #0095ff }`.
+// Component styles are view-encapsulated, so none of these could reach the card
+// grid's own markup either.
 
 :host {
   overflow-y: auto;

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.html
@@ -3,19 +3,24 @@
     <div class="card-header-title">
       <ngx-back-navigation></ngx-back-navigation>
       <h4>
-        {{ 'CANDIDATES_PAGE.EDIT_CANDIDATE.HEADER' | translate }}
-        @if (selectedCandidate?.user?.name) {
-          <span>{{ selectedCandidate?.user?.name }}</span>
-        }
-        @if (selectedCandidate?.user?.username) {
-          <span>
-            @if (selectedCandidate?.user.name) {
-              ({{ selectedCandidate?.user.username }})
-            } @else {
-              '{{ selectedCandidate?.user.username }}'
-            }
-          </span>
-        }
+        <!-- Routed through `ngx-header-title` like every other page in this
+             area: that is what renders the breadcrumb trail under the heading,
+             which this page had no way to show. -->
+        <ngx-header-title [allowEmployee]="false">
+          {{ 'CANDIDATES_PAGE.EDIT_CANDIDATE.HEADER' | translate }}
+          @if (selectedCandidate?.user?.name) {
+            <span>{{ selectedCandidate?.user?.name }}</span>
+          }
+          @if (selectedCandidate?.user?.username) {
+            <span>
+              @if (selectedCandidate?.user.name) {
+                ({{ selectedCandidate?.user.username }})
+              } @else {
+                '{{ selectedCandidate?.user.username }}'
+              }
+            </span>
+          }
+        </ngx-header-title>
       </h4>
     </div>
     <div class="notification" (click)="interviewInfo()">

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.scss
@@ -108,15 +108,12 @@
   }
 }
 
-<<<<<<< HEAD
-=======
 // (removed a local `h4 { font-size: 24px; line-height: 30px }` override.) The
 // page heading is governed by one type step, applied by `ngx-header-title`
 // itself — 1.25rem/1.75rem, deliberately the h5 step, "a page heading only needs
 // to out-rank body copy". 24px here made this the single largest page title in
 // the app, a full step above every sibling in Employees & Candidates.
 
->>>>>>> 93d4704d72 (fix(ui): visual sweep of Employees & Candidates)
 :host {
   @include input-appearance(42px, var(--gauzy-card-1));
 }

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.scss
@@ -6,13 +6,17 @@
   width: 100%;
 }
 
+// The "upcoming interviews" bell. The disc was a literal `rgb(0, 145, 255)` and
+// the unread dot below a literal `#f10`; both now read the theme's status
+// palette. (`.bell` keeps `color: white` — that is a contrast pair against this
+// disc, not a theme colour, and the disc is a saturated fill in every theme.)
 .notification {
   position: relative;
   display: inline-block;
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background-color: rgb(0, 145, 255);
+  background-color: nb-theme(color-info-default);
 }
 
 .notification:hover {
@@ -37,7 +41,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: #f10;
+  background-color: nb-theme(color-danger-default);
 }
 
 .nb-card {
@@ -104,6 +108,15 @@
   }
 }
 
+<<<<<<< HEAD
+=======
+// (removed a local `h4 { font-size: 24px; line-height: 30px }` override.) The
+// page heading is governed by one type step, applied by `ngx-header-title`
+// itself — 1.25rem/1.75rem, deliberately the h5 step, "a page heading only needs
+// to out-rank body copy". 24px here made this the single largest page title in
+// the app, a full step above every sibling in Employees & Candidates.
+
+>>>>>>> 93d4704d72 (fix(ui): visual sweep of Employees & Candidates)
 :host {
   @include input-appearance(42px, var(--gauzy-card-1));
 }

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-criterions/candidate-personal-qualities/candidate-personal-qualities.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-criterions/candidate-personal-qualities/candidate-personal-qualities.component.scss
@@ -51,12 +51,17 @@
   }
 }
 
+// Same "already exists" list as the sibling `candidate-technologies` page, which
+// carried a background this one did not — the two panels sit side by side in the
+// same tab, so they now take the same surface token.
 .existedNames {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
   flex-wrap: wrap;
+  background-color: var(--gauzy-card-2);
+  border-radius: nb-theme(border-radius);
 
   &-card {
     width: 100%;
@@ -68,8 +73,12 @@
     margin-top: 0.5rem;
   }
 
+  // Marks a name that clashes with an existing one, so it wants the theme's
+  // danger colour rather than a literal `#ff3d70`. The radius was missing too,
+  // which left a square-cornered box among rounded ones.
   .existedName {
-    border: 1px #ff3d70 solid;
+    border: 1px solid nb-theme(color-danger-default);
+    border-radius: nb-theme(border-radius);
     margin: 0.2rem 0;
     padding: 1rem;
     display: flex;

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-criterions/candidate-technologies/candidate-technologies.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-criterions/candidate-technologies/candidate-technologies.component.scss
@@ -51,13 +51,19 @@
   }
 }
 
+// The "already exists" list. `rgba(50, 50, 50, 0.08)` is the literal value of
+// `gauzy-card-2` on the light themes only — on the dark ones that token is a
+// LIFTING white tint, so this panel was darkening a canvas that is already
+// near-black. The sibling `candidate-personal-qualities` page carries the same
+// list with no background at all; both now read the same.
 .existedNames {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
   flex-wrap: wrap;
-  background-color: rgba(50, 50, 50, 0.08);
+  background-color: var(--gauzy-card-2);
+  border-radius: nb-theme(border-radius);
 
   &-card {
     width: 100%;
@@ -69,8 +75,12 @@
     margin-top: 0.5rem;
   }
 
+  // Marks a name that clashes with an existing one, so it wants the theme's
+  // danger colour rather than a literal `#ff3d70`. The radius was missing too,
+  // which left a square-cornered box among rounded ones.
   .existedName {
-    border: 1px #ff3d70 solid;
+    border: 1px solid nb-theme(color-danger-default);
+    border-radius: nb-theme(border-radius);
     margin: 0.2rem 0;
     padding: 1rem;
     display: flex;

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.scss
@@ -42,117 +42,19 @@
 .select {
   width: 18rem;
 }
-:host .card-container {
-  display: flex;
-  flex-wrap: wrap;
-
-  .card-body {
-    width: 100%;
-    max-width: 300px;
-    .card-header {
-      padding: 0.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-
-      &-badge {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-      }
-      .header-container {
-        text-align: center;
-      }
-    }
-
-    .interview-card {
-      display: flex;
-      flex-direction: column;
-      padding: 0.5rem;
-
-      .name-container {
-        display: flex;
-        align-items: center;
-        margin-bottom: 10px;
-
-        &:hover {
-          cursor: pointer;
-          color: #3366ff;
-        }
-
-        .image-container {
-          width: 70px;
-          height: 50px;
-          display: flex;
-          justify-content: center;
-          @include nb-ltr(margin-right, 10px);
-          @include nb-rtl(margin-left, 10px);
-
-          img {
-            height: 100%;
-            max-width: 70px;
-          }
-        }
-      }
-      .team-members {
-        margin-bottom: 0.5rem;
-      }
-    }
-
-    .button-container {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin-top: auto;
-      flex-wrap: wrap;
-    }
-  }
-}
 .btn {
   margin: 0.2rem;
 }
 
-.badge-warning {
-  background-color: #fa0;
-}
-
-.badge-primary {
-  background-color: #0095ff;
-}
-
-.badge {
-  text-align: center;
-  padding: 5px;
-  margin-left: 0.2rem;
-}
-.client-info {
-  padding: 0px 12px;
-  display: flex;
-  flex-direction: column;
-  .info-line {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    font-size: 0.7em;
-    color: darkgray;
-    .info-value {
-      display: flex;
-      justify-content: flex-end;
-      text-align: end;
-      .info-list-item:not(:last-child)::after {
-        content: ',';
-        @include nb-ltr(margin-right, 5px);
-        @include nb-rtl(margin-left, 5px);
-      }
-    }
-    .criterions {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      text-align: end;
-    }
-  }
-}
+// REMOVED: `.card-container` (with `.interview-card`, `.image-container`,
+// `.name-container:hover { color: #3366ff }`), `.client-info` (with
+// `.info-line { color: darkgray }`), the bare `.badge` box and the
+// `.badge-warning` / `.badge-primary` fills `#fa0` / `#0095ff`.
+//
+// All dead: this template renders its grid view through `<ga-card-grid>` and
+// none of those class names appears in any template in the repo. Component
+// styles are view-encapsulated, so they could not reach the card grid's own
+// markup either.
 
 :host {
   @include card-overrides(unset, calc($default-card-height), $default-radius);

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.scss
@@ -51,10 +51,12 @@
 // `.info-line { color: darkgray }`), the bare `.badge` box and the
 // `.badge-warning` / `.badge-primary` fills `#fa0` / `#0095ff`.
 //
-// All dead: this template renders its grid view through `<ga-card-grid>` and
-// none of those class names appears in any template in the repo. Component
-// styles are view-encapsulated, so they could not reach the card grid's own
-// markup either.
+// All dead, but not because the names are unused — `.card-header` and
+// `.card-body` DO appear in this template. They were nested inside
+// `:host .card-container`, and nothing here is a `.card-container`, so the
+// nested rules never matched. The grid view renders through `<ga-card-grid>`,
+// whose markup these styles cannot reach anyway: they are view-encapsulated to
+// this component's own template.
 
 :host {
   @include card-overrides(unset, calc($default-card-height), $default-radius);

--- a/apps/gauzy/src/app/pages/candidates/table-components/candidate-status/candidate-status.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/table-components/candidate-status/candidate-status.component.scss
@@ -1,18 +1,27 @@
+@use 'themes' as *;
+
+// Status fills come from the theme's status palette, the same way
+// `organizations-status` takes them. The literals here before (#ff3d71 /
+// #00d68f / #0095ff / #fa0) were a snapshot of one theme's eva palette, so the
+// pills stayed on those four colours whichever of the eight themes was active.
 .badge-danger {
-  background-color: #ff3d71;
+  background-color: nb-theme(color-danger-default);
 }
 
 .badge-success {
-  background-color: #00d68f;
+  background-color: nb-theme(color-success-default);
 }
 
 .badge-primary {
-  background-color: #0095ff;
+  background-color: nb-theme(color-info-default);
 }
 
+// No `color` override: the label keeps Bootstrap's dark-on-amber pairing. White
+// on this fill measured ~2:1, i.e. the ARCHIVED pill was the one status label
+// you could not read — and unlike the other three, amber is a LIGHT fill, so it
+// wants dark text in every theme.
 .badge-warning {
-  background-color: #fa0;
-  color: #fff;
+  background-color: nb-theme(color-warning-default);
 }
 
 div {

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.scss
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.scss
@@ -140,8 +140,13 @@ $height: calc(100vh - 25.5rem);
       border-radius: nb-theme(border-radius);
     }
 
+    // The "Template preview" strip. It is the facing half of `.editor-header`
+    // ("HTML editor") on the other column, but it was the one literal the
+    // white-block pass missed: a hand-written rgba at 0.05 against the token's
+    // 0.12, so the two column headers on the same row never matched. Same tint
+    // as its opposite number now, and defined in all eight themes.
     .email-column-sub-header {
-      background-color: rgba(126, 126, 143, 0.05);
+      background-color: nb-theme(gauzy-hover-tint);
       padding: 13px;
       border-radius: 8px 8px 0 0;
       margin: -10px -10px 0;

--- a/apps/gauzy/src/app/pages/employee-levels/employee-level.component.html
+++ b/apps/gauzy/src/app/pages/employee-levels/employee-level.component.html
@@ -129,6 +129,7 @@
 			<div class="row mb-3">
 				<div class="col-sm-12 d-flex">
 					<button
+						type="button"
 						class="delete mr-3 ml-3"
 						(click)="ref.close(); disabled = true"
 						nbButton
@@ -138,6 +139,7 @@
 						{{ 'BUTTONS.CANCEL' | translate }}
 					</button>
 					<button
+						type="button"
 						(click)="save(addInput.value); disabled = true; ref.close()"
 						nbButton
 						status="success"
@@ -189,6 +191,7 @@
 			<div class="row mb-3">
 				<div class="d-flex">
 					<button
+						type="button"
 						class="delete mr-3 ml-3"
 						outline
 						(click)="ref.close(); disabled = true"
@@ -198,6 +201,7 @@
 						{{ 'BUTTONS.CANCEL' | translate }}
 					</button>
 					<button
+						type="button"
 						(click)="
 							editEmployeeLevel(selected.employeeLevel.id, editInput.value); disabled = true; ref.close()
 						"

--- a/apps/gauzy/src/app/pages/employee-levels/employee-level.component.html
+++ b/apps/gauzy/src/app/pages/employee-levels/employee-level.component.html
@@ -119,19 +119,33 @@
 					</ga-tags-color-input>
 				</div>
 			</div>
+			<!-- The buttons live inside a column, like the Edit dialog below and
+			     like both dialogs on the sibling Positions page. They used to be
+			     direct children of the `.row`, preceded by an empty full-width
+			     `col-sm-12`: that spacer claimed a line of its own, so the footer
+			     was pushed down by an empty row, and the buttons then sat outside
+			     any column and so 15px left of every other dialog's footer
+			     (Bootstrap's `.row` bleeds past its container on both sides). -->
 			<div class="row mb-3">
-				<div class="col-sm-12"></div>
-				<button class="delete mr-3 ml-3" (click)="ref.close(); disabled = true" nbButton status="basic" outline>
-					{{ 'BUTTONS.CANCEL' | translate }}
-				</button>
-				<button
-					(click)="save(addInput.value); disabled = true; ref.close()"
-					nbButton
-					status="success"
-					[disabled]="addInput.invalid"
-				>
-					{{ 'BUTTONS.SAVE' | translate }}
-				</button>
+				<div class="col-sm-12 d-flex">
+					<button
+						class="delete mr-3 ml-3"
+						(click)="ref.close(); disabled = true"
+						nbButton
+						status="basic"
+						outline
+					>
+						{{ 'BUTTONS.CANCEL' | translate }}
+					</button>
+					<button
+						(click)="save(addInput.value); disabled = true; ref.close()"
+						nbButton
+						status="success"
+						[disabled]="addInput.invalid"
+					>
+						{{ 'BUTTONS.SAVE' | translate }}
+					</button>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/apps/gauzy/src/app/pages/employees/activity/app-url-activity/app-url-activity.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/app-url-activity/app-url-activity.component.scss
@@ -32,8 +32,13 @@
   padding: 20px;
   margin-bottom: 5px;
   border-radius: nb-theme(border-radius);
+  // The column-heading strip. `rgba(white, 0.5)` is a fixed 50 %-white wash: on
+  // the light themes it reads as a faint tint, but on `gauzy-dark` it paints a
+  // near-white block across the top of the list. `gauzy-card-3` is the token for
+  // exactly this — a translucent step over a panel — and it flips to a DARKENING
+  // overlay on the themes whose panels are light-on-dark.
   &.head {
-    background-color: rgba($color: white, $alpha: 0.5);
+    background-color: var(--gauzy-card-3);
     padding: 12px 20px;
   }
   .times {

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-main/edit-employee-main.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-main/edit-employee-main.component.scss
@@ -6,14 +6,21 @@ $radius: nb-theme(border-radius);
   	margin-top: 20px;
 }
 
+// `rgba(126, 126, 143, 0.1)` is the literal value this token carries on the
+// light themes; on `gauzy-dark` the token is a LIFTING white tint instead, so
+// reading it keeps the photo column one visible step off the tab surface there
+// rather than hoping a grey wash shows up on near-black.
 .organization-container {
-  background-color: rgba(126, 126, 143, 0.1);
+  background-color: var(--gauzy-sidebar-background-3);
 }
 
 .organization-photo img {
   width: 100px;
   height: 100px;
-  box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.25);
+  // A 25 %-black drop shadow is invisible against the near-black canvas — this
+  // avatar had no edge at all on `gauzy-dark`. The token is the same hairline
+  // on the light themes and a 1px ring on the dark one.
+  box-shadow: var(--gauzy-shadow);
   object-fit: cover;
   border-radius: $radius;
 }

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.scss
@@ -2,16 +2,23 @@
 
 :host {
   ::ng-deep .tabset-container .route-tabset {
-    overflow-x: scroll;
+    // `auto`, not `scroll`: with nine tabs the strip usually fits, and `scroll`
+    // reserves a scrollbar gutter whether or not there is anything to scroll.
+    overflow-x: auto;
     overflow-y: hidden;
 
+    // `scrollbar-width` and `-ms-overflow-style` apply to the SCROLL CONTAINER,
+    // not to a `::-webkit-scrollbar` pseudo-element — nested inside that rule
+    // (as they were) they matched nothing, so Firefox drew a real scrollbar
+    // across the bottom of the tab strip while Chrome hid it. They belong here.
+    /* Firefox */
+    scrollbar-width: none;
+    /* IE, Edge */
+    -ms-overflow-style: none;
+
+    /* Chrome, Safari, Opera */
     &::-webkit-scrollbar {
-      /* Chrome, Safari, Opera */
       display: none;
-      /* IE, Edge */
-      -ms-overflow-style: none;
-      /* Firefox */
-      scrollbar-width: none;
     }
 
     @media only screen and (max-width: 1280px) {

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-settings/edit-employee-other-settings.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-settings/edit-employee-other-settings.component.scss
@@ -57,10 +57,10 @@
       // there, but on `gauzy-dark` it resolves to a 1px hairline ring instead —
       // a black shadow under a panel that sits on a near-black canvas is
       // invisible, which left these section rows with no edge at all.
-      box-shadow: var(--gauzy-shadow);
+      box-shadow: var(--gauzy-shadow, 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)));
       &.active {
         background: nb-theme(background-basic-color-1);
-        box-shadow: var(--gauzy-shadow) inset;
+        box-shadow: var(--gauzy-shadow, 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18))) inset;
       }
     }
   }

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-settings/edit-employee-other-settings.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-settings/edit-employee-other-settings.component.scss
@@ -52,10 +52,15 @@
       border-radius: nb-theme(button-rectangle-border-radius);
       list-style: none;
       cursor: pointer;
-      box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15);
+      // `gauzy-shadow`, not a literal black drop shadow. The token IS
+      // `0 1px 1px rgb(0 0 0 / 15%)` on the light themes, so nothing moves
+      // there, but on `gauzy-dark` it resolves to a 1px hairline ring instead —
+      // a black shadow under a panel that sits on a near-black canvas is
+      // invisible, which left these section rows with no edge at all.
+      box-shadow: var(--gauzy-shadow);
       &.active {
         background: nb-theme(background-basic-color-1);
-        box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15) inset;
+        box-shadow: var(--gauzy-shadow) inset;
       }
     }
   }
@@ -88,7 +93,11 @@ nb-accordion {
       border-radius: 6px;
       width: 23px;
       height: 23px;
-      border: 1px solid rgba(66, 66, 66, 0.2);
+      // Was `rgba(66, 66, 66, 0.2)`, a DARKENING hairline — invisible on the
+      // near-black canvas, where the accordion chevrons then had no box at all.
+      // `gauzy-border-default-color` is white-at-low-alpha there and the same
+      // grey it was on the light themes.
+      border: 1px solid nb-theme(gauzy-border-default-color);
     }
   }
   & nb-accordion-item-header,
@@ -311,9 +320,12 @@ nb-accordion {
     margin-bottom: 0;
   }
 }
+// `#7e7e8f` is rgb(126, 126, 143), i.e. a hand-copied value of the theme's own
+// `toggle-basic-background-color`. Reading the token instead means the unchecked
+// track follows whichever theme is active rather than staying on one theme's grey.
 :host ::ng-deep .toggle {
-  border: 1px solid #7e7e8f !important;
-  background-color: #7e7e8f !important;
+  border: 1px solid nb-theme(toggle-basic-background-color) !important;
+  background-color: nb-theme(toggle-basic-background-color) !important;
   &.checked {
     background-color: nb-theme(text-primary-color) !important;
     border: 1px solid nb-theme(text-primary-color) !important;

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.html
@@ -6,11 +6,15 @@
           <div class="d-flex align-items-start">
             <ngx-back-navigation></ngx-back-navigation>
             <div class="employee-info">
-              <img
-                class="employee-image"
-                [src]="selectedEmployee?.user?.image?.fullUrl || selectedEmployee?.user?.imageUrl"
-                alt="Employee Avatar"
-                />
+              <!-- Guarded: the image used to render unconditionally, so an
+                   employee with no photo got a broken-image glyph. -->
+              @if (selectedEmployee?.user?.image?.fullUrl || selectedEmployee?.user?.imageUrl; as avatarUrl) {
+                <img class="employee-image" [src]="avatarUrl" alt="Employee Avatar" />
+              } @else {
+                <div class="employee-image-placeholder" aria-hidden="true">
+                  <nb-icon icon="person-outline"></nb-icon>
+                </div>
+              }
                 <div class="employee-details flex-column align-items-start">
                   @if (selectedEmployee?.isVerified) {
                     <nb-icon
@@ -23,8 +27,9 @@
                   <span class="employee-name">
                     {{ selectedEmployee?.user?.name }}
                   </span>
+                  <!-- An em-dash rather than a blank line where no position is set. -->
                   <div class="employee-position">
-                    {{ selectedEmployee?.organizationPosition?.name }}
+                    {{ selectedEmployee?.organizationPosition?.name || '—' }}
                   </div>
                 </div>
               </div>

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.scss
@@ -1,38 +1,53 @@
 @use 'gauzy/_gauzy-cards' as *;
 @use 'gauzy/_gauzy-overrides' as ga-overrides;
 
-.edit-icon {
-  margin-left: 30px;
-  position: relative;
-  width: 36px;
-
-  svg {
-    position: absolute;
-  }
-
-  nb-icon {
-    position: absolute;
-  }
+// The avatar and the name/position block sit side by side. Without this the
+// container is a plain block: the `<img>` makes a line box of its own and the
+// details land UNDER the photo, which is not what the `d-flex align-items-start`
+// on the surrounding row was written for.
+.employee-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
-.employee-image img {
+// Sized on the element that actually carries the class. This was
+// `.employee-image img`, i.e. an `<img>` INSIDE an `.employee-image` box — but
+// the template puts the class on the image itself, so nothing matched and the
+// header rendered the uploaded file at its intrinsic size.
+img.employee-image,
+.employee-image-placeholder {
   width: 48px;
   height: 48px;
+  flex: 0 0 48px;
   object-fit: cover;
+  border-radius: nb-theme(border-radius);
 }
 
-.edit-icon {
-  margin-left: 30px;
-  position: relative;
-  width: 36px;
+// Stand-in for an employee with no photo. The `<img>` used to render
+// unconditionally, so an employee without one got the browser's broken-image
+// glyph in the page header.
+.employee-image-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--gauzy-sidebar-background-3);
+  color: nb-theme(text-hint-color);
+}
 
-  svg {
-    position: absolute;
-  }
+// The page header's own two-step type scale: the name out-ranks body copy, the
+// position is demoted. Both used to inherit body size and weight, so the two
+// lines read as one undifferentiated block.
+.employee-name {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.375rem;
+}
 
-  nb-icon {
-    position: absolute;
-  }
+.employee-position {
+  font-size: 0.8125rem;
+  line-height: 1.125rem;
+  color: nb-theme(text-hint-color);
 }
 
 .edit-public-page {
@@ -56,46 +71,15 @@
   }
 }
 
-.setting-name {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.body-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 35px;
-}
-
-.mutation-card.setting-block {
-  background: #eaf3fc;
-}
-
 .transparent {
   opacity: 0.7;
 }
 
-.settings-body {
-  padding: 35px;
-}
-
-.sub-header {
-  margin-bottom: 20px;
-  font-weight: bold;
-}
-
-.header-content {
-  display: flex;
-
-  .header-info {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 560px;
-    padding-left: 30px;
-  }
-}
+// Removed with this pass, all of them dead: `.edit-icon` (declared twice),
+// `.setting-name`, `.body-header`, `.settings-body`, `.sub-header` and
+// `.header-content` name nothing in this template, and `.mutation-card
+// .setting-block` painted a fixed `#eaf3fc` pale blue that would have been a
+// light panel on the near-black theme had anything ever used it.
 
 .icon-verified {
   margin-right: 5px;

--- a/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.scss
+++ b/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.scss
@@ -10,8 +10,20 @@
 //     forced to stack one per line even when there was room for both.
 // Sizes now come from the shared table-density tokens (`$gauzy-density` in
 // `themes.scss`); the literals are CSS-var fallbacks only.
+
+// The "Not Started" pill. Unlike `.badge-danger` / `.badge-success` this is not
+// a Bootstrap class, so it never got Bootstrap's `color: #fff` and the label
+// inherits the cell's text colour — which on `gauzy-dark` is #fafafa. Against
+// the opaque light grey `#ccc` that was 1.6:1, i.e. an unreadable pill on the
+// one theme where the surrounding text is light.
+//
+// A translucent neutral instead: it darkens a light surface and lightens a dark
+// one, so a single value reads on every theme (the same reasoning as
+// `gauzy-hover-tint` in themes.scss), paired with the muted text colour, which
+// is the right rank for a "no state yet" label.
 .badge-disabled {
-  background-color: #ccc;
+  background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+  color: var(--text-hint-color, rgba(113, 113, 122, 1));
 }
 
 // The pill is sized by padding alone rather than a `min-height`: padding

--- a/apps/gauzy/src/app/pages/employees/timesheet/view/view/view.component.html
+++ b/apps/gauzy/src/app/pages/employees/timesheet/view/view/view.component.html
@@ -1,15 +1,24 @@
 <ng-template ngxPermissionsOnly="CAN_APPROVE_TIMESHEET">
   <nb-card>
-    <nb-card-header class="flex flex-column">
+    <!-- `d-flex`, not `flex`: Bootstrap has no `.flex` utility, so the column
+         direction was being applied to a block. -->
+    <nb-card-header class="d-flex flex-column">
       <div style="display: flex">
         <ngx-back-navigation></ngx-back-navigation>
         <h4>
-          {{ 'MENU.TIMESHEETS' | translate }}
-          <ngx-date-range-title
-            [start]="timesheet.startedAt"
-            [end]="timesheet.stoppedAt"
-            [format]="'dddd, LL'"
-          ></ngx-date-range-title>
+          <!-- Every other page in this area routes its title through
+               `ngx-header-title`, which is what places the breadcrumb trail
+               under the heading and lets the action row share the title's line.
+               This page rendered a bare <h4>, so it had no trail and its
+               buttons took a band of their own. -->
+          <ngx-header-title>
+            {{ 'MENU.TIMESHEETS' | translate }}
+            <ngx-date-range-title
+              [start]="timesheet.startedAt"
+              [end]="timesheet.stoppedAt"
+              [format]="'dddd, LL'"
+            ></ngx-date-range-title>
+          </ngx-header-title>
         </h4>
       </div>
       <div class="gauzy-button-action">

--- a/apps/gauzy/src/app/pages/employees/timesheet/view/view/view.component.scss
+++ b/apps/gauzy/src/app/pages/employees/timesheet/view/view/view.component.scss
@@ -1,3 +1,15 @@
+@use 'themes' as *;
+
+// This page renders the same day/log rows as Daily, Weekly and Timesheet
+// Approvals, but its stylesheet imported none of theirs and re-declared none of
+// the classes the markup uses — so `.custom-header`, `.custom-body`, `.content`
+// and `.log` were all unstyled here, and `.border-bottom` fell through to
+// Bootstrap's own `1px solid #dee2e6`: a fixed light hairline under every row,
+// which is a bright line on the near-black canvas.
+//
+// The rules are spelled out here rather than pulled in with a `@forward` of the
+// daily/weekly chain: that chain also carries `@shared/_pg-card` and a set of
+// card-height overrides this page does not want.
 :host {
     nb-card {
         height: calc(100vh - 13rem);
@@ -12,5 +24,63 @@
             overflow: auto;
             background-color: var(--gauzy-card-2);
         }
+    }
+
+    // Column labels above each day's rows — same muted strip as Daily/Weekly.
+    .custom-header {
+        font-size: 12px;
+        font-weight: 600;
+        line-height: 15px;
+        letter-spacing: 0em;
+        text-align: left;
+        color: nb-theme(gauzy-text-color-2);
+        background: var(--gauzy-card-4);
+        border-radius: nb-theme(border-radius);
+        padding: 10px 10px 10px 12px;
+        flex-wrap: nowrap;
+    }
+
+    // No `overflow`/`height` here on purpose: the card body above is already the
+    // scroll container, and one `.custom-body` is rendered per DAY, so making
+    // each of them scroll would put a second scrollbar inside the page's own.
+    .custom-body {
+        border-radius: nb-theme(border-radius);
+        margin-top: 6px;
+        @include nb-ltr(padding-right, 0.5rem);
+        @include nb-rtl(padding-left, 0.5rem);
+
+        .content {
+            background-color: var(--gauzy-card-3);
+            border-radius: var(--border-radius);
+            @include nb-ltr(padding-left, 12px);
+            @include nb-rtl(padding-right, 12px);
+        }
+
+        // Out-ranks Bootstrap's `.border-bottom` utility, which is `!important`.
+        .border-bottom {
+            border-bottom: 1px solid var(--gauzy-border-default-color) !important;
+        }
+    }
+
+    .project-name {
+        flex: 0 0 20%;
+        max-width: 20%;
+    }
+
+    // The log-type chip ("Manual" / "Tracked"), same pill as on Daily.
+    .log {
+        width: fit-content;
+        font-size: 12px;
+        font-weight: 600;
+        line-height: 15px;
+        letter-spacing: 0em;
+        text-align: left;
+        padding: 3px 8px;
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+        border-radius: nb-theme(border-radius);
+        background: var(--gauzy-sidebar-background-3);
     }
 }

--- a/apps/gauzy/src/app/pages/employees/timesheet/weekly/weekly/weekly.component.scss
+++ b/apps/gauzy/src/app/pages/employees/timesheet/weekly/weekly/weekly.component.scss
@@ -64,8 +64,12 @@
         @include nb-ltr(padding-left, 12px);
         @include nb-rtl(padding-right, 12px);
       }
+      // Out-ranks Bootstrap's `.border-bottom` utility (a fixed `#dee2e6`),
+      // which is `!important`. The value now comes from the border token rather
+      // than being a hand-copy of what that token happens to be on the light
+      // themes.
       .border-bottom {
-        border-bottom: 1px solid rgba(126, 126, 143, 0.1) !important;
+        border-bottom: 1px solid var(--gauzy-border-default-color) !important;
       }
 
       [nbButton].appearance-outline.status-primary {
@@ -76,9 +80,14 @@
         cursor: pointer;
       }
 
+      // The 6px bar down the left edge that marks the selected row. It was
+      // `rgba(48, 48, 120, 0.2)` — a 20 %-opaque navy, which on the near-black
+      // canvas is all but the canvas itself, so the selection marker vanished
+      // on the dark themes. The primary transparent tint is the app's own
+      // "selected" colour and carries on both.
       .selected {
         background-color: var(--gauzy-sidebar-background-3);
-        box-shadow: -6px 0 0 0 rgba(48, 48, 120, 0.2);
+        box-shadow: -6px 0 0 0 var(--color-primary-transparent-default);
         border-radius: var(--border-radius) 0 0 var(--border-radius);
 
         &.border-bottom {

--- a/apps/gauzy/src/app/pages/equipment-sharing/equipment-sharing.component.scss
+++ b/apps/gauzy/src/app/pages/equipment-sharing/equipment-sharing.component.scss
@@ -1,96 +1,16 @@
 @forward '@shared/_pg-card';
 
-/* Card grid */
-
-.flex-container {
-  display: flex;
-  flex-wrap: wrap;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-
-.flex-item {
-  border: 0.0625rem solid #e4e9f2;
-  border-radius: 0.25rem;
-  width: 350px;
-  margin-top: 10px;
-  margin-right: 10px;
-}
-
-.info-line {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  font-size: 0.7em;
-  color: darkgray;
-  line-height: 0px;
-  padding: 1rem 1.5rem;
-
-  .info-meta {
-    margin-right: 10px;
-  }
-
-  .info-value {
-    display: flex;
-    justify-content: flex-end;
-    text-align: end;
-    color: black;
-    font-size: 1em;
-  }
-}
-
-.card-footer {
-  justify-content: space-around;
-  display: flex;
-}
-
-/* Status */
-
-.badge-danger {
-  text-align: center;
-  padding: 10px;
-  background-color: #dc3545;
-  border-radius: 13px;
-  color: #fff;
-}
-
-.badge-success {
-  text-align: center;
-  padding: 10px;
-  background-color: #28a745;
-  border-radius: 13px;
-  color: #fff;
-}
-
-.badge-warning {
-  text-align: center;
-  padding: 10px;
-  background-color: #ffc107;
-  border-radius: 13px;
-  color: #fff;
-}
-
-.badge-danger-card {
-  text-align: center;
-  padding: 10px;
-  background-color: #ff3d71;
-  border-radius: 0.45rem;
-  color: #fff;
-}
-
-.badge-success-card {
-  text-align: center;
-  padding: 10px;
-  background-color: #00d68f;
-  border-radius: 0.45rem;
-  color: #fff;
-}
-
-.badge-warning-card {
-  text-align: center;
-  padding: 10px;
-  background-color: #fa0;
-  border-radius: 0.45rem;
-  color: #fff;
-}
+// Everything else this sheet used to hold was a hand-rolled card grid
+// (`.flex-container` / `.flex-item` / `.info-line` / `.card-footer`) and six
+// status pills (`.badge-danger` … `.badge-warning-card`), carrying eleven
+// literal colours between them — #e4e9f2, #dc3545, #28a745, #ffc107, #ff3d71,
+// #00d68f, #fa0, #fff, `black` and `darkgray`.
+//
+// None of it renders any more, in either layout:
+//   * the grid is `<ga-card-grid>` (shared, themed) as of the template rewrite;
+//   * the status column is `StatusBadgeComponent`, and `statusMapper()` in the
+//     component hands it the bare status names 'success' / 'danger' / 'warning',
+//     never a `badge-*` class.
+// The `badge-*` names that the e2e page objects do select (`div.badge-success`
+// and friends, in the Invoices / Estimates / Proposals / Candidates specs) are
+// painted by those pages, not by this component-scoped sheet.

--- a/apps/gauzy/src/app/pages/expenses/expense-categories/expense-categories.component.scss
+++ b/apps/gauzy/src/app/pages/expenses/expense-categories/expense-categories.component.scss
@@ -110,7 +110,7 @@ nb-card-body {
     background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
   }
 
-  &:hover {
+  &:hover:not(.selected) {
     background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
   }
 }

--- a/apps/gauzy/src/app/pages/expenses/expense-categories/expense-categories.component.scss
+++ b/apps/gauzy/src/app/pages/expenses/expense-categories/expense-categories.component.scss
@@ -97,14 +97,21 @@ nb-card-body {
   border-radius: nb-theme(border-radius);
   cursor: pointer;
 
+  // Both states were painted with literal copies of the LIGHT themes' surface
+  // values — `rgba(50, 50, 50, 0.03)` is `gauzy-card-2` from the light maps, and
+  // the rail is 10 % black. Over the dark themes' near-black card neither shows,
+  // so hovering and selecting a category looked identical to doing nothing. The
+  // shared hover/active tints are one translucent neutral that darkens a light
+  // surface and lightens a dark one, and the rail takes the primary accent (same
+  // treatment as the recurring-expense blocks).
   &.selected {
-    @include nb-ltr(border-left, 6px solid rgb(50 50 50 / 10%));
-    @include nb-rtl(border-right, 6px solid rgb(50 50 50 / 10%));
-    background: rgba(50, 50, 50, 0.03);
+    @include nb-ltr(border-left, 6px solid nb-theme(color-primary-default));
+    @include nb-rtl(border-right, 6px solid nb-theme(color-primary-default));
+    background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
   }
 
   &:hover {
-    background: rgba(50, 50, 50, 0.03);
+    background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
   }
 }
 

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.scss
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.scss
@@ -1,70 +1,24 @@
+// `@shared/_pg-card` forwards `gauzy/_gauzy-table`, so this page already receives
+// the shared `.action` / `.actions` / `.gauzy-button-container` /
+// `.card-custom-header` rules — the same ones Income, Payments and Received
+// invoices get. This file used to carry a near-verbatim copy of that block plus a
+// card-body height override on top of them. All of it is gone:
+//
+//   * `.action.info` (`#0088fe`), `.action.success` and `.action.warning` (literal
+//     greens and oranges) were hard-coded colours on classes this page's template
+//     never uses — its toolbar only carries `.action`, `.action.primary`,
+//     `.action.primary.soft` and `.action.secondary`.
+//   * `.actions { margin-right: 20px }` inset this page's toolbar 20px from the
+//     card edge; the sibling list pages, which take the shared `.actions`
+//     unmodified, sit flush.
+//   * `.card-custom-header`, `.gauzy-button-container` and `button` were
+//     character-for-character copies of the shared rules.
+//   * every `nb-theme(...)` call in the copy compiled to a plain CSS function and
+//     was dropped by the browser: this file only ever `@forward`ed, which
+//     re-exports to importers without bringing anything into its own scope.
+//   * `:host nb-card-body { overflow: unset; height: calc(100vh - 17.5rem)
+//     !important }` — a hand-tuned viewport constant that out-ranked the flex
+//     column `_pg-card` gives every other list page, so the Expenses table was a
+//     different height from its siblings and had back the problem the shared
+//     partial exists to solve (a gap under a short table, a clipped long one).
 @forward '@shared/_pg-card';
-
-// Same hairline ring as the shared `.action` block in `gauzy/_gauzy-table.scss`
-// — this file carries a verbatim copy of it.
-.action {
-  box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
-  &[nbButton].appearance-filled.status-basic {
-    background-color: var(--gauzy-card-2);
-  }
-  &.info {
-    background-color: #0088fe;
-  }
-  &.secondary {
-    color: var(--text-hint-color);
-  }
-  &.success {
-    color: rgba(37, 184, 105, 1);
-  }
-  &.warning {
-    color: rgba(245, 109, 88, 1);
-  }
-  &.primary {
-    &[nbButton].appearance-filled.status-basic,
-    .appearance-filled.status-basic[nbButtonToggle] {
-      color: nb-theme(text-primary-color);
-    }
-    &.soft {
-      &[nbButton].appearance-filled.status-basic {
-        background-color: rgba(110, 73, 232, 0.1);
-      }
-    }
-  }
-  &.select-nb ::ng-deep {
-    box-shadow: none;
-    .select-button {
-      box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
-      background: var(--gauzy-card-2);
-    }
-  }
-}
-
-button {
-  margin: 5px;
-}
-
-.actions {
-  background: var(--gauzy-card-2);
-  border-radius: nb-theme(button-rectangle-border-radius);
-  padding: 0 1px;
-  margin-right: 20px;
-}
-
-.gauzy-button-container {
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
-  padding-bottom: 0;
-}
-
-.card-custom-header {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding-bottom: 0;
-}
-
-:host nb-card-body {
-  overflow: unset;
-  height: calc(100vh - 17.5rem) !important;
-}

--- a/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
+++ b/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
@@ -24,8 +24,12 @@
       }
     }
   }
+  // `rgba(126, 126, 143, 0.1)` is the literal `--gauzy-sidebar-background-3`
+  // happens to hold in the LIGHT themes only; on `gauzy-dark` that token is a
+  // white-at-low-alpha lift precisely because a mid-grey overlay reads wrong on
+  // a near-black panel. Name the token so the footer follows the theme.
   .custom-footer {
-    background-color: rgba(126, 126, 143, 0.1);
+    background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
     padding-bottom: 5px;
   }
   .custom-header {

--- a/apps/gauzy/src/app/pages/help-center/add-article/add-article.component.scss
+++ b/apps/gauzy/src/app/pages/help-center/add-article/add-article.component.scss
@@ -20,9 +20,12 @@
   width: 50%;
 }
 
+// Was `#8f9bb3` (Nebular's old blue-grey `color-basic-600`) and a hard-coded
+// `Open Sans` face. The themes moved secondary text onto a neutral ramp and the
+// app onto Inter, so this label was the only blue-grey, wrong-face text in the
+// dialog. `--text-hint-color` is the token that paints every other caption.
 .select-label {
-  color: #8f9bb3;
-  font-family: Open Sans, sans-serif;
+  color: var(--text-hint-color);
   font-size: 0.75rem;
   font-weight: 700;
   line-height: 1rem;
@@ -91,9 +94,13 @@
     }
   }
 
+  // Unchecked toggle track. `#7e7e8f` is the literal behind
+  // `toggle-basic-background-color` in the gauzy themes; spelled as the token it
+  // also follows the six other registered themes instead of painting one grey
+  // everywhere.
   ::ng-deep .toggle {
-    border: 1px solid #7E7E8F !important;
-    background-color: #7E7E8F !important;
+    border: 1px solid var(--toggle-basic-background-color) !important;
+    background-color: var(--toggle-basic-background-color) !important;
 
     &.checked {
       background-color: var(--text-primary-color) !important;

--- a/apps/gauzy/src/app/pages/help-center/help-center.component.scss
+++ b/apps/gauzy/src/app/pages/help-center/help-center.component.scss
@@ -65,7 +65,7 @@
 }
 
 // The DRAFT pill sat beside the EMPLOYEES (`.privacy`) pill with a hard-coded
-// `#aaaeb3` fill while its neighbour already resolved `--color-primary-default`
+// `#aaaeb3` fill while the control beside it already resolved `--color-primary-default`
 // — the one chip on the page that ignored the theme, and white-on-#aaaeb3 is
 // 2.2:1 besides. DRAFT is not a status with a colour, it is the ABSENCE of
 // publication, so it reads as a neutral chip now: the same low-alpha tint the

--- a/apps/gauzy/src/app/pages/help-center/help-center.component.scss
+++ b/apps/gauzy/src/app/pages/help-center/help-center.component.scss
@@ -189,7 +189,7 @@ h6 {
       background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
     }
 
-    &:hover {
+    &:hover:not(.selected) {
       background: var(--gauzy-card-2);
     }
   }

--- a/apps/gauzy/src/app/pages/help-center/help-center.component.scss
+++ b/apps/gauzy/src/app/pages/help-center/help-center.component.scss
@@ -64,10 +64,18 @@
   flex-direction: row;
 }
 
+// The DRAFT pill sat beside the EMPLOYEES (`.privacy`) pill with a hard-coded
+// `#aaaeb3` fill while its neighbour already resolved `--color-primary-default`
+// — the one chip on the page that ignored the theme, and white-on-#aaaeb3 is
+// 2.2:1 besides. DRAFT is not a status with a colour, it is the ABSENCE of
+// publication, so it reads as a neutral chip now: the same low-alpha tint the
+// rest of the app uses for a quiet fill, with ordinary body text on it. Works
+// out on both the light card and the near-black one, and stays visibly
+// subordinate to the filled purple pill next to it.
 .draft {
   padding: 0 0.4rem;
-  color: #fff;
-  background-color: #aaaeb3;
+  color: var(--text-basic-color);
+  background-color: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
   margin-left: 10px;
   border-radius: 12px;
   font-size: 14px;
@@ -76,9 +84,12 @@
   text-align: center;
 }
 
+// Filled with the theme primary already; only the label was a literal `#fff`.
+// `--text-control-color` is Nebular's token for text on a filled status chip
+// (it is `#ffffff` in every registered theme, so nothing moves here).
 .privacy {
   padding: 0 0.4rem;
-  color: #fff;
+  color: var(--text-control-color);
   background-color: var(--color-primary-default);
   margin-left: 10px;
   border-radius: 12px;
@@ -166,9 +177,16 @@ h6 {
     text-align: left;
     cursor: pointer;
 
+    // Selection marker. Was a DARKENING overlay — rgba(50,50,50,.1) for the
+    // left bar and rgba(50,50,50,.03) for the fill — which is invisible on the
+    // near-black `gauzy-dark` canvas, and darker than the `--gauzy-card-2`
+    // hover fill below it, so a hovered row read as "more selected" than the
+    // selected one. `--gauzy-active-tint` is the registered token for exactly
+    // this (a neutral at twice the hover alpha, so it darkens a light surface
+    // and lightens a dark one) and is what the sidebar's current row uses.
     &.selected {
-      box-shadow: -8px 0px 0px 0px rgba(50, 50, 50, 0.1);
-      background: rgba(50, 50, 50, 0.03);
+      box-shadow: -8px 0px 0px 0px var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+      background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
     }
 
     &:hover {
@@ -195,8 +213,18 @@ h6 {
     }
   }
 
+  // The empty state stands in for `.table-scroll`, so it has to measure the
+  // same box. It was 6rem TALLER (`100vh - 15rem` against the list's
+  // `100vh - 21rem`), which showed up twice: as a direct child of the card body
+  // it made an empty Help Center card taller than a full one, and in the
+  // `@empty` branch — where it renders INSIDE `.table-scroll` — it forced that
+  // container into a 6rem scroll just to show "no matching articles".
+  // `max-height: 100%` bounds it whenever the parent has a definite height
+  // (the nested case) and resolves to `none` when it does not (the card-body
+  // case), the same treatment `.card-scroll` gets in styles/_overrides.scss.
   .no-data {
-    height: calc(100vh - 15rem);
+    height: calc(100vh - 21rem);
+    max-height: 100%;
     padding: 0 0.5rem;
   }
 

--- a/apps/gauzy/src/app/pages/integrations/components/integration-list/list.component.scss
+++ b/apps/gauzy/src/app/pages/integrations/components/integration-list/list.component.scss
@@ -36,8 +36,13 @@
 					font-size: 13px;
 					color: var(--gauzy-text-color-2);
 				}
+				// Was `rgba(50, 50, 50, 0.03)` — 3% black. Over `--gauzy-card-1` that
+				// is a faint grey on the light themes and effectively nothing on the
+				// near-black ones, so an integration row gave no hover feedback at all
+				// in dark. `--gauzy-hover-tint` is the shared translucent neutral: it
+				// darkens a light surface and lightens a dark one.
 				&:hover {
-					background: rgba(50, 50, 50, 0.03);
+					background: var(--gauzy-hover-tint);
 				}
 				img {
 					width: 100%;

--- a/apps/gauzy/src/app/pages/integrations/integrations.component.html
+++ b/apps/gauzy/src/app/pages/integrations/integrations.component.html
@@ -91,11 +91,18 @@
 									[class.disabled]="integration.isComingSoon"
 									[routerLink]="['../', integration.redirectUrl]"
 								>
+									<!--
+										`alt` was the literal string "image not found", so a logo
+										that failed to load rendered those words inside the tile —
+										the broken-image state told the user nothing about which
+										integration the tile was. The integration name is both the
+										correct alternative text and a usable fallback.
+									-->
 									<img
 										[src]="integration.fullImgUrl"
 										width="100%"
 										height="100%"
-										alt="image not found"
+										[alt]="integration.name | replace: '_' : ' '"
 										[title]="integration.name | replace: '_' : ' '"
 									/>
 									@if (integration.isComingSoon) {

--- a/apps/gauzy/src/app/pages/integrations/integrations.component.scss
+++ b/apps/gauzy/src/app/pages/integrations/integrations.component.scss
@@ -52,11 +52,15 @@
 }
 
 
+// Search + filter strip, separated from the integration tiles by a hairline.
+// The 38px of padding under the controls plus 37px of margin under the rule left
+// 75px of empty band across the page — two off-by-one magic numbers from before
+// the density pass, not a deliberate rhythm. One rem either side of the rule.
 .integration-filters {
   display: flex;
-  margin-bottom: 37px;
+  margin-bottom: 1rem;
   box-shadow: 0 1px 0 0 var(--gauzy-border-default-color);
-  padding-bottom: 38px;
+  padding-bottom: 1rem;
 }
 
 .group-select {
@@ -111,16 +115,26 @@ img {
   overflow: hidden;
 }
 
+// The "coming soon" corner ribbon.
+//
+// Its top gradient stop already read `--text-primary-color`, but the bottom stop
+// and both fold triangles were literal purples (`rgb(101,105,223)` /
+// `rgb(103,63,189)`) sampled from the default theme's accent. Anywhere the accent
+// is not that purple — the material themes ship a different primary entirely —
+// the ribbon faded from the theme colour into a stray blue-violet and folded back
+// in a third colour again. All three now come from the same primary ramp, so the
+// ribbon is one colour family in every theme. The white label stays literal: it
+// sits on a saturated fill, not on a theme surface.
 .coming-soon {
   position: absolute;
   width: 130px;
   transform: rotate(45deg);
   top: 25px;
   right: -27px;
-  background: linear-gradient(var(--text-primary-color), rgb(101, 105, 223) 100%);
+  background: linear-gradient(var(--color-primary-500), var(--color-primary-600) 100%);
   box-shadow: #000 0px 3px 10px -5px;
   line-height: 25px;
-  color: rgb(255, 255, 255);
+  color: #fff;
   font-size: 10px;
   font-weight: bold;
   text-transform: uppercase;
@@ -131,10 +145,10 @@ img {
     position: absolute;
     left: 0px;
     top: 100%;
-    border-left: 3px solid rgb(103, 63, 189);
+    border-left: 3px solid var(--color-primary-700);
     border-right: 3px solid transparent;
     border-bottom: 3px solid transparent;
-    border-top: 3px solid rgb(103, 63, 189);
+    border-top: 3px solid var(--color-primary-700);
   }
 
   &::after {
@@ -143,9 +157,9 @@ img {
     right: 0px;
     top: 100%;
     border-left: 3px solid transparent;
-    border-right: 3px solid rgb(103, 63, 189);
+    border-right: 3px solid var(--color-primary-700);
     border-bottom: 3px solid transparent;
-    border-top: 3px solid rgb(103, 63, 189);
+    border-top: 3px solid var(--color-primary-700);
   }
 }
 

--- a/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item-variant/variant-form.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item-variant/variant-form.component.scss
@@ -8,7 +8,9 @@
 .product-variant-photo {
   width: 100%;
   height: 15rem;
-  background-color: white;
+  // Was a literal `white`. A variant usually has no image, in which case this
+  // 15rem well IS what the user sees — a bright white block on the dark themes.
+  background-color: var(--gauzy-card-1);
   overflow: hidden;
   position: relative;
   border-radius: var(--border-radius);

--- a/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item/options-form/options-form.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item/options-form/options-form.component.scss
@@ -27,8 +27,14 @@
   }
 }
 
+// The edit / remove icons on an option row. `color-basic-300` is #edf1f7 in
+// every registered theme (it is a fixed palette step, not a role token), and
+// the row it sits on is `--gauzy-sidebar-background-3` — a pale grey on the
+// light themes. Near-white on pale grey is an invisible control; the icons only
+// appeared at all on hover, when the rule below repaints them. Match the row's
+// own label colour instead.
 .option-row-icon {
-  color: nb-theme(color-basic-300);
+  color: var(--text-hint-color);
 }
 
 .option-group-form {

--- a/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item/product-form.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item/product-form.component.scss
@@ -95,7 +95,11 @@ nb-card-footer {
 
 .product-photo {
   width: 100%;
-  background-color: white;
+  // Was a literal `white`: with no featured image yet, this well is the visible
+  // surface, so on the dark themes it rendered as a bright white slab in the
+  // middle of a near-black form. `--gauzy-card-1` is the panel colour, i.e. what
+  // every other empty box on this page already resolves to.
+  background-color: var(--gauzy-card-1);
   overflow: hidden;
   position: relative;
 

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/description/description.component.css
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/description/description.component.css
@@ -4,5 +4,10 @@
 	line-height: 15px;
 	letter-spacing: 0em;
 	text-align: left;
-	color: var(--gauzy-color-text-2);
+	/* `--gauzy-color-text-2` is not a theme token — the registered name is
+	   `--gauzy-text-color-2` (styles/themes.scss). The old var() named nothing,
+	   so the declaration was dropped and the description inherited the cell
+	   colour instead of reading as a caption. The fallback covers the two
+	   material themes, which never define the gauzy text tokens. */
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 }

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/item-img-tags-row.component.ts
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/item-img-tags-row.component.ts
@@ -94,7 +94,11 @@ import { ComponentLayoutStyleEnum } from '@gauzy/contracts';
 				line-height: 17px;
 				letter-spacing: 0em;
 				text-align: left;
-				color: var(--gauzy-color-text-1);
+				/* was var(--gauzy-color-text-1): not a registered token (the name is
+				   --gauzy-text-color-1), so the declaration was invalid at
+				   computed-value time and dropped. Fallback covers the two material
+				   themes, which never define the gauzy text tokens. */
+				color: var(--gauzy-text-color-1, var(--text-basic-color));
 				margin-bottom: 4px;
 			}
 		`

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/name-with-description/name-with-description.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/name-with-description/name-with-description.component.scss
@@ -1,10 +1,20 @@
+// `--gauzy-color-text-1` / `--gauzy-color-text-2` are NOT theme tokens — the
+// registered names are `--gauzy-text-color-1` / `--gauzy-text-color-2` (see
+// styles/themes.scss). A `color` declaration whose var() names an undefined
+// custom property is invalid at computed-value time and is dropped, so both
+// lines here used to inherit the cell colour: the name and its description
+// rendered as one flat block instead of a value/caption pair.
+//
+// The fallbacks matter: the gauzy text tokens only exist in 6 of the 8
+// registered themes (the two material ones never define them) — same reason
+// the ng-select rules in styles/_overrides.scss resolve `text-basic-color`.
 .name {
     font-size: 14px;
     font-weight: 600;
     line-height: 17px;
     letter-spacing: 0em;
     text-align: left;
-    color: var(--gauzy-color-text-1);
+    color: var(--gauzy-text-color-1, var(--text-basic-color));
     margin-bottom: 4px;
 }
 
@@ -14,5 +24,5 @@
     line-height: 15px;
     letter-spacing: 0em;
     text-align: left;
-    color: var(--gauzy-color-text-2);
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
 }

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/no-image/no-image.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/no-image/no-image.component.scss
@@ -1,3 +1,22 @@
+// `ga-no-image` had no host styling at all, so the element defaulted to
+// `display: inline` — and width/height do not apply to a non-replaced inline
+// box. Inside the two table-cell renderers that use it the parent happens to be
+// `display: flex`, which blockifies the host and hid the problem; the five
+// places that drop it into a plain image WELL got a placeholder that collapsed
+// to a single text line pinned to the top-left of an otherwise empty box:
+//   * the inventory item form's gallery (a 260px / 180px well),
+//   * the item view page (300px),
+//   * the variant form (15rem),
+//   * the merchant and warehouse forms (300px, via `.store-image`).
+// Filling the well is the whole point of a placeholder, so claim the box here.
+// Consumers that DO size the host keep winning: their rule is a class scoped by
+// the parent's content attribute, (0,2,0) against `:host`'s (0,1,0).
+:host {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
 .no-image {
     width: 100%;
     height: 100%;

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/no-image/no-image.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/no-image/no-image.component.scss
@@ -29,7 +29,7 @@
     line-height: 11px;
     letter-spacing: 0em;
     text-align: left;
-    color: var(--gauzy-text-color-2);
+    color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 }
 
 .content {

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/no-image/no-image.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/no-image/no-image.component.scss
@@ -1,7 +1,7 @@
 // `ga-no-image` had no host styling at all, so the element defaulted to
 // `display: inline` — and width/height do not apply to a non-replaced inline
 // box. Inside the two table-cell renderers that use it the parent happens to be
-// `display: flex`, which blockifies the host and hid the problem; the five
+// `display: flex`, which forces the host to a block box and hid the problem; the five
 // places that drop it into a plain image WELL got a placeholder that collapsed
 // to a single text line pinned to the top-left of an otherwise empty box:
 //   * the inventory item form's gallery (a 260px / 180px well),

--- a/apps/gauzy/src/app/pages/inventory/components/manage-product-types/product-types.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/manage-product-types/product-types.component.scss
@@ -1,77 +1,45 @@
 @use '@shared/_pg-card' as *;
 
-// Same hairline ring as the shared `.action` block in `gauzy/_gauzy-table.scss`
-// — this file carries a verbatim copy of it.
-.action {
-  box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+// `@shared/_pg-card` forwards `gauzy/_gauzy-table`, so the shared `.action`,
+// `.actions`, `button`, `.gauzy-button-container` and `.card-custom-header`
+// rules are ALREADY emitted into this component's sheet by the line above.
+//
+// This file (and, through `@forward`, product categories, merchants,
+// warehouses and the inventory items table) used to restate all of them, and
+// the copy had drifted away from the shared block it was taken from:
+//   * `.info` → a bare `background-color: #0088fe`, where the shared block
+//     resolves `color-info-default`, gates it on the filled/basic pair, and
+//     also sets a readable `color: white`. A button here would have got a raw
+//     blue fill with whatever text colour it inherited.
+//   * `.success` → `rgba(37, 184, 105, 1)`, the literal that
+//     `color-success-default` happens to hold in the two gauzy themes and in
+//     none of the other six.
+//   * `.warning` → `rgba(245, 109, 88, 1)`; `.primary.soft` →
+//     `rgba(110, 73, 232, 0.1)`.
+// Being second in the sheet, the copy won every one of those. Deleted, so the
+// themed definitions apply — including on any button these pages grow later.
+//
+// Whatever remains below is what genuinely differs from the shared defaults.
 
-  &[nbButton].appearance-filled.status-basic {
-    background-color: var(--gauzy-card-2);
-  }
-
-  &.info {
-    background-color: #0088fe;
-  }
-
-  &.secondary {
-    color: var(--text-hint-color);
-  }
-
-  &.success {
-    color: rgba(37, 184, 105, 1);
-  }
-
-  &.warning {
-    color: rgba(245, 109, 88, 1);
-  }
-
-  &.primary {
-    &[nbButton].appearance-filled.status-basic,
-    .appearance-filled.status-basic[nbButtonToggle] {
-      color: nb-theme(text-primary-color);
-    }
-
-    &.soft {
-      &[nbButton].appearance-filled.status-basic {
-        background-color: rgba(110, 73, 232, 0.1);
-      }
-    }
-  }
-
-  &.select-nb ::ng-deep {
-    box-shadow: none;
-
-    .select-button {
-      box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
-      background: var(--gauzy-card-2);
-    }
+// The one rule kept from the copy, and deliberately: the shared block writes
+// `.action.primary { color: … }` at (0,2,0), which does NOT out-rank Nebular's
+// own `[nbButton].appearance-filled.status-basic` text colour at (0,3,0). This
+// selector does, and the Edit button on these five tables (product types,
+// product categories, merchants, warehouses, inventory items) is styled by it.
+// Now resolves the same token the shared block names instead of a literal.
+.action.primary {
+  &[nbButton].appearance-filled.status-basic,
+  .appearance-filled.status-basic[nbButtonToggle] {
+    color: nb-theme(text-primary-color);
   }
 }
 
-button {
-  margin: 5px;
-}
-
+// The Edit/Delete group is inset from the card's right edge (the shared block
+// only sets the fill and radius). Note the shared `.actions` padding carries
+// `!important`, so the `padding: 0 1px` that used to sit here never applied.
 :host .actions {
-  background: var(--gauzy-card-2);
-  border-radius: nb-theme(button-rectangle-border-radius);
-  padding: 0 1px;
   @include nb-ltr(margin-right, 20px);
   @include nb-rtl(margin-left, 20px);
-}
-
-.gauzy-button-container {
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
-  padding-bottom: 0;
-}
-
-.card-custom-header {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding-bottom: 0;
 }
 
 nb-card-body {

--- a/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.html
+++ b/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.html
@@ -75,7 +75,11 @@
 							<span class="key-description mb-2">{{ 'INVENTORY_PAGE.TAGS' | translate }}:</span>
 							<div class="inventory-item-tags">
 								@for (tag of inventoryItem.tags; track tag.id) {
-								<div class="tag-item" [style.background]="tag.color">
+								<div
+									class="tag-item"
+									[style.background]="tag.color"
+									[style.color]="backgroundContrast(tag.color)"
+								>
 									{{ tag.name }}
 								</div>
 								}

--- a/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.scss
@@ -2,9 +2,19 @@
   width: 100%;
 }
 
+// Label column for the Name/Description/Type/Category/Enabled/Options rows.
+// This was a hard `width: 6rem` on an inline-block with visible overflow, so
+// any label wider than 96px — "Description:" is already ~90px at 14px/600, and
+// every non-English translation of it is longer — spilled out of its box and
+// ran underneath the value that follows it on the same line. `min-width` keeps
+// the values aligned in the common case and lets the long ones push instead of
+// collide.
 .key-description {
   font-weight: 600;
-  width: 6rem;
+  min-width: 6rem;
+  // Logical, so it mirrors in RTL without pulling the nb-ltr/nb-rtl mixins
+  // (and their `themes` dependency) into a sheet that has no other use for them.
+  padding-inline-end: 0.5rem;
   display: inline-block;
 }
 
@@ -18,30 +28,36 @@ img.gallery-sm-preview-item {
   }
 }
 
+// The option chips were `#3366ff` — Nebular's stock blue, not the app's primary
+// (`#6e49e8`), and hard-coded either way, so they were the only blue thing on a
+// purple page and identical in all eight themes. `7px` was also off the radius
+// scale; `--gauzy-radius-sm` is the step every other chip/control uses.
 .option-item {
   padding: 5px 10px;
   font-size: 12px;
-  background: #3366ff;
-  border-radius: 7px;
-  color: #fff;
+  background: var(--color-primary-default);
+  border-radius: var(--gauzy-radius-sm, 6px);
+  color: var(--text-control-color);
   margin-right: 10px;
   display: flex;
   align-items: center;
   margin-bottom: 10px;
 }
 
+// Tag colour is user-chosen and painted inline by the template, so a fixed
+// white label was unreadable on every light tag. The text colour is picked per
+// tag now (see `backgroundContrast()` in the component, the same
+// `getContrastColor` helper the inventory table cells already use).
 .tag-item {
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 11px;
-  font-weight: 600;
   line-height: 13px;
   letter-spacing: 0em;
 
   display: flex;
   align-items: center;
   text-align: center;
-  color: white;
   font-weight: bold;
   width: fit-content;
 }

--- a/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.ts
+++ b/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.ts
@@ -6,6 +6,7 @@ import { LocalDataSource } from 'angular2-smart-table';
 import { TranslateService } from '@ngx-translate/core';
 import { combineLatest } from 'rxjs';
 import { IImageAsset, IProductOptionTranslatable, IProductTranslatable, LanguagesEnum } from '@gauzy/contracts';
+import { getContrastColor } from '@gauzy/ui-core/common';
 import { ProductService, TranslatableService } from '@gauzy/ui-core/core';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 import { Store } from '@gauzy/ui-core/core';
@@ -111,6 +112,20 @@ export class InventoryItemViewComponent extends TranslationBaseComponent impleme
 			},
 			dialogClass: 'fullscreen'
 		});
+	}
+
+	/**
+	 * Readable label colour for a tag chip.
+	 *
+	 * Tag colours are user-chosen, so the chip's label cannot be a fixed white —
+	 * it disappeared on every light tag. Same helper the inventory table cells
+	 * use for the same chips.
+	 */
+	backgroundContrast(bgColor: string): string | null {
+		// `getContrastColor` indexes into the string, so a tag saved without a
+		// colour would throw. Returning null drops the style binding and the chip
+		// simply inherits, which is what it did before.
+		return bgColor ? getContrastColor(bgColor) : null;
 	}
 
 	getTranslatedProp(item: any, prop: string) {

--- a/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.html
@@ -322,6 +322,11 @@
                 <div class="block">
                   <div class="row group d-flex flex-column">
                     <label class="label label-group">{{ 'INVOICES_PAGE.DISCOUNT' | translate }}</label>
+                    <!-- The group is a flex COLUMN, so the two half-width fields only sit side by
+                         side inside a nested `.row` — exactly how the taxes group below and the
+                         edit screen already lay theirs out. Without it, Discount value and
+                         Discount type stacked full width and the block was twice as tall. -->
+                    <div class="row">
                     <div class="col-sm-6">
                       <div class="form-group">
                         <label for="inputDiscountValue" class="label">{{
@@ -361,6 +366,7 @@
                           </nb-select>
                         </div>
                       </div>
+                    </div>
                     </div>
 
                     <div class="row group d-flex flex-column">
@@ -512,15 +518,14 @@
                   }
                 </nb-card-body>
                 <nb-card-footer class="text-left">
-                  <button size="small" status="basic" size="small" outline nbButton (click)="cancel()">
+                  <button class="mr-3" size="small" status="basic" outline nbButton (click)="cancel()">
                     {{ 'BUTTONS.CANCEL' | translate }}
                   </button>
                   <button
-                    class="mr-3"
+                    class="mr-3 gray"
                     (click)="addInvoice('DRAFT')"
                     size="small"
                     status="primary"
-                    class="gray"
                     [disabled]="disableSaveButton || form.invalid"
                     nbButton
                     >

--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.html
@@ -320,7 +320,7 @@
                                 </div>
                                 <div class="col-sm-6">
                                   <div class="form-group">
-                                    <label for="inputTaxType" class="label">{{
+                                    <label for="inputTax2Type" class="label">{{
                                       'INVOICES_PAGE.TAX_TYPE' | translate
                                     }}</label>
                                     <nb-select
@@ -329,7 +329,7 @@
 											'INVOICES_PAGE.TAX_TYPE' | translate
 										}}"
                                       (ngModelChange)="calculateTotal()"
-                                      id="inputTaxType"
+                                      id="inputTax2Type"
                                       fullWidth
                                       >
                                       @for (
@@ -421,7 +421,6 @@
                     <nb-card-footer>
                       @if (!duplicate) {
                         <button
-                          status="danger"
                           class="mr-3"
                           status="basic"
                           size="small"
@@ -433,12 +432,11 @@
                         </button>
                       }
                       <button
-                        class="mr-3"
+                        class="mr-3 gray"
                         (click)="updateInvoice('DRAFT')"
                         [disabled]="form.invalid"
                         size="small"
                         status="primary"
-                        class="gray"
                         nbButton
                         >
                         {{ 'BUTTONS.SAVE_AS_DRAFT' | translate }}

--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.scss
@@ -1,8 +1,15 @@
 @use 'gauzy/_gauzy-table' as *;
 @use 'gauzy/_gauzy-dialogs' as *;
 
+// Row actions of the invoice-item grid. These were painted with literals: the
+// add/save pill as `#00d68f` and — the visible one — the cancel/delete pill as a
+// flat `white`, i.e. a bright white block on every item row of the four dark
+// themes. Same colours, read from the theme instead of spelled out, and the
+// delete pill takes the hairline ring every other button in the app carries
+// rather than a black drop shadow.
 :host ::ng-deep angular2-smart-table .angular2-smart-actions-title a {
-  background-color: #00d68f !important;
+  background-color: nb-theme(color-success-default) !important;
+  color: nb-theme(text-control-color);
   transform: scale(0.9);
 }
 
@@ -12,25 +19,49 @@
 }
 
 :host ::ng-deep angular2-smart-table .angular2-smart-actions a:nth-child(1) {
-  background-color: #00d68f !important;
-  color: white;
+  background-color: nb-theme(color-success-default) !important;
+  color: nb-theme(text-control-color);
 }
 
 :host ::ng-deep angular2-smart-table .angular2-smart-actions a:nth-child(2) {
-  background-color: white !important;
-  color: #ff3d71;
-  box-shadow: var(--gauzy-shadow);
+  background-color: var(--gauzy-card-1) !important;
+  color: nb-theme(color-danger-default);
+  box-shadow: $action-hairline;
 }
 
+// The subtotal/total chips under the item grid.
+//
+// `float: right` took the block out of flow, so its parent did not grow to
+// contain it: the chips could ride over whatever the card put below them, and
+// the card body never counted their height. A right-justified flex row keeps the
+// same placement and stays in flow.
+//
+// The chips themselves were drawn with a 2px border in
+// `--button-filled-info-disabled-border-color` (a *disabled button* token, used
+// here only because it happened to be a pale grey) and a 5px corner against the
+// 10px radius everything else on the page uses.
 .total {
-  float: right;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin: 1rem 0.5rem 0.5rem;
+
+  // invoice-edit groups its chips into paid/due rows; invoice-add lists them
+  // directly. Only the inner groups are matched — `.total` itself carries
+  // `d-flex` in both templates.
+  .d-flex {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
 
   &-item {
-    border: solid 2px var(--button-filled-info-disabled-border-color);
-    border-radius: 5px;
-    margin: 20px 20px 20px 10px;
-    padding: 5px;
-    font-size: 14px;
+    box-shadow: $action-hairline;
+    background-color: var(--gauzy-card-1);
+    border-radius: var(--border-radius);
+    padding: 0.375rem 0.75rem;
+    font-size: nb-theme(text-paragraph-font-size);
   }
 }
 

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.html
@@ -25,7 +25,7 @@
 						<!-- `dueDate` is optional and `dateFormat` yields undefined for an
 						     unset one, so this label used to stand over a blank cell. -->
 						<div class="col-6 pr-0 pl-0">
-							{{ invoice ? (invoice.dueDate | dateFormat) || '—' : '' }}
+							{{ invoice ? (invoice.dueDate | dateFormat) || '—' : '—' }}
 						</div>
 					</div>
 					<div class="row">

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.html
@@ -22,8 +22,10 @@
 							</div>
 							<div>:</div>
 						</div>
+						<!-- `dueDate` is optional and `dateFormat` yields undefined for an
+						     unset one, so this label used to stand over a blank cell. -->
 						<div class="col-6 pr-0 pl-0">
-							{{ invoice ? (invoice.dueDate | dateFormat) : '' }}
+							{{ invoice ? (invoice.dueDate | dateFormat) || '—' : '' }}
 						</div>
 					</div>
 					<div class="row">
@@ -73,7 +75,7 @@
 							<div>:</div>
 						</div>
 						<div class="col-6 pr-0 pl-0">
-							{{ invoice?.toContact?.name }}
+							{{ invoice?.toContact?.name || '—' }}
 						</div>
 					</div>
 					<div class="row">
@@ -87,7 +89,7 @@
 							<div>:</div>
 						</div>
 						<div class="col-6 pr-0 pl-0">
-							{{ invoice?.fromOrganization?.name }}
+							{{ invoice?.fromOrganization?.name || '—' }}
 						</div>
 					</div>
 				</div>
@@ -100,17 +102,21 @@
 						| position: organization?.currencyPosition
 				}}
 				<span>
+					<!-- The "n% Paid" caption sits BESIDE the meter, not on top of it.
+					     Painted over the bar it was a hard-coded white, which is
+					     unreadable against the track's pale grey — i.e. for every
+					     invoice that is not already mostly paid. -->
 					<div class="progress-bar-container">
 						<div class="progress-bar">
-							<div class="paid-percent">
-								{{ barWidth }}%
-								{{ 'INVOICES_PAGE.PAYMENTS.PAID' | translate }}
-							</div>
 							<span
 								id="progress-bar-inner"
 								class="progress-bar-inner"
 								style="width: 0%"
 							></span>
+						</div>
+						<div class="paid-percent">
+							{{ barWidth }}%
+							{{ 'INVOICES_PAGE.PAYMENTS.PAID' | translate }}
 						</div>
 					</div>
 				</span>

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.scss
@@ -14,43 +14,57 @@
   margin-left: 8%;
 }
 
-.progress-bar {
-  background-color: rgba(126, 126, 143, 0.2);
-  height: 32px;
-  width: 200px;
-  border-radius: 3px;
+// The paid meter. Previously a 32px slab with the caption absolutely positioned
+// on top of it in a hard-coded `#ffffff` — unreadable against the pale track
+// wherever the green fill had not reached, which is most of the bar for most
+// invoices. The caption is now a sibling (see the template) so its colour is just
+// body text, and the bar itself is a meter on the shared radius rather than a
+// 3px-cornered block.
+.progress-bar-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   margin-top: 10px;
+}
+
+.progress-bar {
+  position: relative;
+  background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+  height: 0.75rem;
+  width: 200px;
+  border-radius: var(--gauzy-radius-sm, 0.375rem);
+  overflow: hidden;
 }
 
 .progress-bar-inner {
   display: block;
-  height: 32px;
-  background-color: rgba(0, 214, 143, 1);
-  border-radius: 3px;
-  position: relative;
+  height: 100%;
+  background-color: nb-theme(color-success-default);
+  border-radius: inherit;
 }
 
 .paid-percent {
-  position: absolute;
-  z-index: 1;
-  margin-left: 1%;
-  color: #ffffff;
-  font-weight: bold;
+  color: var(--gauzy-text-color-1);
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .custom-container {
   margin-top: 32px;
   background-color: var(--gauzy-card-2);
   padding: 0 12px 12px 12px;
-  border-radius: 8px;
-  .gauzy-button-container{
+  // Was an 8px literal; the card this sits inside is drawn on `--border-radius`.
+  border-radius: var(--border-radius);
+  .gauzy-button-container {
     display: flex;
     justify-content: flex-end;
   }
 }
-.body{
+
+.body {
   background-color: var(--gauzy-card-2);
-  border-radius: 0 0 8px 8px;
+  // Same: the body has to finish the card's own corners, not 8px ones.
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
 }
 
 .first-column {

--- a/apps/gauzy/src/app/pages/invoices/invoice-view/invoice-view.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-view/invoice-view.component.html
@@ -1,9 +1,9 @@
 <nb-card class="main">
   <nb-card-header class="header">
     <ngx-back-navigation></ngx-back-navigation>
-    <h3 class="title">
+    <h4 class="title">
       {{ (isEstimate ? 'INVOICES_PAGE.VIEW_ESTIMATE' : 'INVOICES_PAGE.VIEW_INVOICE') | translate }}
-    </h3>
+    </h4>
   </nb-card-header>
   <nb-card-body>
     @if (invoice$ | async; as invoice) {

--- a/apps/gauzy/src/app/pages/invoices/invoice-view/invoice-view.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoice-view/invoice-view.component.scss
@@ -1,30 +1,7 @@
 @use 'gauzy/_gauzy-cards' as *;
 @use 'gauzy/_gauzy-table' as *;
 
-.grid {
-  display: grid;
-  grid-template-columns: 0.3fr 0.3fr;
-  &-item {
-    margin: 15px;
-  }
-}
-
-.item {
-  margin: 15px;
-}
-
-.table {
-  margin-top: 50px;
-}
-
-/**
-* By setting min-height of the card to this value, we ensure the card will properly adjust it's height
-*/
-:host > nb-card {
-  min-height: 47.5rem;
-}
-
-.button-container{
+.button-container {
   background: var(--gauzy-card-2);
   border-radius: nb-theme(button-rectangle-border-radius);
   padding: 6px 8px;
@@ -33,15 +10,27 @@
 .header {
   display: flex;
   align-items: center;
-  // Type comes from the shared card-title rule in `styles/_overrides.scss` —
-  // the title is an <h3>, which that rule covers.
+
+  // The heading used to be an `<h3>` pinned to a literal `24px/30px`. It is now an
+  // `<h4>` — the step the Add / Edit / Payments screens already use — so the size
+  // comes from `text-heading-4-font-size` rather than being spelled out here, and
+  // the heading level matches its sibling screens.
+  //
+  // `margin-bottom: 0` because the row is `align-items: center`, which centres the
+  // MARGIN box: Bootstrap's default `0.5rem` under a heading was tipping the title
+  // half a step above the back arrow beside it.
   .title {
     text-align: left;
+    margin-bottom: 0;
   }
 }
+
 :host {
-  $height: calc(
-    100vh - 18rem
-  );
+  // The body is anchored to the viewport and the card follows it. The card also
+  // carried `min-height: 47.5rem` — a 760px floor no window shorter than roughly
+  // 1050px can satisfy, so on a laptop the card grew past the page frame (bounded
+  // to 100vh in styles/_overrides.scss) and put the whole PAGE into a scroll
+  // instead of scrolling its own content.
+  $height: calc(100vh - 18rem);
   @include nb-card_overrides(unset, $height, $default-radius);
 }

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.scss
@@ -247,7 +247,9 @@ ga-pagination {
 }
 
 .comments {
-  overflow-y: scroll;
+  // `scroll` reserved a scrollbar gutter on the History tab even when an invoice
+  // has one comment or none, so the empty panel showed a dead scrollbar track.
+  overflow-y: auto;
   height: 15rem;
 }
 
@@ -266,9 +268,12 @@ textarea {
     background-color: var(--gauzy-card-2);
   }
 
-  &.info {
-    background-color: #0088fe;
-  }
+  // `&.info { background-color: #0088fe }` used to sit here — a hard-coded blue
+  // that never painted anything. Its only user is the estimates toolbar's "To
+  // invoice" button, which carries `status="info"`, so Nebular's own
+  // `[nbButton].appearance-filled.status-info` background (0,3,0) out-ranked the
+  // bare `.action.info` (0,2,0) on every render. The button is, and stays, a
+  // filled info button drawn from `button-filled-info-background-color`.
 
   &.danger {
     color: nb-theme(color-danger-default);
@@ -345,7 +350,12 @@ input {
 
 nb-tab {
   background-color: var(--gauzy-card-2);
-  border: 0 0 $default-radius $default-radius;
+  // Was `border: 0 0 $default-radius $default-radius`. The `border` shorthand
+  // takes width/style/colour, not four corner radii, so with `$default-radius`
+  // resolving to `var(--border-radius)` the declaration became invalid at
+  // computed-value time and was thrown away whole: the tab panel filled the
+  // bottom of the card with square corners inside the card's rounded ones.
+  border-radius: 0 0 $default-radius $default-radius;
 }
 
 :host {
@@ -356,7 +366,9 @@ nb-tab {
   .remove-scroll {
     overflow: unset;
     width: 100%;
-    border: 0 0 $default-radius $default-radius;
+    // Same `border` / `border-radius` mix-up as the `nb-tab` rule above — this
+    // targets the same element (`nb-tab.remove-scroll`).
+    border-radius: 0 0 $default-radius $default-radius;
     @include nb-ltr(padding, 1rem 0.5rem 1rem 18px);
     @include nb-rtl(padding, 1rem 18px 1rem 0.5rem);
     nb-accordion {

--- a/apps/gauzy/src/app/pages/invoices/table-components/invoice-paid.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/table-components/invoice-paid.component.ts
@@ -5,25 +5,37 @@ import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 
 @Component({
     selector: 'ga-invoice-paid',
+    // The "Paid" cell of the invoices / received-invoices grids. Two defects and a
+    // density mismatch:
+    //
+    //   * the caption was painted UNDER the fill. It carried `z-index: 1` while
+    //     `position: static`, where z-index has no effect, and the fill span was
+    //     absolutely positioned — i.e. in the positioned paint layer, above every
+    //     in-flow sibling. A fully-paid invoice showed a green bar and no text.
+    //   * where the fill had not reached, the caption was hard-coded `#ffffff` on a
+    //     pale grey track: invisible on the four light themes, which is exactly the
+    //     0 %-paid case.
+    //   * a 32px bar in a grid whose cells are 13px/20px on 6px padding made this
+    //     one column set the row height for the whole table.
+    //
+    // The caption now sits beside the meter, so it is plain body text on the card,
+    // and the bar is a 0.5rem meter on the shared small radius.
     template: `
 		<div class="progress-bar-container">
 			<div class="progress-bar">
-				<div class="paid-percent">
-					{{ paidAmountPercentage }}%
-					{{ 'INVOICES_PAGE.PAYMENTS.PAID' | translate }}
-				</div>
-				<span
-					id="progress-bar-inner"
-					class="progress-bar-inner"
-					[style.width]="paidAmountPercentage + '%'"
-				></span>
+				<span class="progress-bar-inner" [style.width]="paidAmountPercentage + '%'"></span>
 			</div>
+			<span class="paid-percent">
+				{{ paidAmountPercentage }}%
+				{{ 'INVOICES_PAGE.PAYMENTS.PAID' | translate }}
+			</span>
 		</div>
 	`,
     styles: [
-        '.progress-bar-inner {background-color: rgba(0, 214, 143, 1); position: absolute; height: 32px; width:100%; border-radius: 4px;}',
-        '.progress-bar {background-color: rgba(126, 126, 143, 0.2); border-radius: 4px; position: relative; height: 32px}',
-        '.paid-percent {color: #ffffff; z-index: 1; font-weight: bold;}'
+        '.progress-bar-container {display: flex; align-items: center; gap: 0.5rem;}',
+        '.progress-bar {background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1)); border-radius: var(--gauzy-radius-sm, 0.375rem); position: relative; height: 0.5rem; flex: 1 1 auto; min-width: 3rem; overflow: hidden;}',
+        '.progress-bar-inner {background-color: var(--color-success-default, rgba(0, 214, 143, 1)); display: block; height: 100%; border-radius: inherit;}',
+        '.paid-percent {color: var(--gauzy-text-color-1); font-weight: 600; white-space: nowrap;}'
     ],
     standalone: false
 })

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
@@ -44,6 +44,7 @@
   }
 }
 
+<<<<<<< HEAD
 // One `.container` block, not two: this file declared it twice (`padding: 0` up
 // here, then `padding: 0.5rem` further down), so the first was dead. The two
 // dead blocks that used to sit above it — `.setting-name` and `.body-header` —
@@ -67,6 +68,8 @@
   display: none;
 }
 
+=======
+>>>>>>> 93d4704d72 (fix(ui): visual sweep of Employees & Candidates)
 :host {
   nb-card,
   nb-card-header {
@@ -89,6 +92,31 @@
     padding: 8px;
   }
 }
+<<<<<<< HEAD
+=======
+// One `.container` rule. There were two — a `padding: 0` block a few lines up
+// that the later one silently overrode — plus a bare `.container::-webkit-scrollbar`
+// rule sitting between them.
+//
+// The rows are laid out with fixed column widths (~57rem), so this really does
+// need to scroll sideways on a narrow viewport; what it does NOT need is
+// `overflow-x: scroll`, which reserves a scrollbar gutter unconditionally. With
+// `auto` the bar only exists when there is something to scroll, and the two
+// hide-the-bar declarations now cover Firefox as well as WebKit rather than
+// WebKit alone.
+.container {
+  padding: 0.5rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+  height: 100%;
+  margin: 0;
+  max-width: unset;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+>>>>>>> 93d4704d72 (fix(ui): visual sweep of Employees & Candidates)
 .history {
   align-items: center;
   gap: 8px;

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
@@ -1,17 +1,5 @@
 @use 'gauzy/_gauzy-table' as *;
 
-.setting-name {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.body-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 35px;
-}
-
 .sub-header {
   margin-bottom: 20px;
   font-weight: bold;
@@ -56,8 +44,23 @@
   }
 }
 
+// One `.container` block, not two: this file declared it twice (`padding: 0` up
+// here, then `padding: 0.5rem` further down), so the first was dead. The two
+// dead blocks that used to sit above it — `.setting-name` and `.body-header` —
+// matched nothing in either template that uses this stylesheet.
+//
+// `overflow-x: scroll` reserved a horizontal scrollbar gutter unconditionally.
+// The `::-webkit-scrollbar` rule below papers over that in Chromium and WebKit,
+// but not in Firefox, where the recurring-expense list carried a permanent
+// horizontal scrollbar however wide the window was. The rows genuinely can
+// overflow on a narrow viewport (`.block-item` / `.block-item-big` are a fixed
+// 11rem / 17.5rem), so `auto` rather than dropping the scroll altogether.
 .container {
-  padding: 0;
+  padding: 0.5rem;
+  overflow-x: auto;
+  height: 100%;
+  margin: 0;
+  max-width: unset;
 }
 
 .container::-webkit-scrollbar {
@@ -85,13 +88,6 @@
     height: calc(100vh - 19.25rem);
     padding: 8px;
   }
-}
-.container {
-  padding: 0.5rem;
-  overflow-x: scroll;
-  height: 100%;
-  margin: 0;
-  max-width: unset;
 }
 .history {
   align-items: center;

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
@@ -44,32 +44,6 @@
   }
 }
 
-<<<<<<< HEAD
-// One `.container` block, not two: this file declared it twice (`padding: 0` up
-// here, then `padding: 0.5rem` further down), so the first was dead. The two
-// dead blocks that used to sit above it — `.setting-name` and `.body-header` —
-// matched nothing in either template that uses this stylesheet.
-//
-// `overflow-x: scroll` reserved a horizontal scrollbar gutter unconditionally.
-// The `::-webkit-scrollbar` rule below papers over that in Chromium and WebKit,
-// but not in Firefox, where the recurring-expense list carried a permanent
-// horizontal scrollbar however wide the window was. The rows genuinely can
-// overflow on a narrow viewport (`.block-item` / `.block-item-big` are a fixed
-// 11rem / 17.5rem), so `auto` rather than dropping the scroll altogether.
-.container {
-  padding: 0.5rem;
-  overflow-x: auto;
-  height: 100%;
-  margin: 0;
-  max-width: unset;
-}
-
-.container::-webkit-scrollbar {
-  display: none;
-}
-
-=======
->>>>>>> 93d4704d72 (fix(ui): visual sweep of Employees & Candidates)
 :host {
   nb-card,
   nb-card-header {
@@ -92,11 +66,11 @@
     padding: 8px;
   }
 }
-<<<<<<< HEAD
-=======
 // One `.container` rule. There were two — a `padding: 0` block a few lines up
 // that the later one silently overrode — plus a bare `.container::-webkit-scrollbar`
-// rule sitting between them.
+// rule sitting between them. The two dead blocks that used to sit above them,
+// `.setting-name` and `.body-header`, matched nothing in either template that
+// uses this stylesheet.
 //
 // The rows are laid out with fixed column widths (~57rem), so this really does
 // need to scroll sideways on a narrow viewport; what it does NOT need is
@@ -116,7 +90,7 @@
     display: none;
   }
 }
->>>>>>> 93d4704d72 (fix(ui): visual sweep of Employees & Candidates)
+
 .history {
   align-items: center;
   gap: 8px;

--- a/apps/gauzy/src/app/pages/reports/all-report/all-report/all-report.component.scss
+++ b/apps/gauzy/src/app/pages/reports/all-report/all-report/all-report.component.scss
@@ -19,8 +19,13 @@
   a {
     text-decoration: none;
   }
+  // The report description. `height: 27px` fits exactly one line, but the seeded
+  // descriptions run 60-90 characters and the grid track is `minmax(21rem, 1fr)`
+  // — so on most cards the second line spilled out of the box and landed on top
+  // of the screenshot below it. A MIN height keeps the single-line cards aligned
+  // with each other and lets the rest push the image down instead.
   .caption {
-    height: 27px;
+    min-height: 27px;
   }
   .image-container {
     position: relative;
@@ -83,9 +88,11 @@ nb-card-body {
   border-radius: 0 0 nb-theme(border-radius) nb-theme(border-radius);
 }
 
-::-webkit-scrollbar {
-  display: none;
-}
+// NOTE: `::-webkit-scrollbar { display: none }` used to sit here. Emulated
+// encapsulation scopes it to this component's own elements, so it hid the
+// scrollbar on the card body holding the whole report grid: the page still
+// scrolled — several category rows deep — with nothing on screen saying so, and
+// it was the only page in this area without the normal scrollbar.
 
 .report-category-name {
   font-size: 16px;

--- a/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.html
+++ b/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.html
@@ -8,24 +8,50 @@
 	</nb-card-header>
 	<nb-card-body>
 		@if (!environment.DEMO) {
+		<!--
+			These two used to be Bootstrap `.btn.btn-danger`. bootstrap.css is loaded
+			globally (apps/gauzy/project.json), so they took Bootstrap's own red, its
+			0.25rem radius and its 0.375rem/0.75rem padding — the only buttons left in
+			the app that ignored the Nebular theme and its density.
+
+			`btn` — the class that carried the layout — is gone; `btn-danger` stays
+			because `apps/gauzy-e2e/.../DangerZonePageObject.ts` selects
+			`nb-card-body button.btn-danger`. On its own that class sets nothing but
+			color / background-color / border-color, and every one of those is
+			out-ranked by Nebular's `[nbButton].appearance-filled.status-danger`, so it
+			is now purely a test hook.
+		-->
 		<ng-template ngxPermissionsOnly="ACCESS_DELETE_ACCOUNT">
-			<button type="button" class="btn btn-danger" (click)="deleteAccount()">
+			<button type="button" nbButton status="danger" size="small" class="btn-danger" (click)="deleteAccount()">
 				<nb-icon class="mr-1" icon="trash-2-outline"> </nb-icon>
 				{{ 'BUTTONS.DELETE_ACCOUNT' | translate }}
 			</button>
 		</ng-template>
 		<ng-template ngxPermissionsOnly="ACCESS_DELETE_ALL_DATA">
-			<button type="button" class="btn btn-danger ml-3 mr-3" [disabled]="loading" (click)="deleteAllData()">
+			<button
+				type="button"
+				nbButton
+				status="danger"
+				size="small"
+				class="btn-danger ml-3 mr-3"
+				[disabled]="loading"
+				(click)="deleteAllData()"
+			>
 				<nb-icon class="mr-1" icon="trash-2-outline"> </nb-icon>
 				{{ 'BUTTONS.DELETE_ALL_DATA' | translate }}
 			</button>
 		</ng-template>
 		@if (process !== 0) {
-		<div class="mt-4">
-			<span style="display: block">
+		<div class="queue-progress mt-4">
+			<span class="queue-progress-label">
 				{{ 'MENU.IMPORT_EXPORT.QUEUE_PROGRESS' | translate }}
 			</span>
-			<br />
+			<!--
+				Bootstrap's `.progress` track is a hardcoded #e9ecef and its `.progress-bar`
+				fill a hardcoded #007bff: a light-grey rail with a blue bar, on every theme.
+				The classes are kept (the shape is Bootstrap's) but the colours now come
+				from theme tokens — see danger-zone.component.scss.
+			-->
 			<div class="progress">
 				<div class="progress-bar" role="progressbar" [style.width]="process + '%'"></div>
 			</div>

--- a/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.scss
+++ b/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.scss
@@ -1,0 +1,36 @@
+@use 'themes' as *;
+
+// The "delete all data" queue progress indicator.
+//
+// The markup is Bootstrap's (`.progress` > `.progress-bar`) and bootstrap.css is
+// loaded globally, so both boxes were taking Bootstrap's own constants: a #e9ecef
+// track and a #007bff fill. That is a light-grey rail with a blue bar on all eight
+// themes — near-invisible on the near-black ones, and the only blue on a page whose
+// every other control is danger-red. Same geometry, theme tokens for the colours.
+.queue-progress {
+	max-width: 32rem;
+
+	.queue-progress-label {
+		display: block;
+		margin-bottom: 0.5rem;
+		font-size: nb-theme(text-label-font-size);
+		color: nb-theme(text-hint-color);
+	}
+
+	// `background-basic-color-3` rather than one of the `gauzy-*` surface tokens:
+	// the latter are only registered on default/cosmic/corporate/dark, so on the
+	// two material themes the track would resolve to an undefined custom property
+	// and the rail would simply vanish.
+	.progress {
+		height: 0.5rem;
+		border-radius: nb-theme(border-radius);
+		background-color: nb-theme(background-basic-color-3);
+		overflow: hidden;
+	}
+
+	.progress-bar {
+		height: 100%;
+		background-color: nb-theme(color-danger-default);
+		transition: width 0.3s ease;
+	}
+}

--- a/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.ts
+++ b/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.ts
@@ -14,6 +14,7 @@ import { DangerZoneMutationComponent } from '@gauzy/ui-core/shared';
 @Component({
     selector: 'ga-danger-zone',
     templateUrl: './danger-zone.component.html',
+    styleUrls: ['./danger-zone.component.scss'],
     standalone: false
 })
 export class DangerZoneComponent extends TranslationBaseComponent implements OnInit {

--- a/apps/gauzy/src/app/pages/settings/email-history/email-history.component.scss
+++ b/apps/gauzy/src/app/pages/settings/email-history/email-history.component.scss
@@ -177,8 +177,15 @@
         > span {
           display: flex;
 
+          // From / To / Subject / Language / Template labels. `width: 90px` alone
+          // is only a flex BASIS: the value beside it (an email address, a long
+          // template title) has a wide content base of its own, so when the pair
+          // overflowed the line both shrank in proportion — the label lost width
+          // and wrapped, and it did so by a different amount on each of the five
+          // rows, so the label column never lined up. Fixing the basis and
+          // forbidding the shrink keeps one straight column.
           .col-fixed {
-            width: 90px;
+            flex: 0 0 90px;
             display: block;
           }
         }

--- a/apps/gauzy/src/app/pages/settings/file-storage/file-storage.component.scss
+++ b/apps/gauzy/src/app/pages/settings/file-storage/file-storage.component.scss
@@ -1,3 +1,10 @@
+// `@forward` re-exports the SMS-gateway sheet to anything that loads THIS file;
+// it does not bring that sheet's own imports into scope here. Without a `@use`
+// of the theme module `nb-theme` was not a Sass function at all — and Sass lets
+// an unknown function through as plain CSS, so every declaration below shipped as
+// the literal text `nb-theme(gauzy-card-4)` and the browser dropped it. The
+// provider card, its footer and its radii have been rendering unstyled.
+@use 'themes' as *;
 @forward '../sms-gateway/sms-gateway.component';
 
 :host {
@@ -9,15 +16,26 @@
     }
     nb-card {
         nb-card-body {
+            // The provider configuration card (S3 / Wasabi / Cloudinary / DigitalOcean).
+            //
+            // `height` pinned it to a viewport-derived box regardless of how many
+            // fields the selected provider actually has — four rows for S3, seven
+            // for DigitalOcean — so short forms sat in a tall empty panel while the
+            // outer `.card-scroll` card, already bounded by the page frame, scrolled
+            // around it. As a MAX it still caps a long form (which then scrolls in
+            // its own body, as before) and lets a short one shrink to its content.
             nb-card {
                 background-color: nb-theme(gauzy-card-4);
-                height: calc(100vh - 24rem) !important;
+                max-height: calc(100vh - 24rem);
                 margin: 0;
 
+                // Was 18px. `text-heading-6-font-size` is the 1rem step the density
+                // pass set for every theme; an 18px section title here was the only
+                // h6 in Settings that ignored it.
                 h6 {
-                    font-size: 18px;
+                    font-size: nb-theme(text-heading-6-font-size);
                     font-weight: 600;
-                    line-height: 19px;
+                    line-height: 1.25;
                     letter-spacing: 0em;
                 }
 

--- a/apps/gauzy/src/app/pages/settings/monitoring/monitoring.component.scss
+++ b/apps/gauzy/src/app/pages/settings/monitoring/monitoring.component.scss
@@ -6,6 +6,20 @@
 }
 
 // main sections
+//
+// Two problems, one rule. The card carries `.card-scroll`, so the page frame
+// already bounds it to the viewport — but this block re-derived a height of its
+// own from `100vh` minus a hand-tuned 19.25rem, a number measured against older
+// chrome and now wrong by the height of the breadcrumb trail the card header
+// gained. And it declared `overflow: hidden` immediately followed by
+// `overflow-y: scroll`, so the second won and painted a permanently visible
+// track whether or not there was anything to scroll.
+//
+// The column that is MEANT to scroll is `.accordion-section` — it reserves an 8px
+// gutter for its own scrollbar, and `.aside-nav` is `height: fit-content` so the
+// service list can stay put while the fields move. Fill the card body and clip
+// here; the accordion column does the scrolling. (At the `md` breakpoint the two
+// stack into a column and this becomes the scroll box instead — see below.)
 :host .main-form {
   width: 100%;
   background-color: nb-theme(gauzy-card-2);
@@ -14,9 +28,9 @@
   padding: 20px;
   @include nb-ltr(padding-right, 8px);
   @include nb-rtl(padding-left, 8px);
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
-  height: calc(100vh - 19.25rem);
-  overflow-y: scroll;
 }
 
 .aside-nav {
@@ -81,9 +95,13 @@
   padding: 0;
 }
 
+// The page's one scroll box. The `- 3rem` in `max-height` cut the box short of
+// the column it sits in, so the accordion always stopped 3rem above the card's
+// bottom edge with a dead strip beneath it — room the fields could have used.
+// Now that `.main-form` clips rather than scrolls, the column IS the budget.
 :host .accordion-section {
   overflow: auto;
-  max-height: calc(100% - 3rem);
+  max-height: 100%;
   @include nb-ltr(padding-right, 8px);
   @include nb-rtl(padding-left, 8px);
 }
@@ -100,9 +118,12 @@
   max-width: 49% !important;
 }
 
-.active {
-  background: #ffffff;
-}
+// NOTE: a bare `.active { background: #ffffff }` used to sit here. The only
+// elements in this template that take `.active` are the service rows in
+// `.aside-nav`, which the rule above already paints with a theme token — so all
+// this one could ever do was drop a literal white block into the seven themes
+// where white is the wrong surface. Removed rather than re-tokenised: there is
+// nothing left for it to style.
 
 // start of nb-overrides
 nb-accordion {
@@ -118,7 +139,11 @@ nb-accordion {
       border-radius: 6px;
       width: 23px;
       height: 23px;
-      border: 1px solid rgba(66, 66, 66, 0.2);
+      // Was `rgba(66, 66, 66, 0.2)` — 20% of the LIGHT theme's body colour, so
+      // the expand/collapse chevron lost its box entirely on the dark canvas.
+      // The shared hairline token darkens a light surface and lightens a dark
+      // one, which is the only way one value works in all eight themes.
+      border: 1px solid nb-theme(gauzy-border-default-color);
     }
   }
 
@@ -209,8 +234,15 @@ nb-accordion {
     padding-right: 0;
   }
 
-  .main-form {
+  // Stacked, the service list is no longer a column beside the fields, so the
+  // accordion column has no cross-axis height to bound its own scroll box. The
+  // whole pane scrolls as one instead — which is also what you want on a narrow
+  // screen, since the service list would otherwise take a fixed slice of it.
+  // `:host` prefix so this out-ranks the `overflow: hidden` above on specificity
+  // rather than on source order.
+  :host .main-form {
     flex-direction: column;
+    overflow-y: auto;
   }
 
   .aside-nav {

--- a/apps/gauzy/src/app/pages/settings/monitoring/monitoring.component.scss
+++ b/apps/gauzy/src/app/pages/settings/monitoring/monitoring.component.scss
@@ -122,7 +122,7 @@
 // elements in this template that take `.active` are the service rows in
 // `.aside-nav`, which the rule above already paints with a theme token — so all
 // this one could ever do was drop a literal white block into the seven themes
-// where white is the wrong surface. Removed rather than re-tokenised: there is
+// where white is the wrong surface. Removed rather than mapped to a token: there is
 // nothing left for it to style.
 
 // start of nb-overrides

--- a/apps/gauzy/src/app/pages/settings/roles-permissions/roles-permissions.component.html
+++ b/apps/gauzy/src/app/pages/settings/roles-permissions/roles-permissions.component.html
@@ -98,8 +98,13 @@
                     [disabled]="isDisabledGeneralPermissions()"
                     >
                     <div class="custom-permission-view">
+                      <!--
+                        The <small> line under this one used to render the SAME
+                        translation key, so every row printed its label twice —
+                        once bold, once as a 11px grey "description". There are no
+                        *_DESCRIPTION keys in the catalogue for it to have meant.
+                      -->
                       <strong>{{ 'ORGANIZATIONS_PAGE.PERMISSIONS.' + permission | translate }}</strong>
-                      <small>{{ 'ORGANIZATIONS_PAGE.PERMISSIONS.' + permission | translate }}</small>
                     </div>
                   </nb-toggle>
                 }
@@ -129,8 +134,8 @@
                     [disabled]="isDisabledAdministrationPermissions()"
                     >
                     <div class="custom-permission-view">
+                      <!-- Same duplicated-label removal as the General group above. -->
                       <strong>{{ 'ORGANIZATIONS_PAGE.PERMISSIONS.' + permission | translate }}</strong>
-                      <small>{{ 'ORGANIZATIONS_PAGE.PERMISSIONS.' + permission | translate }}</small>
                     </div>
                   </nb-toggle>
                 }

--- a/apps/gauzy/src/app/pages/settings/roles-permissions/roles-permissions.component.scss
+++ b/apps/gauzy/src/app/pages/settings/roles-permissions/roles-permissions.component.scss
@@ -9,7 +9,10 @@
   width: fit-content;
   color: nb-theme(color-danger-default);
   padding-right: 10px;
-  font-weight: 600px;
+  // Was `600px`. `font-weight` takes a number, not a length, so the declaration
+  // was invalid and dropped at parse time — the "Create new role" / "Delete
+  // existing role" lines have been rendering at the inherited weight ever since.
+  font-weight: 600;
 }
 
 .delete {
@@ -53,6 +56,9 @@
   border-radius: nb-theme(border-radius);
 }
 
+// One label per permission row. The `<small>` description this used to style was
+// bound to the same translation key as the `<strong>` above it, so it is gone from
+// the template — and with it the 5px gap that was only there to separate the two.
 .custom-permission-view {
   display: flex;
   flex-direction: column;
@@ -64,16 +70,6 @@
     letter-spacing: 0em;
     text-align: left;
     color: nb-theme(gauzy-text-color-1);
-    margin-bottom: 5px;
-  }
-
-  small {
-    font-size: 11px;
-    font-weight: 400;
-    line-height: 13px;
-    letter-spacing: 0em;
-    text-align: left;
-    color: nb-theme(gauzy-text-color-2);
   }
 }
 

--- a/apps/gauzy/src/app/pages/settings/sms-gateway/sms-gateway.component.html
+++ b/apps/gauzy/src/app/pages/settings/sms-gateway/sms-gateway.component.html
@@ -17,6 +17,11 @@
           {{ 'SMS_GATEWAY_PAGE.' + provider | translate }}
         </nb-toggle>
       }
-      <div class="content"></div>
+      <!--
+        An empty `<div class="content"></div>` used to close this body. Nothing
+        ever rendered into it, and its stylesheet gave it a near-white fill and a
+        `calc(100vh - 18rem)` height — a page-tall blank panel under the provider
+        toggles as soon as those styles applied. Both are gone.
+      -->
     </nb-card-body>
   </nb-card>

--- a/apps/gauzy/src/app/pages/settings/sms-gateway/sms-gateway.component.scss
+++ b/apps/gauzy/src/app/pages/settings/sms-gateway/sms-gateway.component.scss
@@ -1,16 +1,23 @@
+// `@forward` re-exports the features sheet downstream; it does NOT put that
+// sheet's imports in scope here. With no `@use` of the theme module `nb-theme`
+// was not a Sass function, and Sass passes an unknown function through as plain
+// CSS — so all four declarations below reached the browser as the literal text
+// `nb-theme(gauzy-card-2)` and were dropped as invalid. The card surfaces and the
+// body's bottom radii on SMS Gateway (and on File Storage, which forwards this
+// file) have never been painted.
+@use 'themes' as *;
 @forward '../feature/feature.component';
 
+// NOTE: a `.content` rule used to sit inside this block — a near-white fill on a
+// `calc(100vh - 18rem)` box, for an empty `<div class="content"></div>` that the
+// template renders under the provider toggles and never puts anything in. It has
+// been invisible all this time only because of the missing `@use` above; with the
+// theme function working it would have become a page-tall blank panel. The empty
+// div goes with it (see sms-gateway.component.html).
 :host {
     nb-card,
     nb-card-body {
         background-color: nb-theme(gauzy-card-2);
-
-        .content {
-            background-color: nb-theme(gauzy-card-4);
-            height: calc(100vh - 18rem);
-            width: 100%;
-            border-radius: nb-theme(border-radius);
-        }
     }
 
     nb-card-body {

--- a/apps/gauzy/src/app/pages/tasks/components/task/task.component.scss
+++ b/apps/gauzy/src/app/pages/tasks/components/task/task.component.scss
@@ -25,6 +25,17 @@ nb-card-body {
   }
 }
 
+// The sprint board is the card body's scrolling child, exactly like
+// `.table-scroll-container` is in the grid layout — @shared/_pg-card makes the
+// body a definite-height flex column, so this wrapper only has to pass that
+// height through to `ga-tasks-sprint-view` (which sizes itself from here).
+.sprint-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 :host ::ng-deep .sprint-view {
   nb-accordion {
     @include nb-ltr(padding-right, 0.5rem);

--- a/apps/gauzy/src/app/pages/tasks/components/task/tasks-layouts/tasks-sprint-view/task/task.component.scss
+++ b/apps/gauzy/src/app/pages/tasks/components/task/tasks-layouts/tasks-sprint-view/task/task.component.scss
@@ -8,9 +8,19 @@ nb-card {
 	margin-bottom: 8px;
 }
 
+// Selecting a card used to REPLACE the body's `--gauzy-shadow` with a bare
+// `-6px 0 0 0 rgba(0 0 0 / 10%)` bar. Two problems on the dark themes, where
+// `--gauzy-shadow` is the 1px hairline ring that gives the card its only edge:
+// the ring disappeared the moment a card was selected, and the replacement is a
+// 10 %-black bar drawn on a near-black canvas, i.e. no marker at all. Compose
+// the two instead, and paint the bar with the token the rest of the app uses
+// for a current row. `--gauzy-shadow` carries a literal fallback because the two
+// material themes register no gauzy tokens at all, and an unresolvable var()
+// anywhere in the list would drop the whole declaration — bar included.
 .selected {
 	background-color: var(--gauzy-sidebar-background-3);
-	box-shadow: -6px 0 0 0 rgba(0 0 0 / 10%);
+	box-shadow: -6px 0 0 0 var(--gauzy-active-tint, rgba(126, 126, 143, 0.2)),
+		var(--gauzy-shadow, 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)));
 }
 
 .view {

--- a/apps/gauzy/src/app/pages/tasks/components/task/tasks-layouts/tasks-sprint-view/tasks-sprint-view.component.scss
+++ b/apps/gauzy/src/app/pages/tasks/components/task/tasks-layouts/tasks-sprint-view/tasks-sprint-view.component.scss
@@ -31,8 +31,25 @@
   color: var(--gauzy-text-color-1);
 }
 
+// The board scrolls inside the card body rather than against a guess at the
+// viewport. It used to be `height: calc(100vh - 24rem)`, hand-measured against
+// older page chrome: the card body the board sits in is sized by @shared/_pg-card
+// (`$default-card-height + 3.75rem`, i.e. roughly `100vh - 14rem` of chrome), so
+// the board stopped ~6rem short of the card and left a dead band under the
+// backlog on every screen size. `_pg-card` already makes that body a flex
+// column with a definite height — this joins the chain instead of restating it.
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .sprints {
-  height: calc(100vh - 24rem);
+  flex: 1 1 auto;
+  // Without this a flex item refuses to shrink below its content, which is what
+  // would push the card past the page frame instead of scrolling here.
+  min-height: 0;
   overflow: auto;
   border-radius: var(--border-radius);
 }

--- a/apps/gauzy/src/app/pages/time-off/time-off-settings/time-off-settings.component.html
+++ b/apps/gauzy/src/app/pages/time-off/time-off-settings/time-off-settings.component.html
@@ -57,8 +57,11 @@
     <!-- If the user does not have the 'ORG_JOB_EMPLOYEE_VIEW' permission -->
     <ng-template [ngxPermissionsExcept]="[PermissionsEnum.ALL_ORG_VIEW, PermissionsEnum.TIME_OFF_POLICY_VIEW]">
       <div>
-        <!-- Content to display if the user does not have the 'TIME_OFF_POLICY_VIEW' permission -->
-        <p>You don't have permission to view this page</p>
+        <!-- Content to display if the user does not have the 'TIME_OFF_POLICY_VIEW' permission.
+             `TIME_OFF_PAGE.NO_PERMISSION` is the identical string the parent Time Off page
+             already uses; this copy was hardcoded English, so it stayed English in every
+             other locale. -->
+        <p>{{ 'TIME_OFF_PAGE.NO_PERMISSION' | translate }}</p>
       </div>
     </ng-template>
   </nb-card-body>

--- a/apps/gauzy/src/app/pages/users/edit-user-mutation/edit-user-mutation.component.scss
+++ b/apps/gauzy/src/app/pages/users/edit-user-mutation/edit-user-mutation.component.scss
@@ -1,8 +1,14 @@
 @use 'gauzy/_gauzy-dialogs' as *;
 
 :host {
+    // The "Add existing user" panel that drops in above the users table.
+    // `rgba(50, 50, 50, 0.06)` is a hand-doubled copy of the LIGHT theme's
+    // `--gauzy-card-2` (`rgba(50, 50, 50, 0.03)`); as a literal it kept
+    // darkening an already near-black surface on the dark themes, so the panel
+    // had no edge against the page behind it. Read the token instead: light is
+    // effectively unchanged and dark gets the surface the other cards use.
     nb-card {
-        background: rgba(50, 50, 50, 0.06);
+        background: var(--gauzy-card-2);
     }
     .add-organization-action{
         gap: 1rem;

--- a/packages/ui-auth/src/lib/components/auth/auth.component.scss
+++ b/packages/ui-auth/src/lib/components/auth/auth.component.scss
@@ -7,12 +7,18 @@
     border: none;
   }
 
+  // `100vw` (here and on `.body` below) is the FULL viewport including the
+  // vertical scrollbar gutter. The register screen is taller than most viewports,
+  // so as soon as its scrollbar appeared these two bands were wider than the space
+  // left for them and the whole auth shell picked up a horizontal scrollbar it
+  // never needed. They already span their column, so `100%` is both correct and
+  // scrollbar-safe.
   & .header {
     border-bottom: none;
     padding-top: 24px;
     padding-left: 30px;
     padding-right: 30px;
-    width: 100vw;
+    width: 100%;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -37,7 +43,7 @@
   //   @media (max-width: 490px) { :root { --header-height: 0px; } }
   // The fallback of 70px matches the current desktop header height.
   & .body {
-    width: 100vw;
+    width: 100%;
     height: 100%;
     min-height: calc(100vh - var(--header-height, 70px));
     display: flex;
@@ -66,7 +72,10 @@
   }
 }
 .back-link {
-  border: 1px solid lightgray;
+  // Was the CSS named colour `lightgray` (#d3d3d3): a ring bright enough to be
+  // the loudest thing in the auth header on the dark themes, and a dead-flat
+  // hairline that ignores the theme on the light ones.
+  border: 1px solid nb-theme(border-basic-color-3);
   border-radius: 50%;
   padding: 15px;
   transition: all 0.3s ease;

--- a/packages/ui-auth/src/lib/components/forgot-password/forgot-password.component.scss
+++ b/packages/ui-auth/src/lib/components/forgot-password/forgot-password.component.scss
@@ -32,7 +32,12 @@
   }
   & .sub-title {
     width: 358px;
-    height: 34px;
+    max-width: 100%;
+    // Was a fixed `height: 34px` on a flex box that centres its text. Two lines
+    // of copy — which is what the longer locales produce for this instruction —
+    // overflowed the box in both directions and crossed the divider under it.
+    // As a minimum, the single-line English case renders identically.
+    min-height: 34px;
     font-family: 'Inter';
     font-style: normal;
     font-weight: 400;

--- a/packages/ui-auth/src/lib/components/login-magic/login-magic.component.scss
+++ b/packages/ui-auth/src/lib/components/login-magic/login-magic.component.scss
@@ -46,7 +46,10 @@
           font-size: 14px;
           font-style: normal;
           font-weight: 400;
-          line-height: 11px;
+          // Was 11px — a line box shorter than the 14px glyphs in it. Same defect
+          // and same fix as login.component.scss; 14/17 is what forgot-password,
+          // reset-password and login-workspace all use for this element.
+          line-height: 17px;
           letter-spacing: 0em;
           margin-bottom: 26px;
           text-align: start;

--- a/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
+++ b/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
@@ -32,7 +32,10 @@
       }
       & .sub-title {
         width: 358px;
-        height: 34px;
+        max-width: 100%;
+        // Same fixed-height flex box as forgot-password / reset-password: a
+        // two-line instruction overflowed it and crossed the divider below.
+        min-height: 34px;
         font-family: 'Inter';
         font-style: normal;
         font-weight: 400;

--- a/packages/ui-auth/src/lib/components/login/login.component.scss
+++ b/packages/ui-auth/src/lib/components/login/login.component.scss
@@ -45,7 +45,12 @@
           font-size: 14px;
           font-style: normal;
           font-weight: 400;
-          line-height: 11px;
+          // Was 11px — a line box SHORTER than the 14px glyphs sitting in it, so
+          // the strap line under "Login" rode into the divider below and its
+          // descenders were cut by the next block. Every other auth screen
+          // (forgot-password, reset-password, login-workspace) sets 14/17 for the
+          // same element; the features column further down this very file does too.
+          line-height: 17px;
           letter-spacing: 0em;
           margin-bottom: 26px;
           text-align: start;

--- a/packages/ui-auth/src/lib/components/reset-password/reset-password.component.scss
+++ b/packages/ui-auth/src/lib/components/reset-password/reset-password.component.scss
@@ -27,7 +27,10 @@
   }
   & .sub-title {
     width: 358px;
-    height: 34px;
+    max-width: 100%;
+    // Same fixed-height flex box as forgot-password: a two-line instruction
+    // overflowed it and crossed the divider below. Minimum, not fixed.
+    min-height: 34px;
     font-family: 'Inter';
     font-style: normal;
     font-weight: 400;

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-block/recurring-expense-block.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-block/recurring-expense-block.component.scss
@@ -6,8 +6,12 @@
   margin-bottom: 8px;
   background-color: nb-theme(gauzy-card-1) !important;
 
+  // Selection rail. This was `rgba(0, 0, 0, 0.15)` — 15 % black, which on the
+  // four dark themes is drawn against an already near-black card and simply does
+  // not appear, so a selected recurring expense had no rail at all. A selection
+  // state has to read in every theme, so it takes the primary accent.
   &.block {
-    box-shadow: -6px 0px 0px 0px rgba(0, 0, 0, 0.15);
+    box-shadow: -6px 0 0 0 nb-theme(color-primary-default);
   }
 
   .setting-row {

--- a/packages/ui-core/shared/src/lib/invoice/components/inner-component/invoice-view-inner.component.html
+++ b/packages/ui-core/shared/src/lib/invoice/components/inner-component/invoice-view-inner.component.html
@@ -33,9 +33,11 @@
                     {{ 'INVOICES_PAGE.DUE_DATE' | translate }}:
                   </div>
                 </div>
+                <!-- `dueDate` is optional and `dateFormat` yields undefined for an unset
+                     date, so these labels used to stand over blanks. -->
                 <div class="ml-3 mr-3">
-                  <div>{{ invoice?.invoiceDate | dateFormat }}</div>
-                  <div>{{ invoice?.dueDate | dateFormat }}</div>
+                  <div>{{ (invoice?.invoiceDate | dateFormat) || '—' }}</div>
+                  <div>{{ (invoice?.dueDate | dateFormat) || '—' }}</div>
                 </div>
               </div>
             </div>
@@ -44,13 +46,14 @@
                 <div class="font-weight-bold text-left">
                   {{ 'INVOICES_PAGE.VIEW.FROM' | translate | titlecase }}:
                 </div>
-                <div>{{ invoice?.fromOrganization?.name }}</div>
+                <div>{{ invoice?.fromOrganization?.name || '—' }}</div>
               </div>
               <div class="ml-3">
                 <div class="font-weight-bold text-left">
                   {{ 'INVOICES_PAGE.VIEW.TO' | translate | titlecase }}:
                 </div>
-                <div>{{ invoice?.toContact?.name }}</div>
+                <!-- A draft invoice can have no contact yet; the label used to sit over a blank. -->
+                <div>{{ invoice?.toContact?.name || '—' }}</div>
               </div>
             </div>
           </div>
@@ -89,12 +92,14 @@
               }
               @if (invoice.taxType === discountTaxTypes.PERCENT) {
                 <span>
-                  {{ invoice?.tax || 0 }} %
+                  {{ invoice?.tax || 0 }}%
                 </span>
               }
             </div>
+            <!-- The second tax row was keyed off `taxType`, so a percentage Tax 2 on
+                 a flat-value Tax 1 was rendered as a currency amount. -->
             <div class="mt-2">
-              @if (invoice.taxType === discountTaxTypes.FLAT_VALUE) {
+              @if (invoice.tax2Type === discountTaxTypes.FLAT_VALUE) {
                 <span>
                   {{
                   invoice?.tax2 || 0
@@ -103,7 +108,7 @@
                   }}
                 </span>
               }
-              @if (invoice.taxType === discountTaxTypes.PERCENT) {
+              @if (invoice.tax2Type === discountTaxTypes.PERCENT) {
                 <span>
                   {{ invoice?.tax2 || 0 }}%
                 </span>
@@ -120,10 +125,9 @@
                 </span>
               }
               @if (invoice.discountType === discountTaxTypes.PERCENT) {
-                <span>
-                  {{ invoice?.discountValue || 0 }}
-                  %
-                </span>
+                <!-- The `%` was on its own line, which renders as "12 %"; the tax rows
+                     above it read "12%". Same figure, one spelling. -->
+                <span>{{ invoice?.discountValue || 0 }}%</span>
               }
             </div>
             <div class="mt-2">

--- a/packages/ui-core/shared/src/lib/invoice/components/inner-component/invoice-view-inner.component.scss
+++ b/packages/ui-core/shared/src/lib/invoice/components/inner-component/invoice-view-inner.component.scss
@@ -4,16 +4,29 @@
   margin-top: 20px;
   padding: 10px;
   background-color: nb-theme(gauzy-card-2);
+  // NOTE: `max-height: 17.5rem` is a flat 280px cap on the item list whatever the
+  // window, so an invoice of more than about eight lines scrolls internally while
+  // the card around it still has room. Left alone deliberately: the cap is also
+  // what keeps the totals block below it on screen without the page scrolling,
+  // and re-balancing the two needs the running app.
   max-height: 17.5rem;
 }
 
-.bottom-data-container {
-  width: 25%;
-  justify-content: space-between;
-  margin-left: auto;
-}
-
-::ng-deep ga-invoice-view-inner {
-  padding: 0 100px;
-  padding-top: 25px;
+// Was `::ng-deep ga-invoice-view-inner { padding: 0 100px; padding-top: 25px }`.
+// Three things wrong with it:
+//
+//   * a LEADING `::ng-deep` has no compound selector to scope, so this was
+//     emitted as a GLOBAL `ga-invoice-view-inner` rule rather than staying with
+//     the component;
+//   * the host is a custom element with no `display` of its own — an inline box
+//     — and its only child is a block-level `nb-card-body`. Padding on an inline
+//     box does not lay out as the block gutter this was written to be;
+//   * 100px per side is a constant: on a narrow window 200px of it went to
+//     padding, squeezing the item grid into a column.
+//
+// The host is now a block, so the gutter is the one the declaration always meant,
+// and it scales with the viewport, topping out at the original 100px.
+:host {
+  display: block;
+  padding: 25px clamp(1rem, 6vw, 100px) 0;
 }


### PR DESCRIPTION
Wave 4 of the page-by-page visual sweep (item 14). Four areas, one branch:

| Area | Commit |
|---|---|
| Accounting templates, email templates, expenses, invoices, approvals | `d0ce3e0` |
| Employees, candidates, recurring expenses, time-off | `93d4704` |
| Organization, inventory, equipment sharing, goals, tasks, help centre | `474071c` |
| Settings, reports, users, integrations, auth | `d35eda0` |

### What the sweep did

Removed hardcoded colours that were theme-blind (`#fff`, `#909cb4`, `#fa0`,
`#0095ff`, `darkgray`, `#e5e5e5`, `#e4e9f2`) in favour of the theme tokens, and
deleted dead rule blocks whose selectors matched nothing in their own templates.
Every removal carries a comment saying what went and why.

### Three things worth reviewing rather than skimming

1. **Approvals** — the sweep re-added filled Approve/Refuse buttons (via tokens
   rather than literals). That would have undone item 16 on the exact page the
   issue cited, so develop's outline treatment was kept instead.

2. **Roles & Permissions** — the sweep deleted `.menu-setting { font-weight: 400 }`
   on the grounds that "the `h4 .menu-setting` block above already carries the
   lighter weight". No such block exists. Develop's rule was kept.

3. **interview-panel** — the removal is correct but the original justification
   ("none of those class names appears in any template in the repo") was wrong:
   `.card-header` and `.card-body` appear in that component's own template. They
   were nested under `.card-container`, which nothing there is, so the rules never
   matched. Comment corrected in `9224bc8` so the next reader isn't misled.

### Verification

- `nx build gauzy -c local` → green (287s, exit 0).
- Audited every class the sweep deleted against the templates beside it; the only
  hit was interview-panel above, and it is a false alarm for the reason given.
- cspell clean over all 87 files.
- Prettier reports 45 of these files unformatted — all of them already were on
  develop, so they are left alone rather than burying the diff in reflows.

Two commits in here are repairs to my own earlier mistakes: `66cd6a4` removes
conflict markers that got committed when `git add -A` swept up files that were
still conflicted, and `ec5dcc5` rewords four comment words the dictionary rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wave 4 UI visual sweep across accounting, employees, organization, settings, reports, integrations, inventory, invoices, tasks, and auth. Replaces theme-blind colors and duplicated CSS with theme tokens and shared styles, fixing dark-theme readability and small layout/i18n issues.

- **Refactors**
  - Add CSS var fallbacks for `--gauzy-shadow` and `--gauzy-text-color-*` so styles render on Material themes.
  - Keep selected-row styling on hover with `&:hover:not(.selected)` in Help Center and Expense Categories.

- **Bug Fixes**
  - Payments: due date shows an em-dash when missing in all paths; aligns with invoice views.
  - Employee Levels: dialog buttons set `type="button"` to avoid unintended submits.
  - Time Off e2e: update selector to match approval policy cell markup (`.policy` chip or em-dash).

<sup>Written for commit 386cb98fccdf2fe01e32bd9efc1d5f31c116b5a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

