### PR TITLE
cascade: develop -> stage (e2e: fix the two real failures behind the churning shard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ You can also view a full list of our [contributors tracked by Github](https://gi
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ever-co/ever-gauzy&type=Date)](https://star-history.com/#ever-co/ever-gauzy&Date)
+[![Star History Chart](https://stats-github.ever.co/svg?repos=ever-co/ever-gauzy&type=Date)](https://stats-github.ever.co/#ever-co/ever-gauzy&Date)
 
 ## ❤️ Powered By
 

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/MessageButtonPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/MessageButtonPageObject.ts
@@ -1,4 +1,23 @@
 export const MessageButton = {
-	messageButtonCss: 'nb-action[icon="message-circle-outline"]',
-	menuItemCss: 'ul.menu-items'
+	// The support entries (Support Chat / FAQ / Help / About) used to hang off a
+	// speech-bubble `nb-action[icon="message-circle-outline"]` in the header. That
+	// control was removed when the entries were folded into the Quick Settings
+	// panel, so this spec opens Quick Settings instead.
+	//
+	// There is no attribute that identifies that trigger. It is rendered from
+	// `navigationBuilderService.sidebarActions$` as
+	// `<nb-action [icon]="action.icon" [class]="action.class">` — `[icon]` is a
+	// PROPERTY binding, so no `icon="..."` attribute reaches the DOM, and the class
+	// (`toggle-layout`) is shared with the changelog action registered beside it.
+	// So the trigger is identified by OUTCOME instead: click the candidates until
+	// the settings panel expands (see MessageButton.po).
+	// `:not(.show-large-down)` excludes the narrow-viewport-only extra-actions toggle,
+	// which is present in the DOM but hidden at desktop widths — without it the first
+	// match is an element that can never be visible.
+	toggleActionCss: 'nb-layout-header nb-action.toggle-layout:not(.show-large-down)',
+	// Assert against the EXPANDED panel: `ngx-theme-settings` is always in the DOM
+	// (the sidebar is merely collapsed), so keying off the component alone would
+	// pass without the panel ever having opened.
+	panelCss: 'nb-sidebar.settings-sidebar.expanded ngx-theme-settings',
+	supportLinksCss: 'nb-sidebar.settings-sidebar.expanded ngx-theme-settings .support-links'
 };

--- a/apps/gauzy-e2e/tests/bdd/steps/message-button.steps.ts
+++ b/apps/gauzy-e2e/tests/bdd/steps/message-button.steps.ts
@@ -1,16 +1,31 @@
 import { When } from '../../support/bdd';
+import { getPage } from '../../support/page-context';
 import * as messageButton from '../../support/pages/MessageButton.po';
 import { MessageButtonData } from '../../../src/support/Base/pagedata/MessageButtonPageData';
+import { MessageButton } from '../../../src/support/Base/pageobjects/MessageButtonPageObject';
 
-// Converted 1:1 from the plain MessageButtonTest.spec.ts: the single test() -> one Scenario, the single
-// test.step() -> one When step whose body is the verbatim .po call sequence, so runtime behaviour is
-// identical to the already-CI-tested spec. The `Given I am logged in as the default user` Background
-// step is defined once in common.steps.ts.
+// Originally converted 1:1 from the plain MessageButtonTest.spec.ts. The entries it checks
+// (Support Chat / FAQ / Help / About) have since moved out of a header speech-bubble menu
+// and into the Quick Settings panel, so this step opens that panel instead. The Scenario
+// wording is unchanged because what it asserts is unchanged: those entries are reachable.
 
 When('I verify the message button menu items exist', async () => {
 	await messageButton.messageButtonVisible();
 	await messageButton.clickMessageButton();
-	await messageButton.verifyTextExist(MessageButtonData.supportChat);
+
+	// Support Chat renders only when the deployment configured a Chatwoot website token
+	// (`isSupportChatAvailable` in ThemeSettingsComponent). CI sets none, so the entry is
+	// legitimately absent there — asserting it unconditionally would fail a correct build.
+	const supportChatPresent = await getPage()
+		.locator(MessageButton.supportLinksCss)
+		.getByText(MessageButtonData.supportChat, { exact: true })
+		.count()
+		.then((n) => n > 0)
+		.catch(() => false);
+	if (supportChatPresent) {
+		await messageButton.verifyTextExist(MessageButtonData.supportChat);
+	}
+
 	await messageButton.verifyTextExist(MessageButtonData.faq);
 	await messageButton.verifyTextExist(MessageButtonData.help);
 	await messageButton.verifyTextExist(MessageButtonData.about);

--- a/apps/gauzy-e2e/tests/support/pages/MessageButton.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/MessageButton.po.ts
@@ -28,16 +28,33 @@ export const clickMessageButton = async () => {
 	await waitForSpinnerGone();
 
 	const candidates = page.locator(MessageButton.toggleActionCss);
+	const panel = page.locator(MessageButton.panelCss).first();
 	const count = await candidates.count();
 
 	for (let i = 0; i < count; i++) {
 		await candidates.nth(i).dispatchEvent('click');
-		try {
-			await page.locator(MessageButton.panelCss).first().waitFor({ state: 'visible', timeout: 6_000 });
-			return;
-		} catch {
-			// Wrong panel (or none). Collapse whatever opened so the next candidate is
-			// not clicked through an open overlay, then continue.
+
+		const opened = await panel
+			.waitFor({ state: 'visible', timeout: 8_000 })
+			.then(() => true)
+			.catch(() => false);
+		if (opened) return;
+
+		// A timeout means "not visible YET" — it does not mean "wrong candidate".
+		// Re-check once before concluding, because mistaking a slow render for the
+		// wrong control and then clicking again would toggle the correctly-open
+		// panel shut. (That is the same conflation this branch fixes in
+		// `dispatchClickWhenSettled`; it must not be reintroduced here.)
+		if (await panel.isVisible().catch(() => false)) return;
+
+		// Only collapse when something ELSE actually opened — never blind-toggle the
+		// candidate. If the click opened nothing, a second click could open it late,
+		// leaving an unexpected overlay for the next candidate to be clicked through.
+		const otherOpen = await page
+			.locator('nb-sidebar.expanded:not(.settings-sidebar)')
+			.count()
+			.catch(() => 0);
+		if (otherOpen > 0) {
 			await candidates.nth(i).dispatchEvent('click').catch(() => undefined);
 			await page.waitForTimeout(400);
 		}

--- a/apps/gauzy-e2e/tests/support/pages/MessageButton.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/MessageButton.po.ts
@@ -1,9 +1,51 @@
-import { verifyElementIsVisible, clickButton, verifyText } from '../util';
+import { verifyElementIsVisible, verifyText, waitForSpinnerGone } from '../util';
+import { getPage } from '../page-context';
 // Selectors + data are framework-agnostic — reused from the Cypress tree during migration.
 import { MessageButton } from '../../../src/support/Base/pageobjects/MessageButtonPageObject';
 
-export const messageButtonVisible = async () => verifyElementIsVisible(MessageButton.messageButtonCss);
+/**
+ * The support entries moved out of a header speech-bubble menu and into the Quick
+ * Settings panel, so this page object drives that panel now.
+ */
 
-export const clickMessageButton = async () => clickButton(MessageButton.messageButtonCss);
+export const messageButtonVisible = async () => verifyElementIsVisible(MessageButton.toggleActionCss);
 
-export const verifyTextExist = async (text: string) => verifyText(MessageButton.menuItemCss, text);
+/**
+ * Open Quick Settings.
+ *
+ * Identified by OUTCOME, not by selector: the trigger carries no distinguishing
+ * attribute (see MessageButtonPageObject), and the changelog action sits beside it
+ * wearing the same class. Clicking each candidate until the panel expands is stable
+ * against icon changes, class changes and registration order — all of which have
+ * moved at least once.
+ *
+ * Uses `dispatchEvent('click')` rather than a real click so the header's own
+ * re-rendering cannot swallow it, and closes any wrong panel it opens before trying
+ * the next candidate.
+ */
+export const clickMessageButton = async () => {
+	const page = getPage();
+	await waitForSpinnerGone();
+
+	const candidates = page.locator(MessageButton.toggleActionCss);
+	const count = await candidates.count();
+
+	for (let i = 0; i < count; i++) {
+		await candidates.nth(i).dispatchEvent('click');
+		try {
+			await page.locator(MessageButton.panelCss).first().waitFor({ state: 'visible', timeout: 6_000 });
+			return;
+		} catch {
+			// Wrong panel (or none). Collapse whatever opened so the next candidate is
+			// not clicked through an open overlay, then continue.
+			await candidates.nth(i).dispatchEvent('click').catch(() => undefined);
+			await page.waitForTimeout(400);
+		}
+	}
+
+	// Nothing opened it — fail with the assertion the caller expects rather than
+	// silently continuing into a confusing text assertion.
+	await verifyElementIsVisible(MessageButton.panelCss);
+};
+
+export const verifyTextExist = async (text: string) => verifyText(MessageButton.supportLinksCss, text);

--- a/apps/gauzy-e2e/tests/support/util.ts
+++ b/apps/gauzy-e2e/tests/support/util.ts
@@ -129,6 +129,21 @@ export const dispatchClickWhenSettled = async (selector: string, confirmSelector
 		// Bounded on purpose: this is a settle attempt, not a gate. waitForLoadState defaults to the
 		// 60s navigationTimeout, and a page that never goes idle must not cost a minute per click.
 		await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => {});
+
+		// Check the desired END STATE before dispatching, not only after. The previous version
+		// documented this ("an already-open dialog is not opened twice") but did not do it: the
+		// confirm was only ever read AFTER the dispatch, so a retry fired a second click into an
+		// already-open dialog. `dispatchEvent` targets the element directly and ignores hit-testing,
+		// so that second click reached the trigger THROUGH the dialog backdrop and re-ran the open
+		// handler — which is why organization-tags saw `#inputName` pass its visibility check and
+		// then vanish before `clear()` could act on it (failing all 3 CI attempts, so not a flake).
+		//
+		// This can only ever skip work that is already done: when the confirm target is absent the
+		// behaviour below is unchanged.
+		if (confirmSelector && (await loc(confirmSelector).first().isVisible().catch(() => false))) {
+			return;
+		}
+
 		const target = loc(selector).first();
 		await target.waitFor({ state: 'visible', timeout: defaultCommandTimeout });
 		await target.dispatchEvent('click');
@@ -137,8 +152,7 @@ export const dispatchClickWhenSettled = async (selector: string, confirmSelector
 			await loc(confirmSelector).first().waitFor({ state: 'visible', timeout: 12_000 });
 			return;
 		} catch {
-			/* the click was swallowed — settle again and re-dispatch. Never re-dispatch blindly: the
-			   confirm target is checked first, so an already-open dialog is not opened twice. */
+			/* the click was swallowed — settle and try again, re-checking the end state first. */
 		}
 	}
 };


### PR DESCRIPTION
﻿Cascade `develop` → `stage`. Carries PR #9902 only.

## What lands

Two **real** e2e failures fixed — the ones behind the "one failing spec per shard that churns between runs" pattern. Both were reproduced locally against a running stack and verified fixed, not retried until green.

**`organization-tags`** — `dispatchClickWhenSettled` re-clicked an already-open dialog. Its comment claimed the confirm target was "checked first"; it was only ever read *after* the dispatch. Since `dispatchEvent` targets the element directly and ignores hit-testing, the retry's click reached the trigger *through* the dialog backdrop and re-ran the open handler. Symptom: `#inputName` passed its visibility check then vanished before `clear()` — failing all three CI attempts, so never a flake. Retries could not help because each retry re-triggered the race.

**`message-button`** — the spec asserted the header speech-bubble `nb-action[icon="message-circle-outline"]`, which was deliberately removed when Support Chat / FAQ / Help / About were folded into Quick Settings. The suite was right; the spec was stale. It now opens Quick Settings, identified by **outcome** (click candidates until the panel expands) because the trigger carries no identifying attribute — `[icon]` is a property binding so no `icon="…"` reaches the DOM, and `toggle-layout` is shared with the changelog action.

Support Chat is asserted only when present: it renders solely when a Chatwoot token is configured, and CI sets none.

## Review finding applied

cubic caught that the new candidate loop reintroduced the very conflation being fixed — treating "panel not visible within the window" as "wrong candidate" and clicking again, which would toggle a merely-slow panel shut and fail an otherwise-passing build. Now it re-checks once before concluding, only collapses when something *else* actually opened, and never blind-toggles.

## Verification

Local, against a real API + built web bundle:

```
organization-tags   1 passed (1.2m)
message-button      1 passed (29.1s)
```

Merged with a **merge commit**, never a squash, so the desktop-apps release gate can resolve the tag at `HEAD` or `HEAD^2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two real e2e failures that caused the churning shard by making clicks idempotent and updating the message-button test to open Quick Settings. Also switches the README Star History chart to our self-hosted endpoint.

- **Bug Fixes**
  - organization-tags: `dispatchClickWhenSettled` now checks the end state before dispatching, preventing a second click through the dialog backdrop that closed the form mid-test.
  - message-button: replaces the removed header icon with an outcome-based flow that opens Quick Settings (click candidates until the settings sidebar expands), re-checks after timeouts instead of blind-toggling, and asserts Support Chat only when present.

<sup>Written for commit df93df08101def006a3e987edd1dba6f3857e176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

