### PR TITLE
fix(ui): stop the sidebar menu re-querying Nebular on every change-detection pass

### DIFF
--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.ts
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.ts
@@ -1,17 +1,10 @@
-import {
-	AfterViewChecked,
-	ChangeDetectorRef,
-	Component,
-	EventEmitter,
-	inject,
-	Input,
-	OnInit,
-	Output
-} from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, inject, Input, OnInit, Output } from '@angular/core';
 import { CommonModule, Location } from '@angular/common';
 import { Router } from '@angular/router';
 import { NbAccordionModule, NbSidebarService, NbTooltipModule } from '@nebular/theme';
-import { tap } from 'rxjs/operators';
+import { merge } from 'rxjs';
+import { filter, take, tap } from 'rxjs/operators';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { NgxPermissionsModule } from 'ngx-permissions';
 import { IUser } from '@gauzy/contracts';
 import { IMenuItem, IMenuItemFocusChangeEvent } from '../../interface/menu-item.interface';
@@ -21,6 +14,10 @@ import { JitsuAnalyticsEvents, JitsuAnalyticsEventsEnum } from '../../../../../s
 import { TooltipDirective } from '../../../../../directives/tooltip.directive';
 import { ChildrenMenuItemComponent } from '../children-menu-item/children-menu-item.component';
 
+/** Tag of the Nebular sidebar this menu renders into (see one-column.layout.html). */
+const MENU_SIDEBAR_TAG = 'menu-sidebar';
+
+@UntilDestroy()
 @Component({
 	selector: 'ga-menu-item',
 	templateUrl: './menu-item.component.html',
@@ -35,7 +32,7 @@ import { ChildrenMenuItemComponent } from '../children-menu-item/children-menu-i
 		ChildrenMenuItemComponent
 	]
 })
