### PR TITLE
Cascade develop → stage: UI sweep waves 4-5, image-build concurrency fix, e2e selector repair

### DIFF
--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -8,12 +8,26 @@ on:
     types: [completed]
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-mcp-auth-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-demo.yml
@@ -11,12 +11,26 @@ permissions:
   packages: write
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-mcp-auth-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-stage.yml
@@ -10,12 +10,26 @@ permissions:
   packages: write
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-mcp-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-demo.yml
@@ -11,12 +11,26 @@ permissions:
   packages: write
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -10,12 +10,26 @@ permissions:
   packages: write
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -6,12 +6,26 @@ on:
       - stage
 
 concurrency:
-  # Shared across all non-prod gauzy image-build workflows so demo/stage/mcp builds QUEUE
-  # instead of overlapping (they used to run ~6-8 parallel installs against one registry VIP).
-  # cancel-in-progress:false = never kill a running build; a newer queued run supersedes an
-  # older *pending* one (fine for WIP images — the next push rebuilds). The prod (master)
-  # build workflows are deliberately NOT in this group.
-  group: gauzy-docker-build
+  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  #
+  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
+  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
+  # already waiting, whatever workflow it came from. A single push to develop fires three
+  # of these, a push to stage another three; five of every six were cancelled before they
+  # started. Environments then silently kept serving their previous image, which is how
+  # stage sat on an image five PRs old while its branch looked merged and green.
+  #
+  # Keyed by workflow so the useful part survives: a newer push still supersedes this
+  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
+  # build that is already running. What it no longer does is let an unrelated image build
+  # cancel this one.
+  #
+  # The cost is that these can once again overlap. That was the original worry — ~6-8
+  # parallel installs against one registry VIP — but an image that never builds is a worse
+  # failure than a slow one, and this is the only lever Actions offers: there is no way to
+  # ask for a queue deeper than one. The prod (master) workflows are still not in any
+  # shared group.
+  group: gauzy-docker-build-${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/apps/gauzy-e2e/tests/support/commands.ts
+++ b/apps/gauzy-e2e/tests/support/commands.ts
@@ -68,7 +68,17 @@ export const CustomCommands = {
 			}
 		});
 		await getPage()
-			.locator('h4.card-header-title:has-text("Tags")')
+			// Anchored to the CLASS, not to the element carrying it. The heading used
+			// to be `<h4 class="card-header-title">`; moving the page actions up onto
+			// the title line needed the heading in a block of its own, so it became
+			// `<div class="card-header-title"><h4>`. `h4.card-header-title` then
+			// matched nothing — on every page, since this helper is shared — and all
+			// four shards failed here rather than on anything they were testing.
+			//
+			// Scoped to the main card because this page renders a second header for
+			// the tag-type filter rail, and an unscoped `:has-text("Tags")` is a
+			// substring match.
+			.locator('nb-card.tags-component .card-header-title:has-text("Tags")')
 			.first()
 			.waitFor({ state: 'visible', timeout: 30000 });
 		await organizationTagsUserPage.gridButtonVisible();

