### PR TITLE
fix(ui): visual sweep of the remaining page areas (wave 5), with adversarial audit

### DIFF
--- a/apps/gauzy/src/app/pages/contacts/contact-mutation/contact-mutation.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/contact-mutation/contact-mutation.component.scss
@@ -18,6 +18,9 @@
 
     .image-overlay {
       pointer-events: none;
+      // Deliberately a literal, and deliberately NOT a theme token: this is a
+      // scrim over the uploaded PHOTO (0 -> 0.2 opacity on hover), so what it has
+      // to darken is the picture, not the surface the card is painted on.
       background: black;
       position: absolute;
       height: 100%;
@@ -33,20 +36,33 @@
       border-radius: nb-theme(border-radius);
     }
 
+    // The empty-state placeholder behind the uploader. It is a NEUTRAL tint, not
+    // a colour of its own: the same token the rest of the app hovers with, so it
+    // darkens a white card and lightens a near-black one instead of staying a
+    // fixed light grey that vanishes on the four dark themes.
     .image {
-      background-color: rgba(126, 126, 143, 0.1);
+      background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+      // Centers the prompt for real. It used to be absolutely positioned at
+      // `left: calc(50% - 141px / 2)` — 141px being a guess at the width of the
+      // English string. Any other translation, or any other root font size, put
+      // the label off center, and a longer one ran out of the 12.5rem box with
+      // nowhere to wrap.
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 0.75rem;
 
       i {
         margin: 5px;
       }
 
       > span {
-        color: rgba(126, 126, 143, 1);
+        // `rgba(126, 126, 143, 1)` is the LIGHT themes' muted text value written
+        // out by hand; on a dark card it is barely above the background.
+        color: var(--gauzy-text-color-2, var(--text-hint-color));
         z-index: 2;
         transition: opacity 0.2s ease-in;
-        position: absolute;
-        top: calc(50% - 16px / 2);
-        left: calc(50% - 141px / 2);
+        text-align: center;
       }
     }
 
@@ -99,26 +115,15 @@
     display: flex;
     align-items: center;
     margin-bottom: 10px;
-
-    .image-container {
-      width: 70px;
-      height: 50px;
-      display: flex;
-
-      img {
-        height: 100%;
-        max-width: 70px;
-      }
-    }
   }
 
-  .button-container {
-    display: flex;
-    width: 160px;
-    justify-content: space-between;
-    margin-top: 15px;
-    margin-left: 9px;
-  }
+  /*
+   * REMOVED: `.image-container` (and its `img`) and `.button-container`.
+   * Neither class occurs anywhere in contact-mutation.component.html or
+   * contact-mutation.component.ts — the members step renders
+   * `.team-card > .name-container > ngx-avatar` and nothing else, and a
+   * component stylesheet cannot reach past its own template.
+   */
 }
 
 /*
@@ -284,7 +289,13 @@
     border-radius: 0;
   }
 
-  @include dialog(transparent, var(--gauzy-card-1));
+  // The second argument paints every input/select in the wizard. It needs a
+  // fallback: `gauzy-card-1` is not registered for `material-light` /
+  // `material-dark` (they inherit from Nebular's material themes, not from the
+  // gauzy default), and an unresolvable `var()` takes the whole
+  // `background-color` declaration with it — there the fields would fall back to
+  // Nebular's own field background, which is not the surface they sit on.
+  @include dialog(transparent, var(--gauzy-card-1, var(--card-background-color)));
 
   /*
    * Step buttons — restated AFTER `dialog()` so these win at equal specificity.

--- a/apps/gauzy/src/app/pages/contacts/contact-view/contact-view.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/contact-view/contact-view.component.scss
@@ -10,6 +10,17 @@
  *
  * Everything below is label/value pairs on theme tokens: no borrowed utilities,
  * no fake control chrome, and values that wrap instead of escaping their panel.
+ *
+ * Every `var(--gauzy-…)` here carries a fallback. `material-light` and
+ * `material-dark` register against Nebular's own material themes rather than
+ * against the gauzy default, so they inherit NONE of the `gauzy-card-*`,
+ * `gauzy-text-color-*`, `gauzy-shadow`, `gauzy-sidebar-background-*` or
+ * `gauzy-border-default-color` keys (themes.scss lines 501-554 set none of them).
+ * A `var()` with no fallback resolves to nothing there and the browser drops the
+ * WHOLE declaration — which is how this panel lost its text colours, its
+ * surfaces and its edges on two of the eight themes. The fallbacks are
+ * translucent neutrals or Nebular keys that every theme does define, so one
+ * value stays right on a white card and on a near-black one.
  */
 
 // The tab body is sized from the viewport so the page fits without the window
@@ -19,7 +30,7 @@ $pane-height: calc(100vh - 17.25rem);
 $aside-height: calc(100vh - 14.25rem);
 
 :host nb-card {
-	background-color: var(--gauzy-card-2);
+	background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
 	margin: 0;
 }
 
@@ -57,15 +68,15 @@ $aside-height: calc(100vh - 14.25rem);
 	height: 2.25rem;
 	border-radius: 50%;
 	object-fit: cover;
-	box-shadow: var(--gauzy-shadow);
+	box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
 }
 
 .identity-avatar-fallback {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background-color: var(--gauzy-hover-tint);
-	color: var(--gauzy-text-color-2);
+	background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.8125rem;
 	font-weight: 600;
 	line-height: 1;
@@ -79,7 +90,7 @@ $aside-height: calc(100vh - 14.25rem);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--gauzy-text-color-1);
+	color: var(--gauzy-text-color-1, var(--text-basic-color));
 	font-size: 1.125rem;
 	font-weight: 600;
 	line-height: 1.5rem;
@@ -90,8 +101,8 @@ $aside-height: calc(100vh - 14.25rem);
 	flex: 0 0 auto;
 	padding: 0.125rem 0.5rem;
 	border-radius: 999px;
-	background-color: var(--gauzy-hover-tint);
-	color: var(--gauzy-text-color-2);
+	background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.6875rem;
 	font-weight: 600;
 	line-height: 1rem;
@@ -130,7 +141,7 @@ $aside-height: calc(100vh - 14.25rem);
 	// Header and body paint to the edges, so the container has to clip them for
 	// the rounded corner to survive.
 	overflow: hidden;
-	box-shadow: var(--gauzy-shadow);
+	box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
 
 	nb-accordion-item-header {
 		font-size: 0.8125rem;
@@ -138,15 +149,15 @@ $aside-height: calc(100vh - 14.25rem);
 		line-height: 1.125rem;
 		letter-spacing: 0em;
 		text-align: left;
-		color: var(--gauzy-text-color-2);
+		color: var(--gauzy-text-color-2, var(--text-hint-color));
 
 		&.accordion-item-header-expanded {
-			background-color: var(--gauzy-sidebar-background-3);
+			background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
 		}
 	}
 
 	nb-accordion-item-body {
-		background-color: var(--gauzy-card-3);
+		background-color: var(--gauzy-card-3, rgba(126, 126, 143, 0.05));
 	}
 }
 
