### PR TITLE
fix(e2e): dismiss the datepicker overlay that was blocking the payment-method select

### DIFF
--- a/apps/gauzy-e2e/tests/support/pages/Payments.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Payments.po.ts
@@ -122,8 +122,8 @@ export const enterDateInputData = async () => {
 	const date = dayjs().format('MMM D, YYYY');
 	await enterInput(PaymentsPage.dateInputCss, date);
 	// Typing into the Nebular datepicker leaves its calendar overlay open with focus
-	// still in the field — the failure snapshot shows `textbox "Payment Date" [active]`
-	// with the Payment Method select immediately below it still closed on its
+	// still in the field — the failure snapshot shows the Payment Date field marked
+	// active, with the Payment Method select immediately below it still closed on its
 	// placeholder, and no `.option-list` anywhere. The next step clicks that select,
 	// the open overlay eats it, and the spec then times out waiting for an option
 	// list that was never opened. It failed all three retries, so it is deterministic

--- a/apps/gauzy-e2e/tests/support/pages/Payments.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Payments.po.ts
@@ -121,6 +121,20 @@ export const enterDateInputData = async () => {
 	await clearField(PaymentsPage.dateInputCss);
 	const date = dayjs().format('MMM D, YYYY');
 	await enterInput(PaymentsPage.dateInputCss, date);
+	// Typing into the Nebular datepicker leaves its calendar overlay open with focus
+	// still in the field — the failure snapshot shows `textbox "Payment Date" [active]`
+	// with the Payment Method select immediately below it still closed on its
+	// placeholder, and no `.option-list` anywhere. The next step clicks that select,
+	// the open overlay eats it, and the spec then times out waiting for an option
+	// list that was never opened. It failed all three retries, so it is deterministic
+	// rather than flaky.
+	//
+	// Dismissed with the same in-dialog outside-click this file already uses for the
+	// project dropdown: the inert dialog TITLE. NOT Escape — the payment dialog is
+	// opened with NbDialog defaults (closeOnEsc = true), so a document-level Escape
+	// closes the WHOLE form, which is a failure mode this suite has already hit.
+	await getPage().locator(PaymentsPage.cardBodyCss).first().click({ force: true }).catch(() => {});
+	await getPage().waitForTimeout(300);
 };
 
 export const paymentMethodDropdownVisible = async () => {


### PR DESCRIPTION
The last remaining e2e failure. After the selector repair took the suite from **0/4 shards
to 3/4**, shard 4 fails on one spec only — `payments.feature`:

```
TimeoutError: locator.click: Timeout 60000ms exceeded.
  - waiting for locator('.option-list nb-option').filter({ hasText: 'Cash' }).first()
```

It failed all three retries, so it is deterministic, not a flake.

### Diagnosed from the trace, not guessed

I ruled out the two obvious explanations first, and both were wrong:

- **The label is correct.** `INVOICES_PAGE.PAYMENTS.CASH = "Cash"` does exist in `en.json`
  (my first probe printed only the first 20 keys and missed it).
- **The scope is correct.** `ga-payment-add` is the real component selector, used as the
  dialog's host element when NbDialog creates it.

The failure's aria snapshot gives the actual answer:

| observation | meaning |
|---|---|
| `heading "Record Payment"` | the dialog **is** open |
| `button "Payment Method"` showing its placeholder | the select is present but **closed** |
| no `.option-list` anywhere in the page | the dropdown never opened at all |
| **`textbox "Payment Date" [active]`** | focus is still in the date field |

`enterDateInputData()` types into the Nebular datepicker and never dismisses it, so its
calendar overlay is still open when the next step clicks the Payment Method select. The
overlay swallows the click, the select never opens, and the spec waits 60s for options that
were never rendered.

### Fix

Dismiss the datepicker with the **in-dialog outside-click this same file already uses** for
the project dropdown — the inert dialog title (`cardBodyCss`).

Deliberately **not** Escape. The payment dialog is opened with NbDialog defaults
(`closeOnEsc = true`), so a document-level Escape closes the entire form — a failure mode
this suite has already hit and documented in the page object.

### Verification

Not reproducible on this box, so CI is the verifier: shard 4 should go green and the run
reach 4/4. I would rather say that plainly than claim a local check I did not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the payments e2e by dismissing the datepicker overlay after entering the date so the Payment Method select can open and render options. Unblocks shard 4 and stabilizes `payments.feature`.

- **Bug Fixes**
  - After typing the date, click the dialog title to dismiss the calendar overlay; avoid Escape because it would close the dialog.
  - Add a brief wait to ensure the overlay is gone before opening the Payment Method select.

- **Refactors**
  - Reworded an inline comment to satisfy the repo dictionary; no functional change.

<sup>Written for commit 3cd4ebffba95fec0c3b57fe1129f84aa34a518a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