--- a/apps/gauzy-e2e/tests/support/pages/TimeOff.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/TimeOff.po.ts
@@ -547,7 +547,8 @@ export const waitMessageToHide = async () => waitElementToHide(TimeOffPage.toast
 
 export const verifyPolicyExists = async (text: string) => {
 	// Assert the policy name renders in a grid cell. Used for BOTH the request grid (Policy column, a
-	// custom ApprovalPolicyComponent that renders <div>{{ value.name }}</div>) and the settings grid
+	// custom ApprovalPolicyComponent that renders <div class="policy">{{ value.name }}</div>, or an
+	// em-dash in a <span class="empty"> when the request has no policy) and the settings grid
 	// (Name column, a type:'string' cell). The old 'div.ng-star-inserted' worked for the custom-render
 	// request cell but a plain string cell has no such wrapper div — so scope the verify to the smart-table
 	// CELL element (present in both grids) filtered by the exact name. This is pollution-safe (matches the

--- a/apps/gauzy/src/app/pages/accounting-templates/accounting-templates.component.scss
+++ b/apps/gauzy/src/app/pages/accounting-templates/accounting-templates.component.scss
@@ -1,3 +1,11 @@
+// The email-templates sheet `@use`s the theme module, which keeps it private to
+// that file — loading it here brings in `$height` but not `nb-theme`. Sass passes
+// an unknown function through as plain CSS, so the two rules at the bottom of this
+// file shipped as the literal text `nb-theme(...)` and the browser dropped them:
+// the language/template selects lost their background, and — the visible one —
+// the rendered template preview never had `color: text-basic-color` applied, so
+// it kept the seeded HTML's own near-black text on the dark themes' dark panel.
+@use 'themes' as *;
 @use '../email-templates/email-templates.component' as *;
 
 :host {

--- a/apps/gauzy/src/app/pages/approvals/approvals.component.scss
+++ b/apps/gauzy/src/app/pages/approvals/approvals.component.scss
@@ -1,4 +1,7 @@
 @forward '@shared/_pg-card';
+// `@forward` re-exports to importers but does NOT bring members into this file,
+// so `nb-theme()` needs its own `@use`.
+@use 'themes' as *;
 
 :host {
   nb-card-body {

--- a/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.html
+++ b/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.html
@@ -1,3 +1,8 @@
-<div>
-	{{ value ? value.name : null }}
-</div>
+<!-- The chip used to render whether or not there was a policy, so a request with
+     none showed an empty grey pill. An em-dash reads as "not set"; the pill is
+     kept for the case where there is something to put in it. -->
+@if (value?.name) {
+	<div class="policy">{{ value.name }}</div>
+} @else {
+	<span class="empty">&mdash;</span>
+}

--- a/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.scss
+++ b/apps/gauzy/src/app/pages/approvals/table-components/approval-policy/approval-policy.component.scss
@@ -1,29 +1,38 @@
 @use 'themes' as *;
 
-div {
+// The approval-policy chip in a smart-table cell.
+//
+// The selector was a bare `div`, which is why the template could not grow a
+// second branch without the empty state inheriting the pill; it is `.policy`
+// now (a new class, nothing was renamed — no template or page object referred
+// to this element by name).
+//
+// Sized from the shared table-density tokens (`$gauzy-density` in `themes.scss`)
+// like every other in-cell chip; the literals are CSS-var fallbacks only. The
+// radius was `12px`, i.e. a full stadium pill on a ~19px chip — the same thing
+// `tag-border-radius` was taken off across the app — and the background was a
+// hand-copy of `gauzy-sidebar-background-3`. The `margin: 0 10px` is gone too:
+// the cell already has its own horizontal padding, so the chip was indented
+// 10px further than the text in every adjacent column.
+.policy {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  padding: 3px 8px;
-
   width: fit-content;
-
-  background: rgba(126, 126, 143, 0.1);
-  border-radius: 12px;
-
-  /* Inside auto layout */
-
-  flex: none;
-  order: 0;
-  flex-grow: 0;
-  margin: 0px 10px;
-
-  /* Typography */
-
-  font-size: 12px;
+  padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
+  background: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+  border-radius: var(--gauzy-radius-sm, 0.375rem);
+  font-size: var(--gauzy-table-header-font-size, 0.75rem);
   font-weight: 600;
-  line-height: 15px;
+  line-height: var(--gauzy-table-header-line-height, 0.9375rem);
   letter-spacing: 0em;
   text-align: left;
+  white-space: nowrap;
+}
+
+// "No policy set". Muted, and deliberately WITHOUT the chip box, so an unset
+// value does not read as a value.
+.empty {
+  color: nb-theme(text-hint-color);
 }

--- a/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/average-criterions-rating-chart/average-criterions-rating-chart.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/average-criterions-rating-chart/average-criterions-rating-chart.component.scss
@@ -1,22 +1,31 @@
+@use 'themes' as *;
+
 .select {
   width: 20rem;
   margin: 0 0 1.25rem 0;
 }
 
+// Same empty state as the page-level one in `candidate-statistic.component.scss`
+// and now from the same tokens. `#e5e5e5` is a fixed light hairline and
+// `#909cb4` a fixed blue-grey: on the near-black canvas the border vanished and
+// the caption fought the neutral text ramp. The radius and gap were missing
+// here too, so the two empty states did not match even on the light themes.
 .no-data {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: 1px #e5e5e5 solid;
+  gap: 0.5rem;
   height: 150px;
+  border: 1px solid nb-theme(border-basic-color-3);
+  border-radius: nb-theme(border-radius);
 
   &-text {
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 
   &-icon {
     font-size: 1.5rem !important;
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 }

--- a/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/criterions-rating-chart/criterions-rating-chart.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/criterions-rating-chart/criterions-rating-chart.component.scss
@@ -22,20 +22,27 @@
   @include nb-rtl(padding-right, 1rem);
 }
 
+// Same empty state as the page-level one in `candidate-statistic.component.scss`
+// and now from the same tokens. `#e5e5e5` is a fixed light hairline and
+// `#909cb4` a fixed blue-grey: on the near-black canvas the border vanished and
+// the caption fought the neutral text ramp. The radius and gap were missing
+// here too, so the two empty states did not match even on the light themes.
 .no-data {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: 1px #e5e5e5 solid;
+  gap: 0.5rem;
   height: 150px;
+  border: 1px solid nb-theme(border-basic-color-3);
+  border-radius: nb-theme(border-radius);
 
   &-text {
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 
   &-icon {
     font-size: 1.5rem !important;
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 }

--- a/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/interview-rating-chart/interview-rating-chart.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidate-statistic/candidate-statistic-charts/interview-rating-chart/interview-rating-chart.component.scss
@@ -1,22 +1,31 @@
+@use 'themes' as *;
+
 .select {
   width: 100%;
   margin: 0 0 1.25rem 0;
 }
 
+// Same empty state as the page-level one in `candidate-statistic.component.scss`
+// and now from the same tokens. `#e5e5e5` is a fixed light hairline and
+// `#909cb4` a fixed blue-grey: on the near-black canvas the border vanished and
+// the caption fought the neutral text ramp. The radius and gap were missing
+// here too, so the two empty states did not match even on the light themes.
 .no-data {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: 1px #e5e5e5 solid;
+  gap: 0.5rem;
   height: 150px;
+  border: 1px solid nb-theme(border-basic-color-3);
+  border-radius: nb-theme(border-radius);
 
   &-text {
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 
   &-icon {
     font-size: 1.5rem !important;
-    color: #909cb4;
+    color: nb-theme(text-hint-color);
   }
 }

--- a/apps/gauzy/src/app/pages/candidates/candidates.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidates.component.scss
@@ -9,100 +9,13 @@
   justify-content: space-between;
 }
 
-:host .grid-scroll-container {
-  .flex-container {
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: flex-start;
-    padding: 0;
-    margin: 0;
-    list-style: none;
-
-    .flex-item {
-      border: 0.0625rem solid #e4e9f2;
-      border-radius: 0.25rem;
-      width: 23%;
-      margin: 10px;
-
-      .fullName {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        padding: 1rem 1.5rem;
-        line-height: 40px;
-        font-size: 1.5em;
-      }
-
-      .avatar {
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-      }
-
-      .email {
-        @include nb-ltr(text-align, right);
-        @include nb-rtl(text-align, left);
-        padding-right: 1.5rem;
-        bottom: 36px;
-        position: relative;
-      }
-
-      .info-line {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 0.8em;
-        color: darkgray;
-        line-height: 0px;
-        padding: 0.7rem 1.5rem;
-
-        .info-meta {
-          margin-right: 10px;
-          @include nb-ltr(margin-right, 10px);
-          @include nb-rtl(margin-left, 10px);
-        }
-
-        .info-value {
-          display: flex;
-          justify-content: flex-end;
-          text-align: end;
-          color: black;
-          font-size: 1em;
-        }
-
-        .status-badge {
-          text-align: center;
-          padding: 10px 30px;
-          border-radius: 0.25rem;
-          color: #fff;
-        }
-
-        /* Status */
-        .badge-danger {
-          background-color: #ff3d71;
-        }
-
-        .badge-success {
-          background-color: #00d68f;
-        }
-
-        .badge-primary {
-          background-color: #0095ff;
-        }
-
-        .badge-warning {
-          background-color: #fa0;
-        }
-      }
-
-      .card-footer {
-        justify-content: space-around;
-        display: flex;
-      }
-    }
-  }
-}
+// REMOVED: a `:host .grid-scroll-container .flex-container .flex-item` block
+// describing a hand-rolled candidate card — `.avatar`, `.fullName`, `.email`,
+// `.status-badge` and four `.badge-*` fills. No template in the repo renders
+// `.flex-container`; the grid view goes through `<ga-card-grid>`, whose own
+// stylesheet is already token-based. So none of it ever applied, and what it
+// carried was `#e4e9f2` / `darkgray` / `color: black` / four literal status
+// fills — exactly the values a later theme sweep would waste time "fixing".
 
 :host {
   nb-card-body {

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.scss
@@ -46,24 +46,29 @@ input {
   margin: 0 0 8px;
 }
 
+// Secondary caption under a document name. `grey` (#808080) measures 3.5:1 on
+// the light card and is the wrong hue on the neutral dark ramp; `text-hint-color`
+// is the app's own muted step and is tuned per theme.
 .document-data {
   font-size: 12px;
-  color: grey;
+  color: nb-theme(text-hint-color);
 }
 
+// The download glyph — the theme's link colour rather than a literal blue.
 .doc-icon {
-  color: #3365ff !important;
+  color: nb-theme(text-primary-color) !important;
 }
 
 .header {
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  border-color: 1px solid black;
+  // (dropped `border-color: 1px solid black` — `border-color` takes a colour,
+  // not a border shorthand, so the declaration was invalid and discarded.)
 }
 
 .documents-card-container {
-  background-color: rgba(126, 126, 143, 0.05);
+  background-color: var(--gauzy-sidebar-background-4);
   border-radius: nb-theme(border-radius);
   padding: 1rem;
 }

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-employment/edit-candidate-employment.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-employment/edit-candidate-employment.component.scss
@@ -1,16 +1,8 @@
-.notes {
-  margin-top: 16px;
-  padding: 10px;
-  border-radius: 5px;
-  text-indent: 1em;
-}
-
-.notes p {
-  margin: 0;
-  color: #eac72d;
-  font-size: 0.75rem;
-  font-weight: 700;
-}
+// REMOVED: a `.notes` / `.notes p { color: #eac72d }` pair. This template has no
+// `.notes` element — the sibling employee tab is the one that renders a note,
+// and its own stylesheet already paints it from
+// `--color-warning-transparent-100` / `--color-warning-default`. What was here
+// was a stale copy carrying a literal mustard `#eac72d` and no background at all.
 :host {
   overflow-y: auto;
   max-height: calc(100vh - 28rem);

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.html
@@ -5,10 +5,14 @@
 				@if (allFeedbacks?.length > 0) {
 					<div class="filters">
 						@if (dataLayoutStyle === 'CARDS_GRID') {
+							<!-- Was a hardcoded English `placeholder="Select interview"`:
+							     untranslated in every other locale, and still carrying the
+							     "Select …" prefix that was dropped from the app's other
+							     comboboxes. -->
 							<nb-select
 								[formControl]="selectInterview"
 								class="select mr-3 show"
-								placeholder="Select interview"
+								[placeholder]="'CANDIDATES_PAGE.EDIT_CANDIDATE.INTERVIEW.INTERVIEW' | translate"
 								(selectedChange)="onInterviewSelected($event)"
 							>
 								<nb-option [value]="all">

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component.scss
@@ -34,7 +34,9 @@
 }
 
 .block {
-  border: 0.0625rem solid #e4e9f2;
+  // `#e4e9f2` is a fixed pale-blue hairline: on the near-black canvas it draws a
+  // light box, and it ignores the theme everywhere else too.
+  border: 0.0625rem solid nb-theme(gauzy-border-default-color);
   padding: 0.5rem;
   width: 12rem;
   border-radius: 5px;
@@ -130,12 +132,14 @@
   font-size: 15px;
 }
 
+// The thumbs-up / thumbs-down glyphs beside the Hire / Reject radios. Literal
+// eva-palette values before, so they stayed put whichever theme was active.
 .success {
-  color: #00d68f;
+  color: nb-theme(color-success-default);
 }
 
 .error {
-  color: #ff3d71;
+  color: nb-theme(color-danger-default);
 }
 
 .image-small {
@@ -258,7 +262,8 @@
           flex-direction: row;
           justify-content: space-between;
           align-items: center;
-          border: 1px #e4e9f2 solid;
+          // See `.block` above — `#e4e9f2` is a fixed pale-blue hairline.
+          border: 1px solid nb-theme(gauzy-border-default-color);
           @include nb-ltr(margin, 0.15rem 0.15rem 0.15rem 0);
           @include nb-rtl(margin, 0.15rem 0 0.15rem 0.15rem);
           padding: 0.2rem 0.5rem;

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.scss
@@ -1,153 +1,23 @@
 @use 'gauzy/_gauzy-table' as *;
 @use 'gauzy/_gauzy-overrides' as *;
 
-.right-block {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
 .checkboxes {
   display: flex;
   justify-content: flex-end;
   align-items: center;
 }
 
-:host .card-container {
-  display: flex;
-  flex-wrap: wrap;
-
-  .card-body {
-    width: 100%;
-    max-width: 300px;
-    margin: 20px;
-
-    .card-header {
-      padding: 0.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-
-      &-badge {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-      }
-
-      .header-container {
-        text-align: center;
-      }
-    }
-
-    .interview-card {
-      display: flex;
-      flex-direction: column;
-      padding: 0.5rem;
-
-      .name-container {
-        display: flex;
-        align-items: center;
-        margin-bottom: 10px;
-
-        &:hover {
-          cursor: pointer;
-          color: #3366ff;
-        }
-
-        .image-container {
-          width: 70px;
-          height: 50px;
-          display: flex;
-          justify-content: center;
-          margin-right: 10px;
-          @include nb-ltr(margin-right, 10px);
-          @include nb-rtl(margin-left, 10px);
-
-          img {
-            height: 100%;
-            max-width: 70px;
-          }
-        }
-      }
-
-      .team-members {
-        margin-bottom: 0.5rem;
-      }
-    }
-
-    .button-container {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin-top: auto;
-      flex-wrap: wrap;
-    }
-  }
-}
-
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  .btn {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-  }
-}
-
-:host .badge {
-  text-align: center;
-  padding: 5px;
-  @include nb-ltr(margin-left, 0.2rem);
-  @include nb-rtl(margin-right, 0.2rem);
-}
-
-:host .client-info {
-  padding: 0px 12px;
-  display: flex;
-  flex-direction: column;
-
-  .info-line {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    font-size: 0.7em;
-    color: darkgray;
-
-    .info-value {
-      display: flex;
-      justify-content: flex-end;
-      text-align: end;
-
-      .info-list-item:not(:last-child)::after {
-        content: ',';
-        @include nb-ltr(margin-right, 5px);
-        @include nb-rtl(margin-left, 5px);
-      }
-    }
-
-    .criterions {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      text-align: end;
-    }
-  }
-}
-
-.btn {
-  margin: 0.2rem;
-}
-
-.badge-warning {
-  background-color: #fa0;
-}
-
-.badge-primary {
-  background-color: #0095ff;
-}
+// REMOVED with the visual sweep, all of it dead against this template (which
+// renders `.checkboxes`, `.table-scroll-container`, `.custom-card-body` and the
+// action buttons, and nothing else):
+//   * `.right-block`, `.header`, `.btn`;
+//   * `.card-container` / `.interview-card` / `.image-container`, a hand-rolled
+//     interview card replaced by `<ga-card-grid>` — it carried
+//     `.name-container:hover { color: #3366ff }`;
+//   * `.client-info .info-line { color: darkgray }`;
+//   * `.badge`, plus `.badge-warning { #fa0 }` and `.badge-primary { #0095ff }`.
+// Component styles are view-encapsulated, so none of these could reach the card
+// grid's own markup either.
 
 :host {
   overflow-y: auto;

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.html
@@ -3,19 +3,24 @@
     <div class="card-header-title">
       <ngx-back-navigation></ngx-back-navigation>
       <h4>
-        {{ 'CANDIDATES_PAGE.EDIT_CANDIDATE.HEADER' | translate }}
-        @if (selectedCandidate?.user?.name) {
-          <span>{{ selectedCandidate?.user?.name }}</span>
-        }
-        @if (selectedCandidate?.user?.username) {
-          <span>
-            @if (selectedCandidate?.user.name) {
-              ({{ selectedCandidate?.user.username }})
-            } @else {
-              '{{ selectedCandidate?.user.username }}'
-            }
-          </span>
-        }
+        <!-- Routed through `ngx-header-title` like every other page in this
+             area: that is what renders the breadcrumb trail under the heading,
+             which this page had no way to show. -->
+        <ngx-header-title [allowEmployee]="false">
+          {{ 'CANDIDATES_PAGE.EDIT_CANDIDATE.HEADER' | translate }}
+          @if (selectedCandidate?.user?.name) {
+            <span>{{ selectedCandidate?.user?.name }}</span>
+          }
+          @if (selectedCandidate?.user?.username) {
+            <span>
+              @if (selectedCandidate?.user.name) {
+                ({{ selectedCandidate?.user.username }})
+              } @else {
+                '{{ selectedCandidate?.user.username }}'
+              }
+            </span>
+          }
+        </ngx-header-title>
       </h4>
     </div>
     <div class="notification" (click)="interviewInfo()">

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.scss
@@ -6,13 +6,17 @@
   width: 100%;
 }
 
+// The "upcoming interviews" bell. The disc was a literal `rgb(0, 145, 255)` and
+// the unread dot below a literal `#f10`; both now read the theme's status
+// palette. (`.bell` keeps `color: white` — that is a contrast pair against this
+// disc, not a theme colour, and the disc is a saturated fill in every theme.)
 .notification {
   position: relative;
   display: inline-block;
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background-color: rgb(0, 145, 255);
+  background-color: nb-theme(color-info-default);
 }
 
 .notification:hover {
@@ -37,7 +41,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: #f10;
+  background-color: nb-theme(color-danger-default);
 }
 
 .nb-card {
@@ -103,6 +107,12 @@
     }
   }
 }
+
+// (removed a local `h4 { font-size: 24px; line-height: 30px }` override.) The
+// page heading is governed by one type step, applied by `ngx-header-title`
+// itself — 1.25rem/1.75rem, deliberately the h5 step, "a page heading only needs
+// to out-rank body copy". 24px here made this the single largest page title in
+// the app, a full step above every sibling in Employees & Candidates.
 
 :host {
   @include input-appearance(42px, var(--gauzy-card-1));

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.scss
@@ -11,7 +11,7 @@
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background-color: rgb(0, 145, 255);
+  background-color: nb-theme(color-info-default);
 }
 
 .notification:hover {
@@ -27,7 +27,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: #f10;
+  background-color: nb-theme(color-danger-default);
 }
 
 :host .bell {
@@ -62,30 +62,13 @@
   padding: 1rem;
 }
 
-.org-details {
-  .edit-public-page {
-    cursor: pointer;
-    color: #027ad6;
-    padding-top: 3px;
-  }
-}
-
-.setting-name {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.body-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 35px;
-}
-
-.mutation-card.setting-block {
-  background: #eaf3fc;
-}
-
+// Removed as dead: `.org-details .edit-public-page` (a literal `#027ad6` link
+// blue), `.setting-name`, `.body-header`, and `.mutation-card.setting-block`
+// (a literal `#eaf3fc` pale-blue panel, which would have been a light slab on
+// the near-black themes had anything used it). None of those class names
+// appears in this component's own template — only `notification`, `exist` and
+// `bell` do — and these styles are view-encapsulated, so they could not reach a
+// child route's markup either.
 .transparent {
   opacity: 0.7;
 }

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-criterions/candidate-personal-qualities/candidate-personal-qualities.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-criterions/candidate-personal-qualities/candidate-personal-qualities.component.scss
@@ -51,12 +51,17 @@
   }
 }
 
+// Same "already exists" list as the sibling `candidate-technologies` page, which
+// carried a background this one did not — the two panels sit side by side in the
+// same tab, so they now take the same surface token.
 .existedNames {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
   flex-wrap: wrap;
+  background-color: var(--gauzy-card-2);
+  border-radius: nb-theme(border-radius);
 
   &-card {
     width: 100%;
@@ -68,8 +73,12 @@
     margin-top: 0.5rem;
   }
 
+  // Marks a name that clashes with an existing one, so it wants the theme's
+  // danger colour rather than a literal `#ff3d70`. The radius was missing too,
+  // which left a square-cornered box among rounded ones.
   .existedName {
-    border: 1px #ff3d70 solid;
+    border: 1px solid nb-theme(color-danger-default);
+    border-radius: nb-theme(border-radius);
     margin: 0.2rem 0;
     padding: 1rem;
     display: flex;

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-criterions/candidate-technologies/candidate-technologies.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-criterions/candidate-technologies/candidate-technologies.component.scss
@@ -51,13 +51,19 @@
   }
 }
 
+// The "already exists" list. `rgba(50, 50, 50, 0.08)` is the literal value of
+// `gauzy-card-2` on the light themes only — on the dark ones that token is a
+// LIFTING white tint, so this panel was darkening a canvas that is already
+// near-black. The sibling `candidate-personal-qualities` page carries the same
+// list with no background at all; both now read the same.
 .existedNames {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
   flex-wrap: wrap;
-  background-color: rgba(50, 50, 50, 0.08);
+  background-color: var(--gauzy-card-2);
+  border-radius: nb-theme(border-radius);
 
   &-card {
     width: 100%;
@@ -69,8 +75,12 @@
     margin-top: 0.5rem;
   }
 
+  // Marks a name that clashes with an existing one, so it wants the theme's
+  // danger colour rather than a literal `#ff3d70`. The radius was missing too,
+  // which left a square-cornered box among rounded ones.
   .existedName {
-    border: 1px #ff3d70 solid;
+    border: 1px solid nb-theme(color-danger-default);
+    border-radius: nb-theme(border-radius);
     margin: 0.2rem 0;
     padding: 1rem;
     display: flex;

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.scss
@@ -42,117 +42,21 @@
 .select {
   width: 18rem;
 }
-:host .card-container {
-  display: flex;
-  flex-wrap: wrap;
-
-  .card-body {
-    width: 100%;
-    max-width: 300px;
-    .card-header {
-      padding: 0.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-
-      &-badge {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-      }
-      .header-container {
-        text-align: center;
-      }
-    }
-
-    .interview-card {
-      display: flex;
-      flex-direction: column;
-      padding: 0.5rem;
-
-      .name-container {
-        display: flex;
-        align-items: center;
-        margin-bottom: 10px;
-
-        &:hover {
-          cursor: pointer;
-          color: #3366ff;
-        }
-
-        .image-container {
-          width: 70px;
-          height: 50px;
-          display: flex;
-          justify-content: center;
-          @include nb-ltr(margin-right, 10px);
-          @include nb-rtl(margin-left, 10px);
-
-          img {
-            height: 100%;
-            max-width: 70px;
-          }
-        }
-      }
-      .team-members {
-        margin-bottom: 0.5rem;
-      }
-    }
-
-    .button-container {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin-top: auto;
-      flex-wrap: wrap;
-    }
-  }
-}
 .btn {
   margin: 0.2rem;
 }
 
-.badge-warning {
-  background-color: #fa0;
-}
-
-.badge-primary {
-  background-color: #0095ff;
-}
-
-.badge {
-  text-align: center;
-  padding: 5px;
-  margin-left: 0.2rem;
-}
-.client-info {
-  padding: 0px 12px;
-  display: flex;
-  flex-direction: column;
-  .info-line {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    font-size: 0.7em;
-    color: darkgray;
-    .info-value {
-      display: flex;
-      justify-content: flex-end;
-      text-align: end;
-      .info-list-item:not(:last-child)::after {
-        content: ',';
-        @include nb-ltr(margin-right, 5px);
-        @include nb-rtl(margin-left, 5px);
-      }
-    }
-    .criterions {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      text-align: end;
-    }
-  }
-}
+// REMOVED: `.card-container` (with `.interview-card`, `.image-container`,
+// `.name-container:hover { color: #3366ff }`), `.client-info` (with
+// `.info-line { color: darkgray }`), the bare `.badge` box and the
+// `.badge-warning` / `.badge-primary` fills `#fa0` / `#0095ff`.
+//
+// All dead, but not because the names are unused — `.card-header` and
+// `.card-body` DO appear in this template. They were nested inside
+// `:host .card-container`, and nothing here is a `.card-container`, so the
+// nested rules never matched. The grid view renders through `<ga-card-grid>`,
+// whose markup these styles cannot reach anyway: they are view-encapsulated to
+// this component's own template.
 
 :host {
   @include card-overrides(unset, calc($default-card-height), $default-radius);

--- a/apps/gauzy/src/app/pages/candidates/table-components/candidate-status/candidate-status.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/table-components/candidate-status/candidate-status.component.scss
@@ -1,18 +1,27 @@
+@use 'themes' as *;
+
+// Status fills come from the theme's status palette, the same way
+// `organizations-status` takes them. The literals here before (#ff3d71 /
+// #00d68f / #0095ff / #fa0) were a snapshot of one theme's eva palette, so the
+// pills stayed on those four colours whichever of the eight themes was active.
 .badge-danger {
-  background-color: #ff3d71;
+  background-color: nb-theme(color-danger-default);
 }
 
 .badge-success {
-  background-color: #00d68f;
+  background-color: nb-theme(color-success-default);
 }
 
 .badge-primary {
-  background-color: #0095ff;
+  background-color: nb-theme(color-info-default);
 }
 
+// No `color` override: the label keeps Bootstrap's dark-on-amber pairing. White
+// on this fill measured ~2:1, i.e. the ARCHIVED pill was the one status label
+// you could not read — and unlike the other three, amber is a LIGHT fill, so it
+// wants dark text in every theme.
 .badge-warning {
-  background-color: #fa0;
-  color: #fff;
+  background-color: nb-theme(color-warning-default);
 }
 
 div {

--- a/apps/gauzy/src/app/pages/contacts/contact-mutation/contact-mutation.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/contact-mutation/contact-mutation.component.scss
@@ -18,6 +18,9 @@
 
     .image-overlay {
       pointer-events: none;
+      // Deliberately a literal, and deliberately NOT a theme token: this is a
+      // scrim over the uploaded PHOTO (0 -> 0.2 opacity on hover), so what it has
+      // to darken is the picture, not the surface the card is painted on.
       background: black;
       position: absolute;
       height: 100%;
@@ -33,20 +36,33 @@
       border-radius: nb-theme(border-radius);
     }
 
+    // The empty-state placeholder behind the uploader. It is a NEUTRAL tint, not
+    // a colour of its own: the same token the rest of the app hovers with, so it
+    // darkens a white card and lightens a near-black one instead of staying a
+    // fixed light grey that vanishes on the four dark themes.
     .image {
-      background-color: rgba(126, 126, 143, 0.1);
+      background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+      // Centers the prompt for real. It used to be absolutely positioned at
+      // `left: calc(50% - 141px / 2)` — 141px being a guess at the width of the
+      // English string. Any other translation, or any other root font size, put
+      // the label off center, and a longer one ran out of the 12.5rem box with
+      // nowhere to wrap.
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 0.75rem;
 
       i {
         margin: 5px;
       }
 
       > span {
-        color: rgba(126, 126, 143, 1);
+        // `rgba(126, 126, 143, 1)` is the LIGHT themes' muted text value written
+        // out by hand; on a dark card it is barely above the background.
+        color: var(--gauzy-text-color-2, var(--text-hint-color));
         z-index: 2;
         transition: opacity 0.2s ease-in;
-        position: absolute;
-        top: calc(50% - 16px / 2);
-        left: calc(50% - 141px / 2);
+        text-align: center;
       }
     }
 
@@ -99,26 +115,15 @@
     display: flex;
     align-items: center;
     margin-bottom: 10px;
-
-    .image-container {
-      width: 70px;
-      height: 50px;
-      display: flex;
-
-      img {
-        height: 100%;
-        max-width: 70px;
-      }
-    }
   }
 
-  .button-container {
-    display: flex;
-    width: 160px;
-    justify-content: space-between;
-    margin-top: 15px;
-    margin-left: 9px;
-  }
+  /*
+   * REMOVED: `.image-container` (and its `img`) and `.button-container`.
+   * Neither class occurs anywhere in contact-mutation.component.html or
+   * contact-mutation.component.ts — the members step renders
+   * `.team-card > .name-container > ngx-avatar` and nothing else, and a
+   * component stylesheet cannot reach past its own template.
+   */
 }
 
 /*
@@ -284,7 +289,13 @@
     border-radius: 0;
   }
 
-  @include dialog(transparent, var(--gauzy-card-1));
+  // The second argument paints every input/select in the wizard. It needs a
+  // fallback: `gauzy-card-1` is not registered for `material-light` /
+  // `material-dark` (they inherit from Nebular's material themes, not from the
+  // gauzy default), and an unresolvable `var()` takes the whole
+  // `background-color` declaration with it — there the fields would fall back to
+  // Nebular's own field background, which is not the surface they sit on.
+  @include dialog(transparent, var(--gauzy-card-1, var(--card-background-color)));
 
   /*
    * Step buttons — restated AFTER `dialog()` so these win at equal specificity.

--- a/apps/gauzy/src/app/pages/contacts/contact-view/contact-view.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/contact-view/contact-view.component.scss
@@ -10,6 +10,17 @@
  *
  * Everything below is label/value pairs on theme tokens: no borrowed utilities,
  * no fake control chrome, and values that wrap instead of escaping their panel.
+ *
+ * Every `var(--gauzy-…)` here carries a fallback. `material-light` and
+ * `material-dark` register against Nebular's own material themes rather than
+ * against the gauzy default, so they inherit NONE of the `gauzy-card-*`,
+ * `gauzy-text-color-*`, `gauzy-shadow`, `gauzy-sidebar-background-*` or
+ * `gauzy-border-default-color` keys (themes.scss lines 501-554 set none of them).
+ * A `var()` with no fallback resolves to nothing there and the browser drops the
+ * WHOLE declaration — which is how this panel lost its text colours, its
+ * surfaces and its edges on two of the eight themes. The fallbacks are
+ * translucent neutrals or Nebular keys that every theme does define, so one
+ * value stays right on a white card and on a near-black one.
  */
 
 // The tab body is sized from the viewport so the page fits without the window
@@ -19,7 +30,7 @@ $pane-height: calc(100vh - 17.25rem);
 $aside-height: calc(100vh - 14.25rem);
 
 :host nb-card {
-	background-color: var(--gauzy-card-2);
+	background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
 	margin: 0;
 }
 
@@ -57,15 +68,15 @@ $aside-height: calc(100vh - 14.25rem);
 	height: 2.25rem;
 	border-radius: 50%;
 	object-fit: cover;
-	box-shadow: var(--gauzy-shadow);
+	box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
 }
 
 .identity-avatar-fallback {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background-color: var(--gauzy-hover-tint);
-	color: var(--gauzy-text-color-2);
+	background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.8125rem;
 	font-weight: 600;
 	line-height: 1;
@@ -79,7 +90,7 @@ $aside-height: calc(100vh - 14.25rem);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--gauzy-text-color-1);
+	color: var(--gauzy-text-color-1, var(--text-basic-color));
 	font-size: 1.125rem;
 	font-weight: 600;
 	line-height: 1.5rem;
@@ -90,8 +101,8 @@ $aside-height: calc(100vh - 14.25rem);
 	flex: 0 0 auto;
 	padding: 0.125rem 0.5rem;
 	border-radius: 999px;
-	background-color: var(--gauzy-hover-tint);
-	color: var(--gauzy-text-color-2);
+	background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.6875rem;
 	font-weight: 600;
 	line-height: 1rem;
@@ -130,7 +141,7 @@ $aside-height: calc(100vh - 14.25rem);
 	// Header and body paint to the edges, so the container has to clip them for
 	// the rounded corner to survive.
 	overflow: hidden;
-	box-shadow: var(--gauzy-shadow);
+	box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
 
 	nb-accordion-item-header {
 		font-size: 0.8125rem;
@@ -138,15 +149,15 @@ $aside-height: calc(100vh - 14.25rem);
 		line-height: 1.125rem;
 		letter-spacing: 0em;
 		text-align: left;
-		color: var(--gauzy-text-color-2);
+		color: var(--gauzy-text-color-2, var(--text-hint-color));
 
 		&.accordion-item-header-expanded {
-			background-color: var(--gauzy-sidebar-background-3);
+			background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
 		}
 	}
 
 	nb-accordion-item-body {
-		background-color: var(--gauzy-card-3);
+		background-color: var(--gauzy-card-3, rgba(126, 126, 143, 0.05));
 	}
 }
 
@@ -163,8 +174,8 @@ $aside-height: calc(100vh - 14.25rem);
 .panel-count {
 	padding: 0 0.375rem;
 	border-radius: 999px;
-	background-color: var(--gauzy-hover-tint);
-	color: var(--gauzy-text-color-2);
+	background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.6875rem;
 	font-weight: 600;
 	line-height: 1rem;
@@ -172,7 +183,7 @@ $aside-height: calc(100vh - 14.25rem);
 
 .panel-empty {
 	margin: 0;
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.8125rem;
 	line-height: 1.125rem;
 }
@@ -198,7 +209,7 @@ $aside-height: calc(100vh - 14.25rem);
 
 .field-label {
 	margin: 0 0 0.125rem;
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.6875rem;
 	font-weight: 600;
 	line-height: 1rem;
@@ -210,7 +221,7 @@ $aside-height: calc(100vh - 14.25rem);
 .field-value {
 	margin: 0;
 	min-width: 0;
-	color: var(--gauzy-text-color-1);
+	color: var(--gauzy-text-color-1, var(--text-basic-color));
 	font-size: 0.8125rem;
 	font-weight: 400;
 	line-height: 1.125rem;
@@ -237,7 +248,7 @@ $aside-height: calc(100vh - 14.25rem);
 }
 
 .field-empty {
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	// A dash is a placeholder, not a value: keep it out of the reading order.
 	user-select: none;
 }
@@ -265,15 +276,15 @@ $aside-height: calc(100vh - 14.25rem);
 	height: 1.75rem;
 	border-radius: var(--gauzy-radius-sm, 0.375rem);
 	object-fit: cover;
-	box-shadow: var(--gauzy-shadow);
+	box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
 }
 
 .entity-avatar-fallback {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background-color: var(--gauzy-hover-tint);
-	color: var(--gauzy-text-color-2);
+	background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.75rem;
 	font-weight: 600;
 	line-height: 1;
@@ -291,14 +302,14 @@ $aside-height: calc(100vh - 14.25rem);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--gauzy-text-color-1);
+	color: var(--gauzy-text-color-1, var(--text-basic-color));
 	font-size: 0.8125rem;
 	font-weight: 600;
 	line-height: 1.125rem;
 }
 
 .entity-meta {
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 	font-size: 0.6875rem;
 	font-weight: 400;
 	line-height: 0.9375rem;
@@ -322,9 +333,9 @@ $aside-height: calc(100vh - 14.25rem);
 	// Same surface as the accordion bodies opposite, so the two columns read as
 	// one screen. The tab BAR is deliberately left on the card behind it — that
 	// is the shape Nebular draws and fighting it only adds a second seam.
-	background-color: var(--gauzy-card-3);
+	background-color: var(--gauzy-card-3, rgba(126, 126, 143, 0.05));
 	border-radius: var(--border-radius);
-	box-shadow: var(--gauzy-shadow);
+	box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
 }
 
 .pane {
@@ -354,7 +365,7 @@ $aside-height: calc(100vh - 14.25rem);
 	min-height: 14rem;
 	overflow: hidden;
 	border-radius: var(--gauzy-radius-sm, 0.375rem);
-	border: 1px solid var(--gauzy-border-default-color);
+	border: 1px solid var(--gauzy-border-default-color, var(--border-basic-color-3));
 }
 
 :host ga-leaflet-map {
@@ -408,11 +419,11 @@ $aside-height: calc(100vh - 14.25rem);
 	align-items: center;
 	min-width: 0;
 	padding: 0.375rem 0.5rem;
-	border: 1px solid var(--gauzy-border-default-color);
+	border: 1px solid var(--gauzy-border-default-color, var(--border-basic-color-3));
 	border-radius: var(--gauzy-radius-sm, 0.375rem);
 
 	&:hover {
-		background-color: var(--gauzy-hover-tint);
+		background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
 	}
 
 	// Without this the avatar's own `min-width: auto` keeps the card as wide as

--- a/apps/gauzy/src/app/pages/contacts/contacts.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/contacts.component.scss
@@ -1,41 +1,16 @@
 @use '@shared/_pg-card' as *;
 
-.contact-list {
-  display: flex;
-  flex-wrap: wrap;
-
-  .member-card {
-    display: flex;
-    flex-wrap: wrap;
-    max-width: 340px;
-    width: 100%;
-  }
-
-  .contact-info {
-    padding-right: 12px;
-    display: flex;
-    flex-direction: column;
-
-    .info-line {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      font-size: 0.7em;
-      color: darkgray;
-
-      .info-value {
-        display: flex;
-        justify-content: flex-end;
-        text-align: end;
-
-        .info-list-item:not(:last-child)::after {
-          content: ',';
-          margin-right: 5px;
-        }
-      }
-    }
-  }
-}
+/*
+ * REMOVED: the `.contact-list` block (`.member-card`, `.contact-info`,
+ * `.info-line`, `.info-value`, `.info-list-item`).
+ *
+ * `contact-list` appears nowhere in the repository outside this file — the card
+ * layout is rendered by `ga-card-grid`, a CHILD component, whose elements carry
+ * ITS `_ngcontent` attribute, so these rules could never have reached them under
+ * the default emulated encapsulation. (`ga-card-grid` styles its own `.info-line`
+ * in card-grid.component.scss.) The block also carried `color: darkgray`, a
+ * literal that belongs to no theme.
+ */
 
 .main-header {
   display: flex;

--- a/apps/gauzy/src/app/pages/contacts/invite-contact/invite-contact.component.scss
+++ b/apps/gauzy/src/app/pages/contacts/invite-contact/invite-contact.component.scss
@@ -2,10 +2,50 @@
 
 nb-card {
   width: 645px;
-  background-color: nb-theme(gauzy-card-1);
-  nb-card-header {
-    nb-icon.close {
-      cursor: pointer;
-    }
+  // 645px was a hard width with nothing to stop it, so below ~700px of viewport
+  // the dialog ran past both edges of the screen and took its footer with it.
+  max-width: calc(100vw - 3rem);
+  // `nb-theme(gauzy-card-1)` compiles to a bare `var(--gauzy-card-1)` — Nebular
+  // runs in CSS-custom-property mode here — and that key is not registered for
+  // `material-light` / `material-dark`, which are registered against Nebular's
+  // own material themes rather than against the gauzy default (themes.scss lines
+  // 501-554). An unresolvable `var()` takes the whole declaration with it, so on
+  // those two themes the dialog had no surface colour of its own at all.
+  background-color: var(--gauzy-card-1, var(--card-background-color));
+
+  /*
+   * REMOVED: `nb-card-header nb-icon.close { cursor: pointer }`.
+   * invite-contact.component.html has no `nb-icon` anywhere — the close control
+   * is `<span class="cancel"><i class="fas fa-times">`, and `_gauzy-dialogs`
+   * already gives every `i` in this component `cursor: pointer`.
+   */
+}
+
+/*
+ * Cancel, restated AFTER `_gauzy-dialogs` so it wins at equal specificity.
+ *
+ * That shared partial paints EVERY `[nbButton].appearance-outline.status-basic`
+ * a literal `rgba(245, 109, 88, 1)` orange, 2px wide, with an orange glow on
+ * hover. No theme in themes.scss holds that colour. Here it landed on the one
+ * button in the dialog that should be quietest: "Cancel" read louder than the
+ * invite action next to it, which the theme's action tokens draw as a restrained
+ * accent. So a hairline in the neutral border token, a muted label, and the same
+ * hover tint the rest of the app uses.
+ */
+:host [nbButton].appearance-outline.status-basic {
+  background-color: transparent;
+  border-width: 1px;
+  border-color: nb-theme(border-basic-color-4);
+  color: nb-theme(text-hint-color);
+
+  &:hover {
+    border-color: nb-theme(border-basic-color-5);
+    color: nb-theme(text-basic-color);
+    background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
   }
+}
+
+// The partial's orange hover glow, which no longer matches anything above.
+:host [nbButton].appearance-outline:hover {
+  box-shadow: none;
 }

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.scss
@@ -143,20 +143,25 @@
       font-size: 18px;
       color: var(--text-basic-color);
 
+      // Four literal status colours here resolved to two meanings: green for
+      // "profit up" / "income", orange-yellow for "profit down" / "expense".
+      // They were two slightly different greens and two slightly different
+      // yellows, none of which changed per theme. Mapped onto the status
+      // tokens, which do.
       .profit-positive-color {
-        color: #66de0b;
+        color: nb-theme(color-success-default);
       }
 
       .profit-negative-color {
-        color: #ff7b00;
+        color: nb-theme(color-warning-default);
       }
 
       .expense-color {
-        color: #dbc300;
+        color: nb-theme(color-warning-default);
       }
 
       .income-color {
-        color: #089c17;
+        color: nb-theme(color-success-default);
       }
     }
 
@@ -195,7 +200,7 @@
       :last-child {
         font-size: 46px;
         font-weight: bold;
-        color: #0091ff;
+        color: nb-theme(color-info-default);
       }
 
       .negative-bonus-color {

--- a/apps/gauzy/src/app/pages/dashboard/human-resources/human-resources.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/human-resources/human-resources.component.scss
@@ -45,7 +45,7 @@
 		.employee-salary {
 			font-size: 24px;
 			font-weight: bold;
-			color: #0091ff;
+			color: nb-theme(color-info-default);
 		}
 	}
 }
@@ -89,11 +89,11 @@
 			:last-child {
 				font-size: 36px;
 				font-weight: bold;
-				color: #0091ff;
+				color: nb-theme(color-info-default);
 			}
 
 			.negative-bonus-color {
-				color: red;
+				color: nb-theme(color-danger-default);
 			}
 		}
 

--- a/apps/gauzy/src/app/pages/dashboard/project-management/project-management-details/project-management-details.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/project-management/project-management-details/project-management-details.component.scss
@@ -53,11 +53,14 @@ $gap: 1rem;
       width: 100%;
       cursor: pointer;
       .dot {
-        border: 1px solid #6e49e8;
+        // Was a literal `#6e49e8` on both the ring and the checked fill — the
+        // accent, spelled out rather than resolved, so it stayed the same purple
+        // on every theme including the ones whose primary is not purple.
+        border: 1px solid nb-theme(color-primary-default);
         padding: 4px;
         border-radius: var(--border-radius);
         &.checked {
-          background-color: #6e49e8;
+          background-color: nb-theme(color-primary-default);
         }
       }
       .status {

--- a/apps/gauzy/src/app/pages/documents/documents.component.html
+++ b/apps/gauzy/src/app/pages/documents/documents.component.html
@@ -28,7 +28,13 @@
 				>
 					<div>
 						<nb-icon icon="file-text-outline"></nb-icon>
-						<a [href]="document.documentUrl">
+						<!--
+							The target is an uploaded file on another origin, and the row it sits
+							in also handles the click to SELECT the document — following the link
+							in place threw the whole app away to open an attachment. `noopener`
+							keeps the opened tab from reaching back through `window.opener`.
+						-->
+						<a [href]="document.documentUrl" target="_blank" rel="noopener noreferrer">
 							{{ document.name }}
 						</a>
 					</div>

--- a/apps/gauzy/src/app/pages/documents/documents.component.scss
+++ b/apps/gauzy/src/app/pages/documents/documents.component.scss
@@ -1,1 +1,67 @@
+// `@forward` re-exports for anyone importing THIS file; it does not bring
+// `nb-theme()` into scope here, so the theme module is also `@use`d. Sass loads
+// each module once, so this does not duplicate the emitted CSS.
+@use 'gauzy/_gauzy-cards' as *;
 @forward '../vendors/vendors.component';
+
+/*
+ * Everything above comes from the vendors sheet (which itself forwards
+ * `expense-categories`): the page frame, the dialog, and the row hover /
+ * selection treatment. Only the parts where this page's markup differs from
+ * vendors' are restated here.
+ */
+
+// A document row is `<div><nb-icon><a>name</a></div>` followed by
+// `<div>{{ updatedAt }}</div>`. Both are plain blocks, so the timestamp landed on
+// its own line under the file name, left-aligned, with the icon sitting on the
+// text baseline instead of beside it — one list entry cost two lines and read as
+// two unrelated values. Name on the leading edge, date on the trailing one.
+:host .custom-table {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+
+  > div {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-width: 0;
+  }
+
+  // The date is the secondary value here, and it must not push the name out.
+  > div:last-child {
+    flex: 0 0 auto;
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
+    font-size: nb-theme(text-caption-font-size);
+  }
+
+  // `min-width: 0` as well as on the wrapper: a flex item's default
+  // `min-width: auto` is its content width, so without this the name never
+  // shrinks and the ellipsis never appears — it just pushes the date out.
+  a {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  nb-icon {
+    flex: 0 0 auto;
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
+  }
+}
+
+// The dialog's close control. `expense-categories` gives every `<i>` in
+// `.editable` a pointer cursor, which is what the vendors dialog uses — this one
+// is an `<nb-icon>`, so it was the one close button across these two pages that
+// gave no hint it could be clicked, at full icon size and full text contrast.
+.editable nb-icon {
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--gauzy-text-color-2, var(--text-hint-color));
+
+  &:hover {
+    color: nb-theme(text-basic-color);
+  }
+}

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.scss
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.scss
@@ -140,8 +140,13 @@ $height: calc(100vh - 25.5rem);
       border-radius: nb-theme(border-radius);
     }
 
+    // The "Template preview" strip. It is the facing half of `.editor-header`
+    // ("HTML editor") on the other column, but it was the one literal the
+    // white-block pass missed: a hand-written rgba at 0.05 against the token's
+    // 0.12, so the two column headers on the same row never matched. Same tint
+    // as its opposite number now, and defined in all eight themes.
     .email-column-sub-header {
-      background-color: rgba(126, 126, 143, 0.05);
+      background-color: nb-theme(gauzy-hover-tint);
       padding: 13px;
       border-radius: 8px 8px 0 0;
       margin: -10px -10px 0;

--- a/apps/gauzy/src/app/pages/employee-levels/employee-level.component.html
+++ b/apps/gauzy/src/app/pages/employee-levels/employee-level.component.html
@@ -119,19 +119,35 @@
 					</ga-tags-color-input>
 				</div>
 			</div>
+			<!-- The buttons live inside a column, like the Edit dialog below and
+			     like both dialogs on the sibling Positions page. They used to be
+			     direct children of the `.row`, preceded by an empty full-width
+			     `col-sm-12`: that spacer claimed a line of its own, so the footer
+			     was pushed down by an empty row, and the buttons then sat outside
+			     any column and so 15px left of every other dialog's footer
+			     (Bootstrap's `.row` bleeds past its container on both sides). -->
 			<div class="row mb-3">
-				<div class="col-sm-12"></div>
-				<button class="delete mr-3 ml-3" (click)="ref.close(); disabled = true" nbButton status="basic" outline>
-					{{ 'BUTTONS.CANCEL' | translate }}
-				</button>
-				<button
-					(click)="save(addInput.value); disabled = true; ref.close()"
-					nbButton
-					status="success"
-					[disabled]="addInput.invalid"
-				>
-					{{ 'BUTTONS.SAVE' | translate }}
-				</button>
+				<div class="col-sm-12 d-flex">
+					<button
+						type="button"
+						class="delete mr-3 ml-3"
+						(click)="ref.close(); disabled = true"
+						nbButton
+						status="basic"
+						outline
+					>
+						{{ 'BUTTONS.CANCEL' | translate }}
+					</button>
+					<button
+						type="button"
+						(click)="save(addInput.value); disabled = true; ref.close()"
+						nbButton
+						status="success"
+						[disabled]="addInput.invalid"
+					>
+						{{ 'BUTTONS.SAVE' | translate }}
+					</button>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -175,6 +191,7 @@
 			<div class="row mb-3">
 				<div class="d-flex">
 					<button
+						type="button"
 						class="delete mr-3 ml-3"
 						outline
 						(click)="ref.close(); disabled = true"
@@ -184,6 +201,7 @@
 						{{ 'BUTTONS.CANCEL' | translate }}
 					</button>
 					<button
+						type="button"
 						(click)="
 							editEmployeeLevel(selected.employeeLevel.id, editInput.value); disabled = true; ref.close()
 						"

--- a/apps/gauzy/src/app/pages/employees/activity/app-url-activity/app-url-activity.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/app-url-activity/app-url-activity.component.scss
@@ -32,8 +32,13 @@
   padding: 20px;
   margin-bottom: 5px;
   border-radius: nb-theme(border-radius);
+  // The column-heading strip. `rgba(white, 0.5)` is a fixed 50 %-white wash: on
+  // the light themes it reads as a faint tint, but on `gauzy-dark` it paints a
+  // near-white block across the top of the list. `gauzy-card-3` is the token for
+  // exactly this — a translucent step over a panel — and it flips to a DARKENING
+  // overlay on the themes whose panels are light-on-dark.
   &.head {
-    background-color: rgba($color: white, $alpha: 0.5);
+    background-color: var(--gauzy-card-3);
     padding: 12px 20px;
   }
   .times {

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-main/edit-employee-main.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-main/edit-employee-main.component.scss
@@ -6,14 +6,21 @@ $radius: nb-theme(border-radius);
   	margin-top: 20px;
 }
 
+// `rgba(126, 126, 143, 0.1)` is the literal value this token carries on the
+// light themes; on `gauzy-dark` the token is a LIFTING white tint instead, so
+// reading it keeps the photo column one visible step off the tab surface there
+// rather than hoping a grey wash shows up on near-black.
 .organization-container {
-  background-color: rgba(126, 126, 143, 0.1);
+  background-color: var(--gauzy-sidebar-background-3);
 }
 
 .organization-photo img {
   width: 100px;
   height: 100px;
-  box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.25);
+  // A 25 %-black drop shadow is invisible against the near-black canvas — this
+  // avatar had no edge at all on `gauzy-dark`. The token is the same hairline
+  // on the light themes and a 1px ring on the dark one.
+  box-shadow: var(--gauzy-shadow);
   object-fit: cover;
   border-radius: $radius;
 }

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.scss
@@ -2,16 +2,23 @@
 
 :host {
   ::ng-deep .tabset-container .route-tabset {
-    overflow-x: scroll;
+    // `auto`, not `scroll`: with nine tabs the strip usually fits, and `scroll`
+    // reserves a scrollbar gutter whether or not there is anything to scroll.
+    overflow-x: auto;
     overflow-y: hidden;
 
+    // `scrollbar-width` and `-ms-overflow-style` apply to the SCROLL CONTAINER,
+    // not to a `::-webkit-scrollbar` pseudo-element — nested inside that rule
+    // (as they were) they matched nothing, so Firefox drew a real scrollbar
+    // across the bottom of the tab strip while Chrome hid it. They belong here.
+    /* Firefox */
+    scrollbar-width: none;
+    /* IE, Edge */
+    -ms-overflow-style: none;
+
+    /* Chrome, Safari, Opera */
     &::-webkit-scrollbar {
-      /* Chrome, Safari, Opera */
       display: none;
-      /* IE, Edge */
-      -ms-overflow-style: none;
-      /* Firefox */
-      scrollbar-width: none;
     }
 
     @media only screen and (max-width: 1280px) {

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-settings/edit-employee-other-settings.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-settings/edit-employee-other-settings.component.scss
@@ -52,10 +52,15 @@
       border-radius: nb-theme(button-rectangle-border-radius);
       list-style: none;
       cursor: pointer;
-      box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15);
+      // `gauzy-shadow`, not a literal black drop shadow. The token IS
+      // `0 1px 1px rgb(0 0 0 / 15%)` on the light themes, so nothing moves
+      // there, but on `gauzy-dark` it resolves to a 1px hairline ring instead —
+      // a black shadow under a panel that sits on a near-black canvas is
+      // invisible, which left these section rows with no edge at all.
+      box-shadow: var(--gauzy-shadow, 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)));
       &.active {
         background: nb-theme(background-basic-color-1);
-        box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15) inset;
+        box-shadow: var(--gauzy-shadow, 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18))) inset;
       }
     }
   }
@@ -88,7 +93,11 @@ nb-accordion {
       border-radius: 6px;
       width: 23px;
       height: 23px;
-      border: 1px solid rgba(66, 66, 66, 0.2);
+      // Was `rgba(66, 66, 66, 0.2)`, a DARKENING hairline — invisible on the
+      // near-black canvas, where the accordion chevrons then had no box at all.
+      // `gauzy-border-default-color` is white-at-low-alpha there and the same
+      // grey it was on the light themes.
+      border: 1px solid nb-theme(gauzy-border-default-color);
     }
   }
   & nb-accordion-item-header,
@@ -311,9 +320,12 @@ nb-accordion {
     margin-bottom: 0;
   }
 }
+// `#7e7e8f` is rgb(126, 126, 143), i.e. a hand-copied value of the theme's own
+// `toggle-basic-background-color`. Reading the token instead means the unchecked
+// track follows whichever theme is active rather than staying on one theme's grey.
 :host ::ng-deep .toggle {
-  border: 1px solid #7e7e8f !important;
-  background-color: #7e7e8f !important;
+  border: 1px solid nb-theme(toggle-basic-background-color) !important;
+  background-color: nb-theme(toggle-basic-background-color) !important;
   &.checked {
     background-color: nb-theme(text-primary-color) !important;
     border: 1px solid nb-theme(text-primary-color) !important;

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.html
@@ -6,11 +6,15 @@
           <div class="d-flex align-items-start">
             <ngx-back-navigation></ngx-back-navigation>
             <div class="employee-info">
-              <img
-                class="employee-image"
-                [src]="selectedEmployee?.user?.image?.fullUrl || selectedEmployee?.user?.imageUrl"
-                alt="Employee Avatar"
-                />
+              <!-- Guarded: the image used to render unconditionally, so an
+                   employee with no photo got a broken-image glyph. -->
+              @if (selectedEmployee?.user?.image?.fullUrl || selectedEmployee?.user?.imageUrl; as avatarUrl) {
+                <img class="employee-image" [src]="avatarUrl" alt="Employee Avatar" />
+              } @else {
+                <div class="employee-image-placeholder" aria-hidden="true">
+                  <nb-icon icon="person-outline"></nb-icon>
+                </div>
+              }
                 <div class="employee-details flex-column align-items-start">
                   @if (selectedEmployee?.isVerified) {
                     <nb-icon
@@ -23,8 +27,9 @@
                   <span class="employee-name">
                     {{ selectedEmployee?.user?.name }}
                   </span>
+                  <!-- An em-dash rather than a blank line where no position is set. -->
                   <div class="employee-position">
-                    {{ selectedEmployee?.organizationPosition?.name }}
+                    {{ selectedEmployee?.organizationPosition?.name || '—' }}
                   </div>
                 </div>
               </div>

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.scss
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.scss
@@ -1,38 +1,53 @@
 @use 'gauzy/_gauzy-cards' as *;
 @use 'gauzy/_gauzy-overrides' as ga-overrides;
 
-.edit-icon {
-  margin-left: 30px;
-  position: relative;
-  width: 36px;
-
-  svg {
-    position: absolute;
-  }
-
-  nb-icon {
-    position: absolute;
-  }
+// The avatar and the name/position block sit side by side. Without this the
+// container is a plain block: the `<img>` makes a line box of its own and the
+// details land UNDER the photo, which is not what the `d-flex align-items-start`
+// on the surrounding row was written for.
+.employee-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
-.employee-image img {
+// Sized on the element that actually carries the class. This was
+// `.employee-image img`, i.e. an `<img>` INSIDE an `.employee-image` box — but
+// the template puts the class on the image itself, so nothing matched and the
+// header rendered the uploaded file at its intrinsic size.
+img.employee-image,
+.employee-image-placeholder {
   width: 48px;
   height: 48px;
+  flex: 0 0 48px;
   object-fit: cover;
+  border-radius: nb-theme(border-radius);
 }
 
-.edit-icon {
-  margin-left: 30px;
-  position: relative;
-  width: 36px;
+// Stand-in for an employee with no photo. The `<img>` used to render
+// unconditionally, so an employee without one got the browser's broken-image
+// glyph in the page header.
+.employee-image-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--gauzy-sidebar-background-3);
+  color: nb-theme(text-hint-color);
+}
 
-  svg {
-    position: absolute;
-  }
+// The page header's own two-step type scale: the name out-ranks body copy, the
+// position is demoted. Both used to inherit body size and weight, so the two
+// lines read as one undifferentiated block.
+.employee-name {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.375rem;
+}
 
-  nb-icon {
-    position: absolute;
-  }
+.employee-position {
+  font-size: 0.8125rem;
+  line-height: 1.125rem;
+  color: nb-theme(text-hint-color);
 }
 
 .edit-public-page {
@@ -56,46 +71,15 @@
   }
 }
 
-.setting-name {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.body-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 35px;
-}
-
-.mutation-card.setting-block {
-  background: #eaf3fc;
-}
-
 .transparent {
   opacity: 0.7;
 }
 
-.settings-body {
-  padding: 35px;
-}
-
-.sub-header {
-  margin-bottom: 20px;
-  font-weight: bold;
-}
-
-.header-content {
-  display: flex;
-
-  .header-info {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 560px;
-    padding-left: 30px;
-  }
-}
+// Removed with this pass, all of them dead: `.edit-icon` (declared twice),
+// `.setting-name`, `.body-header`, `.settings-body`, `.sub-header` and
+// `.header-content` name nothing in this template, and `.mutation-card
+// .setting-block` painted a fixed `#eaf3fc` pale blue that would have been a
+// light panel on the near-black theme had anything ever used it.
 
 .icon-verified {
   margin-right: 5px;

--- a/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.scss
+++ b/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.scss
@@ -10,8 +10,20 @@
 //     forced to stack one per line even when there was room for both.
 // Sizes now come from the shared table-density tokens (`$gauzy-density` in
 // `themes.scss`); the literals are CSS-var fallbacks only.
+
+// The "Not Started" pill. Unlike `.badge-danger` / `.badge-success` this is not
+// a Bootstrap class, so it never got Bootstrap's `color: #fff` and the label
+// inherits the cell's text colour — which on `gauzy-dark` is #fafafa. Against
+// the opaque light grey `#ccc` that was 1.6:1, i.e. an unreadable pill on the
+// one theme where the surrounding text is light.
+//
+// A translucent neutral instead: it darkens a light surface and lightens a dark
+// one, so a single value reads on every theme (the same reasoning as
+// `gauzy-hover-tint` in themes.scss), paired with the muted text colour, which
+// is the right rank for a "no state yet" label.
 .badge-disabled {
-  background-color: #ccc;
+  background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+  color: var(--text-hint-color, rgba(113, 113, 122, 1));
 }
 
 // The pill is sized by padding alone rather than a `min-height`: padding

--- a/apps/gauzy/src/app/pages/employees/timesheet/view/view/view.component.html
+++ b/apps/gauzy/src/app/pages/employees/timesheet/view/view/view.component.html
@@ -1,15 +1,24 @@
 <ng-template ngxPermissionsOnly="CAN_APPROVE_TIMESHEET">
   <nb-card>
-    <nb-card-header class="flex flex-column">
+    <!-- `d-flex`, not `flex`: Bootstrap has no `.flex` utility, so the column
+         direction was being applied to a block. -->
+    <nb-card-header class="d-flex flex-column">
       <div style="display: flex">
         <ngx-back-navigation></ngx-back-navigation>
         <h4>
-          {{ 'MENU.TIMESHEETS' | translate }}
-          <ngx-date-range-title
-            [start]="timesheet.startedAt"
-            [end]="timesheet.stoppedAt"
-            [format]="'dddd, LL'"
-          ></ngx-date-range-title>
+          <!-- Every other page in this area routes its title through
+               `ngx-header-title`, which is what places the breadcrumb trail
+               under the heading and lets the action row share the title's line.
+               This page rendered a bare <h4>, so it had no trail and its
+               buttons took a band of their own. -->
+          <ngx-header-title>
+            {{ 'MENU.TIMESHEETS' | translate }}
+            <ngx-date-range-title
+              [start]="timesheet.startedAt"
+              [end]="timesheet.stoppedAt"
+              [format]="'dddd, LL'"
+            ></ngx-date-range-title>
+          </ngx-header-title>
         </h4>
       </div>
       <div class="gauzy-button-action">

--- a/apps/gauzy/src/app/pages/employees/timesheet/view/view/view.component.scss
+++ b/apps/gauzy/src/app/pages/employees/timesheet/view/view/view.component.scss
@@ -1,3 +1,15 @@
+@use 'themes' as *;
+
+// This page renders the same day/log rows as Daily, Weekly and Timesheet
+// Approvals, but its stylesheet imported none of theirs and re-declared none of
+// the classes the markup uses — so `.custom-header`, `.custom-body`, `.content`
+// and `.log` were all unstyled here, and `.border-bottom` fell through to
+// Bootstrap's own `1px solid #dee2e6`: a fixed light hairline under every row,
+// which is a bright line on the near-black canvas.
+//
+// The rules are spelled out here rather than pulled in with a `@forward` of the
+// daily/weekly chain: that chain also carries `@shared/_pg-card` and a set of
+// card-height overrides this page does not want.
 :host {
     nb-card {
         height: calc(100vh - 13rem);
@@ -12,5 +24,63 @@
             overflow: auto;
             background-color: var(--gauzy-card-2);
         }
+    }
+
+    // Column labels above each day's rows — same muted strip as Daily/Weekly.
+    .custom-header {
+        font-size: 12px;
+        font-weight: 600;
+        line-height: 15px;
+        letter-spacing: 0em;
+        text-align: left;
+        color: nb-theme(gauzy-text-color-2);
+        background: var(--gauzy-card-4);
+        border-radius: nb-theme(border-radius);
+        padding: 10px 10px 10px 12px;
+        flex-wrap: nowrap;
+    }
+
+    // No `overflow`/`height` here on purpose: the card body above is already the
+    // scroll container, and one `.custom-body` is rendered per DAY, so making
+    // each of them scroll would put a second scrollbar inside the page's own.
+    .custom-body {
+        border-radius: nb-theme(border-radius);
+        margin-top: 6px;
+        @include nb-ltr(padding-right, 0.5rem);
+        @include nb-rtl(padding-left, 0.5rem);
+
+        .content {
+            background-color: var(--gauzy-card-3);
+            border-radius: var(--border-radius);
+            @include nb-ltr(padding-left, 12px);
+            @include nb-rtl(padding-right, 12px);
+        }
+
+        // Out-ranks Bootstrap's `.border-bottom` utility, which is `!important`.
+        .border-bottom {
+            border-bottom: 1px solid var(--gauzy-border-default-color) !important;
+        }
+    }
+
+    .project-name {
+        flex: 0 0 20%;
+        max-width: 20%;
+    }
+
+    // The log-type chip ("Manual" / "Tracked"), same pill as on Daily.
+    .log {
+        width: fit-content;
+        font-size: 12px;
+        font-weight: 600;
+        line-height: 15px;
+        letter-spacing: 0em;
+        text-align: left;
+        padding: 3px 8px;
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+        border-radius: nb-theme(border-radius);
+        background: var(--gauzy-sidebar-background-3);
     }
 }

--- a/apps/gauzy/src/app/pages/employees/timesheet/weekly/weekly/weekly.component.scss
+++ b/apps/gauzy/src/app/pages/employees/timesheet/weekly/weekly/weekly.component.scss
@@ -64,8 +64,12 @@
         @include nb-ltr(padding-left, 12px);
         @include nb-rtl(padding-right, 12px);
       }
+      // Out-ranks Bootstrap's `.border-bottom` utility (a fixed `#dee2e6`),
+      // which is `!important`. The value now comes from the border token rather
+      // than being a hand-copy of what that token happens to be on the light
+      // themes.
       .border-bottom {
-        border-bottom: 1px solid rgba(126, 126, 143, 0.1) !important;
+        border-bottom: 1px solid var(--gauzy-border-default-color) !important;
       }
 
       [nbButton].appearance-outline.status-primary {
@@ -76,9 +80,14 @@
         cursor: pointer;
       }
 
+      // The 6px bar down the left edge that marks the selected row. It was
+      // `rgba(48, 48, 120, 0.2)` — a 20 %-opaque navy, which on the near-black
+      // canvas is all but the canvas itself, so the selection marker vanished
+      // on the dark themes. The primary transparent tint is the app's own
+      // "selected" colour and carries on both.
       .selected {
         background-color: var(--gauzy-sidebar-background-3);
-        box-shadow: -6px 0 0 0 rgba(48, 48, 120, 0.2);
+        box-shadow: -6px 0 0 0 var(--color-primary-transparent-default);
         border-radius: var(--border-radius) 0 0 var(--border-radius);
 
         &.border-bottom {

--- a/apps/gauzy/src/app/pages/employment-types/employment-types.component.scss
+++ b/apps/gauzy/src/app/pages/employment-types/employment-types.component.scss
@@ -14,10 +14,13 @@
       flex-direction: column;
       @include nb-ltr(padding, 1rem 0.5rem 1rem 18px);
       @include nb-rtl(padding, 1rem 18px 1rem 0.5rem);
-      nb-accordion {
-        @include nb-ltr(margin-right, 0.625rem);
-        @include nb-rtl(margin-left, 0.625rem);
-      }
+      // Removed: `nb-accordion { margin-right/left: 0.625rem }`. Grepping this
+      // page for "accordion" matches only this stylesheet — the template
+      // (employment-types.component.html) renders nb-tabset > nb-card >
+      // ga-notes-with-tags / ga-card-grid, never an accordion, and the .ts adds
+      // no class or element bindings. With emulated encapsulation the selector
+      // could only ever have matched an nb-accordion in this component's own
+      // template, so it styled nothing.
     }
     nb-tabset {
       // Card body height: the viewport less the app chrome above the tabset.
@@ -38,7 +41,12 @@
     }
     nb-card,
     nb-tab.content-active {
-      background-color: var(--gauzy-card-2);
+      // material-light / material-dark register no `gauzy-card-2` (themes.scss
+      // gives them only gauzy-primary-background, gauzy-sidebar-background-*
+      // and gauzy-border-table), so a bare var() is invalid there and the whole
+      // declaration is dropped — the row cards lose their panel tint and sit
+      // flat on the tab body. Neutral translucent gray as the fallback.
+      background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
     }
     nb-card-body{
       overflow: unset;
@@ -57,12 +65,11 @@
     @include tabset-action-row(16px);
 }
 
-nb-accordion-item-header ::ng-deep nb-icon {
-    border: 1px solid nb-theme(border-basic-color-4);
-    border-radius: nb-theme(input-rectangle-border-radius);
-    width: 1.75rem;
-    height: 1.75rem;
-}
+// Removed: `nb-accordion-item-header ::ng-deep nb-icon { border/radius/size }`.
+// Same reason as the nb-accordion rule above — this page has no accordion, and
+// the part of the selector before `::ng-deep` still carries this component's
+// encapsulation attribute, so it could only have matched an
+// nb-accordion-item-header in employment-types.component.html. There is none.
 
 nb-card-body {
     background: none;

--- a/apps/gauzy/src/app/pages/equipment-sharing/equipment-sharing.component.scss
+++ b/apps/gauzy/src/app/pages/equipment-sharing/equipment-sharing.component.scss
@@ -1,96 +1,16 @@
 @forward '@shared/_pg-card';
 
-/* Card grid */
-
-.flex-container {
-  display: flex;
-  flex-wrap: wrap;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-
-.flex-item {
-  border: 0.0625rem solid #e4e9f2;
-  border-radius: 0.25rem;
-  width: 350px;
-  margin-top: 10px;
-  margin-right: 10px;
-}
-
-.info-line {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  font-size: 0.7em;
-  color: darkgray;
-  line-height: 0px;
-  padding: 1rem 1.5rem;
-
-  .info-meta {
-    margin-right: 10px;
-  }
-
-  .info-value {
-    display: flex;
-    justify-content: flex-end;
-    text-align: end;
-    color: black;
-    font-size: 1em;
-  }
-}
-
-.card-footer {
-  justify-content: space-around;
-  display: flex;
-}
-
-/* Status */
-
-.badge-danger {
-  text-align: center;
-  padding: 10px;
-  background-color: #dc3545;
-  border-radius: 13px;
-  color: #fff;
-}
-
-.badge-success {
-  text-align: center;
-  padding: 10px;
-  background-color: #28a745;
-  border-radius: 13px;
-  color: #fff;
-}
-
-.badge-warning {
-  text-align: center;
-  padding: 10px;
-  background-color: #ffc107;
-  border-radius: 13px;
-  color: #fff;
-}
-
-.badge-danger-card {
-  text-align: center;
-  padding: 10px;
-  background-color: #ff3d71;
-  border-radius: 0.45rem;
-  color: #fff;
-}
-
-.badge-success-card {
-  text-align: center;
-  padding: 10px;
-  background-color: #00d68f;
-  border-radius: 0.45rem;
-  color: #fff;
-}
-
-.badge-warning-card {
-  text-align: center;
-  padding: 10px;
-  background-color: #fa0;
-  border-radius: 0.45rem;
-  color: #fff;
-}
+// Everything else this sheet used to hold was a hand-rolled card grid
+// (`.flex-container` / `.flex-item` / `.info-line` / `.card-footer`) and six
+// status pills (`.badge-danger` … `.badge-warning-card`), carrying eleven
+// literal colours between them — #e4e9f2, #dc3545, #28a745, #ffc107, #ff3d71,
+// #00d68f, #fa0, #fff, `black` and `darkgray`.
+//
+// None of it renders any more, in either layout:
+//   * the grid is `<ga-card-grid>` (shared, themed) as of the template rewrite;
+//   * the status column is `StatusBadgeComponent`, and `statusMapper()` in the
+//     component hands it the bare status names 'success' / 'danger' / 'warning',
+//     never a `badge-*` class.
+// The `badge-*` names that the e2e page objects do select (`div.badge-success`
+// and friends, in the Invoices / Estimates / Proposals / Candidates specs) are
+// painted by those pages, not by this component-scoped sheet.

--- a/apps/gauzy/src/app/pages/expenses/expense-categories/expense-categories.component.scss
+++ b/apps/gauzy/src/app/pages/expenses/expense-categories/expense-categories.component.scss
@@ -97,14 +97,21 @@ nb-card-body {
   border-radius: nb-theme(border-radius);
   cursor: pointer;
 
+  // Both states were painted with literal copies of the LIGHT themes' surface
+  // values — `rgba(50, 50, 50, 0.03)` is `gauzy-card-2` from the light maps, and
+  // the rail is 10 % black. Over the dark themes' near-black card neither shows,
+  // so hovering and selecting a category looked identical to doing nothing. The
+  // shared hover/active tints are one translucent neutral that darkens a light
+  // surface and lightens a dark one, and the rail takes the primary accent (same
+  // treatment as the recurring-expense blocks).
   &.selected {
-    @include nb-ltr(border-left, 6px solid rgb(50 50 50 / 10%));
-    @include nb-rtl(border-right, 6px solid rgb(50 50 50 / 10%));
-    background: rgba(50, 50, 50, 0.03);
+    @include nb-ltr(border-left, 6px solid nb-theme(color-primary-default));
+    @include nb-rtl(border-right, 6px solid nb-theme(color-primary-default));
+    background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
   }
 
-  &:hover {
-    background: rgba(50, 50, 50, 0.03);
+  &:hover:not(.selected) {
+    background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
   }
 }
 

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.scss
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.scss
@@ -1,70 +1,24 @@
+// `@shared/_pg-card` forwards `gauzy/_gauzy-table`, so this page already receives
+// the shared `.action` / `.actions` / `.gauzy-button-container` /
+// `.card-custom-header` rules — the same ones Income, Payments and Received
+// invoices get. This file used to carry a near-verbatim copy of that block plus a
+// card-body height override on top of them. All of it is gone:
+//
+//   * `.action.info` (`#0088fe`), `.action.success` and `.action.warning` (literal
+//     greens and oranges) were hard-coded colours on classes this page's template
+//     never uses — its toolbar only carries `.action`, `.action.primary`,
+//     `.action.primary.soft` and `.action.secondary`.
+//   * `.actions { margin-right: 20px }` inset this page's toolbar 20px from the
+//     card edge; the sibling list pages, which take the shared `.actions`
+//     unmodified, sit flush.
+//   * `.card-custom-header`, `.gauzy-button-container` and `button` were
+//     character-for-character copies of the shared rules.
+//   * every `nb-theme(...)` call in the copy compiled to a plain CSS function and
+//     was dropped by the browser: this file only ever `@forward`ed, which
+//     re-exports to importers without bringing anything into its own scope.
+//   * `:host nb-card-body { overflow: unset; height: calc(100vh - 17.5rem)
+//     !important }` — a hand-tuned viewport constant that out-ranked the flex
+//     column `_pg-card` gives every other list page, so the Expenses table was a
+//     different height from its siblings and had back the problem the shared
+//     partial exists to solve (a gap under a short table, a clipped long one).
 @forward '@shared/_pg-card';
-
-// Same hairline ring as the shared `.action` block in `gauzy/_gauzy-table.scss`
-// — this file carries a verbatim copy of it.
-.action {
-  box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
-  &[nbButton].appearance-filled.status-basic {
-    background-color: var(--gauzy-card-2);
-  }
-  &.info {
-    background-color: #0088fe;
-  }
-  &.secondary {
-    color: var(--text-hint-color);
-  }
-  &.success {
-    color: rgba(37, 184, 105, 1);
-  }
-  &.warning {
-    color: rgba(245, 109, 88, 1);
-  }
-  &.primary {
-    &[nbButton].appearance-filled.status-basic,
-    .appearance-filled.status-basic[nbButtonToggle] {
-      color: nb-theme(text-primary-color);
-    }
-    &.soft {
-      &[nbButton].appearance-filled.status-basic {
-        background-color: rgba(110, 73, 232, 0.1);
-      }
-    }
-  }
-  &.select-nb ::ng-deep {
-    box-shadow: none;
-    .select-button {
-      box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
-      background: var(--gauzy-card-2);
-    }
-  }
-}
-
-button {
-  margin: 5px;
-}
-
-.actions {
-  background: var(--gauzy-card-2);
-  border-radius: nb-theme(button-rectangle-border-radius);
-  padding: 0 1px;
-  margin-right: 20px;
-}
-
-.gauzy-button-container {
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
-  padding-bottom: 0;
-}
-
-.card-custom-header {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding-bottom: 0;
-}
-
-:host nb-card-body {
-  overflow: unset;
-  height: calc(100vh - 17.5rem) !important;
-}

--- a/apps/gauzy/src/app/pages/goal-settings/edit-time-frame/edit-time-frame.component.scss
+++ b/apps/gauzy/src/app/pages/goal-settings/edit-time-frame/edit-time-frame.component.scss
@@ -1,20 +1,20 @@
 @use 'gauzy/_gauzy-dialogs' as *;
 
-.main-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  .subtitle {
-    font-size: 16px;
-    font-weight: 600;
-    line-height: 16px;
-    letter-spacing: 0em;
-    text-align: center;
-  }
-}
+// Removed: a `.main-header` block (and the `.subtitle` rule nested inside it).
+// `edit-time-frame.component.html` has no `main-header` element — the dialog
+// puts its heading straight into `nb-card-header` — so neither selector could
+// ever match; the file's only `.subtitle` is the "Predefined Time Frames" <h6>,
+// which is not inside a `.main-header` and so was never reached by the nested
+// rule either. This stylesheet is not shared: no other component points its
+// `styleUrls` at it, and nothing `@use`s or `@forward`s it.
 
 :host {
   nb-card {
-    background-color: var(--gauzy-card-1);
+    // Fallback required: `--gauzy-card-1` is undefined in material-light and
+    // material-dark (`themes.scss` registers those two against Nebular's own
+    // parent themes, which carry no `gauzy-card-*` keys), and a `var()` with no
+    // fallback makes the browser drop the whole declaration. Nebular's own card
+    // background is what `gauzy-card-1` aliases in most themes anyway.
+    background-color: var(--gauzy-card-1, var(--card-background-color));
   }
 }

--- a/apps/gauzy/src/app/pages/goal-settings/goal-settings.component.scss
+++ b/apps/gauzy/src/app/pages/goal-settings/goal-settings.component.scss
@@ -31,7 +31,11 @@
   }
   nb-card,
   nb-tab {
-    background-color: var(--gauzy-card-2);
+    // Fallback required: `--gauzy-card-2` is undefined in material-light and
+    // material-dark — `themes.scss` registers those two against Nebular's own
+    // parent themes, so they never inherit the `gauzy-card-*` keys — and a
+    // `var()` without one makes the browser discard the whole declaration.
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
     margin: 0;
   }
   nb-card-body {
@@ -42,7 +46,10 @@
 }
 
 .card-general {
-  background: var(--gauzy-card-3);
+  // Same story as `--gauzy-card-2` above: `--gauzy-card-3` is not defined in
+  // material-light / material-dark, so without a fallback the General tab's
+  // settings panel lost its background entirely there.
+  background: var(--gauzy-card-3, rgba(126, 126, 143, 0.05));
   border-radius: nb-theme(border-radius);
 }
 

--- a/apps/gauzy/src/app/pages/goals/edit-keyresults/edit-keyresults.component.scss
+++ b/apps/gauzy/src/app/pages/goals/edit-keyresults/edit-keyresults.component.scss
@@ -16,13 +16,20 @@
   }
 }
 
+// `--gauzy-card-1` / `--gauzy-card-2` are undefined in material-light and
+// material-dark: `themes.scss` registers those two against Nebular's own parent
+// themes, which carry no `gauzy-card-*` keys. A `var()` with no fallback makes
+// the browser throw the entire declaration away, so both uses below carry one.
+// This stylesheet is shared — `key-result-parameters` points its `styleUrls`
+// here and `edit-objective` / `goal-details` `@forward` it — so the fix reaches
+// all four dialogs.
 :host {
   nb-card {
-    background: var(--gauzy-card-1);
+    background: var(--gauzy-card-1, var(--card-background-color));
   }
   nb-tab,
   .content {
-    background-color: var(--gauzy-card-2);
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   }
   nb-tab {
     height: 20.75vh;

--- a/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.html
+++ b/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.html
@@ -67,10 +67,7 @@
       <nb-tabset>
         <nb-tab tabTitle="{{ 'GOALS_PAGE.KEY_RESULTS' | translate }}">
           @if (goal.keyResults.length == 0) {
-            <div
-              class="card-key-result"
-              å
-              >
+            <div class="card-key-result">
               {{ 'GOALS_PAGE.MESSAGE.NO_KEY_RESULT' | translate }}
             </div>
           }
@@ -285,7 +282,7 @@
                     <textarea
                       nbInput
                       fullWidth
-                      placeholder="Add Comment"
+                      [placeholder]="'BUTTONS.ADD_COMMENT' | translate"
                     ></textarea>
                   </div>
                   <div class="col-3 btn-comment">

--- a/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
+++ b/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
@@ -29,7 +29,18 @@
   // white-at-low-alpha lift precisely because a mid-grey overlay reads wrong on
   // a near-black panel. Name the token so the footer follows the theme.
   .custom-footer {
-    background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+    // Was a literal `rgba(126, 126, 143, 0.1)`. This is the same recessed
+    // surface the identical update cards in `keyresult-details` paint with
+    // `--gauzy-card-2`, so it follows the same token. The FALLBACKS differ on
+    // purpose — 0.1 here, 0.08 there — because each keeps the literal its own
+    // file already used, and the fallback is only reached by the two material
+    // themes. The token is what makes them agree everywhere else.
+    // The fallback is required:
+    // `--gauzy-card-2` is not defined in material-light / material-dark (see
+    // `themes.scss` — those two register against Nebular's own parents and
+    // never pick up the `gauzy-card-*` keys), and without one the whole
+    // declaration is dropped there.
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.1));
     padding-bottom: 5px;
   }
   .custom-header {

--- a/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
+++ b/apps/gauzy/src/app/pages/goals/goal-details/goal-details.component.scss
@@ -24,8 +24,12 @@
       }
     }
   }
+  // `rgba(126, 126, 143, 0.1)` is the literal `--gauzy-sidebar-background-3`
+  // happens to hold in the LIGHT themes only; on `gauzy-dark` that token is a
+  // white-at-low-alpha lift precisely because a mid-grey overlay reads wrong on
+  // a near-black panel. Name the token so the footer follows the theme.
   .custom-footer {
-    background-color: rgba(126, 126, 143, 0.1);
+    background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
     padding-bottom: 5px;
   }
   .custom-header {

--- a/apps/gauzy/src/app/pages/goals/goals.component.scss
+++ b/apps/gauzy/src/app/pages/goals/goals.component.scss
@@ -16,10 +16,14 @@
   }
 }
 
+// `--gauzy-card-2` is undefined in material-light / material-dark — those two
+// themes register against Nebular's own parents in `themes.scss` and never pick
+// up the `gauzy-card-*` keys — and a `var()` with no fallback makes the browser
+// throw the whole declaration away. Every use below carries one.
 :host {
   nb-card,
   nb-card-body {
-    background-color: var(--gauzy-card-2);
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   }
   nb-card-body {
     overflow: unset;
@@ -57,10 +61,23 @@
     box-shadow: unset;
   }
 }
+// Key-result rows inside an objective. Hover and "this is the selected row"
+// used to share one declaration, so the row the action bar is actually acting
+// on looked exactly like whatever the pointer happened to be over. They are two
+// different states and now read as two:
+//   * selection takes the primary accent — the tint the rest of the app uses
+//     for "current" — rather than the neutral hover fill;
+//   * the hover rule is guarded with `:not(.selected)`. The two selectors are
+//     the same specificity (0,2,1 either way), so without the guard whichever
+//     came last would simply win, and hovering the selected row would repaint
+//     it as an ordinary hover.
 nb-accordion-item-body {
-  &:hover,
+  &:hover:not(.selected) {
+    background: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
+  }
+
   &.item.selected {
-    background: var(--gauzy-card-2);
+    background: nb-theme(color-primary-transparent-100);
   }
 }
 .keyResult {

--- a/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.html
+++ b/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.html
@@ -201,11 +201,11 @@
       <div class="d-flex float-left">
         <div class="button-container">
           <button
-            class="mr-3"
+            type="button"
+            class="mr-3 action"
             status="basic"
             nbButton
             size="small"
-            class="action"
             (click)="deleteKeyResult()"
             [nbTooltip]="'BUTTONS.DELETE' | translate"
             >

--- a/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.scss
+++ b/apps/gauzy/src/app/pages/goals/keyresult-details/keyresult-details.component.scss
@@ -40,14 +40,19 @@
   }
 }
 
+// `--gauzy-card-*` is undefined in material-light / material-dark (see
+// `themes.scss`: those two register against Nebular's own parent themes and so
+// never inherit the `gauzy-card-*` keys). A `var()` with no fallback makes the
+// browser drop the WHOLE declaration there, which left these panels unpainted,
+// so every use below carries one.
 .button-container {
-  background: var(--gauzy-card-2);
+  background: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   padding: 5px;
   border-radius: nb-theme(button-rectangle-border-radius);
 }
 .custom-card,
 .custom-footer {
-  background: var(--gauzy-card-2);
+  background: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
 }
 .custom-header,
 .custom-footer {
@@ -79,7 +84,14 @@
   text-align: left;
 }
 
+// The key-result summary panel. Its class comes from Bootstrap 4, whose
+// `.border` is literally `border: 1px solid #dee2e6 !important` — a light grey
+// hairline drawn identically in all eight themes, i.e. a visible pale box on
+// the near-black cards of `dark` / `cosmic` / `gauzy-dark` / `material-dark`.
+// Restated here from a theme token; `!important` only to out-rank Bootstrap's
+// own, and the same 1px so nothing re-flows.
 .border {
+  border: 1px solid nb-theme(border-basic-color-3) !important;
   border-radius: nb-theme(border-radius);
   margin: 3rem 0;
 }

--- a/apps/gauzy/src/app/pages/goals/keyresult-progress-chart/keyresult-progress-chart.component.ts
+++ b/apps/gauzy/src/app/pages/goals/keyresult-progress-chart/keyresult-progress-chart.component.ts
@@ -1,11 +1,14 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ElementRef, inject } from '@angular/core';
 import { IKeyResult, KeyResultDeadlineEnum, IKPI, IOrganization } from '@gauzy/contracts';
 import { GoalSettingsService } from '@gauzy/ui-core/core';
 import { differenceInCalendarDays, addMonths, compareDesc, addDays, addWeeks, addQuarters, isAfter } from 'date-fns';
 import { Store } from '@gauzy/ui-core/core';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 import { TranslateService } from '@ngx-translate/core';
+import { NbThemeService } from '@nebular/theme';
+import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 
+@UntilDestroy({ checkProperties: true })
 @Component({
     selector: 'ga-keyresult-progress-chart',
     templateUrl: './keyresult-progress-chart.component.html',
@@ -19,6 +22,15 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 	@Input() keyResult: IKeyResult;
 	@Input() kpi: IKPI;
 	@Input() organization: IOrganization;
+
+	/**
+	 * Host element for theme colour lookups. Nebular emits its theme tokens as
+	 * CSS custom properties on the themed subtree (`.nb-theme-*` on `nb-layout`),
+	 * NOT on `<html>`, so they have to be resolved against an element inside it.
+	 */
+	private readonly elementRef = inject(ElementRef);
+	private readonly themeService = inject(NbThemeService);
+
 	constructor(
 		private goalSettingsService: GoalSettingsService,
 		private store: Store,
@@ -29,6 +41,16 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 
 	ngOnInit() {
 		this.updateChart(this.keyResult);
+
+		// Chart.js copies concrete colour strings into the dataset; it cannot hold a
+		// `var()` and re-resolve it. So a theme switch while this dialog is open would
+		// otherwise leave both lines painted in the colours of the theme that was
+		// active when the chart was built — the exact contrast problem the tokens were
+		// introduced to solve. Rebuilding on theme change re-reads them.
+		this.themeService
+			.onThemeChange()
+			.pipe(untilDestroyed(this))
+			.subscribe(() => this.updateChart(this.keyResult));
 	}
 
 	public async updateChart(keyResult: IKeyResult) {
@@ -114,7 +136,12 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 						labelsData
 					),
 					borderWidth: 4,
-					borderColor: 'rgb(76, 23, 33,0.25)',
+					// Was `rgb(76, 23, 33,0.25)` — four arguments in the legacy
+					// comma form, which is not a valid colour. The canvas keeps
+					// whatever `strokeStyle` it had, so the "expected" guide line
+					// was drawn in the default black: invisible on every dark
+					// theme. It is a guide, so it takes the muted text colour.
+					borderColor: this.themeColor('--text-hint-color', 'rgba(113, 113, 122, 1)'),
 					borderDash: [10, 5],
 					fill: false
 				},
@@ -122,11 +149,39 @@ export class KeyResultProgressChartComponent extends TranslationBaseComponent im
 					label: this.getTranslation('GOALS_PAGE.PROGRESS'),
 					data: this.progressData(keyResult, labelsData),
 					borderWidth: 4,
-					borderColor: '#00d68f',
+					// Was a hard-coded `#00d68f` — the old Nebular success green,
+					// the same in all eight themes and washed out on the light
+					// canvas. The theme's own success accent has a light and a
+					// dark value, so the line stays legible on both.
+					borderColor: this.themeColor('--gauzy-action-success-text', '#047857'),
 					fill: false
 				}
 			]
 		};