@@ -163,8 +174,8 @@ $aside-height: calc(100vh - 14.25rem);
 .panel-count {
 	padding: 0 0.375rem;
 	border-radius: 999px;
-	background-color: var(--gauzy-hover-tint);
-	color: var(--gauzy-text-color-2);
+	background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.6875rem;
 	font-weight: 600;
 	line-height: 1rem;
@@ -172,7 +183,7 @@ $aside-height: calc(100vh - 14.25rem);
 
 .panel-empty {
 	margin: 0;
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.8125rem;
 	line-height: 1.125rem;
 }
@@ -198,7 +209,7 @@ $aside-height: calc(100vh - 14.25rem);
 
 .field-label {
 	margin: 0 0 0.125rem;
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.6875rem;
 	font-weight: 600;
 	line-height: 1rem;
@@ -210,7 +221,7 @@ $aside-height: calc(100vh - 14.25rem);
 .field-value {
 	margin: 0;
 	min-width: 0;
-	color: var(--gauzy-text-color-1);
+	color: var(--gauzy-text-color-1, var(--text-basic-color));
 	font-size: 0.8125rem;
 	font-weight: 400;
 	line-height: 1.125rem;
@@ -237,7 +248,7 @@ $aside-height: calc(100vh - 14.25rem);
 }
 
 .field-empty {
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	// A dash is a placeholder, not a value: keep it out of the reading order.
 	user-select: none;
 }
@@ -265,15 +276,15 @@ $aside-height: calc(100vh - 14.25rem);
 	height: 1.75rem;
 	border-radius: var(--gauzy-radius-sm, 0.375rem);
 	object-fit: cover;
-	box-shadow: var(--gauzy-shadow);
+	box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
 }
 
 .entity-avatar-fallback {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background-color: var(--gauzy-hover-tint);
-	color: var(--gauzy-text-color-2);
+	background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.75rem;
 	font-weight: 600;
 	line-height: 1;
@@ -291,14 +302,14 @@ $aside-height: calc(100vh - 14.25rem);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--gauzy-text-color-1);
+	color: var(--gauzy-text-color-1, var(--text-basic-color));
 	font-size: 0.8125rem;
 	font-weight: 600;
 	line-height: 1.125rem;
 }
 
 .entity-meta {
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.6875rem;
 	font-weight: 400;
 	line-height: 0.9375rem;
@@ -322,9 +333,9 @@ $aside-height: calc(100vh - 14.25rem);
 	// Same surface as the accordion bodies opposite, so the two columns read as
 	// one screen. The tab BAR is deliberately left on the card behind it — that
 	// is the shape Nebular draws and fighting it only adds a second seam.
-	background-color: var(--gauzy-card-3);
+	background-color: var(--gauzy-card-3, rgba(126, 126, 143, 0.05));
 	border-radius: var(--border-radius);
-	box-shadow: var(--gauzy-shadow);
+	box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
 }
 
 .pane {
@@ -354,7 +365,7 @@ $aside-height: calc(100vh - 14.25rem);
 	min-height: 14rem;
 	overflow: hidden;
 	border-radius: var(--gauzy-radius-sm, 0.375rem);
-	border: 1px solid var(--gauzy-border-default-color);
+	border: 1px solid var(--gauzy-border-default-color, var(--border-basic-color-3));
 }
 
 :host ga-leaflet-map {
@@ -408,11 +419,11 @@ $aside-height: calc(100vh - 14.25rem);
 	align-items: center;
 	min-width: 0;
 	padding: 0.375rem 0.5rem;
-	border: 1px solid var(--gauzy-border-default-color);
+	border: 1px solid var(--gauzy-border-default-color, var(--border-basic-color-3));
 	border-radius: var(--gauzy-radius-sm, 0.375rem);
 
 	&:hover {
-		background-color: var(--gauzy-hover-tint);
+		background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
 	}
 
 	// Without this the avatar's own `min-width: auto` keeps the card as wide as

--- a/apps/gauzy/src/app/pages/contacts/contacts.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/contacts.component.scss
@@ -1,41 +1,16 @@
 @use '@shared/_pg-card' as *;
 
-.contact-list {
-  display: flex;
-  flex-wrap: wrap;
-
-  .member-card {
-    display: flex;
-    flex-wrap: wrap;
-    max-width: 340px;
-    width: 100%;
-  }
-
-  .contact-info {
-    padding-right: 12px;
-    display: flex;
-    flex-direction: column;
-
-    .info-line {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      font-size: 0.7em;
-      color: darkgray;
-
-      .info-value {
-        display: flex;
-        justify-content: flex-end;
-        text-align: end;
-
-        .info-list-item:not(:last-child)::after {
-          content: ',';
-          margin-right: 5px;
-        }
-      }
-    }
-  }
-}
+/*
+ * REMOVED: the `.contact-list` block (`.member-card`, `.contact-info`,
+ * `.info-line`, `.info-value`, `.info-list-item`).
+ *
+ * `contact-list` appears nowhere in the worktree outside this file — the card
+ * layout is rendered by `ga-card-grid`, a CHILD component, whose elements carry
+ * ITS `_ngcontent` attribute, so these rules could never have reached them under
+ * the default emulated encapsulation. (`ga-card-grid` styles its own `.info-line`
+ * in card-grid.component.scss.) The block also carried `color: darkgray`, a
+ * literal that belongs to no theme.
+ */
 
 .main-header {
   display: flex;

--- a/apps/gauzy/src/app/pages/contacts/contacts.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/contacts.component.scss
@@ -4,7 +4,7 @@
  * REMOVED: the `.contact-list` block (`.member-card`, `.contact-info`,
  * `.info-line`, `.info-value`, `.info-list-item`).
  *
- * `contact-list` appears nowhere in the worktree outside this file — the card
+ * `contact-list` appears nowhere in the repository outside this file — the card
  * layout is rendered by `ga-card-grid`, a CHILD component, whose elements carry
  * ITS `_ngcontent` attribute, so these rules could never have reached them under
  * the default emulated encapsulation. (`ga-card-grid` styles its own `.info-line`

--- a/apps/gauzy/src/app/pages/contacts/invite-contact/invite-contact.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/invite-contact/invite-contact.component.scss
@@ -2,10 +2,50 @@
 
 nb-card {
   width: 645px;
-  background-color: nb-theme(gauzy-card-1);
-  nb-card-header {
-    nb-icon.close {
-      cursor: pointer;
-    }
+  // 645px was a hard width with nothing to stop it, so below ~700px of viewport
+  // the dialog ran past both edges of the screen and took its footer with it.
+  max-width: calc(100vw - 3rem);
+  // `nb-theme(gauzy-card-1)` compiles to a bare `var(--gauzy-card-1)` — Nebular
+  // runs in CSS-custom-property mode here — and that key is not registered for
+  // `material-light` / `material-dark`, which are registered against Nebular's
+  // own material themes rather than against the gauzy default (themes.scss lines
+  // 501-554). An unresolvable `var()` takes the whole declaration with it, so on
+  // those two themes the dialog had no surface colour of its own at all.
+  background-color: var(--gauzy-card-1, var(--card-background-color));
+
+  /*
+   * REMOVED: `nb-card-header nb-icon.close { cursor: pointer }`.
+   * invite-contact.component.html has no `nb-icon` anywhere — the close control
+   * is `<span class="cancel"><i class="fas fa-times">`, and `_gauzy-dialogs`
+   * already gives every `i` in this component `cursor: pointer`.
+   */
+}
+
+/*
+ * Cancel, restated AFTER `_gauzy-dialogs` so it wins at equal specificity.
+ *
+ * That shared partial paints EVERY `[nbButton].appearance-outline.status-basic`
+ * a literal `rgba(245, 109, 88, 1)` orange, 2px wide, with an orange glow on
+ * hover. No theme in themes.scss holds that colour. Here it landed on the one
+ * button in the dialog that should be quietest: "Cancel" read louder than the
+ * invite action next to it, which the theme's action tokens draw as a restrained
+ * accent. So a hairline in the neutral border token, a muted label, and the same
+ * hover tint the rest of the app uses.
+ */
+:host [nbButton].appearance-outline.status-basic {
+  background-color: transparent;
+  border-width: 1px;
+  border-color: nb-theme(border-basic-color-4);
+  color: nb-theme(text-hint-color);
+
+  &:hover {
+    border-color: nb-theme(border-basic-color-5);
+    color: nb-theme(text-basic-color);
+    background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
   }
+}
+
+// The partial's orange hover glow, which no longer matches anything above.
+:host [nbButton].appearance-outline:hover {
+  box-shadow: none;
 }

--- a/apps/gauzy/src/app/pages/documents/documents.component.html
+++ b/apps/gauzy/src/app/pages/documents/documents.component.html
@@ -28,7 +28,13 @@
 				>
 					<div>
 						<nb-icon icon="file-text-outline"></nb-icon>
-						<a [href]="document.documentUrl">
+						<!--
+							The target is an uploaded file on another origin, and the row it sits
+							in also handles the click to SELECT the document — following the link
+							in place threw the whole app away to open an attachment. `noopener`
+							keeps the opened tab from reaching back through `window.opener`.
+						-->
+						<a [href]="document.documentUrl" target="_blank" rel="noopener noreferrer">
 							{{ document.name }}
 						</a>
 					</div>

--- a/apps/gauzy/src/app/pages/documents/documents.component.scss
+++ b/apps/gauzy/src/app/pages/documents/documents.component.scss
@@ -1,1 +1,67 @@
+// `@forward` re-exports for anyone importing THIS file; it does not bring
+// `nb-theme()` into scope here, so the theme module is also `@use`d. Sass loads
+// each module once, so this does not duplicate the emitted CSS.
+@use 'gauzy/_gauzy-cards' as *;
 @forward '../vendors/vendors.component';
+
+/*
+ * Everything above comes from the vendors sheet (which itself forwards
+ * `expense-categories`): the page frame, the dialog, and the row hover /
+ * selection treatment. Only the parts where this page's markup differs from
+ * vendors' are restated here.
+ */
+
+// A document row is `<div><nb-icon><a>name</a></div>` followed by
+// `<div>{{ updatedAt }}</div>`. Both are plain blocks, so the timestamp landed on
+// its own line under the file name, left-aligned, with the icon sitting on the
+// text baseline instead of beside it — one list entry cost two lines and read as
+// two unrelated values. Name on the leading edge, date on the trailing one.
+:host .custom-table {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+
+  > div {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-width: 0;
+  }
+
+  // The date is the secondary value here, and it must not push the name out.
+  > div:last-child {
+    flex: 0 0 auto;
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
+    font-size: nb-theme(text-caption-font-size);
+  }
+
+  // `min-width: 0` as well as on the wrapper: a flex item's default
+  // `min-width: auto` is its content width, so without this the name never
+  // shrinks and the ellipsis never appears — it just pushes the date out.
+  a {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  nb-icon {
+    flex: 0 0 auto;
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
+  }
+}
+
+// The dialog's close control. `expense-categories` gives every `<i>` in
+// `.editable` a pointer cursor, which is what the vendors dialog uses — this one
+// is an `<nb-icon>`, so it was the one close button across these two pages that
+// gave no hint it could be clicked, at full icon size and full text contrast.
+.editable nb-icon {
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--gauzy-text-color-2, var(--text-hint-color));
+
+  &:hover {
+    color: nb-theme(text-basic-color);
+  }
+}

--- a/apps/gauzy/src/app/pages/employment-types/employment-types.component.scss
+++ b/apps/gauzy/src/app/pages/employment-types/employment-types.component.scss
@@ -14,10 +14,13 @@
       flex-direction: column;
       @include nb-ltr(padding, 1rem 0.5rem 1rem 18px);
       @include nb-rtl(padding, 1rem 18px 1rem 0.5rem);
-      nb-accordion {
-        @include nb-ltr(margin-right, 0.625rem);
-        @include nb-rtl(margin-left, 0.625rem);
-      }
+      // Removed: `nb-accordion { margin-right/left: 0.625rem }`. Grepping this
+      // page for "accordion" matches only this stylesheet — the template
+      // (employment-types.component.html) renders nb-tabset > nb-card >
+      // ga-notes-with-tags / ga-card-grid, never an accordion, and the .ts adds
+      // no class or element bindings. With emulated encapsulation the selector
+      // could only ever have matched an nb-accordion in this component's own
+      // template, so it styled nothing.
     }
     nb-tabset {
       // Card body height: the viewport less the app chrome above the tabset.
@@ -38,7 +41,12 @@
     }
     nb-card,
     nb-tab.content-active {
-      background-color: var(--gauzy-card-2);
+      // material-light / material-dark register no `gauzy-card-2` (themes.scss
+      // gives them only gauzy-primary-background, gauzy-sidebar-background-*
+      // and gauzy-border-table), so a bare var() is invalid there and the whole
+      // declaration is dropped — the row cards lose their panel tint and sit
+      // flat on the tab body. Neutral translucent gray as the fallback.
+      background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
     }
     nb-card-body{
       overflow: unset;
@@ -57,12 +65,11 @@
     @include tabset-action-row(16px);
 }
 
-nb-accordion-item-header ::ng-deep nb-icon {
-    border: 1px solid nb-theme(border-basic-color-4);
-    border-radius: nb-theme(input-rectangle-border-radius);
-    width: 1.75rem;
-    height: 1.75rem;
-}
+// Removed: `nb-accordion-item-header ::ng-deep nb-icon { border/radius/size }`.
+// Same reason as the nb-accordion rule above — this page has no accordion, and
+// the part of the selector before `::ng-deep` still carries this component's
+// encapsulation attribute, so it could only have matched an
+// nb-accordion-item-header in employment-types.component.html. There is none.
 
 nb-card-body {
     background: none;

--- a/apps/gauzy/src/app/pages/goal-settings/edit-time-frame/edit-time-frame.component.scss
+++ b/apps/gauzy/src/app/pages/goal-settings/edit-time-frame/edit-time-frame.component.scss
@@ -1,20 +1,20 @@
 @use 'gauzy/_gauzy-dialogs' as *;
 
-.main-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  .subtitle {
-    font-size: 16px;
-    font-weight: 600;
-    line-height: 16px;
-    letter-spacing: 0em;
-    text-align: center;
-  }
-}
+// Removed: a `.main-header` block (and the `.subtitle` rule nested inside it).
+// `edit-time-frame.component.html` has no `main-header` element — the dialog
+// puts its heading straight into `nb-card-header` — so neither selector could
+// ever match; the file's only `.subtitle` is the "Predefined Time Frames" <h6>,
+// which is not inside a `.main-header` and so was never reached by the nested
+// rule either. This stylesheet is not shared: no other component points its
+// `styleUrls` at it, and nothing `@use`s or `@forward`s it.
 
 :host {
   nb-card {
-    background-color: var(--gauzy-card-1);
+    // Fallback required: `--gauzy-card-1` is undefined in material-light and
+    // material-dark (`themes.scss` registers those two against Nebular's own
+    // parent themes, which carry no `gauzy-card-*` keys), and a `var()` with no
+    // fallback makes the browser drop the whole declaration. Nebular's own card
+    // background is what `gauzy-card-1` aliases in most themes anyway.
+    background-color: var(--gauzy-card-1, var(--card-background-color));
   }
 }

--- a/apps/gauzy/src/app/pages/goal-settings/goal-settings.component.scss
+++ b/apps/gauzy/src/app/pages/goal-settings/goal-settings.component.scss
@@ -31,7 +31,11 @@
   }
   nb-card,
   nb-tab {
-    background-color: var(--gauzy-card-2);
+    // Fallback required: `--gauzy-card-2` is undefined in material-light and
+    // material-dark — `themes.scss` registers those two against Nebular's own
+    // parent themes, so they never inherit the `gauzy-card-*` keys — and a
+    // `var()` without one makes the browser discard the whole declaration.
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
     margin: 0;
   }
   nb-card-body {
@@ -42,7 +46,10 @@
 }
 
 .card-general {
-  background: var(--gauzy-card-3);
+  // Same story as `--gauzy-card-2` above: `--gauzy-card-3` is not defined in
+  // material-light / material-dark, so without a fallback the General tab's
+  // settings panel lost its background entirely there.
+  background: var(--gauzy-card-3, rgba(126, 126, 143, 0.05));
   border-radius: nb-theme(border-radius);
 }
 

--- a/apps/gauzy/src/app/pages/goals/edit-keyresults/edit-keyresults.component.scss
+++ b/apps/gauzy/src/app/pages/goals/edit-keyresults/edit-keyresults.component.scss
@@ -16,13 +16,20 @@
   }
 }
 
+// `--gauzy-card-1` / `--gauzy-card-2` are undefined in material-light and
+// material-dark: `themes.scss` registers those two against Nebular's own parent
+// themes, which carry no `gauzy-card-*` keys. A `var()` with no fallback makes
+// the browser throw the entire declaration away, so both uses below carry one.
+// This stylesheet is shared — `key-result-parameters` points its `styleUrls`
+// here and `edit-objective` / `goal-details` `@forward` it — so the fix reaches
+// all four dialogs.
 :host {
   nb-card {
-    background: var(--gauzy-card-1);
+    background: var(--gauzy-card-1, var(--card-background-color));
   }
   nb-tab,
   .content {
-    background-color: var(--gauzy-card-2);
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   }
   nb-tab {
     height: 20.75vh;

--- a/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.html
+++ b/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.html
@@ -67,10 +67,7 @@
       <nb-tabset>
         <nb-tab tabTitle="{{ 'GOALS_PAGE.KEY_RESULTS' | translate }}">
           @if (goal.keyResults.length == 0) {
-            <div
-              class="card-key-result"
-              å
-              >
+            <div class="card-key-result">
               {{ 'GOALS_PAGE.MESSAGE.NO_KEY_RESULT' | translate }}
             </div>
           }
@@ -285,7 +282,7 @@
                     <textarea
                       nbInput
                       fullWidth
-                      placeholder="Add Comment"
+                      [placeholder]="'BUTTONS.ADD_COMMENT' | translate"
                     ></textarea>
                   </div>
                   <div class="col-3 btn-comment">

--- a/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
+++ b/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
@@ -31,7 +31,11 @@
   .custom-footer {
     // Was a literal `rgba(126, 126, 143, 0.1)`. This is the same recessed
     // surface the identical update cards in `keyresult-details` paint with
-    // `--gauzy-card-2`, so it follows the same token. The fallback is required:
+    // `--gauzy-card-2`, so it follows the same token. The FALLBACKS differ on
+    // purpose — 0.1 here, 0.08 there — because each keeps the literal its own
+    // file already used, and the fallback is only reached by the two material
+    // themes. The token is what makes them agree everywhere else.
+    // The fallback is required:
     // `--gauzy-card-2` is not defined in material-light / material-dark (see
     // `themes.scss` — those two register against Nebular's own parents and
     // never pick up the `gauzy-card-*` keys), and without one the whole

--- a/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
+++ b/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
@@ -25,7 +25,14 @@
     }
   }
   .custom-footer {
-    background-color: rgba(126, 126, 143, 0.1);
+    // Was a literal `rgba(126, 126, 143, 0.1)`. This is the same recessed
+    // surface the identical update cards in `keyresult-details` paint with
+    // `--gauzy-card-2`, so it follows the same token. The fallback is required:
+    // `--gauzy-card-2` is not defined in material-light / material-dark (see
+    // `themes.scss` — those two register against Nebular's own parents and
+    // never pick up the `gauzy-card-*` keys), and without one the whole
+    // declaration is dropped there.
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.1));
     padding-bottom: 5px;
   }
   .custom-header {

--- a/apps/gauzy/src/app/pages/goals/goals.component.scss
+++ b/apps/gauzy/src/app/pages/goals/goals.component.scss
@@ -16,10 +16,14 @@
   }
 }
 
