### PR TITLE
fix(deps): lock terms-acceptance and @ever-co/legal — restores the demo and stage APIs

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5923,6 +5923,11 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
+"@ever-co/legal@^0.1.0":
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/@ever-co/legal/-/legal-0.1.2.tgz#586ac467d2bb62d4296808b0790459ccd6f593c1"
+  integrity sha512-TbnRbXD2AhGBI0F/odq+TC5eCFrp4eTDziDy3gJhautda9td5Po23GRCQ6PfvW58J8xQrZXNMBIKYle36Kv1/g==
+
 "@ever-gauzy/plugin-integration-plane-api@^0.1.6":
   version "0.1.6"
   resolved "https://registry.npmjs.org/@ever-gauzy/plugin-integration-plane-api/-/plugin-integration-plane-api-0.1.6.tgz#beec9de448ea06050c49a9897c234fb015a4dfa1"
@@ -43345,6 +43350,11 @@ term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
+
+terms-acceptance@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/terms-acceptance/-/terms-acceptance-0.1.0.tgz#4d3651f8f3eb04181b299679e260ad10414f9b98"
+  integrity sha512-UAf6OzWTjX76LVlTMPrzZffDw9GHvoSpbX95nzWUgkiIxeaOFDsdjGt9Cb2DxI40oRmshYWhBmdAi20wlhjP7w==
 
 terser-webpack-plugin@^5.3.11:
   version "5.4.0"


### PR DESCRIPTION
**Demo and stage APIs are down (503).** This restores them.

### Cause

`9e85f6d8ee` added two dependencies to `packages/core/package.json`:

```json
"@ever-co/legal": "^0.1.0",
"terms-acceptance": "^0.1.0",
```

but **`yarn.lock` was never regenerated** — neither package appears in it, and the
lockfile is untouched by all three commits in that range. Both packages are real and
published on public npm; only the lock entry was missing.

`terms-acceptance.service.ts` imports them as **bare specifiers**:

```ts
import { TermsAcceptanceService as Recorder, … } from 'terms-acceptance';
import { TypeOrmAcceptanceAdapter } from 'terms-acceptance/typeorm';
```

There is no tsconfig path alias, so this is real module resolution at runtime — not a
mapping onto the local `packages/core/src/lib/terms-acceptance/` directory.

### Why CI stayed green

`.deploy/api/Dockerfile` copies only the **root** manifest into its install stage:

```dockerfile
COPY decorate-angular-cli.js lerna.json package.json yarn.lock ./
```

`packages/core/package.json` never reaches that stage, so yarn only compares the root
manifest against the lockfile. `--frozen-lockfile` is satisfied, the two packages are
simply never installed, and the image builds green. The API then calls
`require('terms-acceptance')` at boot and dies with `MODULE_NOT_FOUND`.

Everything observed fits: both environments went 503 the moment they picked up images
containing this code and stayed down for hours rather than recovering; the web
frontends stay 200 because they are static nginx; **prod is unaffected** — `9e85f6d8ee`
is not an ancestor of `master`, and master's `package.json`/`yarn.lock` mention neither
package. PR #9884 ported only `packages/plugins/legal-ui` and touched no manifest at all.

### Fix

Regenerated `yarn.lock`. The diff is **10 lines** — the two entries and nothing else.
Neither package pulls transitive dependencies and no existing entry moved.

### Worth doing separately

The API image cannot currently detect this class of mistake, because `--frozen-lockfile`
never sees the workspace manifests. Copying `packages/*/package.json` into the install
stage would make that check real. It is a build-caching change and does not belong in an
outage fix.

Also worth pinning: when the terms-acceptance work eventually goes `develop` → `master`,
it must carry this lockfile change with it. Cherry-picking only the API commits would
reproduce this outage on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores demo and stage APIs (503) by regenerating `yarn.lock` to include `terms-acceptance` and `@ever-co/legal` required at runtime.

- **Dependencies**
  - Regenerated `yarn.lock` to add `terms-acceptance@0.1.0` and `@ever-co/legal@0.1.2`.
  - No other lockfile changes; no new transitive dependencies.

<sup>Written for commit a5e6ae3e8aded2d5df32f263a732989552467f01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

