### PR TITLE
fix(timesheet): daily view jumps to the wrong day after creating a log (and the e2e churn it causes)

### DIFF
--- a/apps/gauzy-e2e/tests/support/pages/Timesheets.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Timesheets.po.ts
@@ -399,7 +399,7 @@ const selectRowFor = async (toolbarBtnCss: string) => {
 	// DIFFERENT DAY than the one the time log was written to, so `?date=` names the bug outright.
 	if ((await getPage().locator(TimesheetsPage.timeLogRowCss).count()) === 0) {
 		throw new Error(
-			`Daily grid rendered NO time-log rows ("No Data") after ${2} reloads, so there is nothing to ` +
+			`Daily grid rendered NO time-log rows ("No Data") after 2 reloads, so there is nothing to ` +
 				`select. The log we created is not inside the day the grid is querying — check the day in ` +
 				`the URL against the log's startedAt. URL=${getPage().url()}`
 		);

--- a/apps/gauzy-e2e/tests/support/pages/Timesheets.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Timesheets.po.ts
@@ -368,10 +368,13 @@ const ensureOurRowRendered = async () => {
 	const ours = page.locator(TimesheetsPage.timeLogRowCss).filter({ hasText: TimesheetsPageData.defaultDescription });
 	for (let attempt = 0; attempt < 2; attempt++) {
 		if ((await ours.count().catch(() => 0)) > 0) return;
-		await page.reload();
+		// Bound both waits. `reload()` and `waitForLoadState('networkidle')` inherit the (long)
+		// navigation/global timeout otherwise, which is how this helper's worst case reached minutes
+		// rather than seconds — util.ts:131 already bounds networkidle for the same reason.
+		await page.reload({ timeout: 20_000 }).catch(() => undefined);
 		await page.waitForTimeout(1500);
 		await waitForSpinnerGone();
-		await page.waitForLoadState('networkidle').catch(() => {});
+		await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => {});
 		await page.waitForTimeout(1500);
 	}
 };
@@ -383,6 +386,25 @@ const selectRowFor = async (toolbarBtnCss: string) => {
 	// Already selected (e.g. left selected after the View dialog closed)? Don't toggle it off.
 	if (await toolbarBtnReady(toolbarBtnCss)) return;
 	await ensureOurRowRendered();
+
+	// Fail HERE, immediately, when the grid rendered nothing.
+	//
+	// Without this the loop below spends the entire 240s test budget "observing" a locator that
+	// matches zero elements — `locator.evaluate()` auto-waits, so every probe burns the full
+	// `actionTimeout` (24s) and returns `undefined`, which the loop correctly treats as "unknown" and
+	// waits out. Six of those is ~144s, the test dies at 240s, and the diagnostic below never runs:
+	// the timeout masks the very message written to explain the failure.
+	//
+	// The URL matters more than the message: this state is reached when the daily grid is querying a
+	// DIFFERENT DAY than the one the time log was written to, so `?date=` names the bug outright.
+	if ((await getPage().locator(TimesheetsPage.timeLogRowCss).count()) === 0) {
+		throw new Error(
+			`Daily grid rendered NO time-log rows ("No Data") after ${2} reloads, so there is nothing to ` +
+				`select. The log we created is not inside the day the grid is querying — check the day in ` +
+				`the URL against the log's startedAt. URL=${getPage().url()}`
+		);
+	}
+
 	const ours = getPage()
 		.locator(TimesheetsPage.timeLogRowCss)
 		.filter({ hasText: TimesheetsPageData.defaultDescription })
@@ -413,8 +435,16 @@ const selectRowFor = async (toolbarBtnCss: string) => {
 	 * "unselected", and collapsing the two would click an already-selected row and
 	 * reintroduce the very oscillation this loop exists to prevent.
 	 */
-	const isSelected = async (): Promise<boolean | undefined> =>
-		row.evaluate((el) => el.classList.contains('selected')).catch(() => undefined);
+	const isSelected = async (): Promise<boolean | undefined> => {
+		// `locator.evaluate()` AUTO-WAITS for the element, so an unmatched locator costs the full
+		// `actionTimeout` (24s, playwright.config.ts:66) per call — a "cheap observation" that is
+		// anything but. Short-circuit on count() first, and bound the read itself, so a probe stays a
+		// probe: worst case ~1s instead of 24s.
+		if ((await row.count().catch(() => 0)) === 0) return undefined;
+		return row
+			.evaluate((el) => el.classList.contains('selected'), undefined, { timeout: 1_000 })
+			.catch(() => undefined);
+	};
 
 	for (let i = 0; i < 6; i++) {
 		if (await toolbarBtnReady(toolbarBtnCss)) return; // selected AND toolbar enabled

--- a/apps/gauzy/src/app/pages/employees/timesheet/calendar/calendar/calendar.component.ts
+++ b/apps/gauzy/src/app/pages/employees/timesheet/calendar/calendar/calendar.component.ts
@@ -376,7 +376,7 @@ export class CalendarComponent extends BaseSelectorFilterComponent implements On
 			.pipe(
 				filter((timeLog: ITimeLog) => !!timeLog),
 				tap((timeLog: ITimeLog) =>
-					this.dateRangePickerBuilderService.refreshDateRangePicker(moment(timeLog.startedAt))
+					this.dateRangePickerBuilderService.refreshDateRangePicker(moment(timeLog.startedAt), this.timeZoneService.currentTimeZone)
 				),
 				tap(() => this.subject$.next(true)),
 				untilDestroyed(this)

--- a/apps/gauzy/src/app/pages/employees/timesheet/daily/daily/daily.component.ts
+++ b/apps/gauzy/src/app/pages/employees/timesheet/daily/daily/daily.component.ts
@@ -290,7 +290,10 @@ export class DailyComponent extends BaseSelectorFilterComponent implements After
 				filter((timeLog: ITimeLog) => !!timeLog),
 				// Tap to refresh the date range picker
 				tap((timeLog: ITimeLog) => {
-					this.dateRangePickerBuilderService.refreshDateRangePicker(moment(timeLog.startedAt));
+					this.dateRangePickerBuilderService.refreshDateRangePicker(
+						moment(timeLog.startedAt),
+						this.timeZoneService.currentTimeZone
+					);
 				}),
 				// Tap to notify subscribers
 				tap(() => this.refreshTrigger$.next(true)),
@@ -317,7 +320,10 @@ export class DailyComponent extends BaseSelectorFilterComponent implements After
 				filter((editedTimeLog: ITimeLog) => !!editedTimeLog),
 				// Tap to refresh the date range picker
 				tap((editedTimeLog: ITimeLog) => {
-					this.dateRangePickerBuilderService.refreshDateRangePicker(moment(editedTimeLog.startedAt));
+					this.dateRangePickerBuilderService.refreshDateRangePicker(
+						moment(editedTimeLog.startedAt),
+						this.timeZoneService.currentTimeZone
+					);
 				}),
 				// Tap to notify subscribers
 				tap(() => this.refreshTrigger$.next(true)),

--- a/apps/gauzy/src/app/pages/employees/timesheet/weekly/weekly/weekly.component.ts
+++ b/apps/gauzy/src/app/pages/employees/timesheet/weekly/weekly/weekly.component.ts
@@ -221,7 +221,7 @@ export class WeeklyComponent extends BaseSelectorFilterComponent implements OnIn
 			.pipe(
 				filter((log: ITimeLog) => !!log),
 				tap((log: ITimeLog) =>
-					this.dateRangePickerBuilderService.refreshDateRangePicker(moment(log.startedAt))
+					this.dateRangePickerBuilderService.refreshDateRangePicker(moment(log.startedAt), this.timeZoneService.currentTimeZone)
 				),
 				tap(() => this.subject$.next(true)),
 				untilDestroyed(this)
@@ -269,7 +269,7 @@ export class WeeklyComponent extends BaseSelectorFilterComponent implements OnIn
 		dialogRef.onClose
 			.pipe(
 				filter((timeLog) => !!timeLog), // Ensure valid timeLog
-				tap((timeLog) => this.dateRangePickerBuilderService.refreshDateRangePicker(moment(timeLog.startedAt))), // Refresh the date range picker
+				tap((timeLog) => this.dateRangePickerBuilderService.refreshDateRangePicker(moment(timeLog.startedAt), this.timeZoneService.currentTimeZone)), // Refresh the date range picker
 				tap(() => this.subject$.next(true)), // Notify observers of changes
 				untilDestroyed(this) // Cleanup when the component is destroyed
 			)

--- a/packages/ui-core/core/src/lib/services/selector-builder/date-range-picker-builder.service.spec.ts
+++ b/packages/ui-core/core/src/lib/services/selector-builder/date-range-picker-builder.service.spec.ts
@@ -1,0 +1,94 @@
+import moment from 'moment';
+import { toTimezone } from '@gauzy/ui-core/common';
+import { DateRangePickerBuilderService } from './date-range-picker-builder.service';
+
+/**
+ * Regression tests for the day the picker lands on after a record is created.
+ *
+ * The bug these pin down cost a CI cycle to find and is invisible to most developers, because it only
+ * appears when the BROWSER's timezone disagrees with the ORGANIZATION's across midnight:
+ *
+ *   - callers pass an INSTANT (a time log's `startedAt`), not a wall-clock day;
+ *   - the picker's value is a wall-clock day that is later re-interpreted in the ORG timezone
+ *     (serialized to the URL as 'YYYY-MM-DD', read back with a UTC offset);
+ *   - so truncating the instant with `startOf()` in the BROWSER's zone can select the previous day,
+ *     and the daily grid then queries a window the new record is not in and shows "No Data".
+ *
+ * The e2e suite hit this ~54% of runs because `organization.seed.ts` picks the org timezone at
+ * random and the failure depends only on the sign of its offset.
+ */
+describe('DateRangePickerBuilderService — day selection across timezones', () => {
+	let service: DateRangePickerBuilderService;
+
+	beforeEach(() => {
+		service = new DateRangePickerBuilderService();
+		service.setDatePickerConfig({
+			unitOfTime: 'day',
+			isLockDatePicker: false,
+			isSaveDatePicker: false,
+			isSingleDatePicker: true,
+			isDisableFutureDate: false,
+			isDisablePastDate: false
+		});
+	});
+
+	/** The picker stores browser-local Dates; the day it represents is what gets serialized. */
+	const selectedDay = (): string => moment(service.selectedDateRange.startDate).format('YYYY-MM-DD');
+
+	describe('when the org is AHEAD of the browser (the failing case)', () => {
+		// Midnight of 5 Aug in Asia/Taipei (UTC+8) is 16:00Z on 4 Aug.
+		const midnightTaipei5Aug = moment.utc('2026-08-04T16:00:00.000Z');
+
+		it('selects the ORGANIZATION day when the timezone is supplied', () => {
+			service.refreshDateRangePicker(midnightTaipei5Aug, 'Asia/Taipei');
+			expect(selectedDay()).toBe('2026-08-05');
+		});
+
+		it('brackets the instant so the record is inside the queried range', () => {
+			service.refreshDateRangePicker(midnightTaipei5Aug, 'Asia/Taipei');
+			const { startDate, endDate } = service.selectedDateRange;
+			// The whole point: the day chosen must CONTAIN the log that was just created.
+			expect(moment(startDate).format('YYYY-MM-DD')).toBe('2026-08-05');
+			expect(moment(endDate).format('YYYY-MM-DD')).toBe('2026-08-05');
+		});
+	});
+
+	describe('when the org is BEHIND the browser', () => {
+		// Midnight of 5 Aug in America/New_York (UTC-4 in August) is 04:00Z on 5 Aug.
+		const midnightNewYork5Aug = moment.utc('2026-08-05T04:00:00.000Z');
+
+		it('still selects the organization day', () => {
+			service.refreshDateRangePicker(midnightNewYork5Aug, 'America/New_York');
+			expect(selectedDay()).toBe('2026-08-05');
+		});
+
+		it('does not drift for an instant late in the org day', () => {
+			// 23:30 on 5 Aug in New York is 03:30Z on 6 Aug — the mirror image of the bug.
+			service.refreshDateRangePicker(moment.utc('2026-08-06T03:30:00.000Z'), 'America/New_York');
+			expect(selectedDay()).toBe('2026-08-05');
+		});
+	});
+
+	it('is unchanged when no timezone is supplied (callers passing a wall-clock day)', () => {
+		// Not every caller deals in instants; those must keep browser-local behaviour exactly.
+		const localNoon = moment('2026-08-05T12:00:00');
+		service.refreshDateRangePicker(localNoon);
+		expect(selectedDay()).toBe('2026-08-05');
+	});
+
+	it('handles a week unit the same way', () => {
+		service.setDatePickerConfig({
+			unitOfTime: 'week',
+			isLockDatePicker: false,
+			isSaveDatePicker: false,
+			isSingleDatePicker: false,
+			isDisableFutureDate: false,
+			isDisablePastDate: false
+		});
+		// Sunday 2 Aug 2026 00:00 Taipei = 1 Aug 16:00Z — a browser behind would pick the prior week.
+		service.refreshDateRangePicker(moment.utc('2026-08-01T16:00:00.000Z'), 'Asia/Taipei');
+		const start = moment(service.selectedDateRange.startDate);
+		const end = moment(service.selectedDateRange.endDate);
+		expect(moment('2026-08-02').isBetween(start, end, 'day', '[]')).toBe(true);
+	});
+});

--- a/packages/ui-core/core/src/lib/services/selector-builder/date-range-picker-builder.service.spec.ts
+++ b/packages/ui-core/core/src/lib/services/selector-builder/date-range-picker-builder.service.spec.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { toTimezone } from '@gauzy/ui-core/common';
+import { toUtcOffset } from '@gauzy/ui-core/common';
 import { DateRangePickerBuilderService } from './date-range-picker-builder.service';
 
 /**
@@ -47,7 +47,18 @@ describe('DateRangePickerBuilderService — day selection across timezones', () 
 		it('brackets the instant so the record is inside the queried range', () => {
 			service.refreshDateRangePicker(midnightTaipei5Aug, 'Asia/Taipei');
 			const { startDate, endDate } = service.selectedDateRange;
-			// The whole point: the day chosen must CONTAIN the log that was just created.
+			// Assert CONTAINMENT, not merely that both ends format to the right day — an interval
+			// inside 2026-08-05 that did not cover the instant would satisfy the latter and still
+			// query a window the record is absent from, which is the entire bug.
+			//
+			// Containment must be checked on the CONVERTED range, not the raw browser-local one. The
+			// picker deliberately holds a wall-clock day; the request layer turns it into instants with
+			// toUtcOffset(range, orgTimeZone) (base-selector-filter.component.ts). For Asia/Taipei that
+			// yields 2026-08-04T16:00Z → 2026-08-05T15:59Z — precisely the window observed in the CI
+			// network trace — and the instant sits at its lower bound.
+			const queriedFrom = toUtcOffset(startDate, 'Asia/Taipei');
+			const queriedTo = toUtcOffset(endDate, 'Asia/Taipei');
+			expect(midnightTaipei5Aug.isBetween(queriedFrom, queriedTo, undefined, '[]')).toBe(true);
 			expect(moment(startDate).format('YYYY-MM-DD')).toBe('2026-08-05');
 			expect(moment(endDate).format('YYYY-MM-DD')).toBe('2026-08-05');
 		});

--- a/packages/ui-core/core/src/lib/services/selector-builder/date-range-picker-builder.service.ts
+++ b/packages/ui-core/core/src/lib/services/selector-builder/date-range-picker-builder.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import moment from 'moment';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { isNotEmpty } from '@gauzy/ui-core/common';
+import { isNotEmpty, toTimezone } from '@gauzy/ui-core/common';
 import { IDateRangePicker } from '@gauzy/contracts';
 import { IDatePickerConfig } from './selector-builder-types';
 
@@ -81,16 +81,34 @@ export class DateRangePickerBuilderService {
 	}
 
 	/**
-	 * Refresh date range picker for specific dates
+	 * Refresh the date range picker so it shows the day/week containing `date`.
 	 *
-	 * @param date The date used to refresh the date range picker.
+	 * @param date  The date used to refresh the picker. Callers pass an INSTANT (e.g. a time log's
+	 *              `startedAt`), not a wall-clock day.
+	 * @param timeZone Organization timezone (IANA). Pass it whenever `date` is an instant that belongs
+	 *              to an organization-local day — see below for why omitting it can select the wrong day.
 	 */
-	refreshDateRangePicker(date: moment.Moment) {
+	refreshDateRangePicker(date: moment.Moment, timeZone?: string) {
 		// Extract the unit of time from the current date picker configuration
 		const unitOfTime = this.datePickerConfig.unitOfTime;
+
+		// The picker's value is a WALL-CLOCK day that is later re-interpreted in the ORGANIZATION's
+		// timezone (the range is written to the URL as 'YYYY-MM-DD' and read back with a UTC offset).
+		// `date`, however, is an instant. Taking startOf/endOf in the BROWSER's zone therefore picks
+		// the wrong calendar day whenever the two disagree across midnight.
+		//
+		// Concretely: a log created at midnight in an org on UTC+8 is the instant 16:00Z the previous
+		// day. A browser on UTC computes startOf('day') as that PREVIOUS day, so the daily view jumps
+		// back a day and shows "No Data" for the log the user just created. It bites any user whose
+		// browser is behind their organization, and it is deterministic, not a race.
+		//
+		// Re-express the instant as the same wall-clock time in the browser's zone before truncating,
+		// so the day is the organization's day while the value stays the browser-local Date the rest
+		// of the picker expects.
+		const local = timeZone ? moment(toTimezone(date, timeZone).format('YYYY-MM-DDTHH:mm:ss')) : moment(date);
 		// Calculate the start and end dates based on the provided date and unit of time
-		const startDate = moment(date).startOf(unitOfTime).toDate();
-		const endDate = moment(date).endOf(unitOfTime).toDate();
+		const startDate = local.clone().startOf(unitOfTime).toDate();
+		const endDate = local.clone().endOf(unitOfTime).toDate();
 
 		this.setDateRangePicker({ startDate, endDate }); // Update the date range picker with the new start and end dates
 		this.setDatePickerConfig(this._datePickerConfig$.getValue()); // Maintain the current date picker configuration

--- a/packages/ui-core/tsconfig.spec.json
+++ b/packages/ui-core/tsconfig.spec.json
@@ -6,7 +6,9 @@
 		"target": "es2016",
 		"types": ["jest", "node"],
 		"moduleResolution": "bundler",
-		"isolatedModules": true
+		"isolatedModules": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true
 	},
 	"files": ["src/test-setup.ts"],
 	"include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]


### PR DESCRIPTION
## The user-facing bug

A user whose browser timezone is **behind** their organization's creates a time log, and the daily view jumps to the **previous day** showing "No Data". The record they just made is invisible. Deterministic, not a race.

`daily.component.ts` (and weekly/calendar) call `refreshDateRangePicker(moment(timeLog.startedAt))`; the service truncates with `moment(date).startOf(unit)` in the **browser's** zone. But:

- `startedAt` is an **instant**;
- the picker's value is a **wall-clock day**, later re-interpreted in the **org's** zone (written to the URL as `YYYY-MM-DD`, read back via `toUtcOffset`).

Midnight in a UTC+8 org is `16:00Z the previous day`, so a UTC browser picks the previous day.

Straight from the CI network trace — no reload in between:

```
POST /api/timesheet/time-log                          201   ← created
GET  time-log 2026-08-04 16:00 → 2026-08-05 15:59   2130B  ← the row IS here
GET  time-log 2026-08-03 16:00 → 2026-08-04 15:59      2B  ← [] ...and the grid uses THIS
```

## Why `timesheets.feature` "churns"

`organization.seed.ts:128` picks the org timezone with `faker.helpers.arrayElement` over all IANA zones. The failure depends only on the **sign of the offset** — **298 of 553 candidate zones (53.9%) are positive**.

**The spec has been a coin flip per seeded run.** That is why it can pass on one branch run and fail 3/3 on the next, and why per-spec selector fixes never closed it. A single green run has never been evidence here.

## The fix

Re-express the instant in the org timezone before truncating, via the package's existing `toTimezone` helper, so the day is the organization's day while the value stays the browser-local `Date` the rest of the picker expects. The parameter is **optional** — callers passing a wall-clock day are unchanged. Five timesheet call sites now pass `timeZoneService.currentTimeZone`.

### The tests are verified to catch the bug

6 regression tests. With the fix reverted, **4 of the 6 fail** — and the 2 that still pass are exactly the cases that *should* be unaffected (no timezone supplied; and a New York midnight, which is `04:00Z` the same day where browser-UTC already agrees). The tests target the bug, not the implementation.

## Also here: the e2e helper that made this unreadable

The spec died with `Test timeout of 240000ms exceeded` / `Target page, context or browser has been closed` — an error naming nothing. **143.9s of the failing step (96%) went into six stalls on one line.**

`locator.evaluate()` **auto-waits**, and `actionTimeout` is 24 000, so probing a locator matching **zero** elements costs 24s and then reports `undefined`. The loop treats `undefined` as "unknown, wait and re-observe" — right in general, exactly wrong when the grid is empty and always will be.

- **Fast-fail before the loop** when no rows rendered, quoting `page.url()` — the `?date=` names the bug outright. This is the change that matters: the helper's own diagnostic throw needed ~290s inside a 240s budget, so **it was unreachable and the timeout masked the very message written to explain the failure**. A diagnostic that only fires after a long wait may never fire.
- Short-circuit the probe on `count()` + explicit 1s `evaluate` timeout: 24s → ~1s.
- Bound `reload()` and `waitForLoadState('networkidle')`, which otherwise inherit the long navigation timeout.

To be clear: **the helpers did not cause the failure** — the save succeeded (201). Earlier helper work fixed the save, which made this pre-existing product bug *reachable* for the first time. What the helpers were guilty of is turning it into an unreadable hang.

## `tsconfig.spec.json`

Gains `esModuleInterop`/`allowSyntheticDefaultImports`, without which ts-jest cannot even `import moment` (webpack's interop hides this in the app build). Scoped to specs, and it does not regress the existing suite — which was **already** failing 31 of 34 suites for unrelated Angular TestBed reasons:

| | suites failed | suites passed | tests failed | tests passed |
|---|---|---|---|---|
| before | 31 | 3 | 8 | 46 |
| after | 30 | 4 | 8 | 52 |

Same 8 pre-existing failures; one more suite runs, six more tests pass.

## Not claimed

I have **not** re-run the full e2e suite on a seed with a positive-offset timezone. Given the 54% coin flip, a single green run would not prove much either — the regression tests are the stronger evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the daily/weekly timesheet jumping to the wrong day after creating a log when the browser timezone is behind the organization. The picker now selects the org-local day, and timesheets e2e no longer hang on empty grids.

- **Bug Fixes**
  - `DateRangePickerBuilderService.refreshDateRangePicker` now accepts an optional org timezone and converts instants via `toTimezone` before truncating, ensuring start/end are computed in the org’s day; behavior is unchanged when no timezone is passed.
  - Timesheet daily/weekly/calendar now pass `timeZoneService.currentTimeZone` when refreshing after create/edit.
  - Regression tests cover day/week selection across timezones and now assert that the created instant is contained by the org-converted range via `toUtcOffset`; removed an unused import.
  - E2E helper: fast-fail when no rows, bound `reload`/`networkidle`, switched to `count()` + 1s `evaluate()` timeout, and simplified the empty-grid error message.
  - Test config: enable `esModuleInterop` and `allowSyntheticDefaultImports` for `moment` in `packages/ui-core` Jest specs.

<sup>Written for commit ba68a60ccad870ae0255787ceb253310f6e59074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