+// `--gauzy-card-2` is undefined in material-light / material-dark — those two
+// themes register against Nebular's own parents in `themes.scss` and never pick
+// up the `gauzy-card-*` keys — and a `var()` with no fallback makes the browser
+// throw the whole declaration away. Every use below carries one.
 :host {
   nb-card,
   nb-card-body {
-    background-color: var(--gauzy-card-2);
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   }
   nb-card-body {
     overflow: unset;
@@ -57,10 +61,23 @@
     box-shadow: unset;
   }
 }
+// Key-result rows inside an objective. Hover and "this is the selected row"
+// used to share one declaration, so the row the action bar is actually acting
+// on looked exactly like whatever the pointer happened to be over. They are two
+// different states and now read as two:
+//   * selection takes the primary accent — the tint the rest of the app uses
+//     for "current" — rather than the neutral hover fill;
+//   * the hover rule is guarded with `:not(.selected)`. The two selectors are
+//     the same specificity (0,2,1 either way), so without the guard whichever
+//     came last would simply win, and hovering the selected row would repaint
+//     it as an ordinary hover.
 nb-accordion-item-body {
-  &:hover,
+  &:hover:not(.selected) {
+    background: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
+  }
+
   &.item.selected {
-    background: var(--gauzy-card-2);
+    background: nb-theme(color-primary-transparent-100);
   }
 }
 .keyResult {

--- a/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.html
+++ b/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.html
@@ -201,11 +201,10 @@
       <div class="d-flex float-left">
         <div class="button-container">
           <button
-            class="mr-3"
+            class="mr-3 action"
             status="basic"
             nbButton
             size="small"
-            class="action"
             (click)="deleteKeyResult()"
             [nbTooltip]="'BUTTONS.DELETE' | translate"
             >

--- a/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.html
+++ b/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.html
@@ -201,6 +201,7 @@
       <div class="d-flex float-left">
         <div class="button-container">
           <button
+            type="button"
             class="mr-3 action"
             status="basic"
             nbButton

--- a/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.scss
+++ b/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.scss
@@ -40,14 +40,19 @@
   }
 }
 
+// `--gauzy-card-*` is undefined in material-light / material-dark (see
+// `themes.scss`: those two register against Nebular's own parent themes and so
+// never inherit the `gauzy-card-*` keys). A `var()` with no fallback makes the
+// browser drop the WHOLE declaration there, which left these panels unpainted,
+// so every use below carries one.
 .button-container {
-  background: var(--gauzy-card-2);
+  background: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   padding: 5px;
   border-radius: nb-theme(button-rectangle-border-radius);
 }
 .custom-card,
 .custom-footer {
-  background: var(--gauzy-card-2);
+  background: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
 }
 .custom-header,
 .custom-footer {
@@ -79,7 +84,14 @@
   text-align: left;
 }
 
+// The key-result summary panel. Its class comes from Bootstrap 4, whose
+// `.border` is literally `border: 1px solid #dee2e6 !important` — a light grey
+// hairline drawn identically in all eight themes, i.e. a visible pale box on
+// the near-black cards of `dark` / `cosmic` / `gauzy-dark` / `material-dark`.
+// Restated here from a theme token; `!important` only to out-rank Bootstrap's
+// own, and the same 1px so nothing re-flows.
 .border {
+  border: 1px solid nb-theme(border-basic-color-3) !important;
   border-radius: nb-theme(border-radius);
   margin: 3rem 0;
 }

--- a/apps/gauzy/src/app/pages/goals/keyresult-progress-chart/keyresult-progress-chart.component.ts
+++ b/apps/gauzy/src/app/pages/goals/keyresult-progress-chart/keyresult-progress-chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ElementRef, inject } from '@angular/core';
 import { IKeyResult, KeyResultDeadlineEnum, IKPI, IOrganization } from '@gauzy/contracts';
 import { GoalSettingsService } from '@gauzy/ui-core/core';
 import { differenceInCalendarDays, addMonths, compareDesc, addDays, addWeeks, addQuarters, isAfter } from 'date-fns';
@@ -19,6 +19,14 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 	@Input() keyResult: IKeyResult;
 	@Input() kpi: IKPI;
 	@Input() organization: IOrganization;
+
+	/**
+	 * Host element for theme colour lookups. Nebular emits its theme tokens as
+	 * CSS custom properties on the themed subtree (`.nb-theme-*` on `nb-layout`),
+	 * NOT on `<html>`, so they have to be resolved against an element inside it.
+	 */
+	private readonly elementRef = inject(ElementRef);
+
 	constructor(
 		private goalSettingsService: GoalSettingsService,
 		private store: Store,
@@ -114,7 +122,12 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 						labelsData
 					),
 					borderWidth: 4,
-					borderColor: 'rgb(76, 23, 33,0.25)',
+					// Was `rgb(76, 23, 33,0.25)` — four arguments in the legacy
+					// comma form, which is not a valid colour. The canvas keeps
+					// whatever `strokeStyle` it had, so the "expected" guide line
+					// was drawn in the default black: invisible on every dark
+					// theme. It is a guide, so it takes the muted text colour.
+					borderColor: this.themeColor('--text-hint-color', 'rgba(113, 113, 122, 1)'),
 					borderDash: [10, 5],
 					fill: false
 				},
@@ -122,11 +135,39 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 					label: this.getTranslation('GOALS_PAGE.PROGRESS'),
 					data: this.progressData(keyResult, labelsData),
 					borderWidth: 4,
-					borderColor: '#00d68f',
+					// Was a hard-coded `#00d68f` — the old Nebular success green,
+					// the same in all eight themes and washed out on the light
+					// canvas. The theme's own success accent has a light and a
+					// dark value, so the line stays legible on both.
+					borderColor: this.themeColor('--gauzy-action-success-text', '#047857'),
 					fill: false
 				}
 			]
 		};
+	}
+
+	/**
+	 * Reads a colour off the active theme's CSS custom properties.
+	 *
+	 * Chart.js paints onto a canvas and cannot resolve `var()` itself, so the
+	 * value has to be looked up here. Guarded for non-browser platforms (SSR,
+	 * unit tests) where `getComputedStyle` does not exist — the chart must fall
+	 * back to a literal, not crash.
+	 *
+	 * @param name - Custom property name, including the leading `--`.
+	 * @param fallback - Colour to use when the property cannot be read.
+	 * @returns A non-empty CSS colour string.
+	 */
+	private themeColor(name: string, fallback: string): string {
+		const host: Element | null = this.elementRef.nativeElement ?? null;
+		if (!host || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+			return fallback;
+		}
+		try {
+			return window.getComputedStyle(host).getPropertyValue(name).trim() || fallback;
+		} catch {
+			return fallback;
+		}
 	}
 
 	progressData(keyResult, labelsData) {

--- a/apps/gauzy/src/app/pages/goals/keyresult-progress-chart/keyresult-progress-chart.component.ts
+++ b/apps/gauzy/src/app/pages/goals/keyresult-progress-chart/keyresult-progress-chart.component.ts
@@ -5,7 +5,10 @@ import { differenceInCalendarDays, addMonths, compareDesc, addDays, addWeeks, ad
 import { Store } from '@gauzy/ui-core/core';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 import { TranslateService } from '@ngx-translate/core';
+import { NbThemeService } from '@nebular/theme';
+import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 
+@UntilDestroy({ checkProperties: true })
 @Component({
     selector: 'ga-keyresult-progress-chart',
     templateUrl: './keyresult-progress-chart.component.html',
@@ -26,6 +29,7 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 	 * NOT on `<html>`, so they have to be resolved against an element inside it.
 	 */
 	private readonly elementRef = inject(ElementRef);
+	private readonly themeService = inject(NbThemeService);
 
 	constructor(
 		private goalSettingsService: GoalSettingsService,
@@ -37,6 +41,16 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 
 	ngOnInit() {
 		this.updateChart(this.keyResult);
+
+		// Chart.js copies concrete colour strings into the dataset; it cannot hold a
+		// `var()` and re-resolve it. So a theme switch while this dialog is open would
+		// otherwise leave both lines painted in the colours of the theme that was
+		// active when the chart was built — the exact contrast problem the tokens were
+		// introduced to solve. Rebuilding on theme change re-reads them.
+		this.themeService
+			.onThemeChange()
+			.pipe(untilDestroyed(this))
+			.subscribe(() => this.updateChart(this.keyResult));
 	}
 
 	public async updateChart(keyResult: IKeyResult) {

--- a/apps/gauzy/src/app/pages/goals/keyresult-update/keyresult-update.component.scss
+++ b/apps/gauzy/src/app/pages/goals/keyresult-update/keyresult-update.component.scss
@@ -4,14 +4,17 @@
   width: 30vw;
 }
 
-.main-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
+// Removed: a `.main-header` flex block. `keyresult-update.component.html` has
+// no element carrying that class (the dialog's heading goes straight into
+// `nb-card-header`), and this stylesheet is not shared — no other component's
+// `styleUrls` points at it and nothing `@use`s or `@forward`s it.
 
 :host {
   nb-card {
-    background: var(--gauzy-card-1);
+    // Fallback required: `--gauzy-card-1` is undefined in material-light and
+    // material-dark (`themes.scss` registers those two against Nebular's own
+    // parent themes, which carry no `gauzy-card-*` keys), and a `var()` with no
+    // fallback makes the browser discard the whole declaration.
+    background: var(--gauzy-card-1, var(--card-background-color));
   }
 }

--- a/apps/gauzy/src/app/pages/import-export/export/export.component.scss
+++ b/apps/gauzy/src/app/pages/import-export/export/export.component.scss
@@ -19,7 +19,12 @@
     // declaration with it, which on a background means the card renders
     // transparent. The `--gauzy-page-title-*` metrics below need none — those
     // come from the shared density preset, which every theme merges.
-    background-color: var(--gauzy-card-2, rgba(50, 50, 50, 0.03));
+    // The fallback is a neutral mid-grey, not the light theme's 3% black: the
+    // only themes that reach it are material-light and material-dark, and 3%
+    // black on the dark one is invisible — which is the one case the fallback
+    // exists to cover. A neutral at the same weight darkens a light surface and
+    // lightens a dark one.
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.1));
 
     &.card-body {
       height: calc(100vh - 21rem);

--- a/apps/gauzy/src/app/pages/import-export/export/export.component.scss
+++ b/apps/gauzy/src/app/pages/import-export/export/export.component.scss
@@ -14,7 +14,12 @@
 
   nb-card,
   nb-card-body {
-    background-color: var(--gauzy-card-2);
+    // Fallbacks on the surface/text `--gauzy-*` tokens in this file: a bare
+    // `var()` naming a custom property a theme does not emit takes the whole
+    // declaration with it, which on a background means the card renders
+    // transparent. The `--gauzy-page-title-*` metrics below need none — those
+    // come from the shared density preset, which every theme merges.
+    background-color: var(--gauzy-card-2, rgba(50, 50, 50, 0.03));
 
     &.card-body {
       height: calc(100vh - 21rem);
@@ -48,7 +53,7 @@
         line-height: 13px;
         letter-spacing: 0em;
         text-align: left;
-        color: var(--gauzy-text-color-2);
+        color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
       }
     }
   }
@@ -58,12 +63,12 @@
   ::ng-deep {
       .download {
           padding: 0.5rem;
-          background-color: var(--gauzy-card-2);
+          background-color: var(--gauzy-card-2, rgba(50, 50, 50, 0.03));
           border-radius: var(--button-rectangle-border-radius);
           @include nb-ltr(float, right);
           @include nb-rtl(float, left);
           .action {
-            box-shadow: var(--gauzy-shadow);
+            box-shadow: var(--gauzy-shadow, 0px 1px 1px 0px rgb(0 0 0 / 15%));
           }
       }
   }
@@ -84,7 +89,7 @@
   line-height: var(--gauzy-page-title-line-height);
   letter-spacing: var(--gauzy-page-title-letter-spacing);
   text-align: left;
-  color: var(--gauzy-text-color-1);
+  color: var(--gauzy-text-color-1, var(--text-basic-color));
   white-space: nowrap;
 }
 
@@ -94,5 +99,5 @@
   line-height: 17px;
   letter-spacing: 0em;
   text-align: left;
-  color: var(--gauzy-text-color-2);
+  color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 }

--- a/apps/gauzy/src/app/pages/import-export/import-export.component.html
+++ b/apps/gauzy/src/app/pages/import-export/import-export.component.html
@@ -16,10 +16,14 @@
     <div class="row">
       <div class="col-sm-12 button-imports">
         <div class="button-import">
+          <!--
+            `shape="round"` was dropped: this was the only one of the four
+            buttons in this row that asked for a pill, so it sat next to three
+            rectangles.
+          -->
           <button
             class="action"
             nbButton
-            shape="round"
             status="success"
             size="small"
             (click)="importPage()"

--- a/apps/gauzy/src/app/pages/import-export/import-export.component.html
+++ b/apps/gauzy/src/app/pages/import-export/import-export.component.html
@@ -17,9 +17,13 @@
       <div class="col-sm-12 button-imports">
         <div class="button-import">
           <!--
-            `shape="round"` was dropped: this was the only one of the four
-            buttons in this row that asked for a pill, so it sat next to three
-            rectangles.
+            `shape="round"` was dropped: this was the only button in this row
+            that asked for a pill, so it sat next to rectangles. (The row holds
+            up to four — Migrate To Cloud is behind `!environment.DEMO` and the
+            MIGRATE_GAUZY_CLOUD permission, so on a demo build there are fewer.)
+
+            This is a deliberate restyle of something that did render, not the
+            removal of a rule that never applied.
           -->
           <button
             class="action"

--- a/apps/gauzy/src/app/pages/import-export/import-export.component.scss
+++ b/apps/gauzy/src/app/pages/import-export/import-export.component.scss
@@ -12,10 +12,14 @@
             gap: 10px;
         }
 
