### PR TITLE
fix(e2e): repair the shared Tags selector that was failing all four shards

### DIFF
--- a/apps/gauzy-e2e/tests/support/commands.ts
+++ b/apps/gauzy-e2e/tests/support/commands.ts
@@ -68,7 +68,17 @@ export const CustomCommands = {
 			}
 		});
 		await getPage()
-			.locator('h4.card-header-title:has-text("Tags")')
+			// Anchored to the CLASS, not to the element carrying it. The heading used
+			// to be `<h4 class="card-header-title">`; moving the page actions up onto
+			// the title line needed the heading in a block of its own, so it became
+			// `<div class="card-header-title"><h4>`. `h4.card-header-title` then
+			// matched nothing — on every page, since this helper is shared — and all
+			// four shards failed here rather than on anything they were testing.
+			//
+			// Scoped to the main card because this page renders a second header for
+			// the tag-type filter rail, and an unscoped `:has-text("Tags")` is a
+			// substring match.
+			.locator('nb-card.tags-component .card-header-title:has-text("Tags")')
 			.first()
 			.waitFor({ state: 'visible', timeout: 30000 });
 		await organizationTagsUserPage.gridButtonVisible();


### PR DESCRIPTION
**I broke this, and this fixes it.**

The latest develop run failed **all four shards**, ~42s per spec, nearly every spec —
and none of the failures were about what those specs test.

### Cause

`tests/support/commands.ts` waits for the Tags page before adding a tag:

```ts
.locator('h4.card-header-title:has-text("Tags")')
```

Moving the page actions up onto the title line (item 8, wave 1 / #9869) needed the
heading in a block of its own, so the class moved off the heading:

```html
before:  <h4 class="card-header-title">
after:   <div class="card-header-title"><h4>
```

`h4.card-header-title` now matches **nothing** — I confirmed there is no such element
left in any template. Because this helper is shared, the timeout took the entire suite
with it, which is why the failure looked catastrophic rather than like the selector
change it was.

### Fix

Anchored to the class rather than to whichever element happens to carry it, and scoped
to `nb-card.tags-component` — this page also renders a header for the tag-type filter
rail, and `:has-text` is a substring match.

### The other six

I checked every remaining e2e selector mentioning `card-header-title` against the
current markup rather than assuming they were fine:

| selector | verdict |
|---|---|
| `nb-card-header.card-header-title` (invoices, estimates, sales-estimates, goal-settings) | still matches — 15 templates still carry it |
| `div.card-header-title > button.action.primary.soft` (Expenses) | still matches — button is a direct child |
| `div.card-header-title > div.mr-2 > button[status="primary"]` (ManageEmployees) | still matches — nesting unchanged |

Only the Tags helper was broken.

### Note for the next markup change

This class of break is invisible locally: the UI looks right, and the suite is the only
thing that notices. Selectors anchored to `element.class` are the fragile ones — the
class survived, the element it sat on did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shared Tags e2e selector to match the new header markup, restoring all four shards. Switches the locator to `.card-header-title` scoped under `nb-card.tags-component`.

- **Bug Fixes**
  - Updated locator to `nb-card.tags-component .card-header-title:has-text("Tags")` to prevent timeouts and avoid matching the filter-rail header.
  - Verified other `card-header-title` selectors still match in invoices, estimates, goal-settings, Expenses, and ManageEmployees.

<sup>Written for commit 2cf59083be2ed099a2605d111dcd22f150329ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

