### PR TITLE
Cascade develop → stage: TermsAcceptance @PrimaryKey — restores the demo/stage APIs

### DIFF
--- a/packages/core/src/lib/terms-acceptance/terms-acceptance.entity.ts
+++ b/packages/core/src/lib/terms-acceptance/terms-acceptance.entity.ts
@@ -1,4 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PrimaryKey } from '@mikro-orm/core';
+import { PrimaryColumn } from 'typeorm';
 import { termsAcceptanceEntitySchema } from 'terms-acceptance/typeorm';
 import type { TermsAcceptanceEntity as ITermsAcceptanceRow } from 'terms-acceptance/typeorm';
 import { isMySQL, isPostgres } from '@gauzy/config';
@@ -74,9 +76,23 @@ function acceptedAtColumnType(): 'timestamptz' | 'datetime' {
  */
 @MultiORMEntity('terms_acceptance', { mikroOrmRepository: () => MikroOrmTermsAcceptanceRepository })
 export class TermsAcceptance implements ITermsAcceptanceRow {
-	/** Identifier minted by `terms-acceptance`, e.g. `ta_m8k2p10000a1b2c3d4e5f6`. */
+	/**
+	 * Identifier minted by `terms-acceptance`, e.g. `ta_m8k2p10000a1b2c3d4e5f6`.
+	 *
+	 * Declared with both ORMs' own primary-key decorators rather than
+	 * `@MultiORMColumn({ primary: true })`. That option only ever reached TypeORM:
+	 * `MultiORMColumn` forwards its options to `@Column()` but always emits a plain
+	 * MikroORM `@Property()`, so MikroORM saw a table with no primary key and
+	 * `discoverEntities` refused to boot the API with
+	 * `MetadataError: TermsAcceptance entity is missing @PrimaryKey()`.
+	 *
+	 * `BaseEntity` stacks the two decorators the same way; it is the pattern in this
+	 * codebase for a primary key. The id is supplied on insert, not generated, so
+	 * this is `@PrimaryColumn` rather than `@PrimaryGeneratedColumn`.
+	 */
 	@ApiProperty({ type: () => String })
-	@MultiORMColumn({ primary: true, type: String, length: len('id', 128) })
+	@PrimaryKey({ type: 'string', length: len('id', 128) })
+	@PrimaryColumn({ type: String, length: len('id', 128) })
 	id: string;
 
 	/** The user the acceptance belongs to. Not an FK — see the class comment. */


### PR DESCRIPTION
Cascade `develop` → `stage`. **This is the fix that actually restores the APIs.**

```
MetadataError: TermsAcceptance entity is missing @PrimaryKey()
    at MikroORM.discoverEntities
```

The id was `@MultiORMColumn({ primary: true, … })`. That decorator forwards its options
to TypeORM's `@Column()`, so `primary: true` reached TypeORM — but for MikroORM it always
emits a plain `@Property()` and has no handling for `primary` at all. MikroORM saw an
entity with no primary key and refused to boot the API.

Fixed by stacking each ORM's own primary-key decorator, the pattern `BaseEntity` already
uses everywhere else in the core. `@PrimaryColumn` rather than `@PrimaryGeneratedColumn`
because `terms-acceptance` mints the id and supplies it on insert.

### Verified locally, both directions, on one build

Ran the built API with `DB_TYPE=better-sqlite3`:

| | result |
|---|---|
| with the fix | `API Running: 6.322s`, `GET /api/version` → **200**, no `MetadataError` |
| without it (same build, `@PrimaryKey` stripped from the emitted JS) | `MetadataError: TermsAcceptance entity is missing @PrimaryKey()` |

One variable changed, failure reproduced and removed — causation, not correlation.

### On #9891

That PR added the genuinely-missing `terms-acceptance` / `@ever-co/legal` entries to
`yarn.lock` and remains correct. It was **not** the outage cause: the stage image build
completed successfully afterwards and `apistage` stayed 503. Both fixes are wanted; only
this one unblocks boot.

### Production

Deliberately not going to `master`. `9e85f6d8ee` is not on it, so prod never had this
entity and is unaffected. When the terms-acceptance work does eventually go
`develop` → `master`, it needs **both** this fix and the #9891 lockfile entries.

**Merge with a merge commit, not a squash** — the desktop-apps release gate resolves the
tag at `HEAD` or `HEAD^2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the demo/stage APIs by giving `TermsAcceptance` a MikroORM primary key. Replaces the ineffective `@MultiORMColumn({ primary: true })` with `@PrimaryKey` (MikroORM) and `@PrimaryColumn` (TypeORM).

- **Bug Fixes**
  - Add `@PrimaryKey` and `@PrimaryColumn` to `TermsAcceptance.id` so MikroORM discovers a primary key and the API boots.
  - Verified locally: API starts and `/api/version` returns 200; no `MetadataError`.
  - Production unaffected (entity not on `master`).

<sup>Written for commit feec854eb231b53031ebe526dd797e4a4db3f9f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

