### PR TITLE
Cascade develop → stage: restore the stage API (lockfile fix) + e2e payments repair

### DIFF
--- a/apps/gauzy-e2e/tests/support/pages/Payments.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Payments.po.ts
@@ -121,6 +121,20 @@ export const enterDateInputData = async () => {
 	await clearField(PaymentsPage.dateInputCss);
 	const date = dayjs().format('MMM D, YYYY');
 	await enterInput(PaymentsPage.dateInputCss, date);
+	// Typing into the Nebular datepicker leaves its calendar overlay open with focus
+	// still in the field — the failure snapshot shows the Payment Date field marked
+	// active, with the Payment Method select immediately below it still closed on its
+	// placeholder, and no `.option-list` anywhere. The next step clicks that select,
+	// the open overlay eats it, and the spec then times out waiting for an option
+	// list that was never opened. It failed all three retries, so it is deterministic
+	// rather than flaky.
+	//
+	// Dismissed with the same in-dialog outside-click this file already uses for the
+	// project dropdown: the inert dialog TITLE. NOT Escape — the payment dialog is
+	// opened with NbDialog defaults (closeOnEsc = true), so a document-level Escape
+	// closes the WHOLE form, which is a failure mode this suite has already hit.
+	await getPage().locator(PaymentsPage.cardBodyCss).first().click({ force: true }).catch(() => {});
+	await getPage().waitForTimeout(300);
 };
 
 export const paymentMethodDropdownVisible = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5923,6 +5923,11 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
+"@ever-co/legal@^0.1.0":
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/@ever-co/legal/-/legal-0.1.2.tgz#586ac467d2bb62d4296808b0790459ccd6f593c1"
+  integrity sha512-TbnRbXD2AhGBI0F/odq+TC5eCFrp4eTDziDy3gJhautda9td5Po23GRCQ6PfvW58J8xQrZXNMBIKYle36Kv1/g==
+
 "@ever-gauzy/plugin-integration-plane-api@^0.1.6":
   version "0.1.6"
   resolved "https://registry.npmjs.org/@ever-gauzy/plugin-integration-plane-api/-/plugin-integration-plane-api-0.1.6.tgz#beec9de448ea06050c49a9897c234fb015a4dfa1"
@@ -43345,6 +43350,11 @@ term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
+
+terms-acceptance@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/terms-acceptance/-/terms-acceptance-0.1.0.tgz#4d3651f8f3eb04181b299679e260ad10414f9b98"
+  integrity sha512-UAf6OzWTjX76LVlTMPrzZffDw9GHvoSpbX95nzWUgkiIxeaOFDsdjGt9Cb2DxI40oRmshYWhBmdAi20wlhjP7w==
 
 terser-webpack-plugin@^5.3.11:
   version "5.4.0"


### PR DESCRIPTION
Cascade `develop` → `stage`. **This restores the stage API**, which has been 503 for
hours; the same fix already went to develop for demo.

| commit | what |
|---|---|
| `8ce6191363` | lock `terms-acceptance` + `@ever-co/legal` — **the outage fix** |
| `e4693e7f14` | e2e: dismiss the datepicker overlay blocking the payment-method select |

### The outage, briefly

`9e85f6d8ee` added both packages to `packages/core/package.json` but never regenerated
`yarn.lock`. `terms-acceptance.service.ts` imports them as bare specifiers with no
tsconfig alias, so at runtime the API calls `require('terms-acceptance')` and dies with
`MODULE_NOT_FOUND`.

CI could not catch it: `.deploy/api/Dockerfile` copies only the root manifest into its
install stage, so `--frozen-lockfile` never sees `packages/core/package.json`. The check
passes, the packages are never installed, the image builds green, and the container
crashes on boot.

The lockfile diff is 10 lines — the two entries, no transitive dependencies, no existing
entry moved.

**Production was never affected**: `9e85f6d8ee` is not an ancestor of `master`, and
master's manifest and lockfile mention neither package. PR #9884 ported only
`packages/plugins/legal-ui` and changed no manifest.

### Carry this forward

When the terms-acceptance work eventually goes `develop` → `master`, it must bring this
lockfile change with it. Cherry-picking only the API commits would reproduce the outage
on production.

Separately worth fixing: copying `packages/*/package.json` into the API image's install
stage would make `--frozen-lockfile` actually validate the workspace manifests, so this
class of mistake fails the build instead of the container. That is a build-caching change
and was deliberately kept out of the outage fix.

**Merge with a merge commit, not a squash** — the desktop-apps release gate resolves the
tag at `HEAD` or `HEAD^2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the stage API by fixing missing runtime deps in the lockfile and unblocks the payments e2e by dismissing the datepicker overlay. Stage was returning 503; this brings it back up.

- **Bug Fixes**
  - Regenerated `yarn.lock` to include `terms-acceptance` and `@ever-co/legal`, so the API resolves these modules at runtime and boots normally.
  - Payments e2e: after typing the date, click the dialog body to close the Nebular datepicker overlay before opening the Payment Method select, preventing timeouts.

<sup>Written for commit e4693e7f145afb1ef98280d77c6f10e45893e5f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

