### PR TITLE
fix(ui): chat as a full-height column; header belongs to the canvas (fixes the UI-wide click blocking)

### DIFF
--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.html
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.html
@@ -1,6 +1,9 @@
 <nb-layout windowMode>
-	<!-- Header — its content shifts aside for the expanded AI chat panel
-	     (the chat is a full-height column; it must displace content, not cover it) -->
+	<!-- Header — belongs to the CANVAS, not to the whole window.
+	     The layout is three full-height columns: Menu | Chat | Canvas. The menu sidebar already
+	     spans the full height (its logo sits above the header band), and the chat does the same, so
+	     the header must start where the canvas starts. Nebular renders a `fixed` header at full
+	     width, so it is inset by the width of whatever columns precede the canvas. -->
 	@if (user()) {
 		<nb-layout-header
 			fixed
@@ -87,8 +90,11 @@
 	     Single @if (like the menu sidebar above): nesting control-flow blocks breaks
 	     nb-layout's select-based content projection for nb-sidebar. -->
 	@if (user() && chatSidebarService.available() && chatSidebarComponent(); as chatComponent) {
+		<!-- A FULL-HEIGHT column, like the nav menu: nothing sits above it, so the panel owns its
+		     own top edge (its title row and icons) instead of starting under the header band.
+		     That needs Nebular's default fixed `.main-container` — see the scss for why COLLAPSED
+		     must then be `display: none` rather than merely zero-width. -->
 		<nb-sidebar
-			#chatSidebarHost
 			class="chat-sidebar"
 			[class]="chatSidebarService.config()?.class ?? ''"
 			[class.chat-sidebar-end]="chatSidebarService.position() === 'end'"

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -80,34 +80,56 @@
 
     // Maximized: take all space except the nav menu (Menu | Chat);
     // the canvas is hidden (components stay alive) until restored.
+    //
+    // The fixed panel's horizontal start is its STATIC position — i.e. wherever the host lands in
+    // the flex row — so pinning `right: 0` and letting the width compute keeps it exactly between
+    // the nav menu and the viewport edge, with no measured width to mirror.
     &.chat-sidebar-maximized {
       flex: 1 1 auto !important;
       width: auto !important;
       min-width: 0 !important;
       max-width: none !important;
 
-      // The visible panel is the fixed `.main-container` below, whose width
-      // comes from --gz-chat-live-width. Its fallback is the DOCKED chat
-      // width, so whenever that variable is missing the host would grow while
-      // the panel stayed narrow — which is exactly what "maximize does
-      // nothing" looks like. Maximized falls back to the viewport instead.
       ::ng-deep .main-container {
-        width: var(--gz-chat-live-width, 100vw) !important;
-        max-width: 100vw !important;
+        right: 0;
+        width: auto !important;
       }
     }
 
+    // COLLAPSED MUST REMOVE THE PANEL, not merely narrow it.
+    //
+    // `.main-container` is `position: fixed`, and a fixed descendant is NOT clipped by an
+    // ancestor's `overflow: hidden` — so a host at `width: 0` cannot hide it. Any residual width
+    // survives as an invisible, full-height, click-eating strip: measured at 1280x720 it was
+    // 384x720 at x=256, and document.elementFromPoint over the org selector and the left third of
+    // the canvas returned `div.main-container` instead of the page. That is the "intermittent
+    // click-blocking across the UI" report.
+    //
+    // Width alone is not a safe lever here (the width declaration did not always win the cascade),
+    // so take the element out of rendering entirely. `display: none` cannot be overridden by a
+    // stale width and cannot receive a hit test.
     &.collapsed {
       width: 0 !important;
       overflow: hidden;
+
+      ::ng-deep .main-container {
+        display: none !important;
+      }
     }
 
+    // Pinned to the viewport's top so the chat is a FULL-HEIGHT column with nothing above it: the
+    // panel owns its own top edge (title row + icons), exactly like the nav menu owns the logo.
+    // The header is inset around it instead (see chatHeaderPad in the layout component), so header
+    // dropdowns open over the canvas, never over the chat.
+    //
+    // Width comes straight from `--gz-chat-width` (the user's chosen/persisted width) rather than
+    // from a ResizeObserver mirroring the host: one source of truth, and nothing to go stale.
     ::ng-deep .main-container {
-      width: var(--gz-chat-live-width, var(--gz-chat-width, 24rem)) !important;
+      width: var(--gz-chat-width, 24rem);
       max-width: none;
       top: 0 !important;
       height: 100vh !important;
-      z-index: 1041; // same layer as the nav menu sidebar — covers the header band
+      z-index: 1041; // same layer as the nav menu sidebar
       transition: width 0.2s ease;
       overflow: hidden;
 

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, effect, inject, viewChild, afterNextRender, DestroyRef, signal, Type } from '@angular/core';
+import { Component, effect, inject, viewChild, afterNextRender, DestroyRef, signal, Type } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NbLayoutComponent, NbSidebarService } from '@nebular/theme';
 import { ChatSidebarService, LayoutService, NavigationBuilderService, Store } from '@gauzy/ui-core/core';
@@ -74,22 +74,9 @@ export class OneColumnLayoutComponent {
 
 		this.themeLanguageSelectorService.initialize();
 
-		// Track the chat sidebar HOST width (flex-computed: normal, maximized
-		// or collapsed) and mirror it to --gz-chat-live-width so the fixed
-		// .main-container always matches the space the host reserves.
-		effect(() => {
-			const hostRef = this.chatSidebarHost();
-			this.chatHostResizeObserver?.disconnect();
-			this.chatHostResizeObserver = undefined;
-			const host = hostRef?.nativeElement as HTMLElement | undefined;
-			// `observe()` throws on a non-Element, which would take the whole
-			// effect (and the width mirror with it) down silently.
-			if (!host || typeof ResizeObserver === 'undefined') return;
-			const apply = () => host.style.setProperty('--gz-chat-live-width', `${host.getBoundingClientRect().width}px`);
-			this.chatHostResizeObserver = new ResizeObserver(apply);
-			this.chatHostResizeObserver.observe(host);
-			apply();
-		});
+		// No ResizeObserver mirroring the chat width any more: the panel takes its width straight from
+		// `--gz-chat-width` (the persisted user width), so there is a single source of truth and
+		// nothing that can go stale. See one-column.layout.scss.
 
 		// Runs only in the browser, after the first render — replaces ngAfterViewInit + isPlatformBrowser
 		afterNextRender(() => {
@@ -100,29 +87,19 @@ export class OneColumnLayoutComponent {
 		this.destroyRef.onDestroy(() => {
 			this.navigationBuilderService.clearSidebars();
 			this.navigationBuilderService.clearActionBars();
-			this.chatHostResizeObserver?.disconnect();
 			this.headerResizeObserver?.disconnect();
 		});
 	}
 
 	/**
-	 * The chat sidebar host ELEMENT (present only while the chat renders).
+	 * Horizontal inset the header needs so it starts where the CANVAS starts.
 	 *
-	 * `read: ElementRef` is required, not cosmetic: `#chatSidebarHost` sits on
-	 * `<nb-sidebar>`, and a template reference variable on a component element
-	 * resolves to the component instance by default — so without it the query
-	 * returned an NbSidebarComponent, `.nativeElement` was undefined, and the
-	 * ResizeObserver effect in the constructor never published
-	 * `--gz-chat-live-width`. The panel then fell back to the docked chat
-	 * width, which is why maximizing looked inert.
-	 */
-	readonly chatSidebarHost = viewChild('chatSidebarHost', { read: ElementRef });
-
-	/**
-	 * Horizontal padding the fixed header needs on the given side so its
-	 * content moves aside for the expanded chat column instead of being
-	 * covered by it. Null when the chat is collapsed, docked to the other
-	 * side, or maximized (maximized covers the header band entirely).
+	 * The layout is three full-height columns — Menu | Chat | Canvas — and the header belongs to the
+	 * canvas alone, so it must not run across the chat. Nebular renders a `fixed` header at full
+	 * viewport width, so the inset is applied as padding on the side the chat is docked to.
+	 *
+	 * Null when there is nothing to inset around: collapsed, docked to the other side, or maximized
+	 * (maximized deliberately covers the header band, since the canvas is hidden anyway).
 	 */
 	chatHeaderPad(side: 'start' | 'end'): number | null {
 		const chat = this.chatSidebarService;
@@ -131,7 +108,6 @@ export class OneColumnLayoutComponent {
 			: null;
 	}
 
-	private chatHostResizeObserver?: ResizeObserver;
 	private headerResizeObserver?: ResizeObserver;
 
 	/**
@@ -144,9 +120,8 @@ export class OneColumnLayoutComponent {
 	 * panel behind the header — it is not visible at 4.5rem-tall headers, which
 	 * is why it survived review.
 	 *
-	 * Mirrors the `--gz-chat-live-width` observer above: measure the box the
-	 * browser actually produced, rather than restating a constant that the layout
-	 * is free to exceed.
+	 * The principle: measure the box the browser actually produced, rather than restating a
+	 * constant that the layout is free to exceed.
 	 */
 	private observeHeaderHeight(): void {
 		if (typeof ResizeObserver === 'undefined' || typeof document === 'undefined') return;


### PR DESCRIPTION
## Target layout

Three **full-height** columns:

```
Sidebar (logo at top) | Chat (its own top edge) | Canvas (header, content, footer)
```

The chat must never sit on top of other content — and nothing may sit on top of the chat. So the header is **inset to start where the canvas starts**, rather than running across the chat column.

## Two things were wrong

**1. The chat overlaid the header band.** The header compensated by padding its own content aside, which is why header dropdowns collided with the panel.

**2. While collapsed, the panel stayed on screen.** `.main-container` is `position: fixed`, and a fixed descendant is **not** clipped by an ancestor's `overflow: hidden` — so the host going to `width: 0` could not hide it. It was invisible only because Nebular zeroes the background-carrying `.scrollable`, not the container.

Measured at 1280×720, chat collapsed — an invisible **384×720 strip at x=256..640**, `pointer-events: auto`, `z-index: 1041`, above the header's 1040:

| probe | before |
|---|---|
| (300, 40) header band | `div.main-container` |
| (500, 40) header band | `div.main-container` |
| (620, 60) header band | `div.main-container` |
| (300, 300) canvas | `div.main-container` |
| (500, 500) canvas | `div.main-container` |

That is the org/tenant selector and the entire left third of the canvas, dead to clicks. **This is the long-standing "intermittent click-blocking across the UI" report** — not intermittent at all, just conditional on the chat being collapsed, which is most of the time.

## Fixes

- **Collapsed sets `display: none`** on the panel. Width is not a safe lever here: the `width` declaration did not reliably win the cascade (setting the width variable to a distinctive value changed nothing, the panel stayed at its fallback). `display: none` cannot be overridden by a stale width and cannot receive a hit test.
- **The panel keeps its fixed, `top: 0`, full-height position**, so the chat is a real column that owns its own top edge — title row and icons — exactly as the nav sidebar owns the logo.
- **Width comes straight from `--gz-chat-width`**, the persisted user width. The ResizeObserver that mirrored a *measured* width onto the panel is gone: one source of truth, nothing to go stale. That variable going missing is what made "maximize does nothing" possible, and what left the phantom strip.
- **Maximized** pins `right: 0` and lets the width compute from the panel's static position, filling everything except the nav menu with no measured width.

## Verified in the browser, on the rebuilt bundle

| | expanded | collapsed |
|---|---|---|
| container | `y=0`, h=720 — full height | `display: none`, 0×0 |
| header `padding-left` | **384px** — inset by exactly the chat width | **0px** — space reclaimed |
| probes over header + canvas | — | all return real content (`DIV.actions`, `INPUT`, `NB-CARD-BODY`, `CANVAS`), **none inside the chat** |

Screenshot confirms: sidebar with logo at top, chat with its own icons at its own top edge and nothing above it, canvas with the header controls at its top, content below, footer at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)