### PR TITLE
ci(prod): build prod images on ARC runners instead of the dead ubicloud pool

### DIFF
--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   gauzy-api:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 300
     steps:
       - name: Checkout
@@ -95,7 +95,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-api:latest
 
   gauzy-webapp:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 300
     steps:
       - name: Checkout
@@ -177,7 +177,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/gauzy-webapp:latest
 
   gauzy-worker:
-    runs-on: ubicloud-standard-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 300
     steps:
       - name: Checkout


### PR DESCRIPTION
Prod image build has been `queued` since 17:08Z — master targets `ubicloud-standard-8`, which no longer answers, so **merges to master never deploy**. Last successful prod build: 2026-07-04.

Three lines, one file. Same label as `develop`, verified byte-identical:
```
runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
```
`vars.RUNNER_LINUX_X64_8` → ARC pool `ever-k8s-linux-x64-8`; the `|| 'ubuntu-latest'` fallback stops it wedging again.

Does **not** import develop's other 56 lines, and does **not** touch the other 55 ubicloud workflows (legacy cloud deploys, plus desktop matrices using `ubicloud-standard-8-arm` which must not be remapped to x64).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch production Docker builds to ARC runners to unblock master deployments. Replaces `runs-on: ubicloud-standard-8` with `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}` in the prod workflow.

- **Bug Fixes**
  - Moves `gauzy-api`, `gauzy-webapp`, and `gauzy-worker` to ARC via org var (`ever-k8s-linux-x64-8`) to stop queued builds.
  - Adds `ubuntu-latest` fallback to prevent future wedges.
  - Limits scope to this workflow; other ubicloud-labeled workflows are unchanged.

<sup>Written for commit 594c955f62febc69f79c76dd4ca2aff98af2c2b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

