### PR TITLE
cascade: develop -> stage (organization selector keyboard operability, WCAG 2.1.1 Level A)

### DIFF
--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
@@ -24,6 +24,11 @@
 		that directive here is a bonus — it declares its output as an emitter of MouseEvent
 		but actually emits a boolean, and the old handler worked only because of the
 		mismatch.
+
+		Dismissal, measured after the change and identical to the employee selector:
+		clicking the control BODY while open lands in the search input and keeps it open,
+		clicking the ARROW closes it, and Escape, an outside click or picking an item all
+		close it too.
 	-->
 	<ng-select
 		#select
@@ -32,7 +37,7 @@
 		[clearable]="false"
 		[items]="organizations"
 		bindLabel="name"
-		(change)="selectOrganization($event); select.blur(); onChange()"
+		(change)="selectOrganization($event); select.blur()"
 		(clear)="select.blur()"
 		[(ngModel)]="selectedOrganization"
 		[placeholder]="'FORM.PLACEHOLDERS.SELECT_COMPANY' | translate"

--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
@@ -1,27 +1,29 @@
 @if (organizations) {
 <div>
 	<!--
-		`isOpen` is REPORTED by ng-select via (open)/(close); it must never be BOUND back
-		in with [isOpen]. Binding it puts ng-select into `_manualOpen`, which early-returns
-		out of open(), close(), _handleSpace and _handleArrowDown — so the component keeps
-		the control in the tab order while making it impossible to operate:
+		The isOpen flag is REPORTED by ng-select through its open and close outputs. It must
+		never be fed back in through the isOpen input: doing so puts ng-select into its
+		_manualOpen mode, which early-returns out of open, close, _handleSpace and
+		_handleArrowDown. The control then stays in the tab order while being impossible to
+		operate. Measured against the sibling employee selector, which does not feed it back:
 
-		  measured, this selector vs the sibling employee selector (no [isOpen])
-		    opens on mousedown   organization 0/3   employee 3/3
-		    Enter / Space / ArrowDown        all fail       all work
-		    Escape closes                    never (stuck open 3/3)   works
+		  opens on mousedown          organization 0 of 3      employee 3 of 3
+		  Enter, Space, ArrowDown     all fail                 all work
+		  Escape closes               never, stuck open 3 of 3 works
 
-		That is a WCAG 2.1.1 (Level A) failure. It also made this the only control in the
-		app that needs a complete, well-formed `click` to open at all: with
-		[searchable]="isOpen" it is non-searchable while closed, so mousedown took the
-		toggle() path and did nothing, and the panel opened solely from a template (click).
+		That is a WCAG 2.1.1 Level A failure. It also made this the only control in the app
+		needing a complete, well-formed click to open at all: because the searchable input
+		is driven from the same flag, the control is non-searchable while closed, so
+		mousedown took the toggle path, early-returned, and did nothing — leaving the
+		template's own click handler as the only way to open it.
 
-		`isOpen` is still needed — [searchable], [addTag] and [class.close] read it — so it
-		stays as a mirror FED BY ng-select rather than a source of truth fighting it.
-		`gauzyOutside`/(clickOutside) went with it: ng-select closes on outside click by
-		itself once it owns its state. (That directive is also worth avoiding here — it
-		declares EventEmitter<MouseEvent> but emits a boolean, and the old handler only
-		worked because of the mismatch.)
+		The flag is still needed, since the searchable, addTag and close-class bindings all
+		read it, so it stays as a mirror FED BY ng-select rather than a second source of
+		truth fighting it. The gauzyOutside directive went away with the manual state:
+		ng-select dismisses itself on an outside click once it owns that state. Avoiding
+		that directive here is a bonus — it declares its output as an emitter of MouseEvent
+		but actually emits a boolean, and the old handler worked only because of the
+		mismatch.
 	-->
 	<ng-select
 		#select

--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.html
@@ -1,5 +1,28 @@
 @if (organizations) {
 <div>
+	<!--
+		`isOpen` is REPORTED by ng-select via (open)/(close); it must never be BOUND back
+		in with [isOpen]. Binding it puts ng-select into `_manualOpen`, which early-returns
+		out of open(), close(), _handleSpace and _handleArrowDown — so the component keeps
+		the control in the tab order while making it impossible to operate:
+
+		  measured, this selector vs the sibling employee selector (no [isOpen])
+		    opens on mousedown   organization 0/3   employee 3/3
+		    Enter / Space / ArrowDown        all fail       all work
+		    Escape closes                    never (stuck open 3/3)   works
+
+		That is a WCAG 2.1.1 (Level A) failure. It also made this the only control in the
+		app that needs a complete, well-formed `click` to open at all: with
+		[searchable]="isOpen" it is non-searchable while closed, so mousedown took the
+		toggle() path and did nothing, and the panel opened solely from a template (click).
+
+		`isOpen` is still needed — [searchable], [addTag] and [class.close] read it — so it
+		stays as a mirror FED BY ng-select rather than a source of truth fighting it.
+		`gauzyOutside`/(clickOutside) went with it: ng-select closes on outside click by
+		itself once it owns its state. (That directive is also worth avoiding here — it
+		declares EventEmitter<MouseEvent> but emits a boolean, and the old handler only
+		worked because of the mismatch.)
+	-->
 	<ng-select
 		#select
 		[addTag]="(hasEditOrganization$ | async) && addTag && isOpen ? createNew : null"
@@ -7,20 +30,17 @@
 		[clearable]="false"
 		[items]="organizations"
 		bindLabel="name"
-		(change)="selectOrganization($event); select.blur()"
+		(change)="selectOrganization($event); select.blur(); onChange()"
 		(clear)="select.blur()"
 		[(ngModel)]="selectedOrganization"
 		[placeholder]="'FORM.PLACEHOLDERS.SELECT_COMPANY' | translate"
 		[addTagText]="'FORM.PLACEHOLDERS.ADD_ORGANIZATION' | translate"
 		appendTo="body"
-		[isOpen]="isOpen"
-		(change)="onChange()"
-		(click)="isOpen = !isOpen"
+		(open)="isOpen = true"
+		(close)="isOpen = false"
 		[class.organization]="isOpen"
 		[class.organization]="!isOpen"
 		[class.close]="!isOpen"
-		gauzyOutside
-		(clickOutside)="onClickOutside($event)"
 	>
 		<ng-template ng-option-tmp let-item="item" let-index="index">
 			@if (item.imageUrl) {

--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.ts
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.ts
@@ -354,15 +354,6 @@ export class OrganizationSelectorComponent implements AfterViewInit, OnInit, OnD
 	};
 
 	/**
-	 * Closes the component when a click occurs outside of it.
-	 *
-	 * @param event - The click event.
-	 */
-	onClickOutside(event: Event): void {
-		if (this.isOpen && !event) this.isOpen = false;
-	}
-
-	/**
 	 * Selects an organization by its ID.
 	 *
 	 * @param organizationId - The ID of the organization to select.

--- a/packages/ui-core/shared/src/lib/selectors/organization/organization.component.ts
+++ b/packages/ui-core/shared/src/lib/selectors/organization/organization.component.ts
@@ -318,13 +318,6 @@ export class OrganizationSelectorComponent implements AfterViewInit, OnInit, OnD
 	}
 
 	/**
-	 * event fired on model change.
-	 */
-	onChange() {
-		this.isOpen = false;
-	}
-
-	/**
 	 * Creates a new organization entry and navigates to the organization's page to open the add dialog.
 	 *
 	 * @param name - The name of the new organization to be created.


### PR DESCRIPTION
﻿Cascade `develop` → `stage`. Carries PR #9899 only.

## What lands

**The header organization selector is operable by keyboard again.** It bound `[isOpen]` back into ng-select, which forces `_manualOpen` and early-returns out of `open()`, `close()`, `_handleSpace` and `_handleArrowDown` — leaving the control in the tab order while being impossible to operate. Measured against the sibling employee selector as a control:

| | organization (before) | employee (control) |
|---|---|---|
| opens on mousedown | 0/3 | 3/3 |
| Enter / Space / ArrowDown | all fail | all work |
| Escape closes | never — stuck open 3/3 | works |

That is a **WCAG 2.1.1 (Level A)** failure.

ng-select now owns its open state and reports it via `(open)`/`(close)`; `isOpen` remains only as a mirror for `[searchable]`, `[addTag]` and `[class.close]`. `gauzyOutside` goes with it — ng-select self-dismisses once it owns the state.

## Verification

Measured in a browser, **8/8**: mousedown opens 3/3, Enter/Space/ArrowDown all open, Escape closes, outside click closes, arrow closes, the isOpen-driven classes still track state.

Behaviour is now identical to every other header selector (Teams, Projects, Employee): clicking the control body while open lands in the search input and keeps it open; the arrow closes it.

## Review findings applied

- **cubic P2** — corrected a claim of mine: the arrow *does* still close the panel (verified on both selectors), so "a second click no longer closes it" was imprecise.
- **cubic P3** — dropped the now-redundant `onChange()`; ng-select's own close already mirrors the flag.
- **SonarCloud** — the gate failed on one MAJOR "commented out code" smell (an explanatory comment containing binding syntax); reworded as prose, now passing.

## Not changed, on purpose

`outside.directive.ts` declares `EventEmitter<MouseEvent>` but emits a **boolean**, and the old handler worked only because of that mismatch. Seven templates use it — correcting the type must touch both sides at once, so it is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores keyboard operability for the header organization selector to meet WCAG 2.1.1 (Level A). Behavior now matches other header selectors: Enter/Space/ArrowDown open, and Escape/outside click/arrow close.

- **Bug Fixes**
  - Let `ng-select` manage open/close; mirror state via `(open)`/`(close)` and removed `[isOpen]`.
  - Removed `gauzyOutside`, `onChange()`, and `onClickOutside()`; `ng-select` self-dismisses on outside click.
  - Kept `isOpen` only for `[searchable]`, `[addTag]`, and close-class bindings.

<sup>Written for commit 650fe20363ce816deb944a975e8cdce1b83ffe90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

