### PR TITLE
fix(e2e): confirm the equipment dropdowns opened before picking from them

### DIFF
--- a/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import {
 	enterInput,
 	verifyElementIsVisible,
+	dispatchClickWhenSettled,
 	clickButton,
 	clearField,
 	clickKeyboardBtnByKeycode,
@@ -339,7 +340,18 @@ export const selectEquipmentDropdownVisible = async () => {
 };
 
 export const clickEquipmentDropdown = async () => {
-	await clickButton(OrganizationEquipmentPage.selectEquipmentDropdownCss);
+	// CONFIRM the panel opened rather than assuming the click landed. `clickButton` is a force-click,
+	// which only skips the actionability check — it still returns whether or not the option list
+	// rendered, and the very next step waits 24s for an option inside it.
+	//
+	// Observed in CI run 31119250876 (shard 3): `locator.waitFor: Timeout 24000ms exceeded — waiting
+	// for locator('.option-list nb-option').filter({ hasText: 'Equipment NrLaT58N' })`. It passed on
+	// retry, so the suite reported "1 flaky" and stayed green — a pass bought with a retry. Same
+	// shape, and same fix, as the tag Edit dialog in OrganizationTags.po.
+	await dispatchClickWhenSettled(
+		OrganizationEquipmentPage.selectEquipmentDropdownCss,
+		OrganizationEquipmentPage.selectEquipmentDropdownOptionCss
+	);
 };
 
 export const selectEquipmentFromDropdown = async (index: number) => {
@@ -368,7 +380,13 @@ export const approvalPolicyDropdownVisible = async () => {
 };
 
 export const clickSelectPolicyDropdown = async () => {
-	await clickButton(OrganizationEquipmentPage.selectPolicyDropdownCss);
+	// Same treatment as the equipment dropdown above. The evidence is for that one; this has the
+	// identical shape — force-click, then the next line picks an option out of a panel nobody
+	// confirmed had opened — so it is the same latent flake waiting for a slow render.
+	await dispatchClickWhenSettled(
+		OrganizationEquipmentPage.selectPolicyDropdownCss,
+		OrganizationEquipmentPage.selectPolicyDropdownOptionCss
+	);
 };
 
 export const selectPolicyFromDropdown = async (index: number) => {
@@ -380,7 +398,12 @@ export const selectEmployeeDropdownVisible = async () => {
 };
 
 export const clickEmployeeDropdown = async () => {
-	await clickButton(OrganizationEquipmentPage.selectEmployeeDropdownCss);
+	// As above. The employee list is fetched (org members "working" in the header range), so of the
+	// three this is the most likely to render late.
+	await dispatchClickWhenSettled(
+		OrganizationEquipmentPage.selectEmployeeDropdownCss,
+		OrganizationEquipmentPage.selectEmployeeDropdownOptionCss
+	);
 };
 
 export const selectEmployeeFromDropdown = async (index: number) => {


### PR DESCRIPTION
## The remaining flake

The suite is green on cascade [#9923](https://github.com/ever-co/ever-gauzy/pull/9923) — all four shards pass. But shard 3 still reports **1 flaky**, and it is a *different* test from last time: [#9918](https://github.com/ever-co/ever-gauzy/pull/9918) fixed `organization-tags` (it passed first try in this run) and `organization-equipment` took its place.

```
locator.waitFor: Timeout 24000ms exceeded — waiting for
  locator('.option-list nb-option').filter({ hasText: 'Equipment NrLaT58N' })
  at selectEquipmentFromDropdownByName (OrganizationEquipment.po.ts:362)
  at organization-equipment.steps.ts:105
```

## Cause

Identical to the tag dialog. `clickEquipmentDropdown` uses `clickButton` — a force-click, which only skips the actionability *check* — so it returns whether or not the option list rendered. The next step then spends 24 seconds waiting for an option inside a panel that never opened.

A pass bought with a retry is not a pass, so this is worth fixing rather than accepting.

## Fix

`dispatchClickWhenSettled(trigger, optionListSelector)` — dispatches at the element and **confirms** the option list is present, re-dispatching if not. The pattern already proven in `OrganizationTags.po`, `AddUser.po`, `EditUser.po` and `InviteUser.po`.

Also applied to the **policy** and **employee** dropdowns in the same flow. The evidence is for the equipment one; those two have the identical shape — force-click, then pick an option out of an unconfirmed panel — and the employee list is fetched from the API, so it is the most likely of the three to render late.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky e2e test in the organization equipment flow by confirming dropdown panels open before selecting options. Uses `dispatchClickWhenSettled` to re-click until the option list is present.

- **Bug Fixes**
  - Replaced force-clicks with `dispatchClickWhenSettled` for equipment, policy, and employee dropdowns in `OrganizationEquipment.po.ts`.
  - Prevents timeouts when options are queried in panels that never opened.
  - Aligns with the proven pattern used in tags and user flows.

<sup>Written for commit f14b037052da2f299c0dc348008f5a3d65ef3ab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

