### PR TITLE
fix(timesheet): a null maxDate means no limit again

### DIFF
--- a/packages/ui-core/shared/src/lib/timer-picker/timer-range-picker/timer-range-picker.component.spec.ts
+++ b/packages/ui-core/shared/src/lib/timer-picker/timer-range-picker/timer-range-picker.component.spec.ts
@@ -148,6 +148,26 @@ describe('TimerRangePickerComponent', () => {
 		});
 	});
 
+	describe('updateTimePickerLimit', () => {
+		it('leaves the slots unbounded when there is no maximum', () => {
+			// `edit-time-log-modal` binds [maxDate]="futureDateAllowed ? null : today", so null is how
+			// an organisation that permits future time entry says so. Reading null as "today" clamped
+			// the pickers to the current time and blocked the very entries that flag allows.
+			component.updateTimePickerLimit(null as unknown as Date);
+
+			expect(component.minSlotStartTime).toBe('00:00');
+			expect(component.maxSlotStartTime).toBe('23:59');
+			expect(component.maxSlotEndTime).toBe('23:59');
+		});
+
+		it('clamps to now when the maximum IS today', () => {
+			component.updateTimePickerLimit(new Date());
+
+			// Bounded by the current time rather than the end of the day.
+			expect(component.maxSlotEndTime < '23:59').toBe(true);
+		});
+	});
+
 	describe('composeRange', () => {
 		it('rolls the end onto the next day when it reads earlier than the start', () => {
 			// The picker holds ONE date for both times, so a midnight-spanning range can only be

--- a/packages/ui-core/shared/src/lib/timer-picker/timer-range-picker/timer-range-picker.component.ts
+++ b/packages/ui-core/shared/src/lib/timer-picker/timer-range-picker/timer-range-picker.component.ts
@@ -316,7 +316,21 @@ export class TimerRangePickerComponent implements OnInit, AfterViewInit {
 	 */
 	updateTimePickerLimit(date: Date) {
 		const now = this.toDisplayZone(new Date());
-		let mTime = this.toDisplayZone(date ?? new Date());
+		// A NULL limit means "no limit", and it must stay that way. `edit-time-log-modal` binds
+		// `[maxDate]="futureDateAllowed ? null : today"`, so null is how an organisation that permits
+		// future time entry says so. The previous `moment(date)` produced an INVALID moment for null,
+		// which failed the same-day test and fell through to the unbounded branch — accidentally
+		// correct. Substituting `new Date()` for null made it read as "today" and clamped the slot
+		// pickers to the current time, silently blocking exactly the entries that flag allows.
+		if (!date) {
+			this.minSlotStartTime = '00:00';
+			this.maxSlotStartTime = '23:59';
+			this.maxSlotEndTime = '23:59';
+			this.updateEndTimeSlot(this.startTime);
+			return;
+		}
+
+		let mTime = this.toDisplayZone(date);
 
 		if (mTime.isSame(now, 'day')) {
 			mTime = mTime.set({


### PR DESCRIPTION
## Regression

Found by an adversarial review of this session's own work. It is already merged and on stage (via #9914 → #9919).

`updateTimePickerLimit` changed from `moment(date)` to `this.toDisplayZone(date ?? new Date())`.

For a **null** limit the old expression produced an *invalid* moment, which failed `isSame(now, 'day')` and fell through to the unbounded branch — accidentally correct. Substituting `new Date()` makes null read as "today", so the same-day branch runs and clamps `maxSlotStartTime` to now−10min and `maxSlotEndTime` to now.

## Why it matters

`edit-time-log-modal.component.html` binds:

```html
[maxDate]="futureDateAllowed ? null : today"
```

Null is how an organisation that **permits future time entry** says so. The change silently blocked exactly the entries that flag exists to allow — the slot pickers stop at the current time.

## Fix

Null is handled explicitly instead of relying on an invalid date to fall through, with a test for both arms (null → `00:00`/`23:59`/`23:59`; today → clamped below `23:59`).

22 tests pass in the picker suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores behavior where a `null` `maxDate` means no limit in the timesheet timer picker. Fixes a regression that clamped slots to the current time and blocked future entries when `futureDateAllowed` is true.

- **Bug Fixes**
  - Handle `null` in `updateTimePickerLimit` as unbounded (slots span `00:00`–`23:59`).
  - Keep clamping only when `maxDate` is today (end capped to “now”).
  - Added unit tests for both `null` and today cases.

<sup>Written for commit 27667d8d1919df157ac70557eadf15fd4c66d487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