+	}
+
+	/**
+	 * Reads a colour off the active theme's CSS custom properties.
+	 *
+	 * Chart.js paints onto a canvas and cannot resolve `var()` itself, so the
+	 * value has to be looked up here. Guarded for non-browser platforms (SSR,
+	 * unit tests) where `getComputedStyle` does not exist — the chart must fall
+	 * back to a literal, not crash.
+	 *
+	 * @param name - Custom property name, including the leading `--`.
+	 * @param fallback - Colour to use when the property cannot be read.
+	 * @returns A non-empty CSS colour string.
+	 */
+	private themeColor(name: string, fallback: string): string {
+		const host: Element | null = this.elementRef.nativeElement ?? null;
+		if (!host || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+			return fallback;
+		}
+		try {
+			return window.getComputedStyle(host).getPropertyValue(name).trim() || fallback;
+		} catch {
+			return fallback;
+		}
 	}
 
 	progressData(keyResult, labelsData) {

--- a/apps/gauzy/src/app/pages/goals/keyresult-update/keyresult-update.component.scss
+++ b/apps/gauzy/src/app/pages/goals/keyresult-update/keyresult-update.component.scss
@@ -4,14 +4,17 @@
   width: 30vw;
 }
 
-.main-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
+// Removed: a `.main-header` flex block. `keyresult-update.component.html` has
+// no element carrying that class (the dialog's heading goes straight into
+// `nb-card-header`), and this stylesheet is not shared — no other component's
+// `styleUrls` points at it and nothing `@use`s or `@forward`s it.
 
 :host {
   nb-card {
-    background: var(--gauzy-card-1);
+    // Fallback required: `--gauzy-card-1` is undefined in material-light and
+    // material-dark (`themes.scss` registers those two against Nebular's own
+    // parent themes, which carry no `gauzy-card-*` keys), and a `var()` with no
+    // fallback makes the browser discard the whole declaration.
+    background: var(--gauzy-card-1, var(--card-background-color));
   }
 }

