### PR TITLE
fix(ui): theme-blind colours the sweep waves did not reach (dashboard, edit-candidate)

### DIFF
--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.scss
@@ -11,7 +11,7 @@
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background-color: rgb(0, 145, 255);
+  background-color: nb-theme(color-info-default);
 }
 
 .notification:hover {
@@ -27,7 +27,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: #f10;
+  background-color: nb-theme(color-danger-default);
 }
 
 :host .bell {
@@ -62,30 +62,13 @@
   padding: 1rem;
 }
 
-.org-details {
-  .edit-public-page {
-    cursor: pointer;
-    color: #027ad6;
-    padding-top: 3px;
-  }
-}
-
-.setting-name {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.body-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 35px;
-}
-
-.mutation-card.setting-block {
-  background: #eaf3fc;
-}
-
+// Removed as dead: `.org-details .edit-public-page` (a literal `#027ad6` link
+// blue), `.setting-name`, `.body-header`, and `.mutation-card.setting-block`
+// (a literal `#eaf3fc` pale-blue panel, which would have been a light slab on
+// the near-black themes had anything used it). None of those class names
+// appears in this component's own template — only `notification`, `exist` and
+// `bell` do — and these styles are view-encapsulated, so they could not reach a
+// child route's markup either.
 .transparent {
   opacity: 0.7;
 }

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.scss
@@ -143,20 +143,25 @@
       font-size: 18px;
       color: var(--text-basic-color);
 
+      // Four literal status colours here resolved to two meanings: green for
+      // "profit up" / "income", orange-yellow for "profit down" / "expense".
+      // They were two slightly different greens and two slightly different
+      // yellows, none of which changed per theme. Mapped onto the status
+      // tokens, which do.
       .profit-positive-color {
-        color: #66de0b;
+        color: nb-theme(color-success-default);
       }
 
       .profit-negative-color {
-        color: #ff7b00;
+        color: nb-theme(color-warning-default);
       }
 
       .expense-color {
-        color: #dbc300;
+        color: nb-theme(color-warning-default);
       }
 
       .income-color {
-        color: #089c17;
+        color: nb-theme(color-success-default);
       }
     }
 
@@ -195,7 +200,7 @@
       :last-child {
         font-size: 46px;
         font-weight: bold;
-        color: #0091ff;
+        color: nb-theme(color-info-default);
       }
 
       .negative-bonus-color {

--- a/apps/gauzy/src/app/pages/dashboard/human-resources/human-resources.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/human-resources/human-resources.component.scss
@@ -45,7 +45,7 @@
 		.employee-salary {
 			font-size: 24px;
 			font-weight: bold;
-			color: #0091ff;
+			color: nb-theme(color-info-default);
 		}
 	}
 }
@@ -89,11 +89,11 @@
 			:last-child {
 				font-size: 36px;
 				font-weight: bold;
-				color: #0091ff;
+				color: nb-theme(color-info-default);
 			}
 
 			.negative-bonus-color {
-				color: red;
+				color: nb-theme(color-danger-default);
 			}
 		}
 

--- a/apps/gauzy/src/app/pages/dashboard/project-management/project-management-details/project-management-details.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/project-management/project-management-details/project-management-details.component.scss
@@ -53,11 +53,14 @@ $gap: 1rem;
       width: 100%;
       cursor: pointer;
       .dot {
-        border: 1px solid #6e49e8;
+        // Was a literal `#6e49e8` on both the ring and the checked fill — the
+        // accent, spelled out rather than resolved, so it stayed the same purple
+        // on every theme including the ones whose primary is not purple.
+        border: 1px solid nb-theme(color-primary-default);
         padding: 4px;
         border-radius: var(--border-radius);
         &.checked {
-          background-color: #6e49e8;
+          background-color: nb-theme(color-primary-default);
         }
       }
       .status {


### PR DESCRIPTION
Four files that every sweep wave missed, found by inventorying colour literals in
actual declarations (excluding comments, which quote the values they removed and
otherwise inflate the count) and subtracting the areas each wave owned.

### Dashboard

Four literals encoded two meanings and neither resolved per theme:

| was | meant | now |
|---|---|---|
| `#66de0b` "profit up", `#089c17` "income" | positive | `color-success-default` |
| `#ff7b00` "profit down", `#dbc300` "expense" | negative | `color-warning-default` |
| `#0091ff` bonus (×3 across two files) | informational | `color-info-default` |
| bare `red` | negative bonus | `color-danger-default` |
| `#6e49e8` ×2 (ring + checked fill) | accent | `color-primary-default` |

The two greens and two yellows were slightly different shades for the same two
semantics, so collapsing them onto the status tokens is a deliberate simplification,
not just a substitution — worth a look if those shades were meant to be distinguishable.
`#6e49e8` is the accent spelled out, so it stayed purple on themes whose primary isn't.

### edit-candidate

`edit-candidate.component.scss` is a twin of `edit-candidate-profile.component.scss`,
which an earlier wave already converted. This copy was missed and still carried the
same notification disc `rgb(0, 145, 255)` and unread dot `#f10`.

Also removed four dead rules from it — `.org-details .edit-public-page` (a literal
`#027ad6`), `.setting-name`, `.body-header`, and `.mutation-card.setting-block`
(a literal `#eaf3fc` pale-blue panel that would have been a light slab on the
near-black themes had anything used it).

**Checked, not assumed.** None of `mutation-card`, `setting-block`, `setting-name`,
`body-header` or `edit-public-page` appears in that component's template — only
`notification`, `exist` and `bell` do — and these styles are view-encapsulated, so
they cannot reach a child route's markup either. I am being explicit about this
because a wave-4 sweep deleted rules on a "matches nothing" claim that turned out to
be false, so the claim is worth stating in a form you can check in one grep.

### Verification

- `nx build gauzy -c local` → green, exit 0.
- cspell clean.
- Brace balance verified on all four files after the deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hard-coded colors with `nb-theme(...)` tokens across dashboard and candidate views so styles adapt to themes. Also removed unused CSS in `edit-candidate`.

- **Bug Fixes**
  - Dashboard: profit/income -> `nb-theme(color-success-default)`, expense/profit-down -> `nb-theme(color-warning-default)`, info -> `nb-theme(color-info-default)`, negative bonus -> `nb-theme(color-danger-default)`.
  - HR dashboard: info -> `nb-theme(color-info-default)`, negative bonus -> `nb-theme(color-danger-default)`.
  - Project management details: accent `#6e49e8` (ring + checked) -> `nb-theme(color-primary-default)`.
  - Edit candidate: notification disc/dot -> `nb-theme(color-info-default)` / `nb-theme(color-danger-default)`.

- **Refactors**
  - Removed unused rules in `edit-candidate.component.scss`: `.org-details .edit-public-page`, `.setting-name`, `.body-header`, `.mutation-card.setting-block` (confirmed not referenced and view-encapsulated).

<sup>Written for commit 6ed3df8d15be1b7fd2027414725c8c39c8eda6e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

