### PR TITLE
fix(ui): make the organization selector operable by keyboard (WCAG 2.1.1 Level A)

### DIFF
--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
@@ -24,6 +24,11 @@
 		that directive here is a bonus — it declares its output as an emitter of MouseEvent
 		but actually emits a boolean, and the old handler worked only because of the
 		mismatch.
+
+		Dismissal, measured after the change and identical to the employee selector:
+		clicking the control BODY while open lands in the search input and keeps it open,
+		clicking the ARROW closes it, and Escape, an outside click or picking an item all
+		close it too.
 	-->
 	<ng-select
 		#select
@@ -32,7 +37,7 @@
 		[clearable]="false"
 		[items]="organizations"
 		bindLabel="name"
-		(change)="selectOrganization($event); select.blur(); onChange()"
+		(change)="selectOrganization($event); select.blur()"
 		(clear)="select.blur()"
 		[(ngModel)]="selectedOrganization"
 		[placeholder]="'FORM.PLACEHOLDERS.SELECT_COMPANY' | translate"

--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
@@ -1,27 +1,29 @@
 @if (organizations) {
 <div>
 	<!--
-		`isOpen` is REPORTED by ng-select via (open)/(close); it must never be BOUND back
-		in with [isOpen]. Binding it puts ng-select into `_manualOpen`, which early-returns
-		out of open(), close(), _handleSpace and _handleArrowDown — so the component keeps
-		the control in the tab order while making it impossible to operate:
+		The isOpen flag is REPORTED by ng-select through its open and close outputs. It must
+		never be fed back in through the isOpen input: doing so puts ng-select into its
+		_manualOpen mode, which early-returns out of open, close, _handleSpace and
+		_handleArrowDown. The control then stays in the tab order while being impossible to
+		operate. Measured against the sibling employee selector, which does not feed it back:
 
-		  measured, this selector vs the sibling employee selector (no [isOpen])
-		    opens on mousedown   organization 0/3   employee 3/3
-		    Enter / Space / ArrowDown        all fail       all work
-		    Escape closes                    never (stuck open 3/3)   works
+		  opens on mousedown          organization 0 of 3      employee 3 of 3
+		  Enter, Space, ArrowDown     all fail                 all work
+		  Escape closes               never, stuck open 3 of 3 works
 
-		That is a WCAG 2.1.1 (Level A) failure. It also made this the only control in the
-		app that needs a complete, well-formed `click` to open at all: with
-		[searchable]="isOpen" it is non-searchable while closed, so mousedown took the
-		toggle() path and did nothing, and the panel opened solely from a template (click).
+		That is a WCAG 2.1.1 Level A failure. It also made this the only control in the app
+		needing a complete, well-formed click to open at all: because the searchable input
+		is driven from the same flag, the control is non-searchable while closed, so
+		mousedown took the toggle path, early-returned, and did nothing — leaving the
+		template's own click handler as the only way to open it.
 
-		`isOpen` is still needed — [searchable], [addTag] and [class.close] read it — so it
-		stays as a mirror FED BY ng-select rather than a source of truth fighting it.
-		`gauzyOutside`/(clickOutside) went with it: ng-select closes on outside click by
-		itself once it owns its state. (That directive is also worth avoiding here — it
-		declares EventEmitter<MouseEvent> but emits a boolean, and the old handler only
-		worked because of the mismatch.)
+		The flag is still needed, since the searchable, addTag and close-class bindings all
+		read it, so it stays as a mirror FED BY ng-select rather than a second source of
+		truth fighting it. The gauzyOutside directive went away with the manual state:
+		ng-select dismisses itself on an outside click once it owns that state. Avoiding
+		that directive here is a bonus — it declares its output as an emitter of MouseEvent
+		but actually emits a boolean, and the old handler worked only because of the
+		mismatch.
 	-->
 	<ng-select
 		#select

--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
@@ -1,5 +1,28 @@
 @if (organizations) {
 <div>
+	<!--
+		`isOpen` is REPORTED by ng-select via (open)/(close); it must never be BOUND back
+		in with [isOpen]. Binding it puts ng-select into `_manualOpen`, which early-returns
+		out of open(), close(), _handleSpace and _handleArrowDown — so the component keeps
+		the control in the tab order while making it impossible to operate:
+
+		  measured, this selector vs the sibling employee selector (no [isOpen])
+		    opens on mousedown   organization 0/3   employee 3/3
+		    Enter / Space / ArrowDown        all fail       all work
+		    Escape closes                    never (stuck open 3/3)   works
+
+		That is a WCAG 2.1.1 (Level A) failure. It also made this the only control in the
+		app that needs a complete, well-formed `click` to open at all: with
+		[searchable]="isOpen" it is non-searchable while closed, so mousedown took the
+		toggle() path and did nothing, and the panel opened solely from a template (click).
+
+		`isOpen` is still needed — [searchable], [addTag] and [class.close] read it — so it
+		stays as a mirror FED BY ng-select rather than a source of truth fighting it.
+		`gauzyOutside`/(clickOutside) went with it: ng-select closes on outside click by
+		itself once it owns its state. (That directive is also worth avoiding here — it
+		declares EventEmitter<MouseEvent> but emits a boolean, and the old handler only
+		worked because of the mismatch.)
+	-->
 	<ng-select
 		#select
 		[addTag]="(hasEditOrganization$ | async) && addTag && isOpen ? createNew : null"
@@ -7,20 +30,17 @@
 		[clearable]="false"
 		[items]="organizations"
 		bindLabel="name"
-		(change)="selectOrganization($event); select.blur()"
+		(change)="selectOrganization($event); select.blur(); onChange()"
 		(clear)="select.blur()"
 		[(ngModel)]="selectedOrganization"
 		[placeholder]="'FORM.PLACEHOLDERS.SELECT_COMPANY' | translate"
 		[addTagText]="'FORM.PLACEHOLDERS.ADD_ORGANIZATION' | translate"
 		appendTo="body"
-		[isOpen]="isOpen"
-		(change)="onChange()"
-		(click)="isOpen = !isOpen"
+		(open)="isOpen = true"
+		(close)="isOpen = false"
 		[class.organization]="isOpen"
 		[class.organization]="!isOpen"
 		[class.close]="!isOpen"
-		gauzyOutside
-		(clickOutside)="onClickOutside($event)"
 	>
 		<ng-template ng-option-tmp let-item="item" let-index="index">
 			@if (item.imageUrl) {

--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.ts
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.ts
@@ -354,15 +354,6 @@ export class OrganizationSelectorComponent implements AfterViewInit, OnInit, OnD
 	};
 
 	/**
-	 * Closes the component when a click occurs outside of it.
-	 *
-	 * @param event - The click event.
-	 */
-	onClickOutside(event: Event): void {
-		if (this.isOpen && !event) this.isOpen = false;
-	}
-
-	/**
 	 * Selects an organization by its ID.
 	 *
 	 * @param organizationId - The ID of the organization to select.

--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.ts
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.ts
@@ -318,13 +318,6 @@ export class OrganizationSelectorComponent implements AfterViewInit, OnInit, OnD
 	}
 
 	/**
-	 * event fired on model change.
-	 */
-	onChange() {
-		this.isOpen = false;
-	}
-
-	/**
 	 * Creates a new organization entry and navigates to the organization's page to open the add dialog.
 	 *
 	 * @param name - The name of the new organization to be created.


### PR DESCRIPTION
The header organization selector is in the tab order but cannot be operated by keyboard at all. This came out of the investigation into the intermittent click-blocking report (#9897) — it is not the reported bug, but it is a real, deterministic defect found on the way.

## The defect

`organization.component.html` bound `[isOpen]` back into ng-select. That puts the component into `_manualOpen`, which early-returns out of `open()`, `close()`, `_handleSpace` and `_handleArrowDown` (`node_modules/@ng-select/ng-select/fesm2022/ng-select-ng-select.mjs` l.2450, l.2465, l.2871). Measured live against the sibling **employee** selector in the same header, which has no `[isOpen]`:

| | organization | employee (control) |
|---|---|---|
| opens on mousedown | **0/3** | 3/3 |
| Enter | **fail** | works |
| Space | **fail** | works |
| ArrowDown | **fail** | works |
| Escape closes | **never — stuck open 3/3** | works |

That is a **WCAG 2.1.1 (Level A)** failure: focusable, announced, and inoperable.

It also made this the only control in the app that needs a complete, well-formed `click` event to open. Because `[searchable]="isOpen"` leaves it non-searchable while closed, ng-select's `handleMousedown` took the `toggle()` path, which early-returns under `_manualOpen` — so mousedown did nothing and the panel opened solely from the template's own `(click)`. Anything that interrupts the press (an Angular re-render replacing the node under the cursor) suppresses the click and the control silently does nothing.

## The change

Invert the relationship. ng-select owns its open state and **reports** it through `(open)`/`(close)`; `isOpen` stays only as a mirror, because `[searchable]`, `[addTag]` and `[class.close]` still read it.

`gauzyOutside` / `(clickOutside)` go with it — ng-select closes on outside click by itself once it owns its state. That also sidesteps a landmine rather than defusing it: `outside.directive.ts:10` declares `@Output() clickOutside = new EventEmitter<MouseEvent>()` but line 25 emits a **boolean**, and the old handler (`if (this.isOpen && !event)`) worked *only* because of that mismatch. Seven templates use the directive, so correcting its type is a separate change that must touch both sides at once.

The two `(change)` bindings on the same element are merged into one — Ivy registered both, so both handlers already fired.

## Verification

Built and measured in a browser, two arms with the employee selector as control:

- mousedown opens **3/3** (was 0/3)
- Enter, Space, ArrowDown all open (all previously failed)
- Escape closes (previously stuck open)
- outside click closes, with no `gauzyOutside`
- the `isOpen`-driven classes still track state

**One deliberate behaviour change:** a second click no longer closes the panel. That is ng-select's native behaviour for a searchable select — the click lands in its text input — and it is what **all four** header selectors do. Measured: Teams, Projects, Employee and Organization now all stay open on a second click, where Organization used to be the odd one out. Escape, outside click and selecting an item all still dismiss it.

## Not changed, on purpose

- **The duplicate `[class.organization]` bindings.** Pre-existing, effective behaviour ambiguous, and touching them risks a visual regression unrelated to this fix.
- **`outside.directive.ts`'s type lie.** Real, but it needs both sides changed together across seven call sites — its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard operation for the header Organization selector by letting `ng-select` manage its open state. Restores full keyboard support and matches the other header selectors, resolving a WCAG 2.1.1 (Level A) failure.

- **Bug Fixes**
  - Let `ng-select` own open state; mirror via `(open)`/`(close)` and remove `[isOpen]` and template `(click)` toggling.
  - Remove `gauzyOutside` and `onClickOutside`; outside clicks now close via `ng-select`.
  - Drop the redundant `(change)` handler and `onChange()`; `ng-select` closes on selection itself.
  - Behavior: Enter/Space/ArrowDown open; Escape and outside click close. While open, clicking the control body keeps it open (focus in search); clicking the arrow closes.

- **Refactors**
  - Reworded the inline comment to avoid a SonarCloud “commented-out code” false positive and clarified arrow-click behavior.

<sup>Written for commit 50f4b00c746de2d2da6154ed572faacb171b31b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