--- a/apps/gauzy/src/app/pages/help-center/add-article/add-article.component.scss
+++ b/apps/gauzy/src/app/pages/help-center/add-article/add-article.component.scss
@@ -20,9 +20,12 @@
   width: 50%;
 }
 
+// Was `#8f9bb3` (Nebular's old blue-grey `color-basic-600`) and a hard-coded
+// `Open Sans` face. The themes moved secondary text onto a neutral ramp and the
+// app onto Inter, so this label was the only blue-grey, wrong-face text in the
+// dialog. `--text-hint-color` is the token that paints every other caption.
 .select-label {
-  color: #8f9bb3;
-  font-family: Open Sans, sans-serif;
+  color: var(--text-hint-color);
   font-size: 0.75rem;
   font-weight: 700;
   line-height: 1rem;
@@ -91,9 +94,13 @@
     }
   }
 
+  // Unchecked toggle track. `#7e7e8f` is the literal behind
+  // `toggle-basic-background-color` in the gauzy themes; spelled as the token it
+  // also follows the six other registered themes instead of painting one grey
+  // everywhere.
   ::ng-deep .toggle {
-    border: 1px solid #7E7E8F !important;
-    background-color: #7E7E8F !important;
+    border: 1px solid var(--toggle-basic-background-color) !important;
+    background-color: var(--toggle-basic-background-color) !important;
 
     &.checked {
       background-color: var(--text-primary-color) !important;

--- a/apps/gauzy/src/app/pages/help-center/help-center.component.scss
+++ b/apps/gauzy/src/app/pages/help-center/help-center.component.scss
@@ -64,10 +64,18 @@
   flex-direction: row;
 }
 
+// The DRAFT pill sat beside the EMPLOYEES (`.privacy`) pill with a hard-coded
+// `#aaaeb3` fill while the control beside it already resolved `--color-primary-default`
+// — the one chip on the page that ignored the theme, and white-on-#aaaeb3 is
+// 2.2:1 besides. DRAFT is not a status with a colour, it is the ABSENCE of
+// publication, so it reads as a neutral chip now: the same low-alpha tint the
+// rest of the app uses for a quiet fill, with ordinary body text on it. Works
+// out on both the light card and the near-black one, and stays visibly
+// subordinate to the filled purple pill next to it.
 .draft {
   padding: 0 0.4rem;
-  color: #fff;
-  background-color: #aaaeb3;
+  color: var(--text-basic-color);
+  background-color: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
   margin-left: 10px;
   border-radius: 12px;
   font-size: 14px;
@@ -76,9 +84,12 @@
   text-align: center;
 }
 
+// Filled with the theme primary already; only the label was a literal `#fff`.
+// `--text-control-color` is Nebular's token for text on a filled status chip
+// (it is `#ffffff` in every registered theme, so nothing moves here).
 .privacy {
   padding: 0 0.4rem;
-  color: #fff;
+  color: var(--text-control-color);
   background-color: var(--color-primary-default);
   margin-left: 10px;
   border-radius: 12px;
@@ -166,12 +177,19 @@ h6 {
     text-align: left;
     cursor: pointer;
 
+    // Selection marker. Was a DARKENING overlay — rgba(50,50,50,.1) for the
+    // left bar and rgba(50,50,50,.03) for the fill — which is invisible on the
+    // near-black `gauzy-dark` canvas, and darker than the `--gauzy-card-2`
+    // hover fill below it, so a hovered row read as "more selected" than the
+    // selected one. `--gauzy-active-tint` is the registered token for exactly
+    // this (a neutral at twice the hover alpha, so it darkens a light surface
+    // and lightens a dark one) and is what the sidebar's current row uses.
     &.selected {
-      box-shadow: -8px 0px 0px 0px rgba(50, 50, 50, 0.1);
-      background: rgba(50, 50, 50, 0.03);
+      box-shadow: -8px 0px 0px 0px var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+      background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
     }
 
-    &:hover {
+    &:hover:not(.selected) {
       background: var(--gauzy-card-2);
     }
   }
@@ -195,8 +213,18 @@ h6 {
     }
   }
 
+  // The empty state stands in for `.table-scroll`, so it has to measure the
+  // same box. It was 6rem TALLER (`100vh - 15rem` against the list's
+  // `100vh - 21rem`), which showed up twice: as a direct child of the card body
+  // it made an empty Help Center card taller than a full one, and in the
+  // `@empty` branch — where it renders INSIDE `.table-scroll` — it forced that
+  // container into a 6rem scroll just to show "no matching articles".
+  // `max-height: 100%` bounds it whenever the parent has a definite height
+  // (the nested case) and resolves to `none` when it does not (the card-body
+  // case), the same treatment `.card-scroll` gets in styles/_overrides.scss.
   .no-data {
-    height: calc(100vh - 15rem);
+    height: calc(100vh - 21rem);
+    max-height: 100%;
     padding: 0 0.5rem;
   }
 

--- a/apps/gauzy/src/app/pages/import-export/export/export.component.scss
+++ b/apps/gauzy/src/app/pages/import-export/export/export.component.scss
@@ -14,7 +14,17 @@
 
   nb-card,
   nb-card-body {
-    background-color: var(--gauzy-card-2);
+    // Fallbacks on the surface/text `--gauzy-*` tokens in this file: a bare
+    // `var()` naming a custom property a theme does not emit takes the whole
+    // declaration with it, which on a background means the card renders
+    // transparent. The `--gauzy-page-title-*` metrics below need none — those
+    // come from the shared density preset, which every theme merges.
+    // The fallback is a neutral mid-grey, not the light theme's 3% black: the
+    // only themes that reach it are material-light and material-dark, and 3%
+    // black on the dark one is invisible — which is the one case the fallback
+    // exists to cover. A neutral at the same weight darkens a light surface and
+    // lightens a dark one.
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.1));
 
     &.card-body {
       height: calc(100vh - 21rem);
@@ -48,7 +58,7 @@
         line-height: 13px;
         letter-spacing: 0em;
         text-align: left;
-        color: var(--gauzy-text-color-2);
+        color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
       }
     }
   }
@@ -58,12 +68,12 @@
   ::ng-deep {
       .download {
           padding: 0.5rem;
-          background-color: var(--gauzy-card-2);
+          background-color: var(--gauzy-card-2, rgba(50, 50, 50, 0.03));
           border-radius: var(--button-rectangle-border-radius);
           @include nb-ltr(float, right);
           @include nb-rtl(float, left);
           .action {
-            box-shadow: var(--gauzy-shadow);
+            box-shadow: var(--gauzy-shadow, 0px 1px 1px 0px rgb(0 0 0 / 15%));
           }
       }
   }
@@ -84,7 +94,7 @@
   line-height: var(--gauzy-page-title-line-height);
   letter-spacing: var(--gauzy-page-title-letter-spacing);
   text-align: left;
-  color: var(--gauzy-text-color-1);
+  color: var(--gauzy-text-color-1, var(--text-basic-color));
   white-space: nowrap;
 }
 
@@ -94,5 +104,5 @@
   line-height: 17px;
   letter-spacing: 0em;
   text-align: left;
-  color: var(--gauzy-text-color-2);
+  color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 }

--- a/apps/gauzy/src/app/pages/import-export/import-export.component.html
+++ b/apps/gauzy/src/app/pages/import-export/import-export.component.html
@@ -16,10 +16,18 @@
     <div class="row">
       <div class="col-sm-12 button-imports">
         <div class="button-import">
+          <!--
+            `shape="round"` was dropped: this was the only button in this row
+            that asked for a pill, so it sat next to rectangles. (The row holds
+            up to four — Migrate To Cloud is behind `!environment.DEMO` and the
+            MIGRATE_GAUZY_CLOUD permission, so on a demo build there are fewer.)
+
+            This is a deliberate restyle of something that did render, not the
+            removal of a rule that never applied.
+          -->
           <button
             class="action"
             nbButton
-            shape="round"
             status="success"
             size="small"
             (click)="importPage()"

--- a/apps/gauzy/src/app/pages/import-export/import-export.component.scss
+++ b/apps/gauzy/src/app/pages/import-export/import-export.component.scss
@@ -12,10 +12,14 @@
             gap: 10px;
         }
 
