### PR TITLE
fix(e2e): confirm the tag Edit dialog opened before typing into it

### DIFF
--- a/apps/gauzy-e2e/tests/support/pages/OrganizationTags.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationTags.po.ts
@@ -122,7 +122,14 @@ export const editTagButtonVisible = async () => {
 };
 
 export const clickEditTagButton = async () => {
-	await clickButton(OrganizationTagsPage.editTagButtonCss);
+	// Same treatment as the Add button above, for the same reason and against the same evidence:
+	// CI run 31053943459 (shard 3) failed here with `locator.clear: Timeout 24000ms exceeded —
+	// waiting for locator('#inputName')`, i.e. the click returned but the dialog had not rendered,
+	// and the very next line typed into a field that did not exist yet. It passed on retry, so the
+	// suite reported "1 flaky" and stayed green — a pass bought with a retry.
+	//
+	// Confirming on the dialog's own input is what makes "I clicked Edit" mean the dialog is open.
+	await dispatchClickWhenSettled(OrganizationTagsPage.editTagButtonCss, OrganizationTagsPage.tagNameInputCss);
 };
 
 export const deleteTagButtonVisible = async () => {


### PR DESCRIPTION
## The flake

The Playwright suite went green on develop after [#9914](https://github.com/ever-co/ever-gauzy/pull/9914), but shard 3 of run `31053943459` reported **1 flaky**: `organization-tags` failed on "And I edit the tag" and passed on retry #1.

```
locator.clear: Timeout 24000ms exceeded — waiting for locator('#inputName')
  at clearField (tests/support/util.ts:283)
  at enterTagNameData (tests/support/pages/OrganizationTags.po.ts:66)
  at organization-tags.steps.ts:36
```

A pass bought with a retry is not a pass, so this is worth fixing rather than accepting.

## Cause

`clickEditTagButton` used a plain `clickButton` (a force-click), which returns whether or not the dialog rendered. The very next line types into `#inputName`, a field that does not exist yet.

The **Add** button in this same file was already hardened against exactly this, and its comment names this exact symptom — `#inputName` passing a visibility check and then vanishing. The treatment was simply never applied to Edit.

## Fix

`dispatchClickWhenSettled(editTagButtonCss, tagNameInputCss)` — dispatches the event at the element (immune to hit-testing) and then confirms the dialog's own input is present, re-dispatching if not. That is what makes "I clicked Edit" mean the dialog is open.

One line, matching the pattern already proven in this file and in AddUser / EditUser / InviteUser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky `organization-tags` e2e by confirming the Edit Tag dialog is open before typing into `#inputName`.
Switches `clickEditTagButton` to `dispatchClickWhenSettled` to avoid force-click races and ensure the dialog input is present.

<sup>Written for commit 362644532641b3873644bb963b103be142f4ea1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

