### PR TITLE
fix(ai-provider-openrouter): cap the platform fallback models array at 3 (free tier fails every turn)

### DIFF
--- a/packages/plugins/ai-provider-openrouter/src/lib/ai-provider-openrouter.provider.ts
+++ b/packages/plugins/ai-provider-openrouter/src/lib/ai-provider-openrouter.provider.ts
@@ -35,6 +35,14 @@ const FALLBACK_FREE_MODELS: IAiChatModel[] = [
 /** OpenRouter marks free models with a `:free` suffix on the slug. */
 const FREE_SUFFIX = ':free';
 
+/**
+ * Hard cap on the server-side fallback list handed to OpenRouter.
+ *
+ * OpenRouter rejects the entire request with `'models' array must have 3 items or fewer.`
+ * if more are sent — so this is a limit of theirs, not a preference of ours.
+ */
+const MAX_FALLBACK_MODELS = 3;
+
 /** Cache the fetched catalogue: this is consulted on every /config call and every turn. */
 const FREE_MODEL_TTL_MS = 30 * 60 * 1000;
 let freeModelCache: { models: IAiChatModel[]; fetchedAt: number } | null = null;
@@ -163,9 +171,15 @@ export const openRouterProviderDefinition: IAiChatProviderDefinition = {
 		// that is rate limited or momentarily unavailable then fails over INSIDE OpenRouter, before
 		// any error reaches us — which is the cheapest possible reduction in 429s on a tier whose
 		// whole characteristic is being rate limited.
+		//
+		// Capped at MAX_FALLBACK_MODELS: OpenRouter refuses a longer `models` array outright, so an
+		// uncapped list fails every turn as soon as the free catalogue exceeds four slugs.
 		let settings: { models?: string[] } | undefined;
 		if (credentials.source === 'platform') {
-			const alternates = (await listFreeModels()).map((m) => m.id).filter((id) => id !== modelId);
+			const alternates = (await listFreeModels())
+				.map((m) => m.id)
+				.filter((id) => id !== modelId)
+				.slice(0, MAX_FALLBACK_MODELS);
 			if (alternates.length) settings = { models: alternates };
 		}
 


### PR DESCRIPTION
## The platform free tier is broken on every turn

`OPENROUTER_PLATFORM_API_KEY` resolves correctly and `GET /api/ai-chat/config` looks perfect —
`configured: true`, `credentialSource: "platform"`, 14 free-only models. Then every message fails.

Observed on stage (`apistage.gauzy.co`), fresh tenant with no BYOK key:

```
ERROR [AiChatService_1] streamText error
  [provider=openrouter model=inclusionai/ling-3.0-flash:free credential=platform]:
  'models' array must have 3 items or fewer.
```

The client sees only `{"type":"error","errorText":"An error occurred."}` on an HTTP 200 SSE stream,
which is why this isn't obvious from the outside.

## Cause

`createModel` hands OpenRouter *every other* free slug as a server-side fallback:

```ts
const alternates = (await listFreeModels()).map((m) => m.id).filter((id) => id !== modelId);
if (alternates.length) settings = { models: alternates };
```

OpenRouter caps that `models` routing array at **3**. The live free catalogue is currently **14**
slugs, so `alternates` is 13 and OpenRouter rejects the whole request. The intent — fail over inside
OpenRouter to cut 429s on a rate-limited tier — is good; it just can't send the whole list.

Boundary confirmed against the live API with the platform key:

| `models[]` size | result |
|---|---|
| 13 | `'models' array must have 3 items or fewer.` |
| 4 | `'models' array must have 3 items or fewer.` |
| 3 | completion returned |

Note this was latent: with ≤4 free models in the catalogue it would have worked. It breaks now
because the free list grew.

## Fix

`.slice(0, MAX_FALLBACK_MODELS)` with `MAX_FALLBACK_MODELS = 3`, documented as OpenRouter's limit
rather than a preference. No behaviour change for tenant BYOK or `OPENROUTER_API_KEY` — the array is
only built for `credentials.source === 'platform'`.

## Not addressed here

- One of the 14 live free slugs is `nvidia/nemotron-3.5-content-safety:free`, a safety classifier
  rather than a chat model. Anything that ends in `:free` is currently offered as a chat model, so a
  user can pick it. Worth a separate filter; out of scope for this fix.
- The stale `FALLBACK_FREE_MODELS` list is #9912 (different region of the same file, should merge
  cleanly).

Found while provisioning the shared platform key for demo/stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes platform free-tier chat failures in `ai-provider-openrouter` by capping the OpenRouter fallback `models` array to three items. This matches OpenRouter’s limit and restores successful requests on the shared platform key.

- **Bug Fixes**
  - When `credentials.source === 'platform'`, send at most 3 alternate free model slugs as fallbacks.
  - Prevents “‘models’ array must have 3 items or fewer.” errors when the free catalog is larger.
  - No behavior change for BYOK or `OPENROUTER_API_KEY`.

<sup>Written for commit ecdcc0ca9fee187b2d4d1bfeda1511ef0bae6d5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