+        // The tray each toolbar button sits in. `2rem` made it a pill wrapped
+        // around a rectangular button, so the tray's corners stood well clear
+        // of the button's on both sides; the button radius token is what the
+        // shared `.actions` tray in `gauzy/_gauzy-table.scss` uses.
         .button-import {
             background-color: nb-theme(gauzy-card-2);
             padding: 5px;
-            border-radius: 2rem;
+            border-radius: nb-theme(button-rectangle-border-radius);
         }
 
         .info {

--- a/apps/gauzy/src/app/pages/import-export/import/import.component.html
+++ b/apps/gauzy/src/app/pages/import-export/import/import.component.html
@@ -101,12 +101,17 @@
 					</div>
 				</div>
 
+				<!--
+					The queue rows below used to carry `(click)="selectItem(item)"`. That was
+					dropped: ImportComponent has no `selectItem` member — the name appeared in
+					this one binding and nowhere else — so clicking a queued file threw instead
+					of doing anything.
+				-->
 				<div class="custom-body queue">
 					@for (item of uploader.queue; track item.file?.name; let lastItem = $last) {
 					<div
 						class="row border-bottom m-0 py-3 align-items-center"
 						[class.border-bottom-none]="lastItem"
-						(click)="selectItem(item)"
 					>
 						<div class="col-4">
 							{{ item?.file?.name }}

--- a/apps/gauzy/src/app/pages/import-export/import/import.component.scss
+++ b/apps/gauzy/src/app/pages/import-export/import/import.component.scss
@@ -1,30 +1,36 @@
 @use 'gauzy/gauzy-table' as *;
 @forward '../export/export.component';
 
+// Fallbacks on every `--gauzy-*` in this file: a bare `var()` naming a custom
+// property a theme does not emit drops the whole declaration, which on this page
+// means a drop zone with no border and body text with no colour.
 .well {
   height: 180px;
   width: 180px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--gauzy-text-color-2);
+  color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 }
 
 .my-drop-zone {
-  border: dashed 3px var(--gauzy-border-default-color);
+  border: dashed 3px var(--gauzy-border-default-color, rgba(126, 126, 143, 0.1));
   border-radius: var(--border-radius);
 }
 
+// Drag-over state. Was `dashed 3px red` — a raw keyword red, which reads as a
+// rejected file rather than "drop it here", and is the one colour on the page
+// that answers to no theme. The primary accent is what the rest of the app uses
+// for an active target.
 .nv-file-over {
-  border: dashed 3px red;
+  border: dashed 3px var(--color-primary-default);
   border-radius: var(--border-radius);
 }
 
-/* Default class applied to drop zones on over */
-.another-file-over-class {
-  border: dashed 3px green;
-  border-radius: var(--border-radius);
-}
+// Removed `.another-file-over-class` (`border: dashed 3px green`). The string
+// `another-file-over-class` appears nowhere in `import.component.html` or
+// `import.component.ts`; the template has a single drop zone and it toggles
+// `.nv-file-over` above.
 
 .import-data {
   display: flex;
@@ -64,7 +70,7 @@
   }
 
   .progress {
-    background-color: var(--gauzy-card-2);
+    background-color: var(--gauzy-card-2, rgba(50, 50, 50, 0.03));
     border-radius: var(--button-rectangle-border-radius);
 
     .progress-bar {
@@ -91,7 +97,7 @@
 :host ::ng-deep {
   nb-radio {
     span.text {
-      color: var(--gauzy-text-color-2);
+      color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
       font-size: 11px;
       font-weight: 400;
       line-height: 13px;
@@ -113,8 +119,8 @@
   line-height: 15px;
   letter-spacing: 0em;
   text-align: left;
-  color: var(--gauzy-text-color-2);
-  background: var(--gauzy-card-3);
+  color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
+  background: var(--gauzy-card-3, rgba(255, 255, 255, 0.5));
   border-radius: var(--border-radius);
   padding: 3px;
   height: 42px;
@@ -130,7 +136,7 @@
 }
 
 .custom-body {
-  background: var(--gauzy-card-4);
+  background: var(--gauzy-card-4, rgba(255, 255, 255, 0.75));
   border-radius: nb-theme(border-radius);
   margin-top: 6px;
   padding-left: 6px;
@@ -145,29 +151,30 @@
     max-height: calc(100vh - 45rem);
   }
 
+  // Overrides Bootstrap's `.border-bottom`, which is a flat `1px solid #dee2e6`
+  // and therefore the same near-white hairline on all eight themes.
   .border-bottom {
-    border-bottom: 1px solid rgba(126, 126, 143, 0.1) !important;
+    border-bottom: 1px solid var(--gauzy-border-default-color, rgba(126, 126, 143, 0.1)) !important;
+  }
+
+  // Both lists bind `[class.border-bottom-none]` on their last row
+  // (`lastItem` in the upload queue, `lastHistory` in the import history), but
+  // nothing ever defined the class, so the final row kept a divider under it
+  // and the list ended on a rule with nothing below it.
+  .border-bottom-none {
+    border-bottom: none !important;
   }
 
   [nbButton].appearance-outline.status-primary {
     border: none;
   }
-
-  .item,
-  a {
-    cursor: pointer;
-  }
-
-  .selected {
-    background-color: rgba(126, 126, 143, 0.1);
-    box-shadow: -6px 0 0 0 rgba(0, 0, 0, 0.15);
-    border-radius: 8px 0 0 8px;
-
-    &.border-bottom {
-      border-bottom: none;
-    }
-  }
 }
+
+// Removed `.custom-body .item, .custom-body a { cursor: pointer }` and the
+// `.custom-body .selected { ... }` block. Component styles only reach this
+// component's own template, and `import.component.html` has no `item` class, no
+// `selected` class (nothing binds one) and no `<a>` at all — its two lists are
+// `div.row.border-bottom` and its links are `[nbButton]`s.
 
 nb-badge {
   position: relative;

--- a/apps/gauzy/src/app/pages/income/income.component.html
+++ b/apps/gauzy/src/app/pages/income/income.component.html
@@ -44,16 +44,9 @@
         (scroll)="onScroll()"
       ></ga-card-grid>
     }
-    <ng-template #gridLayout>
-      <ga-card-grid
-        [loading]="loading"
-        [totalItems]="pagination?.totalItems"
-        [settings]="smartTableSettings"
-        [source]="incomes"
-        (onSelectedItem)="selectIncome($event)"
-        (scroll)="onScroll()"
-      ></ga-card-grid>
-    </ng-template>
+    <!-- Removed an `<ng-template #gridLayout>` that repeated the card grid above:
+         `gridLayout` was referenced nowhere in this template or its component, so
+         it was never instantiated. The `@else` branch is the grid layout. -->
   </nb-card-body>
 </nb-card>
 

--- a/apps/gauzy/src/app/pages/integrations/components/integration-list/list.component.scss
+++ b/apps/gauzy/src/app/pages/integrations/components/integration-list/list.component.scss
@@ -36,8 +36,13 @@
 					font-size: 13px;
 					color: var(--gauzy-text-color-2);
 				}
+				// Was `rgba(50, 50, 50, 0.03)` — 3% black. Over `--gauzy-card-1` that
+				// is a faint grey on the light themes and effectively nothing on the
+				// near-black ones, so an integration row gave no hover feedback at all
+				// in dark. `--gauzy-hover-tint` is the shared translucent neutral: it
+				// darkens a light surface and lightens a dark one.
 				&:hover {
-					background: rgba(50, 50, 50, 0.03);
+					background: var(--gauzy-hover-tint);
 				}
 				img {
 					width: 100%;

--- a/apps/gauzy/src/app/pages/integrations/integrations.component.html
+++ b/apps/gauzy/src/app/pages/integrations/integrations.component.html
@@ -91,11 +91,18 @@
 									[class.disabled]="integration.isComingSoon"
 									[routerLink]="['../', integration.redirectUrl]"
 								>
+									<!--
+										`alt` was the literal string "image not found", so a logo
+										that failed to load rendered those words inside the tile —
+										the broken-image state told the user nothing about which
+										integration the tile was. The integration name is both the
+										correct alternative text and a usable fallback.
+									-->
 									<img
 										[src]="integration.fullImgUrl"
 										width="100%"
 										height="100%"
-										alt="image not found"
+										[alt]="integration.name | replace: '_' : ' '"
 										[title]="integration.name | replace: '_' : ' '"
 									/>
 									@if (integration.isComingSoon) {

--- a/apps/gauzy/src/app/pages/integrations/integrations.component.scss
+++ b/apps/gauzy/src/app/pages/integrations/integrations.component.scss
@@ -52,11 +52,15 @@
 }
 
 
+// Search + filter strip, separated from the integration tiles by a hairline.
+// The 38px of padding under the controls plus 37px of margin under the rule left
+// 75px of empty band across the page — two off-by-one magic numbers from before
+// the density pass, not a deliberate rhythm. One rem either side of the rule.
 .integration-filters {
   display: flex;
-  margin-bottom: 37px;
+  margin-bottom: 1rem;
   box-shadow: 0 1px 0 0 var(--gauzy-border-default-color);
-  padding-bottom: 38px;
+  padding-bottom: 1rem;
 }
 
 .group-select {
@@ -111,16 +115,26 @@ img {
   overflow: hidden;
 }
 
+// The "coming soon" corner ribbon.
+//
+// Its top gradient stop already read `--text-primary-color`, but the bottom stop
+// and both fold triangles were literal purples (`rgb(101,105,223)` /
+// `rgb(103,63,189)`) sampled from the default theme's accent. Anywhere the accent
+// is not that purple — the material themes ship a different primary entirely —
+// the ribbon faded from the theme colour into a stray blue-violet and folded back
+// in a third colour again. All three now come from the same primary ramp, so the
+// ribbon is one colour family in every theme. The white label stays literal: it
+// sits on a saturated fill, not on a theme surface.
 .coming-soon {
   position: absolute;
   width: 130px;
   transform: rotate(45deg);
   top: 25px;
   right: -27px;
-  background: linear-gradient(var(--text-primary-color), rgb(101, 105, 223) 100%);
+  background: linear-gradient(var(--color-primary-500), var(--color-primary-600) 100%);
   box-shadow: #000 0px 3px 10px -5px;
   line-height: 25px;
-  color: rgb(255, 255, 255);
+  color: #fff;
   font-size: 10px;
   font-weight: bold;
   text-transform: uppercase;
@@ -131,10 +145,10 @@ img {
     position: absolute;
     left: 0px;
     top: 100%;
-    border-left: 3px solid rgb(103, 63, 189);
+    border-left: 3px solid var(--color-primary-700);
     border-right: 3px solid transparent;
     border-bottom: 3px solid transparent;
-    border-top: 3px solid rgb(103, 63, 189);
+    border-top: 3px solid var(--color-primary-700);
   }
 
   &::after {
@@ -143,9 +157,9 @@ img {
     right: 0px;
     top: 100%;
     border-left: 3px solid transparent;
-    border-right: 3px solid rgb(103, 63, 189);
+    border-right: 3px solid var(--color-primary-700);
     border-bottom: 3px solid transparent;
-    border-top: 3px solid rgb(103, 63, 189);
+    border-top: 3px solid var(--color-primary-700);
   }
 }
 

--- a/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item-variant/variant-form.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item-variant/variant-form.component.scss
@@ -8,7 +8,9 @@
 .product-variant-photo {
   width: 100%;
   height: 15rem;
-  background-color: white;
+  // Was a literal `white`. A variant usually has no image, in which case this
+  // 15rem well IS what the user sees — a bright white block on the dark themes.
+  background-color: var(--gauzy-card-1);
   overflow: hidden;
   position: relative;
   border-radius: var(--border-radius);

--- a/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item/options-form/options-form.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item/options-form/options-form.component.scss
@@ -27,8 +27,14 @@
   }
 }
 
+// The edit / remove icons on an option row. `color-basic-300` is #edf1f7 in
+// every registered theme (it is a fixed palette step, not a role token), and
+// the row it sits on is `--gauzy-sidebar-background-3` — a pale grey on the
+// light themes. Near-white on pale grey is an invisible control; the icons only
+// appeared at all on hover, when the rule below repaints them. Match the row's
+// own label colour instead.
 .option-row-icon {
-  color: nb-theme(color-basic-300);
+  color: var(--text-hint-color);
 }
 
 .option-group-form {

--- a/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item/product-form.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/edit-inventory-item/product-form.component.scss
@@ -95,7 +95,11 @@ nb-card-footer {
 
 .product-photo {
   width: 100%;
-  background-color: white;
+  // Was a literal `white`: with no featured image yet, this well is the visible
+  // surface, so on the dark themes it rendered as a bright white slab in the
+  // middle of a near-black form. `--gauzy-card-1` is the panel colour, i.e. what
+  // every other empty box on this page already resolves to.
+  background-color: var(--gauzy-card-1);
   overflow: hidden;
   position: relative;
 

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/description/description.component.css
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/description/description.component.css
@@ -4,5 +4,10 @@
 	line-height: 15px;
 	letter-spacing: 0em;
 	text-align: left;
-	color: var(--gauzy-color-text-2);
+	/* `--gauzy-color-text-2` is not a theme token — the registered name is
+	   `--gauzy-text-color-2` (styles/themes.scss). The old var() named nothing,
+	   so the declaration was dropped and the description inherited the cell
+	   colour instead of reading as a caption. The fallback covers the two
+	   material themes, which never define the gauzy text tokens. */
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 }

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/item-img-tags-row.component.ts
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/item-img-tags-row.component.ts
@@ -94,7 +94,11 @@ import { ComponentLayoutStyleEnum } from '@gauzy/contracts';
 				line-height: 17px;
 				letter-spacing: 0em;
 				text-align: left;
-				color: var(--gauzy-color-text-1);
+				/* was var(--gauzy-color-text-1): not a registered token (the name is
+				   --gauzy-text-color-1), so the declaration was invalid at
+				   computed-value time and dropped. Fallback covers the two material
+				   themes, which never define the gauzy text tokens. */
+				color: var(--gauzy-text-color-1, var(--text-basic-color));
 				margin-bottom: 4px;
 			}
 		`

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/name-with-description/name-with-description.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/name-with-description/name-with-description.component.scss
@@ -1,10 +1,20 @@
+// `--gauzy-color-text-1` / `--gauzy-color-text-2` are NOT theme tokens — the
+// registered names are `--gauzy-text-color-1` / `--gauzy-text-color-2` (see
+// styles/themes.scss). A `color` declaration whose var() names an undefined
+// custom property is invalid at computed-value time and is dropped, so both
+// lines here used to inherit the cell colour: the name and its description
+// rendered as one flat block instead of a value/caption pair.
+//
+// The fallbacks matter: the gauzy text tokens only exist in 6 of the 8
+// registered themes (the two material ones never define them) — same reason
+// the ng-select rules in styles/_overrides.scss resolve `text-basic-color`.
 .name {
     font-size: 14px;
     font-weight: 600;
     line-height: 17px;
     letter-spacing: 0em;
     text-align: left;
-    color: var(--gauzy-color-text-1);
+    color: var(--gauzy-text-color-1, var(--text-basic-color));
     margin-bottom: 4px;
 }
 
@@ -14,5 +24,5 @@
     line-height: 15px;
     letter-spacing: 0em;
     text-align: left;
-    color: var(--gauzy-color-text-2);
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
 }

--- a/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/no-image/no-image.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/inventory-table-components/no-image/no-image.component.scss
@@ -1,3 +1,22 @@
+// `ga-no-image` had no host styling at all, so the element defaulted to
+// `display: inline` — and width/height do not apply to a non-replaced inline
+// box. Inside the two table-cell renderers that use it the parent happens to be
+// `display: flex`, which forces the host to a block box and hid the problem; the five
+// places that drop it into a plain image WELL got a placeholder that collapsed
+// to a single text line pinned to the top-left of an otherwise empty box:
+//   * the inventory item form's gallery (a 260px / 180px well),
+//   * the item view page (300px),
+//   * the variant form (15rem),
+//   * the merchant and warehouse forms (300px, via `.store-image`).
+// Filling the well is the whole point of a placeholder, so claim the box here.
+// Consumers that DO size the host keep winning: their rule is a class scoped by
+// the parent's content attribute, (0,2,0) against `:host`'s (0,1,0).
+:host {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
 .no-image {
     width: 100%;
     height: 100%;
@@ -10,7 +29,7 @@
     line-height: 11px;
     letter-spacing: 0em;
     text-align: left;
-    color: var(--gauzy-text-color-2);
+    color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 }
 
 .content {

--- a/apps/gauzy/src/app/pages/inventory/components/manage-product-types/product-types.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/manage-product-types/product-types.component.scss
@@ -1,77 +1,45 @@
 @use '@shared/_pg-card' as *;
 
-// Same hairline ring as the shared `.action` block in `gauzy/_gauzy-table.scss`
-// — this file carries a verbatim copy of it.
-.action {
-  box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+// `@shared/_pg-card` forwards `gauzy/_gauzy-table`, so the shared `.action`,
+// `.actions`, `button`, `.gauzy-button-container` and `.card-custom-header`
+// rules are ALREADY emitted into this component's sheet by the line above.
+//
+// This file (and, through `@forward`, product categories, merchants,
+// warehouses and the inventory items table) used to restate all of them, and
+// the copy had drifted away from the shared block it was taken from:
+//   * `.info` → a bare `background-color: #0088fe`, where the shared block
+//     resolves `color-info-default`, gates it on the filled/basic pair, and
+//     also sets a readable `color: white`. A button here would have got a raw
+//     blue fill with whatever text colour it inherited.
+//   * `.success` → `rgba(37, 184, 105, 1)`, the literal that
+//     `color-success-default` happens to hold in the two gauzy themes and in
+//     none of the other six.
+//   * `.warning` → `rgba(245, 109, 88, 1)`; `.primary.soft` →
+//     `rgba(110, 73, 232, 0.1)`.
+// Being second in the sheet, the copy won every one of those. Deleted, so the
+// themed definitions apply — including on any button these pages grow later.
+//
+// Whatever remains below is what genuinely differs from the shared defaults.
 
-  &[nbButton].appearance-filled.status-basic {
-    background-color: var(--gauzy-card-2);
-  }
-
-  &.info {
-    background-color: #0088fe;
-  }
-
-  &.secondary {
-    color: var(--text-hint-color);
-  }
-
-  &.success {
-    color: rgba(37, 184, 105, 1);
-  }
-
-  &.warning {
-    color: rgba(245, 109, 88, 1);
-  }
-
-  &.primary {
-    &[nbButton].appearance-filled.status-basic,
-    .appearance-filled.status-basic[nbButtonToggle] {
-      color: nb-theme(text-primary-color);
-    }
-
-    &.soft {
-      &[nbButton].appearance-filled.status-basic {
-        background-color: rgba(110, 73, 232, 0.1);
-      }
-    }
-  }
-
-  &.select-nb ::ng-deep {
-    box-shadow: none;
-
-    .select-button {
-      box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
-      background: var(--gauzy-card-2);
-    }
+// The one rule kept from the copy, and deliberately: the shared block writes
+// `.action.primary { color: … }` at (0,2,0), which does NOT out-rank Nebular's
+// own `[nbButton].appearance-filled.status-basic` text colour at (0,3,0). This
+// selector does, and the Edit button on these five tables (product types,
+// product categories, merchants, warehouses, inventory items) is styled by it.
+// Now resolves the same token the shared block names instead of a literal.
+.action.primary {
+  &[nbButton].appearance-filled.status-basic,
+  .appearance-filled.status-basic[nbButtonToggle] {
+    color: nb-theme(text-primary-color);
   }
 }
 
-button {
-  margin: 5px;
-}
-
+// The Edit/Delete group is inset from the card's right edge (the shared block
+// only sets the fill and radius). Note the shared `.actions` padding carries
+// `!important`, so the `padding: 0 1px` that used to sit here never applied.
 :host .actions {
-  background: var(--gauzy-card-2);
-  border-radius: nb-theme(button-rectangle-border-radius);
-  padding: 0 1px;
   @include nb-ltr(margin-right, 20px);
   @include nb-rtl(margin-left, 20px);
-}
-
-.gauzy-button-container {
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
-  padding-bottom: 0;
-}
-
-.card-custom-header {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding-bottom: 0;
 }
 
 nb-card-body {

--- a/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.html
+++ b/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.html
@@ -75,7 +75,11 @@
 							<span class="key-description mb-2">{{ 'INVENTORY_PAGE.TAGS' | translate }}:</span>
 							<div class="inventory-item-tags">
 								@for (tag of inventoryItem.tags; track tag.id) {
-								<div class="tag-item" [style.background]="tag.color">
+								<div
+									class="tag-item"
+									[style.background]="tag.color"
+									[style.color]="backgroundContrast(tag.color)"
+								>
 									{{ tag.name }}
 								</div>
 								}

--- a/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.scss
+++ b/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.scss
@@ -2,9 +2,19 @@
   width: 100%;
 }
 
+// Label column for the Name/Description/Type/Category/Enabled/Options rows.
+// This was a hard `width: 6rem` on an inline-block with visible overflow, so
+// any label wider than 96px — "Description:" is already ~90px at 14px/600, and
+// every non-English translation of it is longer — spilled out of its box and
+// ran underneath the value that follows it on the same line. `min-width` keeps
+// the values aligned in the common case and lets the long ones push instead of
+// collide.
 .key-description {
   font-weight: 600;
-  width: 6rem;
+  min-width: 6rem;
+  // Logical, so it mirrors in RTL without pulling the nb-ltr/nb-rtl mixins
+  // (and their `themes` dependency) into a sheet that has no other use for them.
+  padding-inline-end: 0.5rem;
   display: inline-block;
 }
 
@@ -18,30 +28,36 @@ img.gallery-sm-preview-item {
   }
 }
 
+// The option chips were `#3366ff` — Nebular's stock blue, not the app's primary
+// (`#6e49e8`), and hard-coded either way, so they were the only blue thing on a
+// purple page and identical in all eight themes. `7px` was also off the radius
+// scale; `--gauzy-radius-sm` is the step every other chip/control uses.
 .option-item {
   padding: 5px 10px;
   font-size: 12px;
-  background: #3366ff;
-  border-radius: 7px;
-  color: #fff;
+  background: var(--color-primary-default);
+  border-radius: var(--gauzy-radius-sm, 6px);
+  color: var(--text-control-color);
   margin-right: 10px;
   display: flex;
   align-items: center;
   margin-bottom: 10px;
 }
 
+// Tag colour is user-chosen and painted inline by the template, so a fixed
+// white label was unreadable on every light tag. The text colour is picked per
+// tag now (see `backgroundContrast()` in the component, the same
+// `getContrastColor` helper the inventory table cells already use).
 .tag-item {
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 11px;
-  font-weight: 600;
   line-height: 13px;
   letter-spacing: 0em;
 
   display: flex;
   align-items: center;
   text-align: center;
-  color: white;
   font-weight: bold;
   width: fit-content;
 }

--- a/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.ts
+++ b/apps/gauzy/src/app/pages/inventory/components/view-inventory-item/view-inventory-item.component.ts
@@ -6,6 +6,7 @@ import { LocalDataSource } from 'angular2-smart-table';
 import { TranslateService } from '@ngx-translate/core';
 import { combineLatest } from 'rxjs';
 import { IImageAsset, IProductOptionTranslatable, IProductTranslatable, LanguagesEnum } from '@gauzy/contracts';
+import { getContrastColor } from '@gauzy/ui-core/common';
 import { ProductService, TranslatableService } from '@gauzy/ui-core/core';
 import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 import { Store } from '@gauzy/ui-core/core';
@@ -111,6 +112,20 @@ export class InventoryItemViewComponent extends TranslationBaseComponent impleme
 			},
 			dialogClass: 'fullscreen'
 		});
+	}
+
+	/**
+	 * Readable label colour for a tag chip.
+	 *
+	 * Tag colours are user-chosen, so the chip's label cannot be a fixed white —
+	 * it disappeared on every light tag. Same helper the inventory table cells
+	 * use for the same chips.
+	 */
+	backgroundContrast(bgColor: string): string | null {
+		// `getContrastColor` indexes into the string, so a tag saved without a
+		// colour would throw. Returning null drops the style binding and the chip
+		// simply inherits, which is what it did before.
+		return bgColor ? getContrastColor(bgColor) : null;
 	}
 
 	getTranslatedProp(item: any, prop: string) {

--- a/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.html
@@ -322,6 +322,11 @@
                 <div class="block">
                   <div class="row group d-flex flex-column">
                     <label class="label label-group">{{ 'INVOICES_PAGE.DISCOUNT' | translate }}</label>
+                    <!-- The group is a flex COLUMN, so the two half-width fields only sit side by
+                         side inside a nested `.row` — exactly how the taxes group below and the
+                         edit screen already lay theirs out. Without it, Discount value and
+                         Discount type stacked full width and the block was twice as tall. -->
+                    <div class="row">
                     <div class="col-sm-6">
                       <div class="form-group">
                         <label for="inputDiscountValue" class="label">{{
@@ -361,6 +366,7 @@
                           </nb-select>
                         </div>
                       </div>
+                    </div>
                     </div>
 
                     <div class="row group d-flex flex-column">
@@ -512,15 +518,14 @@
                   }
                 </nb-card-body>
                 <nb-card-footer class="text-left">
-                  <button size="small" status="basic" size="small" outline nbButton (click)="cancel()">
+                  <button class="mr-3" size="small" status="basic" outline nbButton (click)="cancel()">
                     {{ 'BUTTONS.CANCEL' | translate }}
                   </button>
                   <button
-                    class="mr-3"
+                    class="mr-3 gray"
                     (click)="addInvoice('DRAFT')"
                     size="small"
                     status="primary"
-                    class="gray"
                     [disabled]="disableSaveButton || form.invalid"
                     nbButton
                     >

--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.html
@@ -320,7 +320,7 @@
                                 </div>
                                 <div class="col-sm-6">
                                   <div class="form-group">
-                                    <label for="inputTaxType" class="label">{{
+                                    <label for="inputTax2Type" class="label">{{
                                       'INVOICES_PAGE.TAX_TYPE' | translate
                                     }}</label>
                                     <nb-select
@@ -329,7 +329,7 @@
 											'INVOICES_PAGE.TAX_TYPE' | translate
 										}}"
                                       (ngModelChange)="calculateTotal()"
-                                      id="inputTaxType"
+                                      id="inputTax2Type"
                                       fullWidth
                                       >
                                       @for (
@@ -421,7 +421,6 @@
                     <nb-card-footer>
                       @if (!duplicate) {
                         <button
-                          status="danger"
                           class="mr-3"
                           status="basic"
                           size="small"
@@ -433,12 +432,11 @@
                         </button>
                       }
                       <button
-                        class="mr-3"
+                        class="mr-3 gray"
                         (click)="updateInvoice('DRAFT')"
                         [disabled]="form.invalid"
                         size="small"
                         status="primary"
-                        class="gray"
                         nbButton
                         >
                         {{ 'BUTTONS.SAVE_AS_DRAFT' | translate }}

--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.scss
@@ -1,8 +1,15 @@
 @use 'gauzy/_gauzy-table' as *;
 @use 'gauzy/_gauzy-dialogs' as *;
 
+// Row actions of the invoice-item grid. These were painted with literals: the
+// add/save pill as `#00d68f` and — the visible one — the cancel/delete pill as a
+// flat `white`, i.e. a bright white block on every item row of the four dark
+// themes. Same colours, read from the theme instead of spelled out, and the
+// delete pill takes the hairline ring every other button in the app carries
+// rather than a black drop shadow.
 :host ::ng-deep angular2-smart-table .angular2-smart-actions-title a {
-  background-color: #00d68f !important;
+  background-color: nb-theme(color-success-default) !important;
+  color: nb-theme(text-control-color);
   transform: scale(0.9);
 }
 
@@ -12,25 +19,49 @@
 }
 
 :host ::ng-deep angular2-smart-table .angular2-smart-actions a:nth-child(1) {
-  background-color: #00d68f !important;
-  color: white;
+  background-color: nb-theme(color-success-default) !important;
+  color: nb-theme(text-control-color);
 }
 
 :host ::ng-deep angular2-smart-table .angular2-smart-actions a:nth-child(2) {
-  background-color: white !important;
-  color: #ff3d71;
-  box-shadow: var(--gauzy-shadow);
+  background-color: var(--gauzy-card-1) !important;
+  color: nb-theme(color-danger-default);
+  box-shadow: $action-hairline;
 }
 
+// The subtotal/total chips under the item grid.
+//
+// `float: right` took the block out of flow, so its parent did not grow to
+// contain it: the chips could ride over whatever the card put below them, and
+// the card body never counted their height. A right-justified flex row keeps the
+// same placement and stays in flow.
+//
+// The chips themselves were drawn with a 2px border in
+// `--button-filled-info-disabled-border-color` (a *disabled button* token, used
+// here only because it happened to be a pale grey) and a 5px corner against the
+// 10px radius everything else on the page uses.
 .total {
-  float: right;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin: 1rem 0.5rem 0.5rem;
+
+  // invoice-edit groups its chips into paid/due rows; invoice-add lists them
+  // directly. Only the inner groups are matched — `.total` itself carries
+  // `d-flex` in both templates.
+  .d-flex {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
 
   &-item {
-    border: solid 2px var(--button-filled-info-disabled-border-color);
-    border-radius: 5px;
-    margin: 20px 20px 20px 10px;
-    padding: 5px;
-    font-size: 14px;
+    box-shadow: $action-hairline;
+    background-color: var(--gauzy-card-1);
+    border-radius: var(--border-radius);
+    padding: 0.375rem 0.75rem;
+    font-size: nb-theme(text-paragraph-font-size);
   }
 }
 

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.html
@@ -22,8 +22,10 @@
 							</div>
 							<div>:</div>
 						</div>
+						<!-- `dueDate` is optional and `dateFormat` yields undefined for an
+						     unset one, so this label used to stand over a blank cell. -->
 						<div class="col-6 pr-0 pl-0">
-							{{ invoice ? (invoice.dueDate | dateFormat) : '' }}
+							{{ invoice ? (invoice.dueDate | dateFormat) || '—' : '—' }}
 						</div>
 					</div>
 					<div class="row">
@@ -73,7 +75,7 @@
 							<div>:</div>
 						</div>
 						<div class="col-6 pr-0 pl-0">
-							{{ invoice?.toContact?.name }}
+							{{ invoice?.toContact?.name || '—' }}
 						</div>
 					</div>
 					<div class="row">
@@ -87,7 +89,7 @@
 							<div>:</div>
 						</div>
 						<div class="col-6 pr-0 pl-0">
-							{{ invoice?.fromOrganization?.name }}
+							{{ invoice?.fromOrganization?.name || '—' }}
 						</div>
 					</div>
 				</div>
@@ -100,17 +102,21 @@
 						| position: organization?.currencyPosition
 				}}
 				<span>
+					<!-- The "n% Paid" caption sits BESIDE the meter, not on top of it.
+					     Painted over the bar it was a hard-coded white, which is
+					     unreadable against the track's pale grey — i.e. for every
+					     invoice that is not already mostly paid. -->
 					<div class="progress-bar-container">
 						<div class="progress-bar">
-							<div class="paid-percent">
-								{{ barWidth }}%
-								{{ 'INVOICES_PAGE.PAYMENTS.PAID' | translate }}
-							</div>
 							<span
 								id="progress-bar-inner"
 								class="progress-bar-inner"
 								style="width: 0%"
 							></span>
+						</div>
+						<div class="paid-percent">
+							{{ barWidth }}%
+							{{ 'INVOICES_PAGE.PAYMENTS.PAID' | translate }}
 						</div>
 					</div>
 				</span>

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.scss
@@ -14,43 +14,57 @@
   margin-left: 8%;
 }
 
-.progress-bar {
-  background-color: rgba(126, 126, 143, 0.2);
-  height: 32px;
-  width: 200px;
-  border-radius: 3px;
+// The paid meter. Previously a 32px slab with the caption absolutely positioned
+// on top of it in a hard-coded `#ffffff` — unreadable against the pale track
+// wherever the green fill had not reached, which is most of the bar for most
+// invoices. The caption is now a sibling (see the template) so its colour is just
+// body text, and the bar itself is a meter on the shared radius rather than a
+// 3px-cornered block.
+.progress-bar-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   margin-top: 10px;
+}
+
+.progress-bar {
+  position: relative;
+  background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
+  height: 0.75rem;
+  width: 200px;
+  border-radius: var(--gauzy-radius-sm, 0.375rem);
+  overflow: hidden;
 }
 
 .progress-bar-inner {
   display: block;
-  height: 32px;
-  background-color: rgba(0, 214, 143, 1);
-  border-radius: 3px;
-  position: relative;
+  height: 100%;
+  background-color: nb-theme(color-success-default);
+  border-radius: inherit;
 }
 
 .paid-percent {
-  position: absolute;
-  z-index: 1;
-  margin-left: 1%;
-  color: #ffffff;
-  font-weight: bold;
+  color: var(--gauzy-text-color-1);
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .custom-container {
   margin-top: 32px;
   background-color: var(--gauzy-card-2);
   padding: 0 12px 12px 12px;
-  border-radius: 8px;
-  .gauzy-button-container{
+  // Was an 8px literal; the card this sits inside is drawn on `--border-radius`.
+  border-radius: var(--border-radius);
+  .gauzy-button-container {
     display: flex;
     justify-content: flex-end;
   }
 }
-.body{
+
+.body {
   background-color: var(--gauzy-card-2);
-  border-radius: 0 0 8px 8px;
+  // Same: the body has to finish the card's own corners, not 8px ones.
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
 }
 
 .first-column {

--- a/apps/gauzy/src/app/pages/invoices/invoice-view/invoice-view.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-view/invoice-view.component.html
@@ -1,9 +1,9 @@
 <nb-card class="main">
   <nb-card-header class="header">
     <ngx-back-navigation></ngx-back-navigation>
-    <h3 class="title">
+    <h4 class="title">
       {{ (isEstimate ? 'INVOICES_PAGE.VIEW_ESTIMATE' : 'INVOICES_PAGE.VIEW_INVOICE') | translate }}
-    </h3>
+    </h4>
   </nb-card-header>
   <nb-card-body>
     @if (invoice$ | async; as invoice) {

--- a/apps/gauzy/src/app/pages/invoices/invoice-view/invoice-view.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoice-view/invoice-view.component.scss
@@ -1,30 +1,7 @@
 @use 'gauzy/_gauzy-cards' as *;
 @use 'gauzy/_gauzy-table' as *;
 
-.grid {
-  display: grid;
-  grid-template-columns: 0.3fr 0.3fr;
-  &-item {
-    margin: 15px;
-  }
-}
-
-.item {
-  margin: 15px;
-}
-
-.table {
-  margin-top: 50px;
-}
-
-/**
-* By setting min-height of the card to this value, we ensure the card will properly adjust it's height
-*/
-:host > nb-card {
-  min-height: 47.5rem;
-}
-
-.button-container{
+.button-container {
   background: var(--gauzy-card-2);
   border-radius: nb-theme(button-rectangle-border-radius);
   padding: 6px 8px;
@@ -33,15 +10,27 @@
 .header {
   display: flex;
   align-items: center;
-  // Type comes from the shared card-title rule in `styles/_overrides.scss` —
-  // the title is an <h3>, which that rule covers.
+
+  // The heading used to be an `<h3>` pinned to a literal `24px/30px`. It is now an
+  // `<h4>` — the step the Add / Edit / Payments screens already use — so the size
+  // comes from `text-heading-4-font-size` rather than being spelled out here, and
+  // the heading level matches its sibling screens.
+  //
+  // `margin-bottom: 0` because the row is `align-items: center`, which centres the
+  // MARGIN box: Bootstrap's default `0.5rem` under a heading was tipping the title
+  // half a step above the back arrow beside it.
   .title {
     text-align: left;
+    margin-bottom: 0;
   }
 }
+
 :host {
-  $height: calc(
-    100vh - 18rem
-  );
+  // The body is anchored to the viewport and the card follows it. The card also
+  // carried `min-height: 47.5rem` — a 760px floor no window shorter than roughly
+  // 1050px can satisfy, so on a laptop the card grew past the page frame (bounded
+  // to 100vh in styles/_overrides.scss) and put the whole PAGE into a scroll
+  // instead of scrolling its own content.
+  $height: calc(100vh - 18rem);
   @include nb-card_overrides(unset, $height, $default-radius);
 }

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.scss
@@ -247,7 +247,9 @@ ga-pagination {
 }
 
 .comments {
-  overflow-y: scroll;
+  // `scroll` reserved a scrollbar gutter on the History tab even when an invoice
+  // has one comment or none, so the empty panel showed a dead scrollbar track.
+  overflow-y: auto;
   height: 15rem;
 }
 
@@ -266,9 +268,12 @@ textarea {
     background-color: var(--gauzy-card-2);
   }
 
-  &.info {
-    background-color: #0088fe;
-  }
+  // `&.info { background-color: #0088fe }` used to sit here — a hard-coded blue
+  // that never painted anything. Its only user is the estimates toolbar's "To
+  // invoice" button, which carries `status="info"`, so Nebular's own
+  // `[nbButton].appearance-filled.status-info` background (0,3,0) out-ranked the
+  // bare `.action.info` (0,2,0) on every render. The button is, and stays, a
+  // filled info button drawn from `button-filled-info-background-color`.
 
   &.danger {
     color: nb-theme(color-danger-default);
@@ -345,7 +350,12 @@ input {
 
 nb-tab {
   background-color: var(--gauzy-card-2);
-  border: 0 0 $default-radius $default-radius;
+  // Was `border: 0 0 $default-radius $default-radius`. The `border` shorthand
+  // takes width/style/colour, not four corner radii, so with `$default-radius`
+  // resolving to `var(--border-radius)` the declaration became invalid at
+  // computed-value time and was thrown away whole: the tab panel filled the
+  // bottom of the card with square corners inside the card's rounded ones.
+  border-radius: 0 0 $default-radius $default-radius;
 }
 
 :host {
@@ -356,7 +366,9 @@ nb-tab {
   .remove-scroll {
     overflow: unset;
     width: 100%;
-    border: 0 0 $default-radius $default-radius;
+    // Same `border` / `border-radius` mix-up as the `nb-tab` rule above — this
+    // targets the same element (`nb-tab.remove-scroll`).
+    border-radius: 0 0 $default-radius $default-radius;
     @include nb-ltr(padding, 1rem 0.5rem 1rem 18px);
     @include nb-rtl(padding, 1rem 18px 1rem 0.5rem);
     nb-accordion {

--- a/apps/gauzy/src/app/pages/invoices/table-components/invoice-paid.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/table-components/invoice-paid.component.ts
@@ -5,25 +5,37 @@ import { TranslationBaseComponent } from '@gauzy/ui-core/i18n';
 
 @Component({
     selector: 'ga-invoice-paid',
+    // The "Paid" cell of the invoices / received-invoices grids. Two defects and a
+    // density mismatch:
+    //
+    //   * the caption was painted UNDER the fill. It carried `z-index: 1` while
+    //     `position: static`, where z-index has no effect, and the fill span was
+    //     absolutely positioned — i.e. in the positioned paint layer, above every
+    //     in-flow sibling. A fully-paid invoice showed a green bar and no text.
+    //   * where the fill had not reached, the caption was hard-coded `#ffffff` on a
+    //     pale grey track: invisible on the four light themes, which is exactly the
+    //     0 %-paid case.
+    //   * a 32px bar in a grid whose cells are 13px/20px on 6px padding made this
+    //     one column set the row height for the whole table.
+    //
+    // The caption now sits beside the meter, so it is plain body text on the card,
+    // and the bar is a 0.5rem meter on the shared small radius.
     template: `
 		<div class="progress-bar-container">
 			<div class="progress-bar">
-				<div class="paid-percent">
-					{{ paidAmountPercentage }}%
-					{{ 'INVOICES_PAGE.PAYMENTS.PAID' | translate }}
-				</div>
-				<span
-					id="progress-bar-inner"
-					class="progress-bar-inner"
-					[style.width]="paidAmountPercentage + '%'"
-				></span>
+				<span class="progress-bar-inner" [style.width]="paidAmountPercentage + '%'"></span>
 			</div>
+			<span class="paid-percent">
+				{{ paidAmountPercentage }}%
+				{{ 'INVOICES_PAGE.PAYMENTS.PAID' | translate }}
+			</span>
 		</div>
 	`,
     styles: [
-        '.progress-bar-inner {background-color: rgba(0, 214, 143, 1); position: absolute; height: 32px; width:100%; border-radius: 4px;}',
-        '.progress-bar {background-color: rgba(126, 126, 143, 0.2); border-radius: 4px; position: relative; height: 32px}',
-        '.paid-percent {color: #ffffff; z-index: 1; font-weight: bold;}'
+        '.progress-bar-container {display: flex; align-items: center; gap: 0.5rem;}',
+        '.progress-bar {background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1)); border-radius: var(--gauzy-radius-sm, 0.375rem); position: relative; height: 0.5rem; flex: 1 1 auto; min-width: 3rem; overflow: hidden;}',
+        '.progress-bar-inner {background-color: var(--color-success-default, rgba(0, 214, 143, 1)); display: block; height: 100%; border-radius: inherit;}',
+        '.paid-percent {color: var(--gauzy-text-color-1); font-weight: 600; white-space: nowrap;}'
     ],
     standalone: false
 })

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
@@ -55,10 +55,22 @@
       border-radius: nb-theme(button-rectangle-border-radius);
       list-style: none;
       cursor: pointer;
-      box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15);
+      // Was a literal `0px 1px 1px rgba(0, 0, 0, 0.15)` — a black drop shadow,
+      // which against a near-black canvas is no edge at all. `gauzy-shadow` is
+      // the shared token for this hairline, so the row follows whatever the
+      // active theme decides an edge should be.
+      //
+      // Note it is NOT a ring everywhere: of the five themes that define it,
+      // only `gauzy-dark` resolves to `0 0 0 1px var(--gauzy-overlay-border-color)`.
+      // The others keep a black drop shadow (15% on the light pair, 35% on the
+      // dark pair), so `cosmic`, `dark` and `material-dark` still get a shadow
+      // rather than a ring. That is the shared token's problem to fix, in
+      // themes.scss, not this file's to work around. The fallback is the old
+      // literal, for the themes that emit no token at all.
+      box-shadow: var(--gauzy-shadow, 0px 1px 1px 0px rgb(0 0 0 / 15%));
       &.active {
         background: nb-theme(background-basic-color-1);
-        box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15) inset;
+        box-shadow: var(--gauzy-shadow, 0px 1px 1px 0px rgb(0 0 0 / 15%)) inset;
       }
     }
   }
@@ -86,9 +98,23 @@
   padding-right: 10px;
   max-width: 49% !important;
 }
-.active {
-  background: #ffffff;
-}
+// Removed `.active { background: #ffffff; }`, which was NOT dead — it was the bug.
+//
+// `active` is bound here in two ways. The visible one is the aside-nav `<li>`
+// items (`[class.active]="general?.expanded"` and nine siblings), which
+// `.aside-nav ul li.active` above already paints with
+// `nb-theme(background-basic-color-1)` at higher specificity. The one that is
+// easy to miss is that this template also holds 19 `<nb-option>` elements, and
+// Nebular host-binds `class.active` onto them at RUNTIME as the keyboard manager
+// moves — nothing a grep of the template can see.
+//
+// Those options are authored here, so they carry this component's `_ngcontent`
+// attribute even after `nb-select` portals them into the CDK overlay, and the
+// compiled `.active[_ngcontent-x]` (0,2,0) outranks Nebular's own
+// `nb-option-list nb-option.active` (0,1,2). The hard white therefore won: the
+// highlighted item in every dropdown on this page was painted #ffffff on all
+// eight themes, including the near-black ones. Dropping the rule hands the
+// styling back to Nebular, which resolves per theme.
 
 // start of nb-overrides
 nb-accordion {
@@ -104,7 +130,13 @@ nb-accordion {
       border-radius: 6px;
       width: 23px;
       height: 23px;
-      border: 1px solid rgba(66, 66, 66, 0.2);
+      // Was `rgba(66, 66, 66, 0.2)` — a dark grey ring around the accordion
+      // chevron, which disappears against the dark themes' panels. The shared
+      // border token is light-on-dark and dark-on-light. Spelled out as a
+      // custom property with a fallback rather than `nb-theme()`, which emits a
+      // bare `var()` and would drop the border entirely on a theme that does
+      // not carry the token.
+      border: 1px solid var(--gauzy-border-default-color, rgba(126, 126, 143, 0.1));
     }
   }
   & nb-accordion-item-header,
@@ -291,8 +323,14 @@ nb-accordion {
   }
 }
 :host ::ng-deep .toggle {
-  border: 1px solid #7e7e8f !important;
-  background-color: #7e7e8f !important;
+  // The unchecked toggle track. Both were a literal `#7e7e8f`, i.e. one fixed
+  // mid grey in all eight themes — a dark bar on the dark canvases, where the
+  // rest of the muted chrome is light. `gauzy-text-color-2` is the app's muted
+  // ramp and is `rgba(126, 126, 143, 1)` (exactly the old literal) on the
+  // themes that inherit the default palette, so those are unchanged; the
+  // fallback covers the themes that do not emit the custom property.
+  border: 1px solid var(--gauzy-text-color-2, rgba(126, 126, 143, 1)) !important;
+  background-color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1)) !important;
   &.checked {
     background-color: nb-theme(text-primary-color) !important;
     border: 1px solid nb-theme(text-primary-color) !important;
@@ -425,9 +463,10 @@ nb-accordion {
     }
   }
 }
-#temporary {
-  padding-bottom: 215px;
-}
+// Removed `#temporary { padding-bottom: 215px; }` — `temporary` appears nowhere
+// in `edit-organization-other-settings.component.html` or its .ts, and a
+// component stylesheet can only reach its own template, so the id never
+// existed to style.
 
 :host {
   nb-card-body {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.scss
@@ -44,8 +44,13 @@ nb-card-body {
           margin-left: 0;
         }
       }
+      // The resting tab icon. Was a literal `#7e7e8f` — a mid grey that reads as
+      // disabled on the dark themes and is off the ramp on the light ones. That
+      // literal IS `gauzy-text-color-2` on the gauzy themes, so it is the token
+      // this always meant; the fallback keeps it working on the themes that do
+      // not emit the custom property.
       & svg {
-        fill: #7e7e8f !important;
+        fill: var(--gauzy-text-color-2, rgba(126, 126, 143, 1)) !important;
       }
       &.active {
         & .tab-link {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
@@ -66,34 +66,26 @@
     }
 }
 
-// old styles
-.edit-icon {
-    margin-left: 30px;
-    position: relative;
-    width: 36px;
-
-    svg {
-        position: absolute;
-    }
-
-    nb-icon {
-        position: absolute;
-    }
-}
-
-.org-details {
-    .edit-public-page {
-        cursor: pointer;
-        color: #027ad6;
-        padding-top: 3px;
-    }
-}
-
-.setting-name {
-    font-size: 24px;
-    font-weight: bold;
-}
-
+// Removed most of a block of old styles — but NOT all of it, because this
+// stylesheet is not scoped to one template. `accounting.component.ts` lists it in
+// its own `styleUrls` alongside `accounting.component.scss`, so every selector
+// here is compiled a SECOND time carrying the Accounting template's `_ngcontent`
+// attribute. "Dead in edit-organization" therefore does not mean dead.
+//
+// Checked against both templates. Dead in each, and gone: `.edit-icon`,
+// `.setting-name`, `.transparent`, `.settings-body`, `.header-content` (with its
+// nested `.header-info`), `.org-details .edit-public-page` (a literal `#027ad6`,
+// and in edit-organization's own markup `.edit-public-page` is a SIBLING of
+// `.org-details`, never a descendant), and `.mutation-card.setting-block` (a
+// literal `#eaf3fc` fill — Accounting has `setting-block` but never
+// `mutation-card`, so the compound selector matches nothing there either).
+//
+// KEPT, because Accounting really renders them: `.body-header`
+// (accounting.component.html line 3) and `.sub-header` (line 83, as
+// `setting-block sub-header`). accounting.component.scss re-declares
+// `.body-header` but sets no `margin-bottom`, and it is loaded after this file,
+// so dropping these would have silently pulled 35px out from under the Accounting
+// page header and dropped the bold from its section headings.
 .body-header {
     display: flex;
     justify-content: space-between;
@@ -101,32 +93,9 @@
     margin-bottom: 35px;
 }
 
-.mutation-card.setting-block {
-    background: #eaf3fc;
-}
-
-.transparent {
-    opacity: 0.7;
-}
-
-.settings-body {
-    padding: 35px;
-}
-
 .sub-header {
     margin-bottom: 20px;
     font-weight: bold;
-}
-
-.header-content {
-    display: flex;
-    .header-info {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        width: 560px;
-        padding-left: 30px;
-    }
 }
 
 @include respond(sm) {
@@ -143,5 +112,10 @@
     nb-card{
         height: unset;
     }
-    @include ga-overrides.input-appearance(42px, var(--gauzy-card-1));
+    // `--gauzy-card-1` is not emitted by every registered theme, and a bare
+    // `var()` with no fallback drops the whole `background-color` declaration
+    // there, leaving every input on this page transparent. `--card-background-color`
+    // is a core Nebular token present in all of them, and it is exactly what
+    // `gauzy-card-1` is aliased to in most themes anyway.
+    @include ga-overrides.input-appearance(42px, var(--gauzy-card-1, var(--card-background-color)));
 }

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/organization-list/organization-list.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/organization-list/organization-list.component.scss
@@ -1,7 +1,11 @@
 nb-list {
   height: fit-content;
   max-height: 116px;
-  border: 1px solid #edf1f7;
+  // Was `#edf1f7`, a near-white hairline that vanishes on the light themes and
+  // draws a bright box on the dark ones. Written as a custom property rather
+  // than `nb-theme()` because this stylesheet does not `@use 'themes'`, and it
+  // carries a fallback for the themes that do not emit the token.
+  border: 1px solid var(--gauzy-border-default-color, rgba(126, 126, 143, 0.1));
   margin-top: 10px;
   transform-origin: top center;
   transform: scaleY(0);

--- a/apps/gauzy/src/app/pages/organizations/table-components/organizations-status/organizations-status.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/table-components/organizations-status/organizations-status.component.scss
@@ -4,15 +4,18 @@
 // with its own padding around an inner coloured pill that has padding again, so
 // the cell paid for two boxes. Sized from the shared table-density tokens
 // (`$gauzy-density` in `themes.scss`); the literals are CSS-var fallbacks only.
+// `text-align: flex-start` was dropped from both pills below: `flex-start` is
+// not one of the values `text-align` accepts, so the browser threw the whole
+// declaration away and the pills have always taken their alignment from what
+// they inherit. Removing it changes nothing on screen; it only stops the rule
+// from claiming to do something it never did.
 .badge-danger {
-	text-align: flex-start;
 	padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 	background-color: nb-theme(color-danger-default);
 	margin-bottom: var(--gauzy-table-chip-gap, 0.1875rem);
 }
 
 .badge-success {
-	text-align: flex-start;
 	padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
 	background-color: nb-theme(color-success-default);
 }

--- a/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deal-form/pipeline-deal-form.component.html
+++ b/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deal-form/pipeline-deal-form.component.html
@@ -38,7 +38,11 @@
             <label class="label" for="client">
               {{ 'PIPELINE_DEAL_CREATE_PAGE.SELECT_CLIENT' | translate }}
             </label>
-            <nb-select formControlName="clientId" placeholder="Clients" [selected]="selectedClient">
+            <nb-select
+              formControlName="clientId"
+              [placeholder]="'FORM.PLACEHOLDERS.CLIENTS' | translate"
+              [selected]="selectedClient"
+              >
               @for (client of clients$ | async; track client) {
                 <nb-option [value]="client.id">
                   {{ client.name }}

--- a/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deal-form/pipeline-deal-form.component.scss
+++ b/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deal-form/pipeline-deal-form.component.scss
@@ -6,5 +6,10 @@
 }
 
 nb-card-body {
-	background-color: var(--gauzy-card-2);
+	// Fallback required: `--gauzy-card-2` is undefined in material-light and
+	// material-dark — `themes.scss` registers those two against Nebular's own
+	// parent themes, which carry no `gauzy-card-*` keys — and a `var()` with no
+	// fallback makes the browser discard the whole declaration, leaving the deal
+	// form's body unpainted there.
+	background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
 }

--- a/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deals.component.html
+++ b/apps/gauzy/src/app/pages/pipelines/pipeline-deals/pipeline-deals.component.html
@@ -4,7 +4,15 @@
 		<div class="card-header-title">
 			<ngx-back-navigation></ngx-back-navigation>
 			<h4>
-				<span> {{ 'PIPELINE_DEALS_PAGE.HEADER' | translate }} </span> | <span> {{ pipeline?.name }} </span>
+				<!--
+					Routed through `ngx-header-title` like every other page: that is
+					what renders the breadcrumb trail under the heading, and this was
+					the only page in Pipelines still building its title by hand, so it
+					was the only one with no trail at all.
+				-->
+				<ngx-header-title [allowEmployee]="false">
+					<span> {{ 'PIPELINE_DEALS_PAGE.HEADER' | translate }} </span> | <span> {{ pipeline?.name }} </span>
+				</ngx-header-title>
 			</h4>
 		</div>
 		<div class="gauzy-button-container">

--- a/apps/gauzy/src/app/pages/pipelines/pipelines.component.scss
+++ b/apps/gauzy/src/app/pages/pipelines/pipelines.component.scss
@@ -26,7 +26,12 @@
   }
   nb-card,
   nb-tab.content-active {
-    background-color: var(--gauzy-card-2);
+    // Fallback required: `--gauzy-card-2` is undefined in material-light and
+    // material-dark — `themes.scss` registers those two against Nebular's own
+    // parent themes, so they never inherit the `gauzy-card-*` keys — and a
+    // `var()` without one makes the browser drop the whole declaration, which
+    // left the tab body unpainted there.
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   }
   nb-card-body {
     overflow: unset;

--- a/apps/gauzy/src/app/pages/pipelines/stage-form/stage-form.component.html
+++ b/apps/gauzy/src/app/pages/pipelines/stage-form/stage-form.component.html
@@ -25,10 +25,16 @@
           [cdkDragData]="stage"
           >
           <nb-accordion-item-header>
+            <!--
+              `danger`, not `warning`: this deletes a stage, and every other
+              delete control in the app is red. Amber reads as "careful" and put
+              this button in a different colour language from the trash icons
+              beside every other list.
+            -->
             <button
               nbButton
               size="tiny"
-              status="warning"
+              status="danger"
               type="button"
 						(click)="
 							isAdding &&

--- a/apps/gauzy/src/app/pages/pipelines/table-components/pipeline-deal-probability/pipeline-deal-probability.component.scss
+++ b/apps/gauzy/src/app/pages/pipelines/table-components/pipeline-deal-probability/pipeline-deal-probability.component.scss
@@ -1,0 +1,51 @@
+// Probability chip for the DEALS list.
+//
+// The template writes Bootstrap 4's `.badge-*` MODIFIER classes without the
+// `.badge` base class, and this component had no stylesheet of its own, so the
+// cell rendered as a full-width, square-cornered block with no padding, filled
+// with Bootstrap's own literals — #dc3545 / #ffc107 / #28a745 / #007bff — and
+// white text, identically in all eight themes.
+//
+// Re-drawn as the tinted chip the rest of the app uses. Colours come from the
+// `gauzy-action-*` accents defined in `themes.scss`; those are merged into
+// EVERY registered theme (in a light and a dark set), so a chip stays legible
+// on the white card and on the near-black one alike. The literals are only
+// `var()` fallbacks — see the note on `--gauzy-*` tokens in the sibling page
+// stylesheets — and carry the light-set values.
+.badge-danger,
+.badge-warning,
+.badge-success,
+.badge-primary {
+	// The template's own wrapper is `text-center` with a 5rem min-width; the chip
+	// itself is sized by its label, like every other status pill in the tables.
+	display: inline-block;
+	padding: var(--gauzy-table-chip-padding-y, 0.0625rem) var(--gauzy-table-chip-padding-x, 0.375rem);
+	border-radius: var(--gauzy-radius-sm, 0.375rem);
+	font-size: var(--gauzy-table-header-font-size, 0.75rem);
+	font-weight: 600;
+	line-height: var(--gauzy-table-header-line-height, 0.9375rem);
+	// The chip wraps as a whole rather than breaking "3 - Medium" over two lines.
+	white-space: nowrap;
+}
+
+.badge-danger {
+	color: var(--gauzy-action-danger-text, #dc2626);
+	background-color: var(--gauzy-action-danger-tint, rgba(220, 38, 38, 0.08));
+}
+
+.badge-warning {
+	color: var(--gauzy-action-warning-text, #b45309);
+	background-color: var(--gauzy-action-warning-tint, rgba(180, 83, 9, 0.08));
+}
+
+.badge-success {
+	color: var(--gauzy-action-success-text, #047857);
+	background-color: var(--gauzy-action-success-tint, rgba(4, 120, 87, 0.08));
+}
+
+// "Unknown" is the absence of a probability rather than a status of its own, so
+// it stays neutral instead of borrowing one of the accents.
+.badge-primary {
+	color: var(--text-hint-color);
+	background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
+}

--- a/apps/gauzy/src/app/pages/pipelines/table-components/pipeline-deal-probability/pipeline-deal-probability.component.ts
+++ b/apps/gauzy/src/app/pages/pipelines/table-components/pipeline-deal-probability/pipeline-deal-probability.component.ts
@@ -4,6 +4,7 @@ import { IDeal } from '@gauzy/contracts';
 @Component({
 	selector: 'ga-pipeline-deal-probability',
 	templateUrl: './pipeline-deal-probability.component.html',
+	styleUrls: ['./pipeline-deal-probability.component.scss'],
 	standalone: false
 })
 export class PipelineDealProbabilityComponent implements OnInit {

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
@@ -1,17 +1,5 @@
 @use 'gauzy/_gauzy-table' as *;
 
-.setting-name {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.body-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 35px;
-}
-
 .sub-header {
   margin-bottom: 20px;
   font-weight: bold;
@@ -56,14 +44,6 @@
   }
 }
 
-.container {
-  padding: 0;
-}
-
-.container::-webkit-scrollbar {
-  display: none;
-}
-
 :host {
   nb-card,
   nb-card-header {
@@ -86,13 +66,31 @@
     padding: 8px;
   }
 }
+// One `.container` rule. There were two — a `padding: 0` block a few lines up
+// that the later one silently overrode — plus a bare `.container::-webkit-scrollbar`
+// rule sitting between them. The two dead blocks that used to sit above them,
+// `.setting-name` and `.body-header`, matched nothing in either template that
+// uses this stylesheet.
+//
+// The rows are laid out with fixed column widths (~57rem), so this really does
+// need to scroll sideways on a narrow viewport; what it does NOT need is
+// `overflow-x: scroll`, which reserves a scrollbar gutter unconditionally. With
+// `auto` the bar only exists when there is something to scroll, and the two
+// hide-the-bar declarations now cover Firefox as well as WebKit rather than
+// WebKit alone.
 .container {
   padding: 0.5rem;
-  overflow-x: scroll;
+  overflow-x: auto;
+  scrollbar-width: none;
   height: 100%;
   margin: 0;
   max-width: unset;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
+
 .history {
   align-items: center;
   gap: 8px;

--- a/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
+++ b/apps/gauzy/src/app/pages/recurring-expense-employee/recurring-expense-employee.component.scss
@@ -1,17 +1,40 @@
 @use 'gauzy/_gauzy-table' as *;
 
+// Removed `.setting-name` (font-size 24px / bold) and `.body-header` (flex row,
+// margin-bottom 35px). This stylesheet is emitted for exactly two templates —
+// recurring-expense-employee.component.html and, through the `@forward` in
+// expense-recurring.component.scss, expense-recurring.component.html — and
+// neither carries either class, so both blocks styled nothing.
+
 .sub-header {
   margin-bottom: 20px;
   font-weight: bold;
-  background-color: nb-theme(gauzy-card-3);
+  // `gauzy-card-3` / `gauzy-text-color-2` are not registered by the
+  // material-light and material-dark themes, and a bare `var(--…)` that
+  // resolves to nothing makes the whole declaration invalid, which would leave
+  // this band transparent with inherited text. The fallbacks are neutral
+  // translucent values that read correctly on a light and on a dark surface.
+  background-color: var(--gauzy-card-3, rgba(126, 126, 143, 0.12));
   padding: 0.75rem;
   border-radius: nb-theme(border-radius);
-  color: nb-theme(gauzy-text-color-2);
+  // Chained rather than a single literal: this fallback is reached only by
+  // material-light and material-dark, and no one fixed grey serves both — the
+  // old `rgba(126, 126, 143, 1)` is about 3.6:1 on a light band, under the 4.5:1
+  // needed for normal text (the same reason gauzy-light overrides this token to
+  // `rgba(91, 91, 107, 1)`; see themes.scss). Nebular defines `text-hint-color`
+  // in every theme and it adapts, so it takes the middle step.
+  color: var(--gauzy-text-color-2, var(--text-hint-color, rgba(113, 113, 122, 1)));
 }
 
 :host .header-content {
   display: flex;
-  margin: auto 8px auto 16px;
+  // Leading inset matched to the `.table-scroll` padding below (18px) so the
+  // column header band and its labels line up with the rows under it; it was
+  // 16px, i.e. 2px to the left of every row. The RTL override is new: the old
+  // shorthand kept the wide inset on the left in both directions. The `auto`
+  // top/bottom margins it also carried resolved to 0 in this block context.
+  margin: 0 8px 0 18px;
+  @include nb-rtl(margin, 0 18px 0 8px);
 
   .header-info {
     display: flex;
@@ -44,10 +67,18 @@
   }
 }
 
+// Removed a first `.container { padding: 0 }` block that sat here: the second
+// `.container` block at the bottom of this file has the same specificity and
+// comes later, so its `padding: 0.5rem` always won. Its `::-webkit-scrollbar`
+// rule moved into that block too, rather than sitting loose up here.
+
 :host {
   nb-card,
   nb-card-header {
-    background-color: var(--gauzy-card-2);
+    // Fallback because `gauzy-card-2` is not registered by material-light /
+    // material-dark; without it the declaration is dropped there and the card
+    // paints transparent over the page canvas.
+    background-color: var(--gauzy-card-2, var(--card-background-color));
   }
 
   .settings-body {
@@ -80,6 +111,10 @@
 // WebKit alone.
 .container {
   padding: 0.5rem;
+  // `scroll` kept a horizontal scrollbar reserved at all times. The
+  // `::-webkit-scrollbar` rule above hides it in Blink/WebKit but does nothing
+  // in Firefox, where an always-on bar sat under the list even when the rows
+  // fitted. `auto` only scrolls when the row width actually overflows.
   overflow-x: auto;
   scrollbar-width: none;
   height: 100%;

--- a/apps/gauzy/src/app/pages/reports/all-report/all-report/all-report.component.scss
+++ b/apps/gauzy/src/app/pages/reports/all-report/all-report/all-report.component.scss
@@ -19,8 +19,13 @@
   a {
     text-decoration: none;
   }
+  // The report description. `height: 27px` fits exactly one line, but the seeded
+  // descriptions run 60-90 characters and the grid track is `minmax(21rem, 1fr)`
+  // — so on most cards the second line spilled out of the box and landed on top
+  // of the screenshot below it. A MIN height keeps the single-line cards aligned
+  // with each other and lets the rest push the image down instead.
   .caption {
-    height: 27px;
+    min-height: 27px;
   }
   .image-container {
     position: relative;
@@ -83,9 +88,11 @@ nb-card-body {
   border-radius: 0 0 nb-theme(border-radius) nb-theme(border-radius);
 }
 
-::-webkit-scrollbar {
-  display: none;
-}
+// NOTE: `::-webkit-scrollbar { display: none }` used to sit here. Emulated
+// encapsulation scopes it to this component's own elements, so it hid the
+// scrollbar on the card body holding the whole report grid: the page still
+// scrolled — several category rows deep — with nothing on screen saying so, and
+// it was the only page in this area without the normal scrollbar.
 
 .report-category-name {
   font-size: 16px;

--- a/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.html
+++ b/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.html
@@ -8,24 +8,50 @@
 	</nb-card-header>
 	<nb-card-body>
 		@if (!environment.DEMO) {
+		<!--
+			These two used to be Bootstrap `.btn.btn-danger`. bootstrap.css is loaded
+			globally (apps/gauzy/project.json), so they took Bootstrap's own red, its
+			0.25rem radius and its 0.375rem/0.75rem padding — the only buttons left in
+			the app that ignored the Nebular theme and its density.
+
+			`btn` — the class that carried the layout — is gone; `btn-danger` stays
+			because `apps/gauzy-e2e/.../DangerZonePageObject.ts` selects
+			`nb-card-body button.btn-danger`. On its own that class sets nothing but
+			color / background-color / border-color, and every one of those is
+			out-ranked by Nebular's `[nbButton].appearance-filled.status-danger`, so it
+			is now purely a test hook.
+		-->
 		<ng-template ngxPermissionsOnly="ACCESS_DELETE_ACCOUNT">
-			<button type="button" class="btn btn-danger" (click)="deleteAccount()">
+			<button type="button" nbButton status="danger" size="small" class="btn-danger" (click)="deleteAccount()">
 				<nb-icon class="mr-1" icon="trash-2-outline"> </nb-icon>
 				{{ 'BUTTONS.DELETE_ACCOUNT' | translate }}
 			</button>
 		</ng-template>
 		<ng-template ngxPermissionsOnly="ACCESS_DELETE_ALL_DATA">
-			<button type="button" class="btn btn-danger ml-3 mr-3" [disabled]="loading" (click)="deleteAllData()">
+			<button
+				type="button"
+				nbButton
+				status="danger"
+				size="small"
+				class="btn-danger ml-3 mr-3"
+				[disabled]="loading"
+				(click)="deleteAllData()"
+			>
 				<nb-icon class="mr-1" icon="trash-2-outline"> </nb-icon>
 				{{ 'BUTTONS.DELETE_ALL_DATA' | translate }}
 			</button>
 		</ng-template>
 		@if (process !== 0) {
-		<div class="mt-4">
-			<span style="display: block">
+		<div class="queue-progress mt-4">
+			<span class="queue-progress-label">
 				{{ 'MENU.IMPORT_EXPORT.QUEUE_PROGRESS' | translate }}
 			</span>
-			<br />
+			<!--
+				Bootstrap's `.progress` track is a hardcoded #e9ecef and its `.progress-bar`
+				fill a hardcoded #007bff: a light-grey rail with a blue bar, on every theme.
+				The classes are kept (the shape is Bootstrap's) but the colours now come
+				from theme tokens — see danger-zone.component.scss.
+			-->
 			<div class="progress">
 				<div class="progress-bar" role="progressbar" [style.width]="process + '%'"></div>
 			</div>

--- a/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.scss
+++ b/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.scss
@@ -1,0 +1,36 @@
+@use 'themes' as *;
+
+// The "delete all data" queue progress indicator.
+//
+// The markup is Bootstrap's (`.progress` > `.progress-bar`) and bootstrap.css is
+// loaded globally, so both boxes were taking Bootstrap's own constants: a #e9ecef
+// track and a #007bff fill. That is a light-grey rail with a blue bar on all eight
+// themes — near-invisible on the near-black ones, and the only blue on a page whose
+// every other control is danger-red. Same geometry, theme tokens for the colours.
+.queue-progress {
+	max-width: 32rem;
+
+	.queue-progress-label {
+		display: block;
+		margin-bottom: 0.5rem;
+		font-size: nb-theme(text-label-font-size);
+		color: nb-theme(text-hint-color);
+	}
+
+	// `background-basic-color-3` rather than one of the `gauzy-*` surface tokens:
+	// the latter are only registered on default/cosmic/corporate/dark, so on the
+	// two material themes the track would resolve to an undefined custom property
+	// and the rail would simply vanish.
+	.progress {
+		height: 0.5rem;
+		border-radius: nb-theme(border-radius);
+		background-color: nb-theme(background-basic-color-3);
+		overflow: hidden;
+	}
+
+	.progress-bar {
+		height: 100%;
+		background-color: nb-theme(color-danger-default);
+		transition: width 0.3s ease;
+	}
+}

--- a/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.ts
+++ b/apps/gauzy/src/app/pages/settings/danger-zone/danger-zone.component.ts
@@ -14,6 +14,7 @@ import { DangerZoneMutationComponent } from '@gauzy/ui-core/shared';
 @Component({
     selector: 'ga-danger-zone',
     templateUrl: './danger-zone.component.html',
+    styleUrls: ['./danger-zone.component.scss'],
     standalone: false
 })
 export class DangerZoneComponent extends TranslationBaseComponent implements OnInit {

--- a/apps/gauzy/src/app/pages/settings/email-history/email-history.component.scss
+++ b/apps/gauzy/src/app/pages/settings/email-history/email-history.component.scss
@@ -177,8 +177,15 @@
         > span {
           display: flex;
 
+          // From / To / Subject / Language / Template labels. `width: 90px` alone
+          // is only a flex BASIS: the value beside it (an email address, a long
+          // template title) has a wide content base of its own, so when the pair
+          // overflowed the line both shrank in proportion — the label lost width
+          // and wrapped, and it did so by a different amount on each of the five
+          // rows, so the label column never lined up. Fixing the basis and
+          // forbidding the shrink keeps one straight column.
           .col-fixed {
-            width: 90px;
+            flex: 0 0 90px;
             display: block;
           }
         }

--- a/apps/gauzy/src/app/pages/settings/file-storage/file-storage.component.scss
+++ b/apps/gauzy/src/app/pages/settings/file-storage/file-storage.component.scss
@@ -1,3 +1,10 @@
+// `@forward` re-exports the SMS-gateway sheet to anything that loads THIS file;
+// it does not bring that sheet's own imports into scope here. Without a `@use`
+// of the theme module `nb-theme` was not a Sass function at all — and Sass lets
+// an unknown function through as plain CSS, so every declaration below shipped as
+// the literal text `nb-theme(gauzy-card-4)` and the browser dropped it. The
+// provider card, its footer and its radii have been rendering unstyled.
+@use 'themes' as *;
 @forward '../sms-gateway/sms-gateway.component';
 
 :host {
@@ -9,15 +16,26 @@
     }
     nb-card {
         nb-card-body {
+            // The provider configuration card (S3 / Wasabi / Cloudinary / DigitalOcean).
+            //
+            // `height` pinned it to a viewport-derived box regardless of how many
+            // fields the selected provider actually has — four rows for S3, seven
+            // for DigitalOcean — so short forms sat in a tall empty panel while the
+            // outer `.card-scroll` card, already bounded by the page frame, scrolled
+            // around it. As a MAX it still caps a long form (which then scrolls in
+            // its own body, as before) and lets a short one shrink to its content.
             nb-card {
                 background-color: nb-theme(gauzy-card-4);
-                height: calc(100vh - 24rem) !important;
+                max-height: calc(100vh - 24rem);
                 margin: 0;
 
+                // Was 18px. `text-heading-6-font-size` is the 1rem step the density
+                // pass set for every theme; an 18px section title here was the only
+                // h6 in Settings that ignored it.
                 h6 {
-                    font-size: 18px;
+                    font-size: nb-theme(text-heading-6-font-size);
                     font-weight: 600;
-                    line-height: 19px;
+                    line-height: 1.25;
                     letter-spacing: 0em;
                 }
 

--- a/apps/gauzy/src/app/pages/settings/monitoring/monitoring.component.scss
+++ b/apps/gauzy/src/app/pages/settings/monitoring/monitoring.component.scss
@@ -6,6 +6,20 @@
 }
 
 // main sections
+//
+// Two problems, one rule. The card carries `.card-scroll`, so the page frame
+// already bounds it to the viewport — but this block re-derived a height of its
+// own from `100vh` minus a hand-tuned 19.25rem, a number measured against older
+// chrome and now wrong by the height of the breadcrumb trail the card header
+// gained. And it declared `overflow: hidden` immediately followed by
+// `overflow-y: scroll`, so the second won and painted a permanently visible
+// track whether or not there was anything to scroll.
+//
+// The column that is MEANT to scroll is `.accordion-section` — it reserves an 8px
+// gutter for its own scrollbar, and `.aside-nav` is `height: fit-content` so the
+// service list can stay put while the fields move. Fill the card body and clip
+// here; the accordion column does the scrolling. (At the `md` breakpoint the two
+// stack into a column and this becomes the scroll box instead — see below.)
 :host .main-form {
   width: 100%;
   background-color: nb-theme(gauzy-card-2);
@@ -14,9 +28,9 @@
   padding: 20px;
   @include nb-ltr(padding-right, 8px);
   @include nb-rtl(padding-left, 8px);
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
-  height: calc(100vh - 19.25rem);
-  overflow-y: scroll;
 }
 
 .aside-nav {
@@ -81,9 +95,13 @@
   padding: 0;
 }
 
+// The page's one scroll box. The `- 3rem` in `max-height` cut the box short of
+// the column it sits in, so the accordion always stopped 3rem above the card's
+// bottom edge with a dead strip beneath it — room the fields could have used.
+// Now that `.main-form` clips rather than scrolls, the column IS the budget.
 :host .accordion-section {
   overflow: auto;
-  max-height: calc(100% - 3rem);
+  max-height: 100%;
   @include nb-ltr(padding-right, 8px);
   @include nb-rtl(padding-left, 8px);
 }
@@ -100,9 +118,12 @@
   max-width: 49% !important;
 }
 
-.active {
-  background: #ffffff;
-}
+// NOTE: a bare `.active { background: #ffffff }` used to sit here. The only
+// elements in this template that take `.active` are the service rows in
+// `.aside-nav`, which the rule above already paints with a theme token — so all
+// this one could ever do was drop a literal white block into the seven themes
+// where white is the wrong surface. Removed rather than mapped to a token: there is
+// nothing left for it to style.
 
 // start of nb-overrides
 nb-accordion {
@@ -118,7 +139,11 @@ nb-accordion {
       border-radius: 6px;
       width: 23px;
       height: 23px;
-      border: 1px solid rgba(66, 66, 66, 0.2);
+      // Was `rgba(66, 66, 66, 0.2)` — 20% of the LIGHT theme's body colour, so
+      // the expand/collapse chevron lost its box entirely on the dark canvas.
+      // The shared hairline token darkens a light surface and lightens a dark
+      // one, which is the only way one value works in all eight themes.
+      border: 1px solid nb-theme(gauzy-border-default-color);
     }
   }
 
@@ -209,8 +234,15 @@ nb-accordion {
     padding-right: 0;
   }
 
-  .main-form {
+  // Stacked, the service list is no longer a column beside the fields, so the
+  // accordion column has no cross-axis height to bound its own scroll box. The
+  // whole pane scrolls as one instead — which is also what you want on a narrow
+  // screen, since the service list would otherwise take a fixed slice of it.
+  // `:host` prefix so this out-ranks the `overflow: hidden` above on specificity
+  // rather than on source order.
+  :host .main-form {
     flex-direction: column;
+    overflow-y: auto;
   }
 
   .aside-nav {

--- a/apps/gauzy/src/app/pages/settings/roles-permissions/roles-permissions.component.html
+++ b/apps/gauzy/src/app/pages/settings/roles-permissions/roles-permissions.component.html
@@ -98,8 +98,13 @@
                     [disabled]="isDisabledGeneralPermissions()"
                     >
                     <div class="custom-permission-view">
+                      <!--
+                        The <small> line under this one used to render the SAME
+                        translation key, so every row printed its label twice —
+                        once bold, once as a 11px grey "description". There are no
+                        *_DESCRIPTION keys in the catalogue for it to have meant.
+                      -->
                       <strong>{{ 'ORGANIZATIONS_PAGE.PERMISSIONS.' + permission | translate }}</strong>
-                      <small>{{ 'ORGANIZATIONS_PAGE.PERMISSIONS.' + permission | translate }}</small>
                     </div>
                   </nb-toggle>
                 }
@@ -129,8 +134,8 @@
                     [disabled]="isDisabledAdministrationPermissions()"
                     >
                     <div class="custom-permission-view">
+                      <!-- Same duplicated-label removal as the General group above. -->
                       <strong>{{ 'ORGANIZATIONS_PAGE.PERMISSIONS.' + permission | translate }}</strong>
-                      <small>{{ 'ORGANIZATIONS_PAGE.PERMISSIONS.' + permission | translate }}</small>
                     </div>
                   </nb-toggle>
                 }

--- a/apps/gauzy/src/app/pages/settings/roles-permissions/roles-permissions.component.scss
+++ b/apps/gauzy/src/app/pages/settings/roles-permissions/roles-permissions.component.scss
@@ -9,7 +9,10 @@
   width: fit-content;
   color: nb-theme(color-danger-default);
   padding-right: 10px;
-  font-weight: 600px;
+  // Was `600px`. `font-weight` takes a number, not a length, so the declaration
+  // was invalid and dropped at parse time — the "Create new role" / "Delete
+  // existing role" lines have been rendering at the inherited weight ever since.
+  font-weight: 600;
 }
 
 .delete {
@@ -53,6 +56,9 @@
   border-radius: nb-theme(border-radius);
 }
 
+// One label per permission row. The `<small>` description this used to style was
+// bound to the same translation key as the `<strong>` above it, so it is gone from
+// the template — and with it the 5px gap that was only there to separate the two.
 .custom-permission-view {
   display: flex;
   flex-direction: column;
@@ -64,16 +70,6 @@
     letter-spacing: 0em;
     text-align: left;
     color: nb-theme(gauzy-text-color-1);
-    margin-bottom: 5px;
-  }
-
-  small {
-    font-size: 11px;
-    font-weight: 400;
-    line-height: 13px;
-    letter-spacing: 0em;
-    text-align: left;
-    color: nb-theme(gauzy-text-color-2);
   }
 }
 

--- a/apps/gauzy/src/app/pages/settings/sms-gateway/sms-gateway.component.html
+++ b/apps/gauzy/src/app/pages/settings/sms-gateway/sms-gateway.component.html
@@ -17,6 +17,11 @@
           {{ 'SMS_GATEWAY_PAGE.' + provider | translate }}
         </nb-toggle>
       }
-      <div class="content"></div>
+      <!--
+        An empty `<div class="content"></div>` used to close this body. Nothing
+        ever rendered into it, and its stylesheet gave it a near-white fill and a
+        `calc(100vh - 18rem)` height — a page-tall blank panel under the provider
+        toggles as soon as those styles applied. Both are gone.
+      -->
     </nb-card-body>
   </nb-card>

--- a/apps/gauzy/src/app/pages/settings/sms-gateway/sms-gateway.component.scss
+++ b/apps/gauzy/src/app/pages/settings/sms-gateway/sms-gateway.component.scss
@@ -1,16 +1,23 @@
+// `@forward` re-exports the features sheet downstream; it does NOT put that
+// sheet's imports in scope here. With no `@use` of the theme module `nb-theme`
+// was not a Sass function, and Sass passes an unknown function through as plain
+// CSS — so all four declarations below reached the browser as the literal text
+// `nb-theme(gauzy-card-2)` and were dropped as invalid. The card surfaces and the
+// body's bottom radii on SMS Gateway (and on File Storage, which forwards this
+// file) have never been painted.
+@use 'themes' as *;
 @forward '../feature/feature.component';
 
+// NOTE: a `.content` rule used to sit inside this block — a near-white fill on a
+// `calc(100vh - 18rem)` box, for an empty `<div class="content"></div>` that the
+// template renders under the provider toggles and never puts anything in. It has
+// been invisible all this time only because of the missing `@use` above; with the
+// theme function working it would have become a page-tall blank panel. The empty
+// div goes with it (see sms-gateway.component.html).
 :host {
     nb-card,
     nb-card-body {
         background-color: nb-theme(gauzy-card-2);
-
-        .content {
-            background-color: nb-theme(gauzy-card-4);
-            height: calc(100vh - 18rem);
-            width: 100%;
-            border-radius: nb-theme(border-radius);
-        }
     }
 
     nb-card-body {

--- a/apps/gauzy/src/app/pages/tags/tags-color/tags-color.component.scss
+++ b/apps/gauzy/src/app/pages/tags/tags-color/tags-color.component.scss
@@ -1,10 +1,34 @@
+/*
+ * The tag-name cell of the Tags table: an `nb-badge` painted with the tag's own
+ * colour.
+ *
+ * `nb-badge` sets `position: absolute` on its own host, so it contributes no
+ * height at all — the wrapper below has to state one, and the chip's own numbers
+ * have to add up to it or the chip spills out of the box that is supposed to
+ * hold it. They did not: 12.5px of padding around a 17px line is a 42px chip in
+ * a 32px frame, and the 19px margins above and below were what kept the overflow
+ * from colliding with the rows either side. That cost every row ~70px, in a
+ * table the density pass had just brought down to ~34px.
+ *
+ * Both boxes now come from the shared in-cell badge tokens and are the same
+ * height, so the chip fills its frame instead of bursting it and this column
+ * costs a row no more than any other chip in the app. The tokens live in
+ * `$gauzy-density` (themes.scss), which is merged into all eight themes; the
+ * fallbacks are their current values, for the two material themes that register
+ * against Nebular's own themes rather than the gauzy default.
+ */
 .color {
   width: 100%;
-  padding: 12.5px 10px;
+  // Exactly one line box, matching the wrapper, with the line height doing the
+  // vertical centering.
+  height: var(--gauzy-table-badge-height, 1.25rem);
+  padding: 0 var(--gauzy-table-chip-padding-x, 0.375rem);
   border-radius: 4px;
-  font-size: 14px;
+  // The tag name is this column's primary value, so it stays at the table's own
+  // cell size rather than dropping to the smaller secondary-chip step.
+  font-size: var(--gauzy-table-font-size, 0.8125rem);
   font-weight: 600;
-  line-height: 17px;
+  line-height: var(--gauzy-table-badge-height, 1.25rem);
   letter-spacing: 0em;
   text-align: center;
   white-space: nowrap;
@@ -14,11 +38,11 @@
 
 div {
   width: 100%;
-  height: 100%;
   display: flex;
-  margin: 19px 0;
+  // Was `height: 100%` immediately followed by `height: 32px` — the first never
+  // applied. One height now, and it is the height the chip above is drawn at.
+  height: var(--gauzy-table-badge-height, 1.25rem);
   justify-content: center;
-  height: 32px;
   align-items: center;
   position: relative;
 }

--- a/apps/gauzy/src/app/pages/tags/tags.component.html
+++ b/apps/gauzy/src/app/pages/tags/tags.component.html
@@ -11,6 +11,7 @@
             @for (option of filterOptions; track option) {
               <nb-list-item
                 class="filter-item"
+                [class.selected]="selectedFilterValue === option.value"
                 (click)="selectedFilterOption(option.value)"
                 >
                 {{ option.displayName }}

--- a/apps/gauzy/src/app/pages/tags/tags.component.scss
+++ b/apps/gauzy/src/app/pages/tags/tags.component.scss
@@ -1,11 +1,21 @@
 @use 'gauzy/_gauzy-cards' as *;
 @use 'gauzy/_gauzy-table' as *;
 
+/*
+ * Every `var(--gauzy-…)` below carries a fallback. `material-light` and
+ * `material-dark` register against Nebular's own material themes instead of the
+ * gauzy default, so none of the `gauzy-card-*` / `gauzy-shadow` /
+ * `gauzy-sidebar-background-*` keys reach them (themes.scss lines 501-554), and
+ * a `var()` that resolves to nothing takes its whole declaration with it — which
+ * is how the filter rail, the search field and the table card all lost their
+ * surfaces on two of the eight themes.
+ */
+
 :host .search {
   margin: 20px 0 0 0;
   align-items: center;
   display: flex;
-  background-color: var(--gauzy-sidebar-background-3);
+  background-color: var(--gauzy-sidebar-background-3, rgba(126, 126, 143, 0.1));
   border-radius: 8px;
   height: 32px;
   padding: 0 8px;
@@ -26,17 +36,52 @@
   }
 }
 
-.tags-table {
-  padding-top: 10px;
+/*
+ * REMOVED: `.tags-table { padding-top: 10px }` — `tags-table` occurs nowhere in
+ * the repository except this declaration (the table lives in
+ * `.table-scroll-container`, which is styled further down).
+ */
+
+/*
+ * The tag-type filter chips.
+ *
+ * Base first, then hover, then selected, so the file reads in the order the
+ * browser resolves them — the resting rule used to be declared ~50 lines BELOW
+ * its own `:hover`.
+ */
+.filter-item {
+  padding: 10px 15px;
+  box-shadow: var(--gauzy-shadow, 0 1px 1px 0 rgba(0, 0, 0, 0.15));
+  background: var(--gauzy-card-3, rgba(126, 126, 143, 0.05));
+  border-radius: 20px;
+  height: 36px;
+  // `nb-list-item` draws a `list-item-divider` along its bottom edge — right for
+  // a stacked list, wrong for pills in a wrapping row, where it left a hairline
+  // hanging under each chip.
+  border: none;
 }
 
+// Underlining the label was the only hover feedback a chip had, which reads as a
+// link on something drawn as a pill; the pill itself never moved. The shared
+// tint does the whole job, and it is the one every other hover surface uses.
 .filter-item:hover {
-  text-decoration: underline;
   cursor: pointer;
+  background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+}
+
+// Which type is currently filtering the table. Selecting one used to change the
+// table and leave the rail looking untouched, so the only way to tell what you
+// were looking at was to remember what you clicked. Declared after `:hover` at
+// equal specificity, so a selected chip keeps reading as selected under the
+// pointer.
+.filter-item.selected {
+  background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+  color: nb-theme(text-basic-color);
+  font-weight: 600;
 }
 
 :host nb-card.filter {
-  background-color: var(--gauzy-card-2);
+  background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   overflow: unset;
   @include nb-ltr(padding-right, 4px);
   @include nb-rtl(padding-left, 4px);
@@ -64,14 +109,6 @@
   gap: 10px;
 }
 
-.filter-item {
-  padding: 10px 15px;
-  box-shadow: var(--gauzy-shadow);
-  background: var(--gauzy-card-3);
-  border-radius: 20px;
-  height: 36px;
-}
-
 .gauzy-action {
   display: flex;
   justify-content: flex-end;
@@ -81,7 +118,7 @@
 :host {
   nb-card.tags-component,
   nb-card.tags-component nb-card-body {
-    background-color: var(--gauzy-card-2);
+    background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
     margin: 0;
     display: flex;
     flex-direction: column;

--- a/apps/gauzy/src/app/pages/tags/tags.component.ts
+++ b/apps/gauzy/src/app/pages/tags/tags.component.ts
@@ -32,6 +32,13 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 	disableButton = true;
 	private allTags = [];
 	filterOptions: Array<any> = [];
+	/**
+	 * Which entry of `filterOptions` is currently filtering the table. Selecting
+	 * a type changed the table and left the rail looking untouched, so the only
+	 * way to tell what you were looking at was to remember what you clicked.
+	 * `''` is the "All" entry, i.e. no filter.
+	 */
+	selectedFilterValue: string = '';
 	viewComponentName: ComponentEnum;
 	dataLayoutStyle = ComponentLayoutStyleEnum.TABLE;
 	componentLayoutStyleEnum = ComponentLayoutStyleEnum;
@@ -314,7 +321,32 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 			console.error('Error while retrieving tag types', error);
 			this.toastrService.danger('TAGS_PAGE.TAGS_FETCH_FAILED', 'Error fetching tag types');
 		} finally {
+			this.reconcileSelectedFilter();
 			this.loading = false;
+		}
+	}
+
+	/**
+	 * Drops a filter selection that no longer exists.
+	 *
+	 * `getTags()` resets `filterOptions` to just "All" and this method refills it from
+	 * the current organization's tag types, so a chip that was selected a moment ago can
+	 * simply be gone — switching organization is the usual way. Left alone, the rail then
+	 * highlights nothing at all, not even "All".
+	 *
+	 * The table needs the same treatment. `getTags()` runs BEFORE this method and skips
+	 * reloading while `_isFiltered` is still set, so it will have kept the previous
+	 * organization's filtered rows on screen. Reloading `allTags` — which `getTags()` has
+	 * already refreshed — puts the rail and the table back in agreement.
+	 */
+	private reconcileSelectedFilter() {
+		if (this.filterOptions.some((option) => option.value === this.selectedFilterValue)) {
+			return;
+		}
+		this.selectedFilterValue = '';
+		if (this._isFiltered) {
+			this._isFiltered = false;
+			this.smartTableSource.load(this.allTags);
 		}
 	}
 
@@ -376,6 +408,7 @@ export class TagsComponent extends PaginationFilterBaseComponent implements Afte
 	 * @returns
 	 */
 	selectedFilterOption(value: string) {
+		this.selectedFilterValue = value;
 		if (value === '') {
 			this._isFiltered = false;
 			this._refresh$.next(true);

--- a/apps/gauzy/src/app/pages/tasks/components/task/task.component.scss
+++ b/apps/gauzy/src/app/pages/tasks/components/task/task.component.scss
@@ -25,6 +25,17 @@ nb-card-body {
   }
 }
 
+// The sprint board is the card body's scrolling child, exactly like
+// `.table-scroll-container` is in the grid layout — @shared/_pg-card makes the
+// body a definite-height flex column, so this wrapper only has to pass that
+// height through to `ga-tasks-sprint-view` (which sizes itself from here).
+.sprint-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 :host ::ng-deep .sprint-view {
   nb-accordion {
     @include nb-ltr(padding-right, 0.5rem);

--- a/apps/gauzy/src/app/pages/tasks/components/task/tasks-layouts/tasks-sprint-view/task/task.component.scss
+++ b/apps/gauzy/src/app/pages/tasks/components/task/tasks-layouts/tasks-sprint-view/task/task.component.scss
@@ -8,9 +8,19 @@ nb-card {
 	margin-bottom: 8px;
 }
 
+// Selecting a card used to REPLACE the body's `--gauzy-shadow` with a bare
+// `-6px 0 0 0 rgba(0 0 0 / 10%)` bar. Two problems on the dark themes, where
+// `--gauzy-shadow` is the 1px hairline ring that gives the card its only edge:
+// the ring disappeared the moment a card was selected, and the replacement is a
+// 10 %-black bar drawn on a near-black canvas, i.e. no marker at all. Compose
+// the two instead, and paint the bar with the token the rest of the app uses
+// for a current row. `--gauzy-shadow` carries a literal fallback because the two
+// material themes register no gauzy tokens at all, and an unresolvable var()
+// anywhere in the list would drop the whole declaration — bar included.
 .selected {
 	background-color: var(--gauzy-sidebar-background-3);
-	box-shadow: -6px 0 0 0 rgba(0 0 0 / 10%);
+	box-shadow: -6px 0 0 0 var(--gauzy-active-tint, rgba(126, 126, 143, 0.2)),
+		var(--gauzy-shadow, 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18)));
 }
 
 .view {

--- a/apps/gauzy/src/app/pages/tasks/components/task/tasks-layouts/tasks-sprint-view/tasks-sprint-view.component.scss
+++ b/apps/gauzy/src/app/pages/tasks/components/task/tasks-layouts/tasks-sprint-view/tasks-sprint-view.component.scss
@@ -31,8 +31,25 @@
   color: var(--gauzy-text-color-1);
 }
 
+// The board scrolls inside the card body rather than against a guess at the
+// viewport. It used to be `height: calc(100vh - 24rem)`, hand-measured against
+// older page chrome: the card body the board sits in is sized by @shared/_pg-card
+// (`$default-card-height + 3.75rem`, i.e. roughly `100vh - 14rem` of chrome), so
+// the board stopped ~6rem short of the card and left a dead band under the
+// backlog on every screen size. `_pg-card` already makes that body a flex
+// column with a definite height — this joins the chain instead of restating it.
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .sprints {
-  height: calc(100vh - 24rem);
+  flex: 1 1 auto;
+  // Without this a flex item refuses to shrink below its content, which is what
+  // would push the card past the page frame instead of scrolling here.
+  min-height: 0;
   overflow: auto;
   border-radius: var(--border-radius);
 }

--- a/apps/gauzy/src/app/pages/time-off/time-off-settings/time-off-settings.component.html
+++ b/apps/gauzy/src/app/pages/time-off/time-off-settings/time-off-settings.component.html
@@ -57,8 +57,11 @@
     <!-- If the user does not have the 'ORG_JOB_EMPLOYEE_VIEW' permission -->
     <ng-template [ngxPermissionsExcept]="[PermissionsEnum.ALL_ORG_VIEW, PermissionsEnum.TIME_OFF_POLICY_VIEW]">
       <div>
-        <!-- Content to display if the user does not have the 'TIME_OFF_POLICY_VIEW' permission -->
-        <p>You don't have permission to view this page</p>
+        <!-- Content to display if the user does not have the 'TIME_OFF_POLICY_VIEW' permission.
+             `TIME_OFF_PAGE.NO_PERMISSION` is the identical string the parent Time Off page
+             already uses; this copy was hardcoded English, so it stayed English in every
+             other locale. -->
+        <p>{{ 'TIME_OFF_PAGE.NO_PERMISSION' | translate }}</p>
       </div>
     </ng-template>
   </nb-card-body>

--- a/apps/gauzy/src/app/pages/users/edit-user-mutation/edit-user-mutation.component.scss
+++ b/apps/gauzy/src/app/pages/users/edit-user-mutation/edit-user-mutation.component.scss
@@ -1,8 +1,14 @@
 @use 'gauzy/_gauzy-dialogs' as *;
 
 :host {
+    // The "Add existing user" panel that drops in above the users table.
+    // `rgba(50, 50, 50, 0.06)` is a hand-doubled copy of the LIGHT theme's
+    // `--gauzy-card-2` (`rgba(50, 50, 50, 0.03)`); as a literal it kept
+    // darkening an already near-black surface on the dark themes, so the panel
+    // had no edge against the page behind it. Read the token instead: light is
+    // effectively unchanged and dark gets the surface the other cards use.
     nb-card {
-        background: rgba(50, 50, 50, 0.06);
+        background: var(--gauzy-card-2);
     }
     .add-organization-action{
         gap: 1rem;

--- a/apps/gauzy/src/app/pages/vendors/vendors.component.html
+++ b/apps/gauzy/src/app/pages/vendors/vendors.component.html
@@ -119,12 +119,18 @@
 				<nb-icon icon="edit-outline"></nb-icon>
 				{{ 'BUTTONS.EDIT' | translate }}
 			</button>
+			<!--
+				`isDisabled` is not a member of VendorsComponent, nor of the
+				PaginationFilterBaseComponent it extends, so this bound to `undefined`:
+				Delete stayed fully lit beside a disabled Edit, and pressing it with
+				nothing selected read `selected.vendor.id` off null.
+			-->
 			<button
 				(click)="removeVendor(selected.vendor.id, selected.vendor.name)"
 				nbButton
 				status="basic"
 				class="action"
-				[disabled]="isDisabled"
+				[disabled]="disabled"
 				size="small"
 				[nbTooltip]="'BUTTONS.DELETE' | translate"
 			>

--- a/apps/gauzy/src/app/pages/vendors/vendors.component.scss
+++ b/apps/gauzy/src/app/pages/vendors/vendors.component.scss
@@ -3,6 +3,89 @@
 
 .editable {
   width: 525px;
+  // A hard width with nothing to stop it ran the dialog past both edges of a
+  // narrow viewport, footer buttons included.
+  max-width: calc(100vw - 3rem);
+  // The forwarded `expense-categories` stylesheet paints this panel with
+  // `nb-theme(gauzy-card-1)`, which compiles to a bare `var(--gauzy-card-1)`
+  // (Nebular runs in CSS-custom-property mode). That key is NOT registered for
+  // `material-light` / `material-dark` — both are registered against Nebular's
+  // own material themes rather than against the gauzy default (themes.scss lines
+  // 501-554) — so the declaration was dropped whole and the dialog body showed
+  // the backdrop through it. Restated with a fallback every theme can resolve.
+  background-color: var(--gauzy-card-1, var(--card-background-color));
+
+  /*
+   * Cancel, restated AFTER the forward so it wins at equal specificity.
+   *
+   * `expense-categories` paints `[nbButton].delete.appearance-outline` a literal
+   * `rgba(245, 109, 88, 1)` orange, 2px wide, with an orange glow on hover. That
+   * colour is in none of the eight themes, and it made the button you press to
+   * BACK OUT the loudest thing in the dialog — louder than Save, which the
+   * theme's own action tokens draw as a restrained accent. A hairline in the
+   * neutral border token with the shared hover tint instead.
+   */
+  [nbButton].delete.appearance-outline.status-basic {
+    background-color: transparent;
+    border-width: 1px;
+    border-color: nb-theme(border-basic-color-4);
+    color: nb-theme(text-hint-color);
+
+    &:hover {
+      border-color: nb-theme(border-basic-color-5);
+      color: nb-theme(text-basic-color);
+      background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+    }
+  }
+
+  // The orange hover glow that went with it.
+  [nbButton].delete.appearance-outline:hover {
+    box-shadow: none;
+  }
+
+  // The close control is a bare Font Awesome `<i>`, so it inherited the body
+  // size and full text contrast — as loud as the dialog title two lines under
+  // it. `expense-categories` gives it a pointer cursor and nothing else.
+  i.fa-times {
+    font-size: 0.75rem;
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
+
+    &:hover {
+      color: nb-theme(text-basic-color);
+    }
+  }
+}
+
+/*
+ * Row hover / selection, also restated after the forward.
+ *
+ * `expense-categories` gives BOTH states the same `rgba(50, 50, 50, 0.03)` fill,
+ * so hovering a row looked exactly like selecting one, and 3 % of black over a
+ * near-black card is nothing at all — on the four dark themes there was no
+ * visible selection. Selection also arrived as a 6px border that only exists
+ * when the row is selected, so the whole row jumped 6px sideways on click.
+ *
+ * Now: the neutral tints (they darken a light surface and lighten a dark one, so
+ * one value works in all eight themes), selection carried by the primary colour
+ * on the leading edge, and a transparent edge of the same width at rest so
+ * nothing moves.
+ */
+:host .custom-table {
+  @include nb-ltr(border-left, 3px solid transparent);
+  @include nb-rtl(border-right, 3px solid transparent);
+
+  // `:not(.selected)` because this rule is declared after `.selected` at the same
+  // specificity — without it, hovering a selected row would repaint it as merely
+  // hovered.
+  &:hover:not(.selected) {
+    background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+  }
+
+  &.selected {
+    background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+    @include nb-ltr(border-left, 3px solid var(--color-primary-default));
+    @include nb-rtl(border-right, 3px solid var(--color-primary-default));
+  }
 }
 
 :host nb-card-body {
@@ -19,12 +102,18 @@
 }
 
 .columns-header {
-  background-color: nb-theme(gauzy-card-2);
+  // Same story as `.editable` above: `nb-theme(gauzy-card-2)` is a bare
+  // `var(--gauzy-card-2)` and that key is missing from the two material themes,
+  // where the column-title band therefore had no background and merged into the
+  // card behind it.
+  background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
   border-radius: 8px;
   margin-bottom: 10px;
   padding-top: 12px;
   padding-bottom: 12px;
-  padding-left: 12px;
+  // Logical, so the title band still indents from the reading edge under RTL —
+  // the row of `col-md-*` cells it labels is mirrored, but `padding-left` was not.
+  padding-inline-start: 12px;
   font-size: 12px;
   font-style: normal;
   font-weight: 600;

--- a/packages/ui-auth/src/lib/components/auth/auth.component.scss
+++ b/packages/ui-auth/src/lib/components/auth/auth.component.scss
@@ -7,12 +7,18 @@
     border: none;
   }
 
+  // `100vw` (here and on `.body` below) is the FULL viewport including the
+  // vertical scrollbar gutter. The register screen is taller than most viewports,
+  // so as soon as its scrollbar appeared these two bands were wider than the space
+  // left for them and the whole auth shell picked up a horizontal scrollbar it
+  // never needed. They already span their column, so `100%` is both correct and
+  // scrollbar-safe.
   & .header {
     border-bottom: none;
     padding-top: 24px;
     padding-left: 30px;
     padding-right: 30px;
-    width: 100vw;
+    width: 100%;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -37,7 +43,7 @@
   //   @media (max-width: 490px) { :root { --header-height: 0px; } }
   // The fallback of 70px matches the current desktop header height.
   & .body {
-    width: 100vw;
+    width: 100%;
     height: 100%;
     min-height: calc(100vh - var(--header-height, 70px));
     display: flex;
@@ -66,7 +72,10 @@
   }
 }
 .back-link {
-  border: 1px solid lightgray;
+  // Was the CSS named colour `lightgray` (#d3d3d3): a ring bright enough to be
+  // the loudest thing in the auth header on the dark themes, and a dead-flat
+  // hairline that ignores the theme on the light ones.
+  border: 1px solid nb-theme(border-basic-color-3);
   border-radius: 50%;
   padding: 15px;
   transition: all 0.3s ease;

--- a/packages/ui-auth/src/lib/components/forgot-password/forgot-password.component.scss
+++ b/packages/ui-auth/src/lib/components/forgot-password/forgot-password.component.scss
@@ -32,7 +32,12 @@
   }
   & .sub-title {
     width: 358px;
-    height: 34px;
+    max-width: 100%;
+    // Was a fixed `height: 34px` on a flex box that centres its text. Two lines
+    // of copy — which is what the longer locales produce for this instruction —
+    // overflowed the box in both directions and crossed the divider under it.
+    // As a minimum, the single-line English case renders identically.
+    min-height: 34px;
     font-family: 'Inter';
     font-style: normal;
     font-weight: 400;

--- a/packages/ui-auth/src/lib/components/login-magic/login-magic.component.scss
+++ b/packages/ui-auth/src/lib/components/login-magic/login-magic.component.scss
@@ -46,7 +46,10 @@
           font-size: 14px;
           font-style: normal;
           font-weight: 400;
-          line-height: 11px;
+          // Was 11px — a line box shorter than the 14px glyphs in it. Same defect
+          // and same fix as login.component.scss; 14/17 is what forgot-password,
+          // reset-password and login-workspace all use for this element.
+          line-height: 17px;
           letter-spacing: 0em;
           margin-bottom: 26px;
           text-align: start;

--- a/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
+++ b/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
@@ -32,7 +32,10 @@
       }
       & .sub-title {
         width: 358px;
-        height: 34px;
+        max-width: 100%;
+        // Same fixed-height flex box as forgot-password / reset-password: a
+        // two-line instruction overflowed it and crossed the divider below.
+        min-height: 34px;
         font-family: 'Inter';
         font-style: normal;
         font-weight: 400;

--- a/packages/ui-auth/src/lib/components/login/login.component.scss
+++ b/packages/ui-auth/src/lib/components/login/login.component.scss
@@ -45,7 +45,12 @@
           font-size: 14px;
           font-style: normal;
           font-weight: 400;
-          line-height: 11px;
+          // Was 11px — a line box SHORTER than the 14px glyphs sitting in it, so
+          // the strap line under "Login" rode into the divider below and its
+          // descenders were cut by the next block. Every other auth screen
+          // (forgot-password, reset-password, login-workspace) sets 14/17 for the
+          // same element; the features column further down this very file does too.
+          line-height: 17px;
           letter-spacing: 0em;
           margin-bottom: 26px;
           text-align: start;

--- a/packages/ui-auth/src/lib/components/reset-password/reset-password.component.scss
+++ b/packages/ui-auth/src/lib/components/reset-password/reset-password.component.scss
@@ -27,7 +27,10 @@
   }
   & .sub-title {
     width: 358px;
-    height: 34px;
+    max-width: 100%;
+    // Same fixed-height flex box as forgot-password: a two-line instruction
+    // overflowed it and crossed the divider below. Minimum, not fixed.
+    min-height: 34px;
     font-family: 'Inter';
     font-style: normal;
     font-weight: 400;

--- a/packages/ui-core/shared/src/lib/entity-with-members-card/entity-with-members-card.component.scss
+++ b/packages/ui-core/shared/src/lib/entity-with-members-card/entity-with-members-card.component.scss
@@ -9,7 +9,10 @@
 
     .members-count {
       font-size: 0.7em;
-      color: darkgray;
+      // `darkgray` (#a9a9a9) is a fixed CSS keyword: too light to read on the
+      // light themes' white card and no darker on the dark ones. `text-hint-color`
+      // is the muted-label token and is registered by all eight themes.
+      color: nb-theme(text-hint-color);
     }
   }
 

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-block/recurring-expense-block.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-block/recurring-expense-block.component.scss
@@ -6,8 +6,12 @@
   margin-bottom: 8px;
   background-color: nb-theme(gauzy-card-1) !important;
 
+  // Selection rail. This was `rgba(0, 0, 0, 0.15)` — 15 % black, which on the
+  // four dark themes is drawn against an already near-black card and simply does
+  // not appear, so a selected recurring expense had no rail at all. A selection
+  // state has to read in every theme, so it takes the primary accent.
   &.block {
-    box-shadow: -6px 0px 0px 0px rgba(0, 0, 0, 0.15);
+    box-shadow: -6px 0 0 0 nb-theme(color-primary-default);
   }
 
   .setting-row {

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-block/recurring-expense-block.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-block/recurring-expense-block.component.scss
@@ -4,14 +4,19 @@
 
   border-radius: nb-theme(border-radius);
   margin-bottom: 8px;
-  background-color: nb-theme(gauzy-card-1) !important;
+  // Fallbacks on every `--gauzy-*` here: material-light and material-dark do
+  // not register these keys, and a `var()` that resolves to nothing invalidates
+  // the whole declaration, which left these rows transparent on those themes.
+  background-color: var(--gauzy-card-1, var(--card-background-color)) !important;
 
-  // Selection rail. This was `rgba(0, 0, 0, 0.15)` — 15 % black, which on the
-  // four dark themes is drawn against an already near-black card and simply does
-  // not appear, so a selected recurring expense had no rail at all. A selection
-  // state has to read in every theme, so it takes the primary accent.
+  // Selection rail. This was `rgba(0, 0, 0, 0.15)` — 15% black, drawn against an
+  // already near-black card on the four dark themes, so a selected recurring
+  // expense had no rail at all. A selection state has to read in every theme, so
+  // it takes the primary accent. The rail sits on the leading edge, so it flips
+  // with the writing direction.
   &.block {
     box-shadow: -6px 0 0 0 nb-theme(color-primary-default);
+    @include nb-rtl(box-shadow, 6px 0 0 0 nb-theme(color-primary-default));
   }
 
   .setting-row {
@@ -19,14 +24,21 @@
     justify-content: space-between;
     width: 100%;
     height: 84px;
-    background-color: nb-theme(gauzy-card-1);
+    background-color: var(--gauzy-card-1, var(--card-background-color));
     border-radius: nb-theme(border-radius);
     @include nb-ltr(padding, 0.75rem 0 0.75rem 0.75rem);
     @include nb-rtl(padding, 0.75rem 0.75rem 0.75rem 0);
 
-    &:hover,
+    // `:hover` and `.active` used to share one fill, so pointing at any row made
+    // it look exactly as selected as the row that really was. The two shared
+    // density tokens are the app-wide hover / current pair and — unlike
+    // `gauzy-sidebar-background-3` — are registered by all eight themes.
+    &:hover:not(.active) {
+      background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+    }
+
     &.active {
-      background-color: nb-theme(gauzy-sidebar-background-3);
+      background-color: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
     }
   }
 
@@ -39,7 +51,9 @@
     display: flex;
     height: 84px;
     align-items: center;
-    background-color: #333;
+    // Was `#333` with `#d7d9de` labels, i.e. a dark slab hard-coded for one
+    // theme. `background-basic-color-3` is a recessed surface in every theme.
+    background-color: nb-theme(background-basic-color-3);
     justify-content: space-evenly;
     overflow: hidden;
     transition: width 0.2s ease-in;
@@ -53,11 +67,11 @@
       cursor: pointer;
 
       ::ng-deep svg {
-        fill: rgb(127, 127, 127);
+        fill: nb-theme(text-hint-color);
       }
 
       span {
-        color: #d7d9de;
+        color: nb-theme(text-hint-color);
         font-size: 10px;
         opacity: 0.6;
       }
@@ -100,7 +114,9 @@
     }
 
     span {
-      color: nb-theme(gauzy-text-color-1);
+      // Fallback: `gauzy-text-color-1` is not registered by material-light /
+      // material-dark, and without one the declaration is dropped there.
+      color: var(--gauzy-text-color-1, var(--text-basic-color));
       font-size: 14px;
     }
 
@@ -118,8 +134,11 @@
     }
   }
 
+  // The per-row settings fly-out. It is deliberately hidden — the same edit /
+  // history / delete actions live in the page toolbar — and the rules below only
+  // survive so the panel can be brought back. Removed a `display: flex` that was
+  // declared here and overruled by the `display: none` lower in the same block.
   .block-panel {
-    display: flex;
     justify-content: space-between;
     align-items: center;
     width: 240px;

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-delete-confirmation/recurring-expense-delete-confirmation.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-delete-confirmation/recurring-expense-delete-confirmation.component.scss
@@ -2,6 +2,9 @@
 
 :host {
     nb-card {
-        background-color: nb-theme(gauzy-card-1);
+        // Fallback because `gauzy-card-1` is not registered by material-light /
+        // material-dark, where a `var()` with nothing to resolve to invalidates
+        // the declaration and left this confirmation dialog transparent.
+        background-color: var(--gauzy-card-1, var(--card-background-color));
     }
 }

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-history/recurring-expense-history.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-history/recurring-expense-history.component.scss
@@ -12,11 +12,27 @@
     max-width: 560px;
     flex: 1;
 
-    row.head {
+    // Was `row.head`, an element selector for a `<row>` tag. The template marks
+    // the column headings with `<div class="row head">`, so the rule matched
+    // nothing and the headings rendered as ordinary bold text. The colour
+    // carries a fallback because `gauzy-text-color-2` is not registered by
+    // material-light / material-dark.
+    .row.head {
       b {
         font-weight: 600;
-        color: nb-theme(gauzy-text-color-2);
+        color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
       }
+    }
+
+    // Every history entry ends with an `<hr>`, but a Bootstrap `.row` is a flex
+    // container, which left that `<hr>` a zero-width flex item, so no separator
+    // was ever drawn. Given a full line of its own it separates the entries, and
+    // the colour replaces Bootstrap's own `rgba(0, 0, 0, .1)` — invisible on
+    // every dark theme.
+    .row hr {
+      flex: 0 0 100%;
+      margin: 0.5rem 0 0;
+      border-top-color: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
     }
 
     h6 {
@@ -25,7 +41,7 @@
       line-height: 17px;
       letter-spacing: 0em;
       text-align: left;
-      color: nb-theme(gauzy-text-color-1);
+      color: var(--gauzy-text-color-1, var(--text-basic-color));
     }
   }
 

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-mutation/recurring-expense-mutation.component.html
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-mutation/recurring-expense-mutation.component.html
@@ -189,6 +189,7 @@
             @if (!recurringExpense) {
               <button
                 (click)="submitForm()"
+                size="small"
                 [disabled]="form.invalid"
                 type="submit"
                 nbButton

--- a/packages/ui-core/shared/src/lib/expenses/recurring-expense-mutation/recurring-expense-mutation.component.scss
+++ b/packages/ui-core/shared/src/lib/expenses/recurring-expense-mutation/recurring-expense-mutation.component.scss
@@ -2,12 +2,19 @@
 
 nb-card-body {
   width: 500px;
+  // The fixed width is a preferred size; without this the dialog overflowed the
+  // overlay on narrow viewports instead of shrinking with it.
+  max-width: 100%;
 }
 
 :host {
 
   nb-card,
   nb-card-body {
-    background-color: nb-theme(gauzy-card-1);
+    // Fallback because `gauzy-card-1` is not registered by material-light /
+    // material-dark: a `var()` with nothing to resolve to invalidates the whole
+    // declaration, and a background-color that falls back to its initial value
+    // is transparent, so the dialog showed the page through it.
+    background-color: var(--gauzy-card-1, var(--card-background-color));
   }
 }

--- a/packages/ui-core/shared/src/lib/income/income-mutation/income-mutation.component.scss
+++ b/packages/ui-core/shared/src/lib/income/income-mutation/income-mutation.component.scss
@@ -3,6 +3,9 @@
 .main {
   .body {
     width: 605px;
+    // The fixed width is a preferred size; without this the dialog overflowed
+    // the overlay on narrow viewports instead of shrinking with it.
+    max-width: 100%;
   }
 
   .close {
@@ -14,13 +17,11 @@
     resize: none;
   }
 
-  nb-card-header .employees {
-    margin-left: 20px;
-    padding-left: 20px;
-    border-left: 1px solid #edf1f7;
-
-    width: 220px;
-  }
+  // Removed `nb-card-header .employees` (margin/padding-left 20px, width 220px
+  // and a hard-coded `border-left: 1px solid #edf1f7` that was invisible on the
+  // dark themes). The only `.employees` element in this template is the
+  // `<div class="row employees">` inside `nb-card-body`, so the rule never
+  // matched anything.
 
   .employees {
     margin-bottom: 15px;

--- a/packages/ui-core/shared/src/lib/invoice/components/inner-component/invoice-view-inner.component.html
+++ b/packages/ui-core/shared/src/lib/invoice/components/inner-component/invoice-view-inner.component.html
@@ -33,9 +33,11 @@
                     {{ 'INVOICES_PAGE.DUE_DATE' | translate }}:
                   </div>
                 </div>
+                <!-- `dueDate` is optional and `dateFormat` yields undefined for an unset
+                     date, so these labels used to stand over blanks. -->
                 <div class="ml-3 mr-3">
-                  <div>{{ invoice?.invoiceDate | dateFormat }}</div>
-                  <div>{{ invoice?.dueDate | dateFormat }}</div>
+                  <div>{{ (invoice?.invoiceDate | dateFormat) || '—' }}</div>
+                  <div>{{ (invoice?.dueDate | dateFormat) || '—' }}</div>
                 </div>
               </div>
             </div>
@@ -44,13 +46,14 @@
                 <div class="font-weight-bold text-left">
                   {{ 'INVOICES_PAGE.VIEW.FROM' | translate | titlecase }}:
                 </div>
-                <div>{{ invoice?.fromOrganization?.name }}</div>
+                <div>{{ invoice?.fromOrganization?.name || '—' }}</div>
               </div>
               <div class="ml-3">
                 <div class="font-weight-bold text-left">
                   {{ 'INVOICES_PAGE.VIEW.TO' | translate | titlecase }}:
                 </div>
-                <div>{{ invoice?.toContact?.name }}</div>
+                <!-- A draft invoice can have no contact yet; the label used to sit over a blank. -->
+                <div>{{ invoice?.toContact?.name || '—' }}</div>
               </div>
             </div>
           </div>
@@ -89,12 +92,14 @@
               }
               @if (invoice.taxType === discountTaxTypes.PERCENT) {
                 <span>
-                  {{ invoice?.tax || 0 }} %
+                  {{ invoice?.tax || 0 }}%
                 </span>
               }
             </div>
+            <!-- The second tax row was keyed off `taxType`, so a percentage Tax 2 on
+                 a flat-value Tax 1 was rendered as a currency amount. -->
             <div class="mt-2">
-              @if (invoice.taxType === discountTaxTypes.FLAT_VALUE) {
+              @if (invoice.tax2Type === discountTaxTypes.FLAT_VALUE) {
                 <span>
                   {{
                   invoice?.tax2 || 0
@@ -103,7 +108,7 @@
                   }}
                 </span>
               }
-              @if (invoice.taxType === discountTaxTypes.PERCENT) {
+              @if (invoice.tax2Type === discountTaxTypes.PERCENT) {
                 <span>
                   {{ invoice?.tax2 || 0 }}%
                 </span>
@@ -120,10 +125,9 @@
                 </span>
               }
               @if (invoice.discountType === discountTaxTypes.PERCENT) {
-                <span>
-                  {{ invoice?.discountValue || 0 }}
-                  %
-                </span>
+                <!-- The `%` was on its own line, which renders as "12 %"; the tax rows
+                     above it read "12%". Same figure, one spelling. -->
+                <span>{{ invoice?.discountValue || 0 }}%</span>
               }
             </div>
             <div class="mt-2">

--- a/packages/ui-core/shared/src/lib/invoice/components/inner-component/invoice-view-inner.component.scss
+++ b/packages/ui-core/shared/src/lib/invoice/components/inner-component/invoice-view-inner.component.scss
@@ -4,16 +4,29 @@
   margin-top: 20px;
   padding: 10px;
   background-color: nb-theme(gauzy-card-2);
+  // NOTE: `max-height: 17.5rem` is a flat 280px cap on the item list whatever the
+  // window, so an invoice of more than about eight lines scrolls internally while
+  // the card around it still has room. Left alone deliberately: the cap is also
+  // what keeps the totals block below it on screen without the page scrolling,
+  // and re-balancing the two needs the running app.
   max-height: 17.5rem;
 }
 
-.bottom-data-container {
-  width: 25%;
-  justify-content: space-between;
-  margin-left: auto;
-}
-
-::ng-deep ga-invoice-view-inner {
-  padding: 0 100px;
-  padding-top: 25px;
+// Was `::ng-deep ga-invoice-view-inner { padding: 0 100px; padding-top: 25px }`.
+// Three things wrong with it:
+//
+//   * a LEADING `::ng-deep` has no compound selector to scope, so this was
+//     emitted as a GLOBAL `ga-invoice-view-inner` rule rather than staying with
+//     the component;
+//   * the host is a custom element with no `display` of its own — an inline box
+//     — and its only child is a block-level `nb-card-body`. Padding on an inline
+//     box does not lay out as the block gutter this was written to be;
+//   * 100px per side is a constant: on a narrow window 200px of it went to
+//     padding, squeezing the item grid into a column.
+//
+// The host is now a block, so the gutter is the one the declaration always meant,
+// and it scales with the viewport, topping out at the original 100px.
+:host {
+  display: block;
+  padding: 25px clamp(1rem, 6vw, 100px) 0;
 }

--- a/packages/ui-core/shared/src/lib/project/project-mutation/project-mutation.component.scss
+++ b/packages/ui-core/shared/src/lib/project/project-mutation/project-mutation.component.scss
@@ -20,8 +20,14 @@
 
 		nb-card-body {
 			padding: 0;
+			// `--gauzy-card-2` is NOT registered by the material-light /
+			// material-dark themes (themes.scss only gives them
+			// gauzy-primary-background / sidebar / border-table), so a bare
+			// var() there resolves to nothing and the browser drops the whole
+			// declaration — the tab body and the action bar lose their panel
+			// and sit on the raw card. Fallback keeps a neutral panel tint.
 			nb-tab.content-active, .action-buttons {
-				background-color: var(--gauzy-card-2);
+				background-color: var(--gauzy-card-2, rgba(126, 126, 143, 0.08));
 				margin: 0;
 			}
 
@@ -51,8 +57,11 @@
 		div.checked+span.text {
 			color: var(--text-primary-color);
 		}
+		// Same story as `--gauzy-card-2` above: `--gauzy-text-color-2` is
+		// undefined in the two material themes, so without a fallback the
+		// declaration is dropped and the label keeps the inherited color.
 		div+span.text {
-			color: var(--gauzy-text-color-2);
+			color: var(--gauzy-text-color-2, var(--text-hint-color));
 		}
 	}
 
@@ -62,7 +71,7 @@
 		line-height: 11px;
 		letter-spacing: 0em;
 		text-align: left;
-		color: var(--gauzy-text-color-2);
+		color: var(--gauzy-text-color-2, var(--text-hint-color));
 	}
 }
 
@@ -114,7 +123,11 @@
 			}
 
 			>span {
-				color: rgba(126, 126, 143, 1);
+				// Was the literal rgba(126, 126, 143, 1), which is exactly the
+				// light-theme value of `gauzy-text-color-2` — so the "Add or
+				// Drop Image" hint stayed dark gray on the dark themes. Token
+				// first, that same literal kept as the fallback.
+				color: var(--gauzy-text-color-2, rgba(126, 126, 143, 1));
 				z-index: 2;
 				transition: opacity 0.2s ease-in;
 				position: absolute;
@@ -143,6 +156,10 @@
 		height: 100% !important;
 	}
 
-	// Apply dialog styles
-	@include dialog(transparent, var(--gauzy-card-1));
+	// Apply dialog styles. Second argument is the input background — it is
+	// applied with `!important`, so on material-light / material-dark (where
+	// `--gauzy-card-1` is not registered) the declaration is dropped entirely
+	// and the inputs go back to Nebular's own color. Fall back to the card
+	// color those themes DO define.
+	@include dialog(transparent, var(--gauzy-card-1, var(--card-background-color)));
 }

--- a/packages/ui-core/shared/src/lib/table-components/project-organization-employees/project-organization-employees.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/project-organization-employees/project-organization-employees.component.scss
@@ -3,8 +3,13 @@
 // The members block of a project card. The people themselves are rendered by
 // `ngx-people-list` and carry no box of their own, so the only thing left here
 // is the surrounding panel and its label.
+// `--gauzy-card-1` / `--gauzy-text-color-2` are not registered by the
+// material-light and material-dark themes (themes.scss), and a var() with no
+// fallback there drops the whole declaration — the members panel lost its
+// background and the title its muted color. Fallbacks are Nebular tokens, which
+// every theme defines.
 .members {
-	background-color: var(--gauzy-card-1);
+	background-color: var(--gauzy-card-1, var(--card-background-color));
 	border-radius: var(--border-radius);
 	padding: 0.625rem;
 	margin: 0;
@@ -16,5 +21,5 @@
 	font-weight: 600;
 	line-height: 0.9375rem;
 	letter-spacing: 0em;
-	color: var(--gauzy-text-color-2);
+	color: var(--gauzy-text-color-2, var(--text-hint-color));
 }

--- a/packages/ui-core/shared/src/lib/table-components/project-organization-grid-details/project-organization-grid-details.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/project-organization-grid-details/project-organization-grid-details.component.scss
@@ -1,5 +1,11 @@
+// `--gauzy-card-1` and `--gauzy-text-color-2` are registered by six of the eight
+// themes only: material-light and material-dark set just gauzy-primary-background,
+// gauzy-sidebar-background-* and gauzy-border-table (see themes.scss). A var()
+// with no fallback there resolves to nothing and the browser throws away the
+// whole declaration, so on those two themes this card had no panel behind it and
+// the left-hand labels lost their muted color.
 .project-container {
-    background-color: var(--gauzy-card-1);
+    background-color: var(--gauzy-card-1, var(--card-background-color));
     display: flex;
     flex-direction: column;
     padding: 10px;
@@ -13,7 +19,7 @@
 
         .detail-left {
             border-radius: var(--border-radius);
-            color: var(--gauzy-text-color-2);
+            color: var(--gauzy-text-color-2, var(--text-hint-color));
             background-color: rgba(126, 126, 143, 0.05);
             padding: 5px 15px 5px 10px;
             width: 5.25rem;

--- a/packages/ui-core/shared/src/lib/table-components/visibility/visibility.component.scss
+++ b/packages/ui-core/shared/src/lib/table-components/visibility/visibility.component.scss
@@ -4,8 +4,12 @@
             color: var(--text-primary-color);
         }
 
+        // `--gauzy-text-color-2` is undefined in material-light /
+        // material-dark, and a var() with no fallback drops the declaration
+        // there, leaving the unchecked "Public" label the same color as the
+        // checked one. `--text-hint-color` is a Nebular token every theme has.
         div+span.text {
-            color: var(--gauzy-text-color-2);
+            color: var(--gauzy-text-color-2, var(--text-hint-color));
         }
     }
 }


### PR DESCRIPTION
Cascade `develop` → `stage`. Five commits.

| PR | What |
|---|---|
| [#9878](https://github.com/ever-co/ever-gauzy/pull/9878) | **CI:** stop the six non-prod image builds cancelling each other |
| [#9877](https://github.com/ever-co/ever-gauzy/pull/9877) | UI sweep wave 4 — accounting, employees, organization, settings, reports |
| [#9879](https://github.com/ever-co/ever-gauzy/pull/9879) | Theme-blind colours the waves missed (dashboard, edit-candidate) |
| [#9880](https://github.com/ever-co/ever-gauzy/pull/9880) | UI sweep wave 5 — remaining page areas, with adversarial audit |
| [#9881](https://github.com/ever-co/ever-gauzy/pull/9881) | Repair the shared e2e Tags selector broken by the header change |

### Why #9878 matters for this branch specifically

Stage's own image builds have been getting cancelled while queued. All six non-prod
image-build workflows shared one concurrency group, and `cancel-in-progress: false`
only protects a run that is already executing — GitHub keeps exactly one *pending*
run per group, so any newly queued run cancelled whichever was waiting, whatever
workflow it belonged to.

That is why `apistage` sat on an image from #9858 while its branch showed #9876 merged
and green, and why demo went to 503 with an image predating the native-rebuild fix.
Both recovered once #9878 landed on develop.

**A queued run uses the workflow file from its own ref**, so stage stayed exposed until
this cascade carries the fix across. That is the main operational reason to merge this.

### Verification

- `nx build gauzy -c local` green on every branch before merge.
- cspell clean on all of them.
- demo recovered: 503 → `v111.15.17`, and `/api/employee` returns 401 rather than 5xx,
  so the database opens — the `better-sqlite3` binary was never a code defect after
  #9870, only an undelivered one.
- 18 pages screenshotted in light and dark: no clipped text, no horizontal overflow,
  no filled colour buttons in page bodies.

### Known state

The e2e suite was failing all four shards on a selector the header change broke; #9881
fixes it and a run is in flight. e2e is a separate check and does not gate image builds,
but flagging it rather than leaving it to be discovered.

**Merge with a merge commit, not a squash** — the desktop-apps release gate resolves the
tag at `HEAD` or `HEAD^2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cascades develop into stage with two UI sweep waves and critical CI/e2e fixes. Non‑prod image builds no longer cancel each other, the shared Tags e2e selector is repaired, and pages get theme-safe, accessible styling.

- Bug Fixes
  - CI: per-workflow concurrency for six non‑prod Docker build workflows so queued runs don’t cancel other workflows; latest images now reach demo/stage.
  - E2E: update Tags page wait selector to a class-based, scoped locator to unblock all shards.
  - Correctness: fix broken/unsafe links, duplicate control ids, untranslated placeholders, missing fallbacks, and unreadable status/chip labels.

- Refactors
  - UI/theme: replace hardcoded colors/borders with theme tokens and add fallbacks for material themes; remove dead/duplicate CSS; normalize chips, badges, tabs, dialogs, and list/table states for contrast and density.
  - Layout: consistent headers via `ngx-header-title`, fix overflow/scroll behavior, align dialog widths to viewport, and tighten grid/list row structure across accounting, employees, organization, settings, reports, integrations, inventory, invoices, import/export, goals, and pipelines.

<sup>Written for commit cc4093e146c4976574f8c5e5c73c6c1647eaf0eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

