### PR TITLE
fix(ai-chat): stop defaulting to a provider that has no credentials (AI chat 503s out of the box)

### DIFF
--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -236,17 +236,30 @@ export class AiChatService {
 				throw new BadRequestException(`Unknown AI provider '${requestedProviderId}'.`);
 			}
 		} else {
-			const defaults = await this.resolveDefaultProvider(definitions.map((d) => d.id));
-			definition = defaults ? AiProviderRegistry.get(defaults.defaultProvider) : undefined;
-			// Last resort: first provider that has credentials.
-			if (!definition) {
-				for (const candidate of definitions) {
-					if (await this.resolveCredentials(candidate)) {
-						definition = candidate;
-						break;
-					}
+			// Only a provider that actually HAS credentials may be defaulted to.
+			//
+			// This used to pass every REGISTERED provider — `definitions.map(d => d.id)` — while
+			// getConfig() (above) correctly passes only the configured ones. That asymmetry was a
+			// live outage: resolveDefaultProvider's last step is `const first = configuredIds[0]`,
+			// returned WITHOUT a credential check, and AiProviderRegistry.list() sorts ascending by
+			// `order`, where gauzy-ai is 10 — always first. So on any install with no tenant-level
+			// default, `definition` became gauzy-ai. Being non-null, it also skipped the
+			// "first provider that has credentials" search that used to sit here, and the request
+			// then died at the `no usable credentials` throw below — or, if GAUZY_AI_API_KEY happened
+			// to be set (the unrelated integration-ai plugin shares that exact variable), at
+			// gauzy-ai's createModel, which throws 'not implemented yet' unconditionally.
+			// Meanwhile GET /config advertised a healthy default, so the UI looked configured and
+			// every single turn failed.
+			const configured: IAiChatProviderDefinition[] = [];
+			for (const candidate of definitions) {
+				if (await this.resolveCredentials(candidate)) {
+					configured.push(candidate);
 				}
 			}
+			const defaults = await this.resolveDefaultProvider(configured.map((d) => d.id));
+			// resolveDefaultProvider already falls back to configuredIds[0], so this covers the
+			// old explicit "last resort" loop; it returns null only when nothing is configured.
+			definition = defaults ? AiProviderRegistry.get(defaults.defaultProvider) : configured[0];
 		}
 
 		if (!definition) {

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -185,7 +185,10 @@ export class AiChatService {
 				id: definition.id,
 				label: definition.label,
 				models: definition.models,
-				configured: credentials !== null,
+				// "Configured" must mean USABLE. A placeholder provider whose createModel throws is not,
+				// however many credentials resolve for it — otherwise /config advertises it, the
+				// settings UI shows it as ready, and it can be chosen as the tenant default.
+				configured: credentials !== null && definition.chatCapable !== false,
 				...(credentials ? { credentialSource: credentials.source } : {}),
 				...(definition.order !== undefined ? { order: definition.order } : {}),
 				...(definition.websiteUrl ? { websiteUrl: definition.websiteUrl } : {}),
@@ -250,12 +253,19 @@ export class AiChatService {
 			// gauzy-ai's createModel, which throws 'not implemented yet' unconditionally.
 			// Meanwhile GET /config advertised a healthy default, so the UI looked configured and
 			// every single turn failed.
-			const configured: IAiChatProviderDefinition[] = [];
-			for (const candidate of definitions) {
-				if (await this.resolveCredentials(candidate)) {
-					configured.push(candidate);
-				}
-			}
+			// Credentials alone are not enough: a placeholder provider whose createModel still throws
+			// must never be defaulted to, and emptying its env vars does not achieve that because a
+			// tenant BYOK credential is resolved FIRST. Gate on the capability too.
+			//
+			// Resolved in parallel — these are independent, and each one can cost a database read plus
+			// a decryption, so doing them in series put up to one round trip per registered provider on
+			// the critical path of every chat request.
+			const selectable = definitions.filter((candidate) => candidate.chatCapable !== false);
+			const configured = (
+				await Promise.all(
+					selectable.map(async (candidate) => ((await this.resolveCredentials(candidate)) ? candidate : null))
+				)
+			).filter((candidate): candidate is IAiChatProviderDefinition => candidate !== null);
 			const defaults = await this.resolveDefaultProvider(configured.map((d) => d.id));
 			// resolveDefaultProvider already falls back to configuredIds[0], so this covers the
 			// old explicit "last resort" loop; it returns null only when nothing is configured.

--- a/packages/plugins/ai-chat/src/lib/provider.types.ts
+++ b/packages/plugins/ai-chat/src/lib/provider.types.ts
@@ -40,6 +40,18 @@ export interface IAiChatProviderDefinition {
 	readonly defaultModel: string;
 	/** Display ordering (ascending) in provider lists/catalogs. Unset sorts last. */
 	readonly order?: number;
+	/**
+	 * Whether this provider can actually serve a chat model. Defaults to true.
+	 *
+	 * Having a credential is NOT proof of that. A provider registered as a placeholder — one whose
+	 * `createModel` still throws — can otherwise be selected the moment ANY credential resolves for
+	 * it, including a tenant BYOK key the user saved themselves, and then fails on every turn.
+	 * Removing its env vars only closes the environment route, because tenant credentials are
+	 * resolved first.
+	 *
+	 * Set this to false until `createModel` returns a real model.
+	 */
+	readonly chatCapable?: boolean;
 	/** Provider marketing/home page (shown in the settings UI). */
 	readonly websiteUrl?: string;
 	/** Page where the user can create/manage API keys ("Get API key" link). */

--- a/packages/plugins/ai-provider-gauzy-ai/src/lib/ai-provider-gauzy-ai.provider.ts
+++ b/packages/plugins/ai-provider-gauzy-ai/src/lib/ai-provider-gauzy-ai.provider.ts
@@ -16,7 +16,19 @@ const PROVIDER_ID = AiProviderEnum.GAUZY_AI;
 export const gauzyAiProviderDefinition: IAiChatProviderDefinition = {
 	id: PROVIDER_ID,
 	label: 'Gauzy AI',
-	apiKeyEnvVars: ['GAUZY_AI_API_KEY'],
+	/**
+	 * Deliberately EMPTY while `createModel` still throws.
+	 *
+	 * This used to be `['GAUZY_AI_API_KEY']`, which let this provider report itself
+	 * `configured: true` — but that variable belongs to the unrelated `integration-ai`
+	 * plugin (`packages/plugins/integration-ai/src/lib/config/gauzy-ai.ts`), so any
+	 * operator using THAT integration silently made a non-functional chat provider look
+	 * usable. Combined with `order: 10` (first in the registry's ascending sort), it could
+	 * win default selection and fail every turn with 'not implemented yet'.
+	 *
+	 * Restore the variable in the same change that makes `createModel` return a real model.
+	 */
+	apiKeyEnvVars: [],
 	baseUrlEnvVar: 'GAUZY_AI_BASE_URL',
 	models: [],
 	defaultModel: '',

--- a/packages/plugins/ai-provider-gauzy-ai/src/lib/ai-provider-gauzy-ai.provider.ts
+++ b/packages/plugins/ai-provider-gauzy-ai/src/lib/ai-provider-gauzy-ai.provider.ts
@@ -29,6 +29,16 @@ export const gauzyAiProviderDefinition: IAiChatProviderDefinition = {
 	 * Restore the variable in the same change that makes `createModel` return a real model.
 	 */
 	apiKeyEnvVars: [],
+	/**
+	 * Not chat-capable while `createModel` throws.
+	 *
+	 * Emptying `apiKeyEnvVars` above only closes the ENVIRONMENT route. Credentials are resolved
+	 * tenant-first, so a tenant that saves a Gauzy AI key through the BYOK settings page would still
+	 * mark this provider `configured`, let it win default selection (it sorts first at order 10), and
+	 * then fail every turn with 'not implemented yet'. Capability is a separate question from
+	 * credentials, so it gets its own flag.
+	 */
+	chatCapable: false,
 	baseUrlEnvVar: 'GAUZY_AI_BASE_URL',
 	models: [],
 	defaultModel: '',


### PR DESCRIPTION
## Impact

**AI chat fails on every turn for any install that has no tenant-level default provider** — i.e. the out-of-the-box state. Nothing in the UI hints at it, because `GET /config` advertises a healthy default at the same moment.

Found while mapping the codebase for the free-tier OpenRouter work; it is a prerequisite for "the AI agent just works by default".

## Root cause

A one-word asymmetry between two callers of the same helper:

```ts
getConfig()      resolveDefaultProvider(configured.map(p => p.id))    // only CONFIGURED ✓
resolveModel()   resolveDefaultProvider(definitions.map(d => d.id))   // every REGISTERED ✗
```

`resolveDefaultProvider` ends with:

```ts
const first = configuredIds[0];
if (!first) return null;
return { defaultProvider: first, ... };   // no credential check
```

The parameter name is a promise the second caller doesn't keep. `AiProviderRegistry.list()` sorts ascending by `order`, and `gauzy-ai` is `order: 10`, so `first` was **always** `gauzy-ai`:

| provider | order |
|---|---|
| **gauzy-ai** | **10** |
| openrouter | 20 |
| vercel-gateway | 30 |
| anthropic | 40 |
| openai | 50 |
| gemini | 60 |
| grok | 70 |

Worse, that non-null result **skipped the fallback written for exactly this case** — the `// Last resort: first provider that has credentials` loop sat immediately below, behind `if (!definition)`. So the request died either at the `no usable credentials` throw, or — if `GAUZY_AI_API_KEY` happened to be set — inside `gauzy-ai`'s `createModel`, which throws *"not implemented yet"* unconditionally.

## Changes

**1. `resolveModel` filters to providers that actually resolve credentials.** `resolveDefaultProvider`'s own `configuredIds[0]` fallback then subsumes the old explicit loop, so the loop is deleted rather than duplicated.

**2. `gauzy-ai`'s `apiKeyEnvVars` emptied while its `createModel` still throws.** It pointed at `GAUZY_AI_API_KEY`, which belongs to the unrelated **integration-ai** plugin (`packages/plugins/integration-ai/src/lib/config/gauzy-ai.ts`) — so any operator using that integration silently promoted a non-functional chat provider to `configured: true`, where `order: 10` let it win default selection. The comment says to restore the variable in the same change that gives it a working `createModel`.

## Verification

- `tsc --noEmit` clean on the plugin.
- All **36** existing unit tests pass.
- **Not** covered by a regression test, and I want to be straight about that: this plugin has no service-level spec harness today (only `system-prompt`, `provider-registry`, and the encryption service). Standing one up needs `RequestContext` + credential-service mocking and is worth its own change rather than being bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AI chat failing out of the box when no tenant default is set. Defaulting now only considers providers with usable credentials and chat capability, so `gauzy-ai` is not auto-selected and 503s are avoided.

- Bug Fixes
  - Introduced `chatCapable` on provider definitions and enforce it: `getConfig` marks a provider configured only if it has credentials and is chat-capable; `resolveModel` filters to chat-capable providers with credentials and uses `resolveDefaultProvider` (removes the old fallback loop).
  - In `ai-provider-gauzy-ai`, cleared `apiKeyEnvVars` and set `chatCapable: false` until `createModel` is implemented.

- Performance
  - Credential checks now run in parallel to reduce per-request latency.

<sup>Written for commit 2c577505ef25e095a2f4989036f188f663d4fb96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

