### PR TITLE
fix(core): give TermsAcceptance a MikroORM @PrimaryKey — restores the demo and stage APIs

### DIFF
--- a/packages/core/src/lib/terms-acceptance/terms-acceptance.entity.ts
+++ b/packages/core/src/lib/terms-acceptance/terms-acceptance.entity.ts
@@ -1,4 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PrimaryKey } from '@mikro-orm/core';
+import { PrimaryColumn } from 'typeorm';
 import { termsAcceptanceEntitySchema } from 'terms-acceptance/typeorm';
 import type { TermsAcceptanceEntity as ITermsAcceptanceRow } from 'terms-acceptance/typeorm';
 import { isMySQL, isPostgres } from '@gauzy/config';
@@ -74,9 +76,23 @@ function acceptedAtColumnType(): 'timestamptz' | 'datetime' {
  */
 @MultiORMEntity('terms_acceptance', { mikroOrmRepository: () => MikroOrmTermsAcceptanceRepository })
 export class TermsAcceptance implements ITermsAcceptanceRow {
-	/** Identifier minted by `terms-acceptance`, e.g. `ta_m8k2p10000a1b2c3d4e5f6`. */
+	/**
+	 * Identifier minted by `terms-acceptance`, e.g. `ta_m8k2p10000a1b2c3d4e5f6`.
+	 *
+	 * Declared with both ORMs' own primary-key decorators rather than
+	 * `@MultiORMColumn({ primary: true })`. That option only ever reached TypeORM:
+	 * `MultiORMColumn` forwards its options to `@Column()` but always emits a plain
+	 * MikroORM `@Property()`, so MikroORM saw a table with no primary key and
+	 * `discoverEntities` refused to boot the API with
+	 * `MetadataError: TermsAcceptance entity is missing @PrimaryKey()`.
+	 *
+	 * `BaseEntity` stacks the two decorators the same way; it is the pattern in this
+	 * codebase for a primary key. The id is supplied on insert, not generated, so
+	 * this is `@PrimaryColumn` rather than `@PrimaryGeneratedColumn`.
+	 */
 	@ApiProperty({ type: () => String })
-	@MultiORMColumn({ primary: true, type: String, length: len('id', 128) })
+	@PrimaryKey({ type: 'string', length: len('id', 128) })
+	@PrimaryColumn({ type: String, length: len('id', 128) })
 	id: string;
 
 	/** The user the acceptance belongs to. Not an FK — see the class comment. */


### PR DESCRIPTION
**This is what has been keeping demo and stage down.**

```
MetadataError: TermsAcceptance entity is missing @PrimaryKey()
    at MikroORM.discoverEntities
```

### Cause

The id was declared as:

```ts
@MultiORMColumn({ primary: true, type: String, length: len('id', 128) })
id: string;
```

`MultiORMColumn` forwards its options to TypeORM's `@Column()`, so `primary: true`
reaches TypeORM and that half is correct. For MikroORM it always emits a plain
`@Property()` — the decorator has **no handling for `primary` at all**
(`core/decorators/entity/column.decorator.ts` imports `Property as MikroORMColumn` and
nothing else). MikroORM therefore saw an entity with no primary key, and
`discoverEntities` refused to start the API at all.

### Fix

Stack each ORM's own primary-key decorator — the pattern `BaseEntity` already uses for
every other entity in the core:

```ts
@PrimaryKey({ type: 'string', length: len('id', 128) })   // MikroORM
@PrimaryColumn({ type: String, length: len('id', 128) })  // TypeORM
id: string;
```

`@PrimaryColumn` rather than `@PrimaryGeneratedColumn` because `terms-acceptance` mints
the id (`ta_…`) and supplies it on insert.

### Verified locally, both directions

Built the API and ran it with `DB_TYPE=better-sqlite3`, the same driver the images
default to:

| | result |
|---|---|
| **with** the fix | `API Running: 6.322s`, `GET /api/version` → **200**, no `MetadataError` |
| **without** it (same build, `@PrimaryKey` stripped from the emitted JS) | `MetadataError: TermsAcceptance entity is missing @PrimaryKey()` |

So the failure reproduces and the fix removes it, on one build, changing only this.

### Relationship to #9891

#9891 added the missing `terms-acceptance` / `@ever-co/legal` entries to `yarn.lock`.
That was a real defect and is still correct — but it was **not** what kept the APIs down.
The stage image build completed successfully after it and `apistage` stayed 503. This is
the actual cause.

### Not for production

`9e85f6d8ee` is not on `master`, so prod never had this entity and is unaffected. When the
terms-acceptance work does eventually go `develop` → `master`, it needs **both** this fix
and the #9891 lockfile entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes demo and stage API boot failures by giving `TermsAcceptance` a real primary key for MikroORM. Adds `@mikro-orm/core` `@PrimaryKey` and TypeORM `@PrimaryColumn` to `id` (ID is provided, not generated).

- **Bug Fixes**
  - Cause: `@MultiORMColumn({ primary: true })` only marked TypeORM; MikroORM saw no PK and threw `MetadataError: TermsAcceptance entity is missing @PrimaryKey()`.
  - Fix: Stack `@PrimaryKey({ type: 'string', length: 128 })` and `@PrimaryColumn({ type: String, length: 128 })` on `id`.
  - Verification: With the fix, API starts and returns 200 using `better-sqlite3`; without MikroORM `@PrimaryKey`, boot fails.

<sup>Written for commit 5c1d17a7b477a727bef88466cbf9ae6995a3ffca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