-export class MenuItemComponent implements OnInit, AfterViewChecked {
+export class MenuItemComponent implements OnInit {
 	private readonly _router = inject(Router);
 	private readonly _sidebarService = inject(NbSidebarService);
 	private readonly _cdr = inject(ChangeDetectorRef);
@@ -117,6 +114,39 @@ export class MenuItemComponent implements OnInit, AfterViewChecked {
 	ngOnInit(): void {
 		// Get the user data from the store
 		this._user = this._store.user;
+
+		// Track the sidebar's expanded/collapsed state (the template hides labels when collapsed).
+		//
+		// `NbSidebarService.getSidebarState()` is a one-shot QUERY, not a live stream: Nebular's own
+		// doc says it "emits once", and NbSidebarComponent answers each request with a single
+		// `observer.next(this.state)`. That is why the original code re-ran it inside
+		// ngAfterViewChecked — re-querying on every change-detection pass was what kept `state` fresh.
+		//
+		// The cost of that was severe. Each pass opened a NEW, never-unsubscribed subscription, and
+		// each getSidebarState() call allocates a ReplaySubject and pushes it onto a module-level
+		// Subject that Nebular broadcasts synchronously to EVERY mounted sidebar — so the work was
+		// app-wide, not local, and multiplied by the dozens of menu items in the tree. Subscriptions
+		// grew without bound for as long as the app stayed open, making change detection steadily more
+		// expensive until clicks stopped getting a frame. It also called detectChanges() re-entrantly
+		// from inside ngAfterViewChecked, which can schedule the very check that re-enters the hook.
+		//
+		// Re-query only when the sidebar ACTUALLY changes. Every path that changes it goes through the
+		// service (the layout's toggle()/expand(), and this component's own toggle below), and this
+		// sidebar is not `responsive`, so it never changes state on its own. Ordering is safe:
+		// NbSidebarComponent hosts these items, so its own subscription is registered first and has
+		// already applied the change by the time we re-read it.
+		this.syncSidebarState();
+		merge(
+			this._sidebarService.onToggle(),
+			this._sidebarService.onExpand(),
+			this._sidebarService.onCollapse(),
+			this._sidebarService.onCompact()
+		)
+			.pipe(
+				filter(({ tag }) => !tag || tag === MENU_SIDEBAR_TAG),
+				untilDestroyed(this)
+			)
+			.subscribe(() => this.syncSidebarState());
 
 		// Check if the 'home' property of the 'item' object is truthy
 		if (this.item.home) {
@@ -218,7 +248,7 @@ export class MenuItemComponent implements OnInit, AfterViewChecked {
 		// Check if the sidebar is closed and the current item is not the home page
 		if (!this.state && !this.item.home) {
 			// If so, toggle the sidebar to open
-			this._sidebarService.toggle(false, 'menu-sidebar');
+			this._sidebarService.toggle(false, MENU_SIDEBAR_TAG);
 		}
 
 		// Perform redirection
@@ -242,9 +272,24 @@ export class MenuItemComponent implements OnInit, AfterViewChecked {
 		}
 	}
 
-	ngAfterViewChecked(): void {
-		const state$ = this._sidebarService.getSidebarState('menu-sidebar');
-		state$.pipe(tap((state) => (this.state = state === 'expanded' ? true : false))).subscribe();
-		this._cdr.detectChanges();
+	/**
+	 * Read the sidebar's current expanded/collapsed state.
+	 *
+	 * `take(1)` is what makes this safe to call repeatedly: getSidebarState() hands back a
+	 * ReplaySubject that receives exactly one value, so without it the subscription would sit open
+	 * forever waiting for a second emission that never comes.
+	 */
+	private syncSidebarState(): void {
+		this._sidebarService
+			.getSidebarState(MENU_SIDEBAR_TAG)
+			.pipe(
+				take(1),
+				tap((state) => {
+					this.state = state === 'expanded';
+					this._cdr.markForCheck();
+				}),
+				untilDestroyed(this)
+			)
+			.subscribe();
 	}
 }

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.ts
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.ts
@@ -130,11 +130,22 @@ export class MenuItemComponent implements OnInit {
 		// expensive until clicks stopped getting a frame. The detectChanges() call was re-entrant too:
 		// running it from inside ngAfterViewChecked can schedule the very check that re-enters the hook.
 		//
-		// Re-query only when the sidebar ACTUALLY changes. Every path that changes it goes through the
-		// service (the layout's toggle()/expand(), and this component's own toggle below), and this
-		// sidebar is not `responsive`, so it never changes state on its own. Ordering is safe:
-		// NbSidebarComponent hosts these items, so its own subscription is registered first and has
-		// already applied the change by the time we re-read it.
+		// Re-query only when the sidebar ACTUALLY changes. Every path that changes it today goes
+		// through the service — the layout's toggle()/expand(), header.component, and this component's
+		// own toggle below — and getSidebarState() is answered by whichever NbSidebarComponent carries
+		// the tag, wherever it is mounted, which is why this also works for the menu rendered in the
+		// workspace-menu overlay (outside nb-layout, inside no sidebar at all). Ordering is safe
+		// because that tagged sidebar is created with the layout at boot, before any menu item renders.
+		//
+		// CAVEAT, deliberately not enforced here: this assumes the sidebar is not `responsive`.
+		// Nebular's subscribeToMediaQueryChange() and the `responsive` setter call
+		// compact()/collapse()/expand() on the component DIRECTLY, never through the service subjects,
+		// so a responsive sidebar would leave this value permanently stale. one-column.layout.html —
+		// the layout actually in use — does not set it, but two-columns/three-columns.layout.ts DO
+		// declare `<nb-sidebar class="menu-sidebar" tag="menu-sidebar" responsive>`. They are currently
+		// unreachable, but they are exported from ThemeModule, so if one is ever wired up this needs to
+		// move to deriving the value from NbSidebarComponent's `(stateChange)` output, which
+		// updateState() emits on EVERY path including the responsive ones.
 		this.syncSidebarState();
 		merge(
 			this._sidebarService.onToggle(),

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.ts
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.ts
@@ -127,8 +127,8 @@ export class MenuItemComponent implements OnInit {
 		// Subject that Nebular broadcasts synchronously to EVERY mounted sidebar — so the work was
 		// app-wide, not local, and multiplied by the dozens of menu items in the tree. Subscriptions
 		// grew without bound for as long as the app stayed open, making change detection steadily more
-		// expensive until clicks stopped getting a frame. It also called detectChanges() re-entrantly
-		// from inside ngAfterViewChecked, which can schedule the very check that re-enters the hook.
+		// expensive until clicks stopped getting a frame. The detectChanges() call was re-entrant too:
+		// running it from inside ngAfterViewChecked can schedule the very check that re-enters the hook.
 		//
 		// Re-query only when the sidebar ACTUALLY changes. Every path that changes it goes through the
 		// service (the layout's toggle()/expand(), and this component's own toggle below), and this
@@ -143,7 +143,9 @@ export class MenuItemComponent implements OnInit {
 			this._sidebarService.onCompact()
 		)
 			.pipe(
-				filter(({ tag }) => !tag || tag === MENU_SIDEBAR_TAG),
+				// Tagged-only, matching how NbSidebarComponent itself filters: a sidebar that HAS a tag
+				// ignores untagged events, so reacting to them here would just re-query for nothing.
+				filter(({ tag }) => tag === MENU_SIDEBAR_TAG),
 				untilDestroyed(this)
 			)
 			.subscribe(() => this.syncSidebarState());

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
@@ -68,7 +68,9 @@ export class ThemeSettingsComponent implements OnInit, OnDestroy {
 			this.sidebarService.onCompact()
 		)
 			.pipe(
-				filter(({ tag }) => !tag || tag === QUICK_SETTINGS_SIDEBAR_TAG),
+				// Tagged-only, matching how NbSidebarComponent itself filters: a sidebar that HAS a tag
+				// ignores untagged events, so reacting to them here would just re-query for nothing.
+				filter(({ tag }) => tag === QUICK_SETTINGS_SIDEBAR_TAG),
 				untilDestroyed(this)
 			)
 			.subscribe(() => this.syncState());

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
@@ -2,8 +2,8 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { NbSidebarService } from '@nebular/theme';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
-import { merge } from 'rxjs';
-import { filter, take, tap } from 'rxjs/operators';
+import { asyncScheduler, merge } from 'rxjs';
+import { filter, observeOn, take, tap } from 'rxjs/operators';
 import { environment } from '@gauzy/ui-config';
 
 /**
@@ -71,6 +71,20 @@ export class ThemeSettingsComponent implements OnInit, OnDestroy {
 				// Tagged-only, matching how NbSidebarComponent itself filters: a sidebar that HAS a tag
 				// ignores untagged events, so reacting to them here would just re-query for nothing.
 				filter(({ tag }) => tag === QUICK_SETTINGS_SIDEBAR_TAG),
+				// DO NOT make this synchronous. The header gear calls sidebarService.toggle() from a
+				// click handler, and `OutsideDirective` listens on `document:click` WITHOUT capture, so
+				// it runs later in that same dispatch. If `state` were already true by then,
+				// onClickOutside() below would see "clicked outside && open" and immediately collapse
+				// the panel the gear just opened — verified: the trace read
+				//   toggle(settings_sidebar) -> state=true -> collapse(settings_sidebar) -> state=false
+				// and the panel became impossible to open.
+				//
+				// The old ngAfterViewChecked version only worked BECAUSE its value was stale for that
+				// tick, so "read the state on demand instead" reintroduces the same bug — by the time
+				// the document click runs, the sidebar really is expanded. The panel must simply not
+				// count as open during the click that opened it, so defer to a macro task. A microtask is
+				// NOT enough: microtask checkpoints drain between individual DOM listeners.
+				observeOn(asyncScheduler),
 				untilDestroyed(this)
 			)
 			.subscribe(() => this.syncState());

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnDestroy, AfterViewChecked } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { NbSidebarService } from '@nebular/theme';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
-import { tap } from 'rxjs/operators';
+import { merge } from 'rxjs';
+import { filter, take, tap } from 'rxjs/operators';
 import { environment } from '@gauzy/ui-config';
 
 /**
@@ -24,7 +25,7 @@ export const QUICK_SETTINGS_SIDEBAR_TAG = 'settings_sidebar';
     templateUrl: './theme-settings.component.html',
     standalone: false
 })
-export class ThemeSettingsComponent implements AfterViewChecked, OnDestroy {
+export class ThemeSettingsComponent implements OnInit, OnDestroy {
 	private state: boolean;
 
 	/**
@@ -48,11 +49,44 @@ export class ThemeSettingsComponent implements AfterViewChecked, OnDestroy {
 
 	constructor(private readonly sidebarService: NbSidebarService, private readonly router: Router) {}
 
-	ngAfterViewChecked(): void {
+	ngOnInit(): void {
+		// This ran in ngAfterViewChecked — i.e. after every change-detection pass — opening a new
+		// subscription each time. untilDestroyed only reclaims them when this component is destroyed,
+		// and it lives for as long as the layout does, so they piled up. `getSidebarState()` is also
+		// not a plain getter: each call allocates a ReplaySubject and pushes it onto a module-level
+		// Subject that Nebular broadcasts to EVERY mounted sidebar, so the cost was app-wide per tick.
+		//
+		// It cannot simply move to a single subscription, though: getSidebarState() emits exactly ONCE
+		// (it is a query, not a stream), and `state` has to stay current — onClickOutside() below uses
+		// it to decide whether an outside click should close the panel, so a value frozen at init would
+		// leave the panel un-closable. Re-read it when the sidebar actually changes instead.
+		this.syncState();
+		merge(
+			this.sidebarService.onToggle(),
+			this.sidebarService.onExpand(),
+			this.sidebarService.onCollapse(),
+			this.sidebarService.onCompact()
+		)
+			.pipe(
+				filter(({ tag }) => !tag || tag === QUICK_SETTINGS_SIDEBAR_TAG),
+				untilDestroyed(this)
+			)
+			.subscribe(() => this.syncState());
+	}
+
+	/**
+	 * Read the Quick Settings sidebar's current state.
+	 *
+	 * `take(1)` is what makes this safe to call repeatedly: getSidebarState() returns a ReplaySubject
+	 * that receives exactly one value, so without it each call would leave a subscription open forever
+	 * waiting for a second emission that never arrives.
+	 */
+	private syncState(): void {
 		this.sidebarService
 			.getSidebarState(QUICK_SETTINGS_SIDEBAR_TAG)
 			.pipe(
-				tap((state) => (this.state = state === 'expanded' ? true : false)),
+				take(1),
+				tap((state) => (this.state = state === 'expanded')),
 				untilDestroyed(this)
 			)
 			.subscribe();


### PR DESCRIPTION
## What

`MenuItemComponent` tracked the sidebar's expanded/collapsed state from inside `ngAfterViewChecked` — a hook that runs after **every** change-detection pass:

```ts
ngAfterViewChecked(): void {
    const state$ = this._sidebarService.getSidebarState('menu-sidebar');
    state$.pipe(tap(...)).subscribe();
    this._cdr.detectChanges();
}
```

## Why it was written that way

`NbSidebarService.getSidebarState()` is a one-shot **query**, not a live stream. Nebular's own doc says it *"emits once"*, and `NbSidebarComponent` answers each request with a single `observer.next(this.state)`. Re-running it every pass was therefore the thing keeping `state` fresh — which matters, because the template hides every menu label when it is false.

So this is not a case of "delete the pointless hook". Any fix has to keep `state` live.

## Why it's a problem

The cost compounded four ways:

- Each pass opened a **new** subscription, with no `untilDestroyed`/`take(1)`, so they accumulated without bound for as long as the app stayed open.
- Each `getSidebarState()` call allocates a `ReplaySubject` and pushes it onto a **module-level** Subject that Nebular broadcasts synchronously to **every** mounted sidebar — the work was app-wide, not local.
- All of it multiplied by the dozens of menu items in the tree.
- `detectChanges()` from inside `ngAfterViewChecked` is re-entrant: it can schedule the very view check that re-enters the hook.

This matches the reported **intermittent click-blocking**: change detection gets progressively more expensive, clicks are dispatched but the handler and its follow-up render never get a frame, so the controls that need a CD pass to respond (comboboxes, ng-select, page inputs) look dead. It recovers when the item tree is torn down and rebuilt — i.e. on navigation — or on reload, which is exactly the reported recovery profile.

## The fix

Re-query only when the sidebar **actually** changes, via the service's `onToggle`/`onExpand`/`onCollapse`/`onCompact` events, seeded once at init.

Safe because:
- every path that changes this sidebar goes through the service (the layout's `toggle()`/`expand()`, and this component's own toggle);
- the sidebar is not `responsive`, so it never changes state on its own;
- ordering holds — `NbSidebarComponent` hosts these items, so its subscription is registered first and has already applied the change before we re-read it.

Same class of fix for `ThemeSettingsComponent` (Quick Settings). Its subscription did have `untilDestroyed`, so the leak was bounded by the component's lifetime rather than unbounded, but it still opened a subscription and triggered the app-wide broadcast on every tick. Note its `state` also has to stay live — `onClickOutside()` uses it to decide whether an outside click should close the panel, so a value frozen at init would leave the panel un-closable.

A repo-wide scan confirms these are the only two `getSidebarState()` callers.

## Deliberately left alone

`WidgetLayoutComponent` and the time-track dashboard's `ngAfterViewChecked -> detectChanges()`. Same anti-pattern, but no subscription leak — and removing them risks `ExpressionChangedAfterItHasBeenChecked` on those canvases, which needs its own visual verification rather than being folded in here.

## Verification status

Compiles (`nx build gauzy -c local`). The behavioural claim that matters — that `state` still tracks expand/collapse — is the one to exercise in review: collapse and expand the sidebar and confirm labels still hide/show, and that clicking a menu item while collapsed still expands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops re-querying Nebular sidebar state on every change-detection pass to remove a subscription leak and app‑wide work. Labels still update correctly, click‑blocking is resolved, and Quick Settings no longer closes on the click that opens it.

- **Bug Fixes**
  - MenuItem: replace ngAfterViewChecked polling with event-driven updates via sidebar events; seed once on init; read with take(1); filter by the `menu-sidebar` tag only; use markForCheck to avoid re-entrant CD.
  - Theme Settings: same event-driven sync for the Quick Settings sidebar; take(1) and tag-only filtering for `settings_sidebar`; defer state sync to a macrotask to avoid immediate self-close on the opening click while keeping outside-click close behavior.

<sup>Written for commit 59e25f4a42e267ad285f65deb491f7e979ab37dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

