### PR TITLE
ci: stop the six non-prod image builds from cancelling each other

### DIFF
--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -8,12 +8,26 @@ on:
     types: [completed]
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-mcp-auth-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-demo.yml
@@ -11,12 +11,26 @@ permissions:
   packages: write
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-mcp-auth-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-stage.yml
@@ -10,12 +10,26 @@ permissions:
   packages: write
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-mcp-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-demo.yml
@@ -11,12 +11,26 @@ permissions:
   packages: write
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -10,12 +10,26 @@ permissions:
   packages: write
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -6,12 +6,26 @@ on:
       - stage
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## The symptom

`stage` merged my cascade (#9876) at `e8b21159e5` and every check went green — but
`apistage.gauzy.co` is still serving an image built from **#9858**, five PRs back.
The branch moved; the environment did not.

## The cause

All six non-prod image-build workflows share one concurrency group:

```yaml
group: gauzy-docker-build
cancel-in-progress: false
```

`cancel-in-progress: false` protects a run that is already *executing*. It does
nothing for runs that are *waiting*: GitHub keeps exactly one pending run per group,
and each newly queued run cancels whichever run was already waiting — no matter which
workflow it came from.

One push to `develop` fires three of these workflows; one push to `stage` fires the
other three. They queue into a single slot and annihilate each other. The current run
list is the whole story:

```
11:58  develop  cancelled  Build and Publish Docker Images Demo
11:51  develop  cancelled  Build and Publish Docker Images Demo
11:50  stage    cancelled  Build and Publish Docker Images Stage      <- my cascade
11:50  stage    cancelled  Build and Publish Gauzy MCP Image Stage
11:50  stage    cancelled  Build and Publish Gauzy MCP Auth Image Stage
11:48  develop  cancelled  Build and Publish Gauzy MCP Auth Image Demo
```

Six queued, six cancelled, nothing built. A cancelled build reports no failed step, so
this looks like success from every angle except the deployed image.

This is also the most likely explanation for the demo API running an image old enough
to predate the `postinstall` native-rebuild fix — the reported missing `better-sqlite3`
binary. Worth re-checking demo once images actually rebuild.

## The change

One group per workflow:

```yaml
group: gauzy-docker-build-${{ github.workflow }}
cancel-in-progress: false
```

Kept: a newer push supersedes this workflow's own older pending run; a running build is
never killed. Removed: unrelated image builds cancelling this one.

## Trade-off, stated plainly

These can overlap again — the ~6-8 parallel installs against one registry VIP that the
shared group was introduced to prevent. I think that is the right call: an image that
never builds is a worse failure than a slow one, and Actions gives no way to request a
queue deeper than one. If registry pressure returns, the fix is a real queue (a
serialising job or a self-hosted lock), not a group that silently drops work.

Prod (`master`) workflows are untouched and were never in the shared group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI for non-prod Docker image builds by using per-workflow concurrency groups. Prevent queued runs from cancelling each other so demo, stage, and MCP images rebuild reliably.

- **Bug Fixes**
  - Switch from shared `gauzy-docker-build` to `gauzy-docker-build-${{ github.workflow }}` across six non-prod workflows.
  - Keep `cancel-in-progress: false` to avoid killing running builds; only supersede older pending runs within the same workflow.
  - Stop cross-workflow cancellations that left environments serving stale images.
  - Trade-off: builds may overlap again; prod (`master`) workflows unchanged.

<sup>Written for commit 1c5e1311be7161fce3ee357d2c0c7963b92d4a0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