+        // The tray each toolbar button sits in. `2rem` made it a pill wrapped
+        // around a rectangular button, so the tray's corners stood well clear
+        // of the button's on both sides; the button radius token is what the
+        // shared `.actions` tray in `gauzy/_gauzy-table.scss` uses.
         .button-import {
             background-color: nb-theme(gauzy-card-2);
             padding: 5px;
-            border-radius: 2rem;
+            border-radius: nb-theme(button-rectangle-border-radius);
         }
 
         .info {

--- a/apps/gauzy/src/app/pages/import-export/import/import.component.html
+++ b/apps/gauzy/src/app/pages/import-export/import/import.component.html
@@ -101,12 +101,17 @@
 					</div>
 				</div>
 
+				<!--
+					The queue rows below used to carry `(click)="selectItem(item)"`. That was
+					dropped: ImportComponent has no `selectItem` member — the name appeared in
+					this one binding and nowhere else — so clicking a queued file threw instead
+					of doing anything.
+				-->
 				<div class="custom-body queue">
 					@for (item of uploader.queue; track item.file?.name; let lastItem = $last) {
 					<div
 						class="row border-bottom m-0 py-3 align-items-center"
 						[class.border-bottom-none]="lastItem"
-						(click)="selectItem(item)"
 					>
 						<div class="col-4">
 							{{ item?.file?.name }}

--- a/apps/gauzy/src/app/pages/import-export/import/import.component.scss
+++ b/apps/gauzy/src/app/pages/import-export/import/import.component.scss
@@ -1,30 +1,36 @@
 @use 'gauzy/gauzy-table' as *;
 @forward '../export/export.component';
 
+// Fallbacks on every `--gauzy-*` in this file: a bare `var()` naming a custom
+// property a theme does not emit drops the whole declaration, which on this page
+// means a drop zone with no border and body text with no colour.
 .well {
   height: 180px;
   width: 180px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--gauzy-text-color-2);
+  color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 }
 
 .my-drop-zone {
-  border: dashed 3px var(--gauzy-border-default-color);
+  border: dashed 3px var(--gauzy-border-default-color, rgba(126, 126, 143, 0.1));
   border-radius: var(--border-radius);
 }
 
+// Drag-over state. Was `dashed 3px red` — a raw keyword red, which reads as a
+// rejected file rather than "drop it here", and is the one colour on the page
+// that answers to no theme. The primary accent is what the rest of the app uses
+// for an active target.
 .nv-file-over {
-  border: dashed 3px red;
+  border: dashed 3px var(--color-primary-default);
   border-radius: var(--border-radius);
 }
 
-/* Default class applied to drop zones on over */
-.another-file-over-class {
-  border: dashed 3px green;
-  border-radius: var(--border-radius);
-}
+// Removed `.another-file-over-class` (`border: dashed 3px green`). The string
+// `another-file-over-class` appears nowhere in `import.component.html` or
+// `import.component.ts`; the template has a single drop zone and it toggles
+// `.nv-file-over` above.
 
 .import-data {
   display: flex;
@@ -64,7 +70,7 @@
   }
 
   .progress {
-    background-color: var(--gauzy-card-2);
+    background-color: var(--gauzy-card-2, rgba(50, 50, 50, 0.03));
     border-radius: var(--button-rectangle-border-radius);
 
     .progress-bar {
@@ -91,7 +97,7 @@
 :host ::ng-deep {
   nb-radio {
     span.text {
-      color: var(--gauzy-text-color-2);
+      color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
       font-size: 11px;
       font-weight: 400;
       line-height: 13px;
@@ -113,8 +119,8 @@
   line-height: 15px;
   letter-spacing: 0em;
   text-align: left;
-  color: var(--gauzy-text-color-2);
-  background: var(--gauzy-card-3);
+  color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
+  background: var(--gauzy-card-3, rgba(255, 255, 255, 0.5));
   border-radius: var(--border-radius);
   padding: 3px;
   height: 42px;
@@ -130,7 +136,7 @@
 }
 
 .custom-body {
-  background: var(--gauzy-card-4);
+  background: var(--gauzy-card-4, rgba(255, 255, 255, 0.75));
   border-radius: nb-theme(border-radius);
   margin-top: 6px;
   padding-left: 6px;
@@ -145,29 +151,30 @@
     max-height: calc(100vh - 45rem);
   }
 
+  // Overrides Bootstrap's `.border-bottom`, which is a flat `1px solid #dee2e6`
+  // and therefore the same near-white hairline on all eight themes.
   .border-bottom {
-    border-bottom: 1px solid rgba(126, 126, 143, 0.1) !important;
+    border-bottom: 1px solid var(--gauzy-border-default-color, rgba(126, 126, 143, 0.1)) !important;
+  }
+
+  // Both lists bind `[class.border-bottom-none]` on their last row
+  // (`lastItem` in the upload queue, `lastHistory` in the import history), but
+  // nothing ever defined the class, so the final row kept a divider under it
+  // and the list ended on a rule with nothing below it.
+  .border-bottom-none {
+    border-bottom: none !important;
   }
 
   [nbButton].appearance-outline.status-primary {
     border: none;
   }
-
-  .item,
-  a {
-    cursor: pointer;
-  }
-
-  .selected {
-    background-color: rgba(126, 126, 143, 0.1);
-    box-shadow: -6px 0 0 0 rgba(0, 0, 0, 0.15);
-    border-radius: 8px 0 0 8px;
-
-    &.border-bottom {
-      border-bottom: none;
-    }
-  }
 }
+
+// Removed `.custom-body .item, .custom-body a { cursor: pointer }` and the
+// `.custom-body .selected { ... }` block. Component styles only reach this
+// component's own template, and `import.component.html` has no `item` class, no
+// `selected` class (nothing binds one) and no `<a>` at all — its two lists are
+// `div.row.border-bottom` and its links are `[nbButton]`s.
 
 nb-badge {
   position: relative;

--- a/apps/gauzy/src/app/pages/income/income.component.html
+++ b/apps/gauzy/src/app/pages/income/income.component.html
@@ -44,16 +44,9 @@
         (scroll)="onScroll()"
       ></ga-card-grid>
     }
-    <ng-template #gridLayout>
-      <ga-card-grid
-        [loading]="loading"
-        [totalItems]="pagination?.totalItems"
-        [settings]="smartTableSettings"
-        [source]="incomes"
-        (onSelectedItem)="selectIncome($event)"
-        (scroll)="onScroll()"
-      ></ga-card-grid>
-    </ng-template>
+    <!-- Removed an `<ng-template #gridLayout>` that repeated the card grid above:
+         `gridLayout` was referenced nowhere in this template or its component, so
+         it was never instantiated. The `@else` branch is the grid layout. -->
   </nb-card-body>
 </nb-card>
 

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
@@ -91,12 +91,23 @@
   padding-right: 10px;
   max-width: 49% !important;
 }
-// Removed `.active { background: #ffffff; }`. In this template `active` is only
-// ever bound on the aside-nav `<li>` items (`[class.active]="general?.expanded"`
-// and its nine siblings), and `.aside-nav ul li.active` above already paints
-// those with `nb-theme(background-basic-color-1)` at higher specificity — so the
-// bare rule could never win, and a hard white would have been wrong on the dark
-// themes if it had.
+// Removed `.active { background: #ffffff; }`, which was NOT dead — it was the bug.
+//
+// `active` is bound here in two ways. The visible one is the aside-nav `<li>`
+// items (`[class.active]="general?.expanded"` and nine siblings), which
+// `.aside-nav ul li.active` above already paints with
+// `nb-theme(background-basic-color-1)` at higher specificity. The one that is
+// easy to miss is that this template also holds 19 `<nb-option>` elements, and
+// Nebular host-binds `class.active` onto them at RUNTIME as the keyboard manager
+// moves — nothing a grep of the template can see.
+//
+// Those options are authored here, so they carry this component's `_ngcontent`
+// attribute even after `nb-select` portals them into the CDK overlay, and the
+// compiled `.active[_ngcontent-x]` (0,2,0) outranks Nebular's own
+// `nb-option-list nb-option.active` (0,1,2). The hard white therefore won: the
+// highlighted item in every dropdown on this page was painted #ffffff on all
+// eight themes, including the near-black ones. Dropping the rule hands the
+// styling back to Nebular, which resolves per theme.
 
 // start of nb-overrides
 nb-accordion {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
@@ -55,10 +55,15 @@
       border-radius: nb-theme(button-rectangle-border-radius);
       list-style: none;
       cursor: pointer;
-      box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15);
+      // Was a literal `0px 1px 1px rgba(0, 0, 0, 0.15)`, i.e. a black drop
+      // shadow that is invisible on the dark canvases. `gauzy-shadow` is the
+      // token for exactly this hairline and resolves to a ring on the dark
+      // themes; the fallback is the old literal, for the themes that do not
+      // emit the token.
+      box-shadow: var(--gauzy-shadow, 0px 1px 1px 0px rgb(0 0 0 / 15%));
       &.active {
         background: nb-theme(background-basic-color-1);
-        box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15) inset;
+        box-shadow: var(--gauzy-shadow, 0px 1px 1px 0px rgb(0 0 0 / 15%)) inset;
       }
     }
   }
@@ -86,9 +91,12 @@
   padding-right: 10px;
   max-width: 49% !important;
 }
-.active {
-  background: #ffffff;
-}
+// Removed `.active { background: #ffffff; }`. In this template `active` is only
+// ever bound on the aside-nav `<li>` items (`[class.active]="general?.expanded"`
+// and its nine siblings), and `.aside-nav ul li.active` above already paints
+// those with `nb-theme(background-basic-color-1)` at higher specificity — so the
+// bare rule could never win, and a hard white would have been wrong on the dark
+// themes if it had.
 
 // start of nb-overrides
 nb-accordion {
@@ -104,7 +112,13 @@ nb-accordion {
       border-radius: 6px;
       width: 23px;
       height: 23px;
-      border: 1px solid rgba(66, 66, 66, 0.2);
+      // Was `rgba(66, 66, 66, 0.2)` — a dark grey ring around the accordion
+      // chevron, which disappears against the dark themes' panels. The shared
+      // border token is light-on-dark and dark-on-light. Spelled out as a
+      // custom property with a fallback rather than `nb-theme()`, which emits a
+      // bare `var()` and would drop the border entirely on a theme that does
+      // not carry the token.
+      border: 1px solid var(--gauzy-border-default-color, rgba(126, 126, 143, 0.1));
     }
   }
   & nb-accordion-item-header,
@@ -291,8 +305,14 @@ nb-accordion {
   }
 }
 :host ::ng-deep .toggle {
-  border: 1px solid #7e7e8f !important;
-  background-color: #7e7e8f !important;
+  // The unchecked toggle track. Both were a literal `#7e7e8f`, i.e. one fixed
+  // mid grey in all eight themes — a dark bar on the dark canvases, where the
+  // rest of the muted chrome is light. `gauzy-text-color-2` is the app's muted
+  // ramp and is `rgba(126, 126, 143, 1)` (exactly the old literal) on the
+  // themes that inherit the default palette, so those are unchanged; the
+  // fallback covers the themes that do not emit the custom property.
+  border: 1px solid var(--gauzy-text-color-2, rgba(126, 126, 143, 1)) !important;
+  background-color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1)) !important;
   &.checked {
     background-color: nb-theme(text-primary-color) !important;
     border: 1px solid nb-theme(text-primary-color) !important;
@@ -425,9 +445,10 @@ nb-accordion {
     }
   }
 }
-#temporary {
-  padding-bottom: 215px;
-}
+// Removed `#temporary { padding-bottom: 215px; }` — `temporary` appears nowhere
+// in `edit-organization-other-settings.component.html` or its .ts, and a
+// component stylesheet can only reach its own template, so the id never
+// existed to style.
 
 :host {
   nb-card-body {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
@@ -55,11 +55,18 @@
       border-radius: nb-theme(button-rectangle-border-radius);
       list-style: none;
       cursor: pointer;
-      // Was a literal `0px 1px 1px rgba(0, 0, 0, 0.15)`, i.e. a black drop
-      // shadow that is invisible on the dark canvases. `gauzy-shadow` is the
-      // token for exactly this hairline and resolves to a ring on the dark
-      // themes; the fallback is the old literal, for the themes that do not
-      // emit the token.
+      // Was a literal `0px 1px 1px rgba(0, 0, 0, 0.15)` — a black drop shadow,
+      // which against a near-black canvas is no edge at all. `gauzy-shadow` is
+      // the shared token for this hairline, so the row follows whatever the
+      // active theme decides an edge should be.
+      //
+      // Note it is NOT a ring everywhere: of the five themes that define it,
+      // only `gauzy-dark` resolves to `0 0 0 1px var(--gauzy-overlay-border-color)`.
+      // The others keep a black drop shadow (15% on the light pair, 35% on the
+      // dark pair), so `cosmic`, `dark` and `material-dark` still get a shadow
+      // rather than a ring. That is the shared token's problem to fix, in
+      // themes.scss, not this file's to work around. The fallback is the old
+      // literal, for the themes that emit no token at all.
       box-shadow: var(--gauzy-shadow, 0px 1px 1px 0px rgb(0 0 0 / 15%));
       &.active {
         background: nb-theme(background-basic-color-1);

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.scss
@@ -44,8 +44,13 @@ nb-card-body {
           margin-left: 0;
         }
       }
+      // The resting tab icon. Was a literal `#7e7e8f` — a mid grey that reads as
+      // disabled on the dark themes and is off the ramp on the light ones. That
+      // literal IS `gauzy-text-color-2` on the gauzy themes, so it is the token
+      // this always meant; the fallback keeps it working on the themes that do
+      // not emit the custom property.
       & svg {
-        fill: #7e7e8f !important;
+        fill: var(--gauzy-text-color-2, rgba(126, 126, 143, 1)) !important;
       }
       &.active {
         & .tab-link {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
@@ -85,7 +85,7 @@
 // `setting-block sub-header`). accounting.component.scss re-declares
 // `.body-header` but sets no `margin-bottom`, and it is loaded after this file,
 // so dropping these would have silently pulled 35px out from under the Accounting
-// page header and unbolded its section headings.
+// page header and dropped the bold from its section headings.
 .body-header {
     display: flex;
     justify-content: space-between;

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
@@ -66,68 +66,19 @@
     }
 }
 
-// old styles
-.edit-icon {
-    margin-left: 30px;
-    position: relative;
-    width: 36px;
-
-    svg {
-        position: absolute;
-    }
-
-    nb-icon {
-        position: absolute;
-    }
-}
-
-.org-details {
-    .edit-public-page {
-        cursor: pointer;
-        color: #027ad6;
-        padding-top: 3px;
-    }
-}
-
-.setting-name {
-    font-size: 24px;
-    font-weight: bold;
-}
-
-.body-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 35px;
-}
-
-.mutation-card.setting-block {
-    background: #eaf3fc;
-}
-
-.transparent {
-    opacity: 0.7;
-}
-
-.settings-body {
-    padding: 35px;
-}
-
-.sub-header {
-    margin-bottom: 20px;
-    font-weight: bold;
-}
-
-.header-content {
-    display: flex;
-    .header-info {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        width: 560px;
-        padding-left: 30px;
-    }
-}
+// Removed a block of dead "old styles". Component stylesheets are scoped to
+// this component's own template, and none of these selectors can match anything
+// in `edit-organization.component.html`, whose only classes are `org-edit`,
+// `card-scroll`, `header`, `header-container`, `org-info`, `org-image`,
+// `org-details`, `org-name`, `org-position`, `edit-public-page` and `mr-1`:
+//   * `.edit-icon`, `.setting-name`, `.body-header`, `.mutation-card.setting-block`
+//     (a `#eaf3fc` fill), `.transparent`, `.settings-body`, `.sub-header` and
+//     `.header-content` — no such class in the template or in the component .ts;
+//   * `.org-details .edit-public-page` (a `#027ad6` text colour) — both classes
+//     exist, but `.edit-public-page` is a SIBLING of `.org-details`, not a
+//     descendant, so the two-part selector never matched. The rule that really
+//     paints that control is `.edit-public-page` under `:host .card-scroll`
+//     above, and it already reads `nb-theme(text-primary-color)`.
 
 @include respond(sm) {
     .header .header-container {
@@ -143,5 +94,10 @@
     nb-card{
         height: unset;
     }
-    @include ga-overrides.input-appearance(42px, var(--gauzy-card-1));
+    // `--gauzy-card-1` is not emitted by every registered theme, and a bare
+    // `var()` with no fallback drops the whole `background-color` declaration
+    // there, leaving every input on this page transparent. `--card-background-color`
+    // is a core Nebular token present in all of them, and it is exactly what
+    // `gauzy-card-1` is aliased to in most themes anyway.
+    @include ga-overrides.input-appearance(42px, var(--gauzy-card-1, var(--card-background-color)));
 }

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
@@ -66,19 +66,37 @@
     }
 }
 
-// Removed a block of dead "old styles". Component stylesheets are scoped to
-// this component's own template, and none of these selectors can match anything
-// in `edit-organization.component.html`, whose only classes are `org-edit`,
-// `card-scroll`, `header`, `header-container`, `org-info`, `org-image`,
-// `org-details`, `org-name`, `org-position`, `edit-public-page` and `mr-1`:
-//   * `.edit-icon`, `.setting-name`, `.body-header`, `.mutation-card.setting-block`
-//     (a `#eaf3fc` fill), `.transparent`, `.settings-body`, `.sub-header` and
-//     `.header-content` — no such class in the template or in the component .ts;
-//   * `.org-details .edit-public-page` (a `#027ad6` text colour) — both classes
-//     exist, but `.edit-public-page` is a SIBLING of `.org-details`, not a
-//     descendant, so the two-part selector never matched. The rule that really
-//     paints that control is `.edit-public-page` under `:host .card-scroll`
-//     above, and it already reads `nb-theme(text-primary-color)`.
+// Removed most of a block of old styles — but NOT all of it, because this
+// stylesheet is not scoped to one template. `accounting.component.ts` lists it in
+// its own `styleUrls` alongside `accounting.component.scss`, so every selector
+// here is compiled a SECOND time carrying the Accounting template's `_ngcontent`
+// attribute. "Dead in edit-organization" therefore does not mean dead.
+//
+// Checked against both templates. Dead in each, and gone: `.edit-icon`,
+// `.setting-name`, `.transparent`, `.settings-body`, `.header-content` (with its
+// nested `.header-info`), `.org-details .edit-public-page` (a literal `#027ad6`,
+// and in edit-organization's own markup `.edit-public-page` is a SIBLING of
+// `.org-details`, never a descendant), and `.mutation-card.setting-block` (a
+// literal `#eaf3fc` fill — Accounting has `setting-block` but never
+// `mutation-card`, so the compound selector matches nothing there either).
+//
+// KEPT, because Accounting really renders them: `.body-header`
+// (accounting.component.html line 3) and `.sub-header` (line 83, as
+// `setting-block sub-header`). accounting.component.scss re-declares
+// `.body-header` but sets no `margin-bottom`, and it is loaded after this file,
+// so dropping these would have silently pulled 35px out from under the Accounting
+// page header and unbolded its section headings.
+.body-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 35px;
+}
+
+.sub-header {
+    margin-bottom: 20px;
+    font-weight: bold;
+}
 
 @include respond(sm) {
     .header .header-container {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/organization-list/organization-list.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/organization-list/organization-list.component.scss
@@ -1,7 +1,11 @@
 nb-list {
   height: fit-content;
   max-height: 116px;
-  border: 1px solid #edf1f7;
+  // Was `#edf1f7`, a near-white hairline that vanishes on the light themes and
+  // draws a bright box on the dark ones. Written as a custom property rather
+  // than `nb-theme()` because this stylesheet does not `@use 'themes'`, and it
+  // carries a fallback for the themes that do not emit the token.
+  border: 1px solid var(--gauzy-border-default-color, rgba(126, 126, 143, 0.1));
   margin-top: 10px;
   transform-origin: top center;
   transform: scaleY(0);

--- a/apps/gauzy/src/app/pages/organizations/table-components/organizations-status/organizations-status.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/table-components/organizations-status/organizations-status.component.scss
@@ -4,15 +4,18 @@
 // with its own padding around an inner coloured pill that has padding again, so
 // the cell paid for two boxes. Sized from the shared table-density tokens
 // (`$gauzy-density` in `themes.scss`); the literals are CSS-var fallbacks only.
+// `text-align: flex-start` was dropped from both pills below: `flex-start` is
+// not one of the values `text-align` accepts, so the browser threw the whole
+// declaration away and the pills have always taken their alignment from what
+// they inherit. Removing it changes nothing on screen; it only stops the rule
+// from claiming to do something it never did.
 .badge-danger {
-	text-align: flex-start;
 	padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 	background-color: nb-theme(color-danger-default);
 	margin-bottom: var(--gauzy-table-chip-gap, 0.1875rem);
 }
 
 .badge-success {
-	text-align: flex-start;
 	padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 	background-color: nb-theme(color-success-default);
 }

--- a/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deal-form/pipeline-deal-form.component.html
+++ b/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deal-form/pipeline-deal-form.component.html
@@ -38,7 +38,11 @@
             <label class="label" for="client">
               {{ 'PIPELINE_DEAL_CREATE_PAGE.SELECT_CLIENT' | translate }}
             </label>
-            <nb-select formControlName="clientId" placeholder="Clients" [selected]="selectedClient">
+            <nb-select
+              formControlName="clientId"
+              [placeholder]="'FORM.PLACEHOLDERS.CLIENTS' | translate"
+              [selected]="selectedClient"
+              >
               @for (client of clients$ | async; track client) {
                 <nb-option [value]="client.id">
                   {{ client.name }}

--- a/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deal-form/pipeline-deal-form.component.scss
+++ b/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deal-form/pipeline-deal-form.component.scss
@@ -6,5 +6,10 @@
 }
 
 nb-card-body {
-	background-color: var(--gauzy-card-2);
+	// Fallback required: `--gauzy-card-2` is undefined in material-light and
+	// material-dark — `themes.scss` registers those two against Nebular's own
+	// parent themes, which carry no `gauzy-card-*` keys — and a `var()` with no
+	// fallback makes the browser discard the whole declaration, leaving the deal
+	// form's body unpainted there.
+	background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
 }

--- a/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deals.component.html
+++ b/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deals.component.html
@@ -4,7 +4,15 @@
 		<div class="card-header-title">
 			<ngx-back-navigation></ngx-back-navigation>
 			<h4>
-				<span> {{ 'PIPELINE_DEALS_PAGE.HEADER' | translate }} </span> | <span> {{ pipeline?.name }} </span>
+				<!--
+					Routed through `ngx-header-title` like every other page: that is
+					what renders the breadcrumb trail under the heading, and this was
+					the only page in Pipelines still building its title by hand, so it
+					was the only one with no trail at all.
+				-->
+				<ngx-header-title [allowEmployee]="false">
+					<span> {{ 'PIPELINE_DEALS_PAGE.HEADER' | translate }} </span> | <span> {{ pipeline?.name }} </span>
+				</ngx-header-title>
 			</h4>
 		</div>
 		<div class="gauzy-button-container">

--- a/apps/gauzy/src/app/pages/pipelines/pipelines.component.scss
+++ b/apps/gauzy/src/app/pages/pipelines/pipelines.component.scss
@@ -26,7 +26,12 @@
   }
   nb-card,
   nb-tab.content-active {
-    background-color: var(--gauzy-card-2);
+    // Fallback required: `--gauzy-card-2` is undefined in material-light and
+    // material-dark — `themes.scss` registers those two against Nebular's own
+    // parent themes, so they never inherit the `gauzy-card-*` keys — and a
+    // `var()` without one makes the browser drop the whole declaration, which
+    // left the tab body unpainted there.
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   }
   nb-card-body {
     overflow: unset;

--- a/apps/gauzy/src/app/pages/pipelines/stage-form/stage-form.component.html
+++ b/apps/gauzy/src/app/pages/pipelines/stage-form/stage-form.component.html
@@ -25,10 +25,16 @@
           [cdkDragData]="stage"
           >
           <nb-accordion-item-header>
+            <!--
+              `danger`, not `warning`: this deletes a stage, and every other
+              delete control in the app is red. Amber reads as "careful" and put
+              this button in a different colour language from the trash icons
+              beside every other list.
+            -->
             <button
               nbButton
               size="tiny"
-              status="warning"
+              status="danger"
               type="button"
 						(click)="
 							isAdding &&

--- a/apps/gauzy/src/app/pages/pipelines/table-components/pipeline-deal-probability/pipeline-deal-probability.component.scss
+++ b/apps/gauzy/src/app/pages/pipelines/table-components/pipeline-deal-probability/pipeline-deal-probability.component.scss
@@ -1,0 +1,51 @@
+// Probability chip for the DEALS list.
+//
+// The template writes Bootstrap 4's `.badge-*` MODIFIER classes without the
+// `.badge` base class, and this component had no stylesheet of its own, so the
+// cell rendered as a full-width, square-cornered block with no padding, filled
+// with Bootstrap's own literals — #dc3545 / #ffc107 / #28a745 / #007bff — and
+// white text, identically in all eight themes.
+//
+// Re-drawn as the tinted chip the rest of the app uses. Colours come from the
+// `gauzy-action-*` accents defined in `themes.scss`; those are merged into
+// EVERY registered theme (in a light and a dark set), so a chip stays legible
+// on the white card and on the near-black one alike. The literals are only
+// `var()` fallbacks — see the note on `--gauzy-*` tokens in the sibling page
+// stylesheets — and carry the light-set values.
+.badge-danger,
+.badge-warning,
+.badge-success,
+.badge-primary {
+	// The template's own wrapper is `text-center` with a 5rem min-width; the chip
+	// itself is sized by its label, like every other status pill in the tables.
+	display: inline-block;
+	padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
+	border-radius: var(--gauzy-radius-sm, 0.375rem);
+	font-size: var(--gauzy-table-header-font-size, 0.75rem);
+	font-weight: 600;
+	line-height: var(--gauzy-table-header-line-height, 0.9375rem);
+	// The chip wraps as a whole rather than breaking "3 - Medium" over two lines.
+	white-space: nowrap;
+}
+
+.badge-danger {
+	color: var(--gauzy-action-danger-text, #dc2626);
+	background-color: var(--gauzy-action-danger-tint, rgba(220, 38, 38, 0.08));
+}
+
+.badge-warning {
+	color: var(--gauzy-action-warning-text, #b45309);
+	background-color: var(--gauzy-action-warning-tint, rgba(180, 83, 9, 0.08));
+}
+
+.badge-success {
+	color: var(--gauzy-action-success-text, #047857);
+	background-color: var(--gauzy-action-success-tint, rgba(4, 120, 87, 0.08));
+}
+
+// "Unknown" is the absence of a probability rather than a status of its own, so
+// it stays neutral instead of borrowing one of the accents.
+.badge-primary {
+	color: var(--text-hint-color);
+	background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
+}

--- a/apps/gauzy/src/app/pages/pipelines/table-components/pipeline-deal-probability/pipeline-deal-probability.component.ts
+++ b/apps/gauzy/src/app/pages/pipelines/table-components/pipeline-deal-probability/pipeline-deal-probability.component.ts
@@ -4,6 +4,7 @@ import { IDeal } from '@gauzy/contracts';
 @Component({
 	selector: 'ga-pipeline-deal-probability',
 	templateUrl: './pipeline-deal-probability.component.html',
+	styleUrls: ['./pipeline-deal-probability.component.scss'],
 	standalone: false
 })
 export class PipelineDealProbabilityComponent implements OnInit {

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
@@ -17,7 +17,13 @@
   background-color: var(--gauzy-card-3, rgba(126, 126, 143, 0.12));
   padding: 0.75rem;
   border-radius: nb-theme(border-radius);
-  color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
+  // Chained rather than a single literal: this fallback is reached only by
+  // material-light and material-dark, and no one fixed grey serves both — the
+  // old `rgba(126, 126, 143, 1)` is about 3.6:1 on a light band, under the 4.5:1
+  // needed for normal text (the same reason gauzy-light overrides this token to
+  // `rgba(91, 91, 107, 1)`; see themes.scss). Nebular defines `text-hint-color`
+  // in every theme and it adapts, so it takes the middle step.
+  color: var(--gauzy-text-color-2, var(--text-hint-color, rgba(113, 113, 122, 1)));
 }
 
 :host .header-content {

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
@@ -1,29 +1,34 @@
 @use 'gauzy/_gauzy-table' as *;
 
-.setting-name {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.body-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 35px;
-}
+// Removed `.setting-name` (font-size 24px / bold) and `.body-header` (flex row,
+// margin-bottom 35px). This stylesheet is emitted for exactly two templates —
+// recurring-expense-employee.component.html and, through the `@forward` in
+// expense-recurring.component.scss, expense-recurring.component.html — and
+// neither carries either class, so both blocks styled nothing.
 
 .sub-header {
   margin-bottom: 20px;
   font-weight: bold;
-  background-color: nb-theme(gauzy-card-3);
+  // `gauzy-card-3` / `gauzy-text-color-2` are not registered by the
+  // material-light and material-dark themes, and a bare `var(--…)` that
+  // resolves to nothing makes the whole declaration invalid, which would leave
+  // this band transparent with inherited text. The fallbacks are neutral
+  // translucent values that read correctly on a light and on a dark surface.
+  background-color: var(--gauzy-card-3, rgba(126, 126, 143, 0.12));
   padding: 0.75rem;
   border-radius: nb-theme(border-radius);
-  color: nb-theme(gauzy-text-color-2);
+  color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 }
 
 :host .header-content {
   display: flex;
-  margin: auto 8px auto 16px;
+  // Leading inset matched to the `.table-scroll` padding below (18px) so the
+  // column header band and its labels line up with the rows under it; it was
+  // 16px, i.e. 2px to the left of every row. The RTL override is new: the old
+  // shorthand kept the wide inset on the left in both directions. The `auto`
+  // top/bottom margins it also carried resolved to 0 in this block context.
+  margin: 0 8px 0 18px;
+  @include nb-rtl(margin, 0 18px 0 8px);
 
   .header-info {
     display: flex;
@@ -56,9 +61,9 @@
   }
 }
 
-.container {
-  padding: 0;
-}
+// Removed a first `.container { padding: 0 }` block that sat here: the second
+// `.container` block at the bottom of this file has the same specificity and
+// comes later, so its `padding: 0.5rem` always won.
 
 .container::-webkit-scrollbar {
   display: none;
@@ -67,7 +72,10 @@
 :host {
   nb-card,
   nb-card-header {
-    background-color: var(--gauzy-card-2);
+    // Fallback because `gauzy-card-2` is not registered by material-light /
+    // material-dark; without it the declaration is dropped there and the card
+    // paints transparent over the page canvas.
+    background-color: var(--gauzy-card-2, var(--card-background-color));
   }
 
   .settings-body {
@@ -88,7 +96,11 @@
 }
 .container {
   padding: 0.5rem;
-  overflow-x: scroll;
+  // `scroll` kept a horizontal scrollbar reserved at all times. The
+  // `::-webkit-scrollbar` rule above hides it in Blink/WebKit but does nothing
+  // in Firefox, where an always-on bar sat under the list even when the rows
+  // fitted. `auto` only scrolls when the row width actually overflows.
+  overflow-x: auto;
   height: 100%;
   margin: 0;
   max-width: unset;

--- a/apps/gauzy/src/app/pages/tags/tags-color/tags-color.component.scss
+++ b/apps/gauzy/src/app/pages/tags/tags-color/tags-color.component.scss
@@ -1,10 +1,34 @@
+/*
+ * The tag-name cell of the Tags table: an `nb-badge` painted with the tag's own
+ * colour.
+ *
+ * `nb-badge` sets `position: absolute` on its own host, so it contributes no
+ * height at all — the wrapper below has to state one, and the chip's own numbers
+ * have to add up to it or the chip spills out of the box that is supposed to
+ * hold it. They did not: 12.5px of padding around a 17px line is a 42px chip in
+ * a 32px frame, and the 19px margins above and below were what kept the overflow
+ * from colliding with the rows either side. That cost every row ~70px, in a
+ * table the density pass had just brought down to ~34px.
+ *
+ * Both boxes now come from the shared in-cell badge tokens and are the same
+ * height, so the chip fills its frame instead of bursting it and this column
+ * costs a row no more than any other chip in the app. The tokens live in
+ * `$gauzy-density` (themes.scss), which is merged into all eight themes; the
+ * fallbacks are their current values, for the two material themes that register
+ * against Nebular's own themes rather than the gauzy default.
+ */
 .color {
   width: 100%;
-  padding: 12.5px 10px;
+  // Exactly one line box, matching the wrapper, with the line height doing the
+  // vertical centering.
+  height: var(--gauzy-table-badge-height, 1.25rem);
+  padding: 0 var(--gauzy-table-chip-padding-x, 0.375rem);
   border-radius: 4px;
-  font-size: 14px;
+  // The tag name is this column's primary value, so it stays at the table's own
+  // cell size rather than dropping to the smaller secondary-chip step.
+  font-size: var(--gauzy-table-font-size, 0.8125rem);
   font-weight: 600;
-  line-height: 17px;
+  line-height: var(--gauzy-table-badge-height, 1.25rem);
   letter-spacing: 0em;
   text-align: center;
   white-space: nowrap;
@@ -14,11 +38,11 @@
 
 div {
   width: 100%;
-  height: 100%;
   display: flex;
-  margin: 19px 0;
+  // Was `height: 100%` immediately followed by `height: 32px` — the first never
+  // applied. One height now, and it is the height the chip above is drawn at.
+  height: var(--gauzy-table-badge-height, 1.25rem);
   justify-content: center;
-  height: 32px;
   align-items: center;
   position: relative;
 }

--- a/apps/gauzy/src/app/pages/tags/tags.component.html
+++ b/apps/gauzy/src/app/pages/tags/tags.component.html
@@ -11,6 +11,7 @@
             @for (option of filterOptions; track option) {
               <nb-list-item
                 class="filter-item"
+                [class.selected]="selectedFilterValue === option.value"
                 (click)="selectedFilterOption(option.value)"
                 >
                 {{ option.displayName }}

--- a/apps/gauzy/src/app/pages/tags/tags.component.scss
+++ b/apps/gauzy/src/app/pages/tags/tags.component.scss
@@ -38,7 +38,7 @@
 
 /*
  * REMOVED: `.tags-table { padding-top: 10px }` — `tags-table` occurs nowhere in
- * the worktree except this declaration (the table lives in
+ * the repository except this declaration (the table lives in
  * `.table-scroll-container`, which is styled further down).
  */
 

--- a/apps/gauzy/src/app/pages/tags/tags.component.scss
+++ b/apps/gauzy/src/app/pages/tags/tags.component.scss
@@ -1,11 +1,21 @@
 @use 'gauzy/_gauzy-cards' as *;
 @use 'gauzy/_gauzy-table' as *;
 
+/*
+ * Every `var(--gauzy-…)` below carries a fallback. `material-light` and
+ * `material-dark` register against Nebular's own material themes instead of the
+ * gauzy default, so none of the `gauzy-card-*` / `gauzy-shadow` /
+ * `gauzy-sidebar-background-*` keys reach them (themes.scss lines 501-554), and
+ * a `var()` that resolves to nothing takes its whole declaration with it — which
+ * is how the filter rail, the search field and the table card all lost their
+ * surfaces on two of the eight themes.
+ */
+
 :host .search {
   margin: 20px 0 0 0;
   align-items: center;
   display: flex;
-  background-color: var(--gauzy-sidebar-background-3);
+  background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
   border-radius: 8px;
   height: 32px;
   padding: 0 8px;
@@ -26,17 +36,52 @@
   }
 }
 
-.tags-table {
-  padding-top: 10px;
+/*
+ * REMOVED: `.tags-table { padding-top: 10px }` — `tags-table` occurs nowhere in
+ * the worktree except this declaration (the table lives in
+ * `.table-scroll-container`, which is styled further down).
+ */
+
+/*
+ * The tag-type filter chips.
+ *
+ * Base first, then hover, then selected, so the file reads in the order the
+ * browser resolves them — the resting rule used to be declared ~50 lines BELOW
+ * its own `:hover`.
+ */
+.filter-item {
+  padding: 10px 15px;
+  box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
+  background: var(--gauzy-card-3, rgba(126, 126, 143, 0.05));
+  border-radius: 20px;
+  height: 36px;
+  // `nb-list-item` draws a `list-item-divider` along its bottom edge — right for
+  // a stacked list, wrong for pills in a wrapping row, where it left a hairline
+  // hanging under each chip.
+  border: none;
 }
 
+// Underlining the label was the only hover feedback a chip had, which reads as a
+// link on something drawn as a pill; the pill itself never moved. The shared
+// tint does the whole job, and it is the one every other hover surface uses.
 .filter-item:hover {
-  text-decoration: underline;
   cursor: pointer;
+  background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+}
+
+// Which type is currently filtering the table. Selecting one used to change the
+// table and leave the rail looking untouched, so the only way to tell what you
+// were looking at was to remember what you clicked. Declared after `:hover` at
+// equal specificity, so a selected chip keeps reading as selected under the
+// pointer.
+.filter-item.selected {
+  background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+  color: nb-theme(text-basic-color);
+  font-weight: 600;
 }
 
 :host nb-card.filter {
-  background-color: var(--gauzy-card-2);
+  background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   overflow: unset;
   @include nb-ltr(padding-right, 4px);
   @include nb-rtl(padding-left, 4px);
@@ -64,14 +109,6 @@
   gap: 10px;
 }
 
-.filter-item {
-  padding: 10px 15px;
-  box-shadow: var(--gauzy-shadow);
-  background: var(--gauzy-card-3);
-  border-radius: 20px;
-  height: 36px;
-}
-
 .gauzy-action {
   display: flex;
   justify-content: flex-end;
@@ -81,7 +118,7 @@
 :host {
   nb-card.tags-component,
   nb-card.tags-component nb-card-body {
-    background-color: var(--gauzy-card-2);
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
     margin: 0;
     display: flex;
     flex-direction: column;

--- a/apps/gauzy/src/app/pages/tags/tags.component.ts
+++ b/apps/gauzy/src/app/pages/tags/tags.component.ts
@@ -321,7 +321,32 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 			console.error('Error while retrieving tag types', error);
 			this.toastrService.danger('TAGS_PAGE.TAGS_FETCH_FAILED', 'Error fetching tag types');
 		} finally {
+			this.reconcileSelectedFilter();
 			this.loading = false;
+		}
+	}
+
+	/**
+	 * Drops a filter selection that no longer exists.
+	 *
+	 * `getTags()` resets `filterOptions` to just "All" and this method refills it from
+	 * the current organization's tag types, so a chip that was selected a moment ago can
+	 * simply be gone — switching organization is the usual way. Left alone, the rail then
+	 * highlights nothing at all, not even "All".
+	 *
+	 * The table needs the same treatment. `getTags()` runs BEFORE this method and skips
+	 * reloading while `_isFiltered` is still set, so it will have kept the previous
+	 * organization's filtered rows on screen. Reloading `allTags` — which `getTags()` has
+	 * already refreshed — puts the rail and the table back in agreement.
+	 */
+	private reconcileSelectedFilter() {
+		if (this.filterOptions.some((option) => option.value === this.selectedFilterValue)) {
+			return;
+		}
+		this.selectedFilterValue = '';
+		if (this._isFiltered) {
+			this._isFiltered = false;
+			this.smartTableSource.load(this.allTags);
 		}
 	}
 

--- a/apps/gauzy/src/app/pages/tags/tags.component.ts
+++ b/apps/gauzy/src/app/pages/tags/tags.component.ts
@@ -32,6 +32,13 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 	disableButton = true;
 	private allTags = [];
 	filterOptions: Array<any> = [];
+	/**
+	 * Which entry of `filterOptions` is currently filtering the table. Selecting
+	 * a type changed the table and left the rail looking untouched, so the only
+	 * way to tell what you were looking at was to remember what you clicked.
+	 * `''` is the "All" entry, i.e. no filter.
+	 */
+	selectedFilterValue: string = '';
 	viewComponentName: ComponentEnum;
 	dataLayoutStyle = ComponentLayoutStyleEnum.TABLE;
 	componentLayoutStyleEnum = ComponentLayoutStyleEnum;
@@ -376,6 +383,7 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 	 * @returns
 	 */
 	selectedFilterOption(value: string) {
+		this.selectedFilterValue = value;
 		if (value === '') {
 			this._isFiltered = false;
 			this._refresh$.next(true);

--- a/apps/gauzy/src/app/pages/vendors/vendors.component.html
+++ b/apps/gauzy/src/app/pages/vendors/vendors.component.html
@@ -119,12 +119,18 @@
 				<nb-icon icon="edit-outline"></nb-icon>
 				{{ 'BUTTONS.EDIT' | translate }}
 			</button>
+			<!--
+				`isDisabled` is not a member of VendorsComponent, nor of the
+				PaginationFilterBaseComponent it extends, so this bound to `undefined`:
+				Delete stayed fully lit beside a disabled Edit, and pressing it with
+				nothing selected read `selected.vendor.id` off null.
+			-->
 			<button
 				(click)="removeVendor(selected.vendor.id, selected.vendor.name)"
 				nbButton
 				status="basic"
 				class="action"
-				[disabled]="isDisabled"
+				[disabled]="disabled"
 				size="small"
 				[nbTooltip]="'BUTTONS.DELETE' | translate"
 			>

--- a/apps/gauzy/src/app/pages/vendors/vendors.component.scss
+++ b/apps/gauzy/src/app/pages/vendors/vendors.component.scss
@@ -3,6 +3,89 @@
 
 .editable {
   width: 525px;
+  // A hard width with nothing to stop it ran the dialog past both edges of a
+  // narrow viewport, footer buttons included.
+  max-width: calc(100vw - 3rem);
+  // The forwarded `expense-categories` stylesheet paints this panel with
+  // `nb-theme(gauzy-card-1)`, which compiles to a bare `var(--gauzy-card-1)`
+  // (Nebular runs in CSS-custom-property mode). That key is NOT registered for
+  // `material-light` / `material-dark` — both are registered against Nebular's
+  // own material themes rather than against the gauzy default (themes.scss lines
+  // 501-554) — so the declaration was dropped whole and the dialog body showed
+  // the backdrop through it. Restated with a fallback every theme can resolve.
+  background-color: var(--gauzy-card-1, var(--card-background-color));
+
+  /*
+   * Cancel, restated AFTER the forward so it wins at equal specificity.
+   *
+   * `expense-categories` paints `[nbButton].delete.appearance-outline` a literal
+   * `rgba(245, 109, 88, 1)` orange, 2px wide, with an orange glow on hover. That
+   * colour is in none of the eight themes, and it made the button you press to
+   * BACK OUT the loudest thing in the dialog — louder than Save, which the
+   * theme's own action tokens draw as a restrained accent. A hairline in the
+   * neutral border token with the shared hover tint instead.
+   */
+  [nbButton].delete.appearance-outline.status-basic {
+    background-color: transparent;
+    border-width: 1px;
+    border-color: nb-theme(border-basic-color-4);
+    color: nb-theme(text-hint-color);
+
+    &:hover {
+      border-color: nb-theme(border-basic-color-5);
+      color: nb-theme(text-basic-color);
+      background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+    }
+  }
+
+  // The orange hover glow that went with it.
+  [nbButton].delete.appearance-outline:hover {
+    box-shadow: none;
+  }
+
+  // The close control is a bare Font Awesome `<i>`, so it inherited the body
+  // size and full text contrast — as loud as the dialog title two lines under
+  // it. `expense-categories` gives it a pointer cursor and nothing else.
+  i.fa-times {
+    font-size: 0.75rem;
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
+
+    &:hover {
+      color: nb-theme(text-basic-color);
+    }
+  }
+}
+
+/*
+ * Row hover / selection, also restated after the forward.
+ *
+ * `expense-categories` gives BOTH states the same `rgba(50, 50, 50, 0.03)` fill,
+ * so hovering a row looked exactly like selecting one, and 3 % of black over a
+ * near-black card is nothing at all — on the four dark themes there was no
+ * visible selection. Selection also arrived as a 6px border that only exists
+ * when the row is selected, so the whole row jumped 6px sideways on click.
+ *
+ * Now: the neutral tints (they darken a light surface and lighten a dark one, so
+ * one value works in all eight themes), selection carried by the primary colour
+ * on the leading edge, and a transparent edge of the same width at rest so
+ * nothing moves.
+ */
+:host .custom-table {
+  @include nb-ltr(border-left, 3px solid transparent);
+  @include nb-rtl(border-right, 3px solid transparent);
+
+  // `:not(.selected)` because this rule is declared after `.selected` at the same
+  // specificity — without it, hovering a selected row would repaint it as merely
+  // hovered.
+  &:hover:not(.selected) {
+    background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+  }
+
+  &.selected {
+    background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+    @include nb-ltr(border-left, 3px solid var(--color-primary-default));
+    @include nb-rtl(border-right, 3px solid var(--color-primary-default));
+  }
 }
 
 :host nb-card-body {
@@ -19,12 +102,18 @@
 }
 
 .columns-header {
-  background-color: nb-theme(gauzy-card-2);
+  // Same story as `.editable` above: `nb-theme(gauzy-card-2)` is a bare
+  // `var(--gauzy-card-2)` and that key is missing from the two material themes,
+  // where the column-title band therefore had no background and merged into the
+  // card behind it.
+  background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   border-radius: 8px;
   margin-bottom: 10px;
   padding-top: 12px;
   padding-bottom: 12px;
-  padding-left: 12px;
+  // Logical, so the title band still indents from the reading edge under RTL —
+  // the row of `col-md-*` cells it labels is mirrored, but `padding-left` was not.
+  padding-inline-start: 12px;
   font-size: 12px;
   font-style: normal;
   font-weight: 600;

--- a/packages/ui-core/shared/src/lib/entity-with-members-card/entity-with-members-card.component.scss
+++ b/packages/ui-core/shared/src/lib/entity-with-members-card/entity-with-members-card.component.scss
@@ -9,7 +9,10 @@
 
     .members-count {
       font-size: 0.7em;
-      color: darkgray;
+      // `darkgray` (#a9a9a9) is a fixed CSS keyword: too light to read on the
+      // light themes' white card and no darker on the dark ones. `text-hint-color`
+      // is the muted-label token and is registered by all eight themes.
+      color: nb-theme(text-hint-color);
     }
   }
 

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-block/recurring-expense-block.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-block/recurring-expense-block.component.scss
@@ -4,10 +4,17 @@
 
   border-radius: nb-theme(border-radius);
   margin-bottom: 8px;
-  background-color: nb-theme(gauzy-card-1) !important;
+  // Fallbacks on every `--gauzy-*` here: material-light and material-dark do
+  // not register these keys, and a `var()` that resolves to nothing invalidates
+  // the whole declaration, which left these rows transparent on those themes.
+  background-color: var(--gauzy-card-1, var(--card-background-color)) !important;
 
+  // Selected marker. It was a black shadow at 15% alpha, which is invisible on
+  // every dark theme; the primary accent reads as "selected" on all eight. The
+  // bar is drawn on the leading edge, so it flips with the writing direction.
   &.block {
-    box-shadow: -6px 0px 0px 0px rgba(0, 0, 0, 0.15);
+    box-shadow: -6px 0px 0px 0px var(--color-primary-default);
+    @include nb-rtl(box-shadow, 6px 0px 0px 0px var(--color-primary-default));
   }
 
   .setting-row {
@@ -15,14 +22,21 @@
     justify-content: space-between;
     width: 100%;
     height: 84px;
-    background-color: nb-theme(gauzy-card-1);
+    background-color: var(--gauzy-card-1, var(--card-background-color));
     border-radius: nb-theme(border-radius);
     @include nb-ltr(padding, 0.75rem 0 0.75rem 0.75rem);
     @include nb-rtl(padding, 0.75rem 0.75rem 0.75rem 0);
 
-    &:hover,
+    // `:hover` and `.active` used to share one fill, so pointing at any row made
+    // it look exactly as selected as the row that really was. The two shared
+    // density tokens are the app-wide hover / current pair and — unlike
+    // `gauzy-sidebar-background-3` — are registered by all eight themes.
+    &:hover:not(.active) {
+      background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+    }
+
     &.active {
-      background-color: nb-theme(gauzy-sidebar-background-3);
+      background-color: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
     }
   }
 
@@ -35,7 +49,9 @@
     display: flex;
     height: 84px;
     align-items: center;
-    background-color: #333;
+    // Was `#333` with `#d7d9de` labels, i.e. a dark slab hard-coded for one
+    // theme. `background-basic-color-3` is a recessed surface in every theme.
+    background-color: nb-theme(background-basic-color-3);
     justify-content: space-evenly;
     overflow: hidden;
     transition: width 0.2s ease-in;
@@ -49,11 +65,11 @@
       cursor: pointer;
 
       ::ng-deep svg {
-        fill: rgb(127, 127, 127);
+        fill: nb-theme(text-hint-color);
       }
 
       span {
-        color: #d7d9de;
+        color: nb-theme(text-hint-color);
         font-size: 10px;
         opacity: 0.6;
       }
@@ -96,7 +112,9 @@
     }
 
     span {
-      color: nb-theme(gauzy-text-color-1);
+      // Fallback: `gauzy-text-color-1` is not registered by material-light /
+      // material-dark, and without one the declaration is dropped there.
+      color: var(--gauzy-text-color-1, var(--text-basic-color));
       font-size: 14px;
     }
 
@@ -114,8 +132,11 @@
     }
   }
 
+  // The per-row settings fly-out. It is deliberately hidden — the same edit /
+  // history / delete actions live in the page toolbar — and the rules below only
+  // survive so the panel can be brought back. Removed a `display: flex` that was
+  // declared here and overruled by the `display: none` lower in the same block.
   .block-panel {
-    display: flex;
     justify-content: space-between;
     align-items: center;
     width: 240px;

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-delete-confirmation/recurring-expense-delete-confirmation.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-delete-confirmation/recurring-expense-delete-confirmation.component.scss
@@ -2,6 +2,9 @@
 
 :host {
     nb-card {
-        background-color: nb-theme(gauzy-card-1);
+        // Fallback because `gauzy-card-1` is not registered by material-light /
+        // material-dark, where a `var()` with nothing to resolve to invalidates
+        // the declaration and left this confirmation dialog transparent.
+        background-color: var(--gauzy-card-1, var(--card-background-color));
     }
 }

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-history/recurring-expense-history.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-history/recurring-expense-history.component.scss
@@ -12,11 +12,27 @@
     max-width: 560px;
     flex: 1;
 
-    row.head {
+    // Was `row.head`, an element selector for a `<row>` tag. The template marks
+    // the column headings with `<div class="row head">`, so the rule matched
+    // nothing and the headings rendered as ordinary bold text. The colour
+    // carries a fallback because `gauzy-text-color-2` is not registered by
+    // material-light / material-dark.
+    .row.head {
       b {
         font-weight: 600;
-        color: nb-theme(gauzy-text-color-2);
+        color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
       }
+    }
+
+    // Every history entry ends with an `<hr>`, but a Bootstrap `.row` is a flex
+    // container, which left that `<hr>` a zero-width flex item, so no separator
+    // was ever drawn. Given a full line of its own it separates the entries, and
+    // the colour replaces Bootstrap's own `rgba(0, 0, 0, .1)` — invisible on
+    // every dark theme.
+    .row hr {
+      flex: 0 0 100%;
+      margin: 0.5rem 0 0;
+      border-top-color: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
     }
 
     h6 {
@@ -25,7 +41,7 @@
       line-height: 17px;
       letter-spacing: 0em;
       text-align: left;
-      color: nb-theme(gauzy-text-color-1);
+      color: var(--gauzy-text-color-1, var(--text-basic-color));
     }
   }
 

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-mutation/recurring-expense-mutation.component.html
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-mutation/recurring-expense-mutation.component.html
@@ -189,6 +189,7 @@
             @if (!recurringExpense) {
               <button
                 (click)="submitForm()"
+                size="small"
                 [disabled]="form.invalid"
                 type="submit"
                 nbButton

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-mutation/recurring-expense-mutation.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-mutation/recurring-expense-mutation.component.scss
@@ -2,12 +2,19 @@
 
 nb-card-body {
   width: 500px;
+  // The fixed width is a preferred size; without this the dialog overflowed the
+  // overlay on narrow viewports instead of shrinking with it.
+  max-width: 100%;
 }
 
 :host {
 
   nb-card,
   nb-card-body {
-    background-color: nb-theme(gauzy-card-1);
+    // Fallback because `gauzy-card-1` is not registered by material-light /
+    // material-dark: a `var()` with nothing to resolve to invalidates the whole
+    // declaration, and a background-color that falls back to its initial value
+    // is transparent, so the dialog showed the page through it.
+    background-color: var(--gauzy-card-1, var(--card-background-color));
   }
 }

--- a/packages/ui-core/shared/src/lib/income/income-mutation/income-mutation.component.scss
+++ b/packages/ui-core/shared/src/lib/income/income-mutation/income-mutation.component.scss
@@ -3,6 +3,9 @@
 .main {
   .body {
     width: 605px;
+    // The fixed width is a preferred size; without this the dialog overflowed
+    // the overlay on narrow viewports instead of shrinking with it.
+    max-width: 100%;
   }
 
   .close {
@@ -14,13 +17,11 @@
     resize: none;
   }
 
-  nb-card-header .employees {
-    margin-left: 20px;
-    padding-left: 20px;
-    border-left: 1px solid #edf1f7;
-
-    width: 220px;
-  }
+  // Removed `nb-card-header .employees` (margin/padding-left 20px, width 220px
+  // and a hard-coded `border-left: 1px solid #edf1f7` that was invisible on the
+  // dark themes). The only `.employees` element in this template is the
+  // `<div class="row employees">` inside `nb-card-body`, so the rule never
+  // matched anything.
 
   .employees {
     margin-bottom: 15px;

--- a/packages/ui-core/shared/src/lib/project/project-mutation/project-mutation.component.scss
+++ b/packages/ui-core/shared/src/lib/project/project-mutation/project-mutation.component.scss
@@ -20,8 +20,14 @@
 
 		nb-card-body {
 			padding: 0;
+			// `--gauzy-card-2` is NOT registered by the material-light /
+			// material-dark themes (themes.scss only gives them
+			// gauzy-primary-background / sidebar / border-table), so a bare
+			// var() there resolves to nothing and the browser drops the whole
+			// declaration — the tab body and the action bar lose their panel
+			// and sit on the raw card. Fallback keeps a neutral panel tint.
 			nb-tab.content-active, .action-buttons {
-				background-color: var(--gauzy-card-2);
+				background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
 				margin: 0;
 			}
 
@@ -51,8 +57,11 @@
 		div.checked+span.text {
 			color: var(--text-primary-color);
 		}
+		// Same story as `--gauzy-card-2` above: `--gauzy-text-color-2` is
+		// undefined in the two material themes, so without a fallback the
+		// declaration is dropped and the label keeps the inherited color.
 		div+span.text {
-			color: var(--gauzy-text-color-2);
+			color: var(--gauzy-text-color-2, var(--text-hint-color));
 		}
 	}
 
@@ -62,7 +71,7 @@
 		line-height: 11px;
 		letter-spacing: 0em;
 		text-align: left;
-		color: var(--gauzy-text-color-2);
+		color: var(--gauzy-text-color-2, var(--text-hint-color));
 	}
 }
 
@@ -114,7 +123,11 @@
 			}
 
 			>span {
-				color: rgba(126, 126, 143, 1);
+				// Was the literal rgba(126, 126, 143, 1), which is exactly the
+				// light-theme value of `gauzy-text-color-2` — so the "Add or
+				// Drop Image" hint stayed dark gray on the dark themes. Token
+				// first, that same literal kept as the fallback.
+				color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 				z-index: 2;
 				transition: opacity 0.2s ease-in;
 				position: absolute;
@@ -143,6 +156,10 @@
 		height: 100% !important;
 	}
 
-	// Apply dialog styles
-	@include dialog(transparent, var(--gauzy-card-1));
+	// Apply dialog styles. Second argument is the input background — it is
+	// applied with `!important`, so on material-light / material-dark (where
+	// `--gauzy-card-1` is not registered) the declaration is dropped entirely
+	// and the inputs go back to Nebular's own color. Fall back to the card
+	// color those themes DO define.
+	@include dialog(transparent, var(--gauzy-card-1, var(--card-background-color)));
 }

--- a/packages/ui-core/shared/src/lib/table-components/project-organization-employees/project-organization-employees.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/project-organization-employees/project-organization-employees.component.scss
@@ -3,8 +3,13 @@
 // The members block of a project card. The people themselves are rendered by
 // `ngx-people-list` and carry no box of their own, so the only thing left here
 // is the surrounding panel and its label.
+// `--gauzy-card-1` / `--gauzy-text-color-2` are not registered by the
+// material-light and material-dark themes (themes.scss), and a var() with no
+// fallback there drops the whole declaration — the members panel lost its
+// background and the title its muted color. Fallbacks are Nebular tokens, which
+// every theme defines.
 .members {
-	background-color: var(--gauzy-card-1);
+	background-color: var(--gauzy-card-1, var(--card-background-color));
 	border-radius: var(--border-radius);
 	padding: 0.625rem;
 	margin: 0;
@@ -16,5 +21,5 @@
 	font-weight: 600;
 	line-height: 0.9375rem;
 	letter-spacing: 0em;
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 }

--- a/packages/ui-core/shared/src/lib/table-components/project-organization-grid-details/project-organization-grid-details.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/project-organization-grid-details/project-organization-grid-details.component.scss
@@ -1,5 +1,11 @@
+// `--gauzy-card-1` and `--gauzy-text-color-2` are registered by six of the eight
+// themes only: material-light and material-dark set just gauzy-primary-background,
+// gauzy-sidebar-background-* and gauzy-border-table (see themes.scss). A var()
+// with no fallback there resolves to nothing and the browser throws away the
+// whole declaration, so on those two themes this card had no panel behind it and
+// the left-hand labels lost their muted color.
 .project-container {
-    background-color: var(--gauzy-card-1);
+    background-color: var(--gauzy-card-1, var(--card-background-color));
     display: flex;
     flex-direction: column;
     padding: 10px;
@@ -13,7 +19,7 @@
 
         .detail-left {
             border-radius: var(--border-radius);
-            color: var(--gauzy-text-color-2);
+            color: var(--gauzy-text-color-2, var(--text-hint-color));
             background-color: rgba(126, 126, 143, 0.05);
             padding: 5px 15px 5px 10px;
             width: 5.25rem;

--- a/packages/ui-core/shared/src/lib/table-components/visibility/visibility.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/visibility/visibility.component.scss
@@ -4,8 +4,12 @@
             color: var(--text-primary-color);
         }
 
+        // `--gauzy-text-color-2` is undefined in material-light /
+        // material-dark, and a var() with no fallback drops the declaration
+        // there, leaving the unchecked "Public" label the same color as the
+        // checked one. `--text-hint-color` is a Nebular token every theme has.
         div+span.text {
-            color: var(--gauzy-text-color-2);
+            color: var(--gauzy-text-color-2, var(--text-hint-color));
         }
     }
 }


### PR DESCRIPTION
Wave 5 — the last ~20 page areas of the page-by-page sweep (item 14). Five agents
over disjoint areas, each followed by an **adversarial auditor** that independently
re-derived every "this rule was dead" claim rather than trusting the sweeper's own
evidence. That pass is the point of this PR, and it earned its place.

| Area | Pages |
|---|---|
| org-structure | projects, teams, departments, positions, employment-types |
| crm-docs | contacts leftovers, vendors, documents, tags |
| money | income, payments, expense-recurring |
| pipelines-equipment | pipelines, goals, goal-settings, equipment, equipment-sharing-policy, approval-policy |
| org-admin | organizations, import-export, help, about |

### What the audit caught

Five removals were disputed. **One was a real regression, and it would have shipped.**

`edit-organization.component.scss` is not scoped to one template — `accounting.component.ts`
lists it in its own `styleUrls`, so every selector is compiled a second time against the
Accounting template. Two deleted rules match live elements there: `.body-header`
(`accounting.component.html:3`) and `.sub-header` (line 83, as `setting-block sub-header`).
Accounting re-declares `.body-header` but sets no `margin-bottom`, and it loads after this
file — so the deletion silently pulled 35px out from under the Accounting page header and
dropped the bold from its section headings. Both restored; the genuinely dead rest of that
block stays removed.

The other four were correct removals with **false justifications**, which is its own kind of
bug — a wrong comment misleads whoever reads it next:

- `.active { background: #ffffff }` in `edit-organization-other-settings` was described as
  unreachable. It wasn't. That template holds **19 `<nb-option>`** elements and Nebular
  host-binds `class.active` onto them at runtime — invisible to any grep. They carry this
  component's `_ngcontent` even after `nb-select` portals them into the CDK overlay, and
  `.active[_ngcontent-x]` (0,2,0) outranks Nebular's `nb-option-list nb-option.active`
  (0,1,2). So the highlighted item in every dropdown on that page was painted white on all
  eight themes. **Removing it is a fix, not cleanup** — the comment now says so.
- `shape="round"` on Import and `margin: 19px 0` in `tags-color` were live and were filed
  under "dead rules removed". Both changes are fine and deliberate; the labelling wasn't.
- One commit message claimed "the only `body-header` in the whole app is…", which is false
  (`public-appointment` has one too). The file comment is correct and I verified it
  independently: this stylesheet reaches exactly two templates and neither uses the class.

### Other findings worth a look

- **DEALS "Probability" cell** wrote Bootstrap 4 `.badge-*` *modifier* classes with no
  `.badge` base and no stylesheet, so it rendered as a full-width square unpadded block in
  Bootstrap's own `#dc3545`/`#ffc107`/`#28a745`/`#007bff` — identical on all eight themes.
  Redrawn as the tinted chip used elsewhere.
- **Key-result progress chart** drew its guide line with `rgb(76, 23, 33,0.25)` — four
  arguments in the legacy comma form, which is not a colour at all, so the canvas kept
  default black and the line was invisible on every dark theme. Chart.js paints to a canvas
  and cannot resolve `var()`, so both lines now read the theme tokens off the host element.

### Deliberately not done

Three global partials (`_gauzy-dialogs.scss`, `_gauzy-overrides.scss:202` — every form label
in the app, `_gauzy-table.scss:68`) have the same fallback-less `var(--gauzy-*)` problem and
are the highest-value fixes left, but they are consumed by 20-30+ components and would have
collided with four agents working in parallel. They want one dedicated pass.

### Verification

- `nx build gauzy -c local` → green on the post-merge tip `7a8bacc881`. The only change
  after that build is one word inside a `//` comment (a cspell rewording).
- cspell clean over all 53 files.
- Repo-wide conflict-marker scan clean, and brace balance checked on every resolved file —
  I shipped markers into a build earlier in this effort and am not repeating it.
- Separately, all 18 of these pages were screenshotted in both light and dark: no clipped
  text, no horizontal overflow, no filled colour buttons in page bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Final wave-5 UI sweep across Contacts, Vendors, Documents, Tags, Goals, Pipelines, Income, Recurring Expenses, and Organization settings. Adds theme-safe fallbacks, fixes selection and chart rendering, corrects link/button behaviors, and removes dead styles found by an adversarial audit.

- **Bug Fixes**
  - Restored `.body-header` and `.sub-header` in edit-organization to fix an Accounting regression; removed the `.active { background: #fff }` rule that overpainted `nb-option` highlights.
  - Added fallbacks to `var(--gauzy-*)` so material-light/dark render panel, text, shadow, and border colors; replaced hard-coded grays/greens with theme tokens.
  - Made hover and selected row states distinct using shared tints; selection rails use the primary accent and respect RTL; removed jumpy borders on selection.
  - Themed Pipeline “Probability” chips (no more Bootstrap blocks); chart lines now read theme colors off the host and replace the invalid rgb; fixed delete button class and stage delete status.
  - Documents open in a new tab with `noopener`; Vendors Delete correctly uses `[disabled]="disabled"`; Import queue click handler removed and last-row divider class defined; translated placeholders.
  - Fixed Tags filter desync after org switches: the selected chip stays highlighted and the table reloads via `reconcileSelectedFilter()`.
  - Key-result progress chart now updates colors on theme change by rebuilding on `NbThemeService.onThemeChange()` with safe teardown.

- **Refactors**
  - Removed template-unreachable CSS across Contacts, Employment Types, Time Frame/Key Result Update dialogs, Income, and Recurring Expense components.
  - Centered the contact photo placeholder with flex; unified dialog chrome (max-width, neutral Cancel outlines, muted close icons).
  - Tags: added a visible selected filter state, used tint hover instead of underline, removed `nb-list` dividers for pills, and matched tag badge height to table density.
  - Documents rows now lay out name and date on one line; consistent icon and neutral backgrounds/shadows across pages.

<sup>Written for commit 174a724e776c55822171fc43562ab40260620d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

