### PR TITLE
fix(core): make a missing upload storage factory a compile error, not a 500

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -538,6 +538,7 @@
         "NTSC",
         "nums",
         "nuxt",
+        "flac",
         "ogg",
         "oidc",
         "omni",

--- a/packages/core/src/lib/core/interceptors/lazy-file-interceptor.spec.ts
+++ b/packages/core/src/lib/core/interceptors/lazy-file-interceptor.spec.ts
@@ -1,0 +1,136 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { memoryStorage } from 'multer';
+import { of } from 'rxjs';
+import { Readable } from 'stream';
+import { LazyFileInterceptor } from './lazy-file-interceptor';
+
+/**
+ * The interceptor is thin, but each thing it does has already failed in production, and the failure
+ * was invisible every time:
+ *
+ *  - a route that omitted `storage` answered 500 on every upload, because `localOptions.storage()`
+ *    is called unconditionally while the old signature made it optional. That broke the chat's
+ *    dictation endpoint completely, and neither the build, the type-checker nor the existing tests
+ *    said anything;
+ *  - a route that declared `limits` read as capped while accepting uploads of any size, because
+ *    only `storage` and `fileFilter` were forwarded to multer.
+ *
+ * Both are "declared option silently ignored" — the shape that cannot be caught by reading the call
+ * site, only by driving a real multipart request through it. So these tests build one.
+ */
+describe('LazyFileInterceptor', () => {
+	const BOUNDARY = 'gauzy-test-boundary';
+
+	/** A real multipart/form-data body — multer parses bytes, so a hand-built object would prove nothing. */
+	const multipartBody = (field: string, filename: string, contents: Buffer): Buffer =>
+		Buffer.concat([
+			Buffer.from(
+				`--${BOUNDARY}\r\n` +
+					`Content-Disposition: form-data; name="${field}"; filename="${filename}"\r\n` +
+					`Content-Type: application/octet-stream\r\n\r\n`
+			),
+			contents,
+			Buffer.from(`\r\n--${BOUNDARY}--\r\n`)
+		]);
+
+	/**
+	 * A minimal Express-shaped request carrying the body as a stream.
+	 *
+	 * Busboy (multer's parser) reads `headers` and consumes the request as a Readable, so a Readable
+	 * with the two headers set is genuinely enough — no HTTP server needed.
+	 */
+	const requestFor = (body: Buffer): any => {
+		const request = new Readable({
+			read() {
+				this.push(body);
+				this.push(null);
+			}
+		}) as any;
+		request.headers = {
+			'content-type': `multipart/form-data; boundary=${BOUNDARY}`,
+			'content-length': String(body.length)
+		};
+		return request;
+	};
+
+	const contextFor = (request: any): ExecutionContext =>
+		({
+			switchToHttp: () => ({
+				getRequest: () => request,
+				getResponse: () => ({})
+			})
+		} as unknown as ExecutionContext);
+
+	const nextHandler: CallHandler = { handle: () => of('handled') };
+
+	/** Run one upload through the interceptor and hand back the request multer populated. */
+	const run = async (options: any, body: Buffer): Promise<any> => {
+		const Interceptor = LazyFileInterceptor('file', options);
+		const interceptor = new (Interceptor as any)();
+		const request = requestFor(body);
+		await interceptor.intercept(contextFor(request), nextHandler);
+		return request;
+	};
+
+	it('populates file.buffer with memoryStorage — what the dictation handler reads', async () => {
+		const audio = Buffer.from('fake-webm-bytes');
+		const request = await run({ storage: () => memoryStorage() }, multipartBody('file', 'dictation.webm', audio));
+
+		expect(request.file).toBeDefined();
+		expect(request.file.buffer).toEqual(audio);
+		expect(request.file.originalname).toBe('dictation.webm');
+	});
+
+	it('passes the ExecutionContext to the storage factory, so per-request destinations work', async () => {
+		// This is the interceptor's entire reason to exist over Nest's own FileInterceptor: the engine
+		// is chosen per request (tenant folder, provider, …) rather than once at module load.
+		const storage = jest.fn(() => memoryStorage());
+		const request = requestFor(multipartBody('file', 'a.bin', Buffer.from('x')));
+		const context = contextFor(request);
+
+		const Interceptor = LazyFileInterceptor('file', { storage } as any);
+		await new (Interceptor as any)().intercept(context, nextHandler);
+
+		expect(storage).toHaveBeenCalledTimes(1);
+		expect(storage).toHaveBeenCalledWith(context);
+	});
+
+	it('fails loudly when no storage factory is supplied', async () => {
+		// The signature now makes this a compile error, so the cast is deliberate: it stands in for a
+		// JS caller, and pins that the failure is at least immediate rather than a corrupted upload.
+		await expect(run({} as any, multipartBody('file', 'a.bin', Buffer.from('x')))).rejects.toThrow();
+	});
+
+	it('enforces a declared fileSize limit instead of silently ignoring it', async () => {
+		// The regression this exists for: `limits` was dropped on the floor, so a route could declare a
+		// cap, pass review, and accept anything. The chat endpoint had to re-implement its own size
+		// check in the service for exactly this reason.
+		const tooBig = Buffer.alloc(2048, 7);
+
+		await expect(
+			run({ storage: () => memoryStorage(), limits: { fileSize: 512 } }, multipartBody('file', 'big.bin', tooBig))
+		).rejects.toThrow();
+	});
+
+	it('accepts a file that fits inside the declared limit', async () => {
+		// The other half of the pair — a limit that rejects everything would also pass the test above.
+		const small = Buffer.alloc(128, 3);
+		const request = await run(
+			{ storage: () => memoryStorage(), limits: { fileSize: 512 } },
+			multipartBody('file', 'small.bin', small)
+		);
+
+		expect(request.file.buffer).toEqual(small);
+	});
+
+	it('applies a declared fileFilter', async () => {
+		// Already forwarded before this change; covered so that a future refactor of the spread cannot
+		// quietly drop it the way `limits` was dropped.
+		const filter = (_req: any, _file: any, callback: (error: Error | null, accept: boolean) => void) =>
+			callback(new Error('rejected by filter'), false);
+
+		await expect(
+			run({ storage: () => memoryStorage(), fileFilter: filter }, multipartBody('file', 'a.bin', Buffer.from('x')))
+		).rejects.toThrow();
+	});
+});

--- a/packages/core/src/lib/core/interceptors/lazy-file-interceptor.ts
+++ b/packages/core/src/lib/core/interceptors/lazy-file-interceptor.ts
@@ -51,14 +51,18 @@ export function LazyFileInterceptor(fieldName: string, localOptions: LazyFileInt
 				...this.options,
 				...{
 					storage,
+					// No optional chaining on `localOptions` here: it is a REQUIRED parameter (the call
+					// above already dereferences it), and a `?.` would imply otherwise — DeepScan rightly
+					// flags the inconsistency (INSUFFICIENT_NULL_CHECK).
+					//
 					// Pass through a per-route fileFilter when provided (e.g. to block executable/SVG uploads).
-					...(localOptions?.fileFilter ? { fileFilter: localOptions.fileFilter } : {}),
+					...(localOptions.fileFilter ? { fileFilter: localOptions.fileFilter } : {}),
 					// …and `limits` likewise. Dropping it was the same silent-no-op trap as the missing
 					// storage factory, one step further along: a route declaring `limits: { fileSize }`
 					// read as capped while accepting uploads of any size, and nothing failed to say so.
 					// No caller relies on the old behaviour — none currently declare `limits` — so this
 					// only changes what happens the next time someone reasonably expects it to work.
-					...(localOptions?.limits ? { limits: localOptions.limits } : {})
+					...(localOptions.limits ? { limits: localOptions.limits } : {})
 				}
 			});
 			await new Promise<void>((resolve, reject) =>

--- a/packages/core/src/lib/core/interceptors/lazy-file-interceptor.ts
+++ b/packages/core/src/lib/core/interceptors/lazy-file-interceptor.ts
@@ -1,4 +1,13 @@
-import { CallHandler, ExecutionContext, Inject, Logger, mixin, NestInterceptor, Optional, Type } from '@nestjs/common';
+import {
+	CallHandler,
+	ExecutionContext,
+	Inject,
+	Logger,
+	mixin,
+	NestInterceptor,
+	Optional,
+	Type
+} from '@nestjs/common';
 import { MulterModuleOptions } from '@nestjs/platform-express';
 import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
 import { MULTER_MODULE_OPTIONS } from '@nestjs/platform-express/multer/files.constants';
@@ -8,7 +17,22 @@ import { Observable } from 'rxjs';
 
 type MulterInstance = any;
 
-export function LazyFileInterceptor(fieldName: string, localOptions?: MulterOptions): Type<NestInterceptor> {
+/**
+ * Options for {@link LazyFileInterceptor}.
+ *
+ * `storage` is a FACTORY, not a `StorageEngine` — that is the whole point of this interceptor, which
+ * resolves the destination per request (tenant folder, provider, …) rather than once at module load.
+ * It is REQUIRED and typed as such: `MulterOptions.storage` is `any`, so the previous signature both
+ * accepted a caller that omitted it and accepted one that passed an engine instead of a factory.
+ * Either mistake compiles and then throws a TypeError on the first upload — the route answers 500
+ * with nothing pointing at the cause. That is not hypothetical: it shipped on the chat's dictation
+ * endpoint and broke every attempt to use it.
+ */
+export type LazyFileInterceptorOptions = Omit<MulterOptions, 'storage'> & {
+	storage: (context: ExecutionContext) => multer.StorageEngine;
+};
+
+export function LazyFileInterceptor(fieldName: string, localOptions: LazyFileInterceptorOptions): Type<NestInterceptor> {
 	class MixinInterceptor implements NestInterceptor {
 		protected multer: MulterInstance;
 		private readonly logger = new Logger('LazyFileInterceptor');
@@ -28,7 +52,13 @@ export function LazyFileInterceptor(fieldName: string, localOptions?: MulterOpti
 				...{
 					storage,
 					// Pass through a per-route fileFilter when provided (e.g. to block executable/SVG uploads).
-					...(localOptions?.fileFilter ? { fileFilter: localOptions.fileFilter } : {})
+					...(localOptions?.fileFilter ? { fileFilter: localOptions.fileFilter } : {}),
+					// …and `limits` likewise. Dropping it was the same silent-no-op trap as the missing
+					// storage factory, one step further along: a route declaring `limits: { fileSize }`
+					// read as capped while accepting uploads of any size, and nothing failed to say so.
+					// No caller relies on the old behaviour — none currently declare `limits` — so this
+					// only changes what happens the next time someone reasonably expects it to work.
+					...(localOptions?.limits ? { limits: localOptions.limits } : {})
 				}
 			});
 			await new Promise<void>((resolve, reject) =>

--- a/packages/plugins/ai-chat/src/lib/ai-chat.controller.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.controller.ts
@@ -100,11 +100,12 @@ export class AiChatController {
 	@Post('/transcribe')
 	@UseInterceptors(
 		LazyFileInterceptor('file', {
-			// `storage` is REQUIRED even though the type marks it optional: the interceptor calls
-			// `localOptions.storage(context)` unconditionally, so omitting it throws a TypeError before
-			// multer ever runs and the endpoint answers 500. Memory specifically — the handler reads
-			// `file.buffer`, which only memoryStorage populates; a disk/FileStorage factory would leave
-			// it undefined and the service would reject the upload as empty.
+			// Memory specifically: the handler reads `file.buffer`, which only memoryStorage populates.
+			// A disk/FileStorage factory would leave it undefined and the service would then reject the
+			// upload as empty — the audio never touches disk, it is forwarded straight upstream.
+			//
+			// (`storage` being omitted entirely is what broke this endpoint originally. It is now
+			// required by LazyFileInterceptor's own signature, so that mistake no longer compiles.)
 			storage: () => memoryStorage()
 		})
 	)

--- a/packages/plugins/ai-chat/src/lib/ai-chat.controller.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.controller.ts
@@ -17,7 +17,7 @@ import { memoryStorage } from 'multer';
 import type { UIMessage } from 'ai';
 import { IAiChatConfig, IAiChatModelCatalogue, PermissionsEnum } from '@gauzy/contracts';
 import { LazyFileInterceptor, PermissionGuard, Permissions, TenantPermissionGuard } from '@gauzy/core';
-import { AiChatService } from './ai-chat.service';
+import { AiChatService, MAX_AUDIO_BYTES } from './ai-chat.service';
 
 /** Request body sent by the `useChat` client (Vercel AI SDK UI). */
 export interface IAiChatRequestBody {
@@ -95,6 +95,8 @@ export class AiChatController {
 	@ApiOperation({ summary: 'Transcribe recorded speech' })
 	@ApiResponse({ status: 200, description: 'Transcript.' })
 	@ApiResponse({ status: 400, description: 'No audio uploaded.' })
+	// multer's LIMIT_FILE_SIZE surfaces as PayloadTooLargeException via transformException.
+	@ApiResponse({ status: 413, description: 'Recording exceeds the 25 MB limit.' })
 	@ApiResponse({ status: 503, description: 'No provider available to transcribe.' })
 	@Permissions(PermissionsEnum.AI_CHAT_ACCESS)
 	@Post('/transcribe')
@@ -106,7 +108,13 @@ export class AiChatController {
 			//
 			// (`storage` being omitted entirely is what broke this endpoint originally. It is now
 			// required by LazyFileInterceptor's own signature, so that mistake no longer compiles.)
-			storage: () => memoryStorage()
+			storage: () => memoryStorage(),
+			// The same constant the service checks — declared here too so an oversized upload is
+			// rejected by multer BEFORE memoryStorage buffers all of it in RAM. The service check
+			// remains as the second line of defense (and covers callers that bypass this route).
+			// Forwarding `limits` at all is part of this change; declaring it earlier would have
+			// silently held nothing.
+			limits: { fileSize: MAX_AUDIO_BYTES }
 		})
 	)
 	async transcribe(@UploadedFile() file: { buffer: Buffer; mimetype: string }): Promise<{ text: string }> {

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -19,8 +19,10 @@ import { buildRateLimitEnvelope, isRateLimitError, rateLimitRetryAfter, RATE_LIM
  * Largest dictation upload accepted, matching what the upstream speech APIs take anyway.
  *
  * Audio is user-supplied and otherwise bounded only by how long someone holds the button.
+ * Exported so the controller can declare the SAME cap as a multer `limits` on the route — one
+ * constant, two enforcement points that cannot drift.
  */
-const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
+export const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
 
 /** Maximum agent steps (model turns incl. tool calls) per user message. */
 const MAX_STEPS = 12;
@@ -485,9 +487,11 @@ export class AiChatService {
 		if (!audio?.length) {
 			throw new BadRequestException('No audio was uploaded.');
 		}
-		// Enforced HERE, not through the interceptor's `limits`: LazyFileInterceptor spreads only
-		// `storage` and `fileFilter` into multer and drops `limits`, so a cap declared at the route
-		// would read as enforced while accepting anything. This is the only place that actually holds.
+		// Second line of defense. The route declares the same MAX_AUDIO_BYTES as a multer `limits`,
+		// which rejects an oversized upload BEFORE memoryStorage buffers it — but this check stays:
+		// it guards any future caller that does not arrive through that interceptor, and it survives
+		// the interceptor's history of silently dropping options (forwarding `limits` at all is a fix
+		// from this same change; for a while a declared cap read as enforced while holding nothing).
 		if (audio.length > MAX_AUDIO_BYTES) {
 			throw new BadRequestException(
 				`Recording is too large (${Math.round(audio.length / 1024 / 1024)}MB). The limit is ${

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -520,7 +520,12 @@ export class AiChatService {
 				// Try the next provider rather than failing the whole dictation on one bad key.
 				const message = error instanceof Error ? error.message : String(error);
 				this.logger.warn(`[ai-chat] Transcription via '${definition.id}' failed: ${message}`);
-				failures.push(message);
+				// Boundary defense for the user-visible join below: an empty Error message or a thrown
+				// non-Error ('[object Object]') would otherwise put a blank or noise where the old text
+				// at least named the provider — so fall back to naming it, and bound the length here
+				// rather than trusting every provider hook to.
+				const usable = message.trim() && message !== '[object Object]';
+				failures.push(usable ? message.slice(0, 400) : `Transcription via '${definition.id}' failed.`);
 			}
 		}
 

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -508,12 +508,12 @@ export class AiChatService {
 			throw new ServiceUnavailableException('No AI provider on this server can transcribe speech.');
 		}
 
-		const attempted: string[] = [];
+		// One entry per attempted provider: every attempt either returns out of the function or pushes
+		// its failure here, so `failures` doubles as the "was anything attempted" signal at the throw.
 		const failures: string[] = [];
 		for (const definition of capable) {
 			const credentials = await this.resolveCredentials(definition);
 			if (!credentials) continue;
-			attempted.push(definition.id);
 			try {
 				return await definition.transcribe(audio, mimeType, credentials);
 			} catch (error) {
@@ -531,7 +531,7 @@ export class AiChatService {
 		// point at Settings only when the failure is credential-shaped.
 		const keyProblem = failures.some((failure) => /api key/i.test(failure));
 		throw new ServiceUnavailableException(
-			attempted.length
+			failures.length
 				? `${failures.join('; ')}${keyProblem ? ' Update the key in Settings → AI Providers.' : ''}`
 				: 'Add an API key for a provider that supports speech (e.g. OpenAI) to dictate messages.'
 		);

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -509,6 +509,7 @@ export class AiChatService {
 		}
 
 		const attempted: string[] = [];
+		const failures: string[] = [];
 		for (const definition of capable) {
 			const credentials = await this.resolveCredentials(definition);
 			if (!credentials) continue;
@@ -517,16 +518,21 @@ export class AiChatService {
 				return await definition.transcribe(audio, mimeType, credentials);
 			} catch (error) {
 				// Try the next provider rather than failing the whole dictation on one bad key.
-				this.logger.warn(
-					`[ai-chat] Transcription via '${definition.id}' failed: ` +
-						`${error instanceof Error ? error.message : error}`
-				);
+				const message = error instanceof Error ? error.message : String(error);
+				this.logger.warn(`[ai-chat] Transcription via '${definition.id}' failed: ${message}`);
+				failures.push(message);
 			}
 		}
 
+		// The chat panel shows this message verbatim, so it must not over-diagnose. The old text
+		// appended "Check the provider's API key" to EVERY failure — a quota hit, a rejected
+		// recording and a provider outage all read as a credential problem. Relay what the provider
+		// hook actually reported (providers classify by status and never echo a response body), and
+		// point at Settings only when the failure is credential-shaped.
+		const keyProblem = failures.some((failure) => /api key/i.test(failure));
 		throw new ServiceUnavailableException(
 			attempted.length
-				? `Transcription failed on ${attempted.join(', ')}. Check the provider's API key in Settings → AI Providers.`
+				? `${failures.join('; ')}${keyProblem ? ' Update the key in Settings → AI Providers.' : ''}`
 				: 'Add an API key for a provider that supports speech (e.g. OpenAI) to dictate messages.'
 		);
 	}

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
@@ -68,6 +68,52 @@ const TRANSCRIBE_TIMEOUT_MS = 60_000;
 const catalogueCache = createCatalogueCache<IAiChatModel[]>();
 
 /**
+ * Upper bound on the upstream error body read for a diagnostic message.
+ *
+ * Far more than any real OpenAI error needs, and small enough that a custom base URL answering with
+ * an arbitrarily large body cannot make this process buffer it: `response.text()` reads EVERYTHING
+ * before a display-side `slice` ever runs, so the bound has to be applied while reading.
+ */
+const MAX_ERROR_DETAIL_BYTES = 2048;
+
+/** Read at most `maxBytes` of a response body, then cancel the rest of the stream. */
+const readBounded = async (response: globalThis.Response, maxBytes: number): Promise<string> => {
+	const reader = response.body?.getReader();
+	if (!reader) return '';
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		while (total < maxBytes) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			chunks.push(value);
+			total += value.byteLength;
+		}
+	} catch {
+		/* a broken error-body stream must not mask the error being reported */
+	} finally {
+		reader.cancel().catch(() => undefined);
+	}
+	const merged = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		merged.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return new TextDecoder().decode(merged.subarray(0, maxBytes)).trim();
+};
+
+/**
+ * Strip the credential in use and anything key-shaped from text bound for the user.
+ *
+ * Both patterns matter: OpenAI keys are `sk-…`, but a custom base URL (Azure, a proxy) issues keys
+ * with no recognizable prefix — only redacting by shape would relay exactly the secret this exists
+ * to protect. Display-truncated at the end so the redaction cannot be sliced through mid-token.
+ */
+const redactSecret = (text: string, apiKey: string): string =>
+	(apiKey ? text.split(apiKey).join('[redacted]') : text).replace(/sk-[A-Za-z0-9_-]+/g, 'sk-***').slice(0, 300).trim();
+
+/**
  * The OpenAI models this API key can address, minus the families that are not chat models.
  *
  * This is the weakest of the six catalogues — `/v1/models` returns `{id, owned_by, created}` and
@@ -145,7 +191,9 @@ const transcribeAudio = async (
 	});
 	if (!response.ok) {
 		// The bare status code was reaching the user as "check your API key" for EVERY failure class,
-		// including quota and bad audio. Classify by status so the message is actionable.
+		// including quota and bad audio. Classify by status so the message is actionable. The status
+		// NUMBER only — statusText is upstream-controlled prose, and a custom base URL means upstream
+		// is whatever the tenant configured, so it gets no free ride into a user-visible message.
 		const credentialFailure = response.status === 401 || response.status === 403;
 		const reason = credentialFailure
 			? 'the API key was rejected'
@@ -153,17 +201,15 @@ const transcribeAudio = async (
 			? 'the rate or quota limit was hit'
 			: response.status === 400
 			? 'the audio was rejected (unsupported or empty recording)'
-			: `HTTP ${response.status} ${response.statusText}`;
+			: `HTTP ${response.status}`;
 		// The response body is genuinely diagnostic for format/limit errors ("Invalid file format"),
 		// so it is relayed — but NEVER on a credential failure, whose body echoes the API key back
-		// ("Incorrect API key provided: sk-…"), and always redacted and truncated in case a proxy
-		// routes a secret into some other status. This error's message reaches the chat user verbatim.
+		// ("Incorrect API key provided: sk-…"). Redacted of both key-shaped tokens AND the exact key
+		// in use (custom endpoints issue keys with no sk- prefix), and read BOUNDED: `.text()` would
+		// buffer however much the upstream cares to send before the display truncation ever ran.
 		const detail = credentialFailure
 			? ''
-			: (await response.text().catch(() => ''))
-					.replace(/sk-[A-Za-z0-9_-]+/g, 'sk-***')
-					.slice(0, 300)
-					.trim();
+			: redactSecret(await readBounded(response, MAX_ERROR_DETAIL_BYTES), credentials.apiKey);
 		throw new Error(`OpenAI transcription failed: ${reason}${detail ? ` — ${detail}` : ''}`);
 	}
 	const body = (await response.json()) as { text?: string };

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
@@ -114,12 +114,21 @@ const transcribeAudio = async (
 	// `audio/mpeg` is MP3, not MP4 — lumping it in with `mp4` named MP3 bytes `dictation.mp4`, and the
 	// extension is exactly what OpenAI trusts to identify the container. MediaRecorder never produces
 	// audio/mpeg, which is why this survived: it only bites when a caller feeds a pre-recorded file.
+	// wav/flac/m4a are covered for the same caller class — every container OpenAI accepts that a MIME
+	// type can name. What remains falling to `.webm` (e.g. raw `audio/aac`) has no extension in
+	// OpenAI's accepted set at all, so no mapping could save it.
 	const extension = mimeType.includes('mp4')
 		? 'mp4'
 		: mimeType.includes('mpeg')
 		? 'mp3'
 		: mimeType.includes('ogg')
 		? 'ogg'
+		: mimeType.includes('wav')
+		? 'wav'
+		: mimeType.includes('flac')
+		? 'flac'
+		: mimeType.includes('m4a') // audio/m4a and audio/x-m4a
+		? 'm4a'
 		: 'webm';
 	const form = new FormData();
 	form.append('file', new Blob([new Uint8Array(audio)], { type: mimeType }), `dictation.${extension}`);
@@ -135,8 +144,18 @@ const transcribeAudio = async (
 		signal: AbortSignal.timeout(TRANSCRIBE_TIMEOUT_MS)
 	});
 	if (!response.ok) {
-		// No body echo: this request carries a credential.
-		throw new Error(`OpenAI transcription failed: ${response.status} ${response.statusText}`);
+		// No body echo — this request carries a credential — but the bare status code was reaching the
+		// user as "check your API key" for EVERY failure class, including quota and bad audio. Classify
+		// by status instead: same security posture, an answer the user can actually act on.
+		const reason =
+			response.status === 401 || response.status === 403
+				? 'the API key was rejected'
+				: response.status === 429
+				? 'the rate or quota limit was hit'
+				: response.status === 400
+				? 'the audio was rejected (unsupported or empty recording)'
+				: `HTTP ${response.status} ${response.statusText}`;
+		throw new Error(`OpenAI transcription failed: ${reason}`);
 	}
 	const body = (await response.json()) as { text?: string };
 	return (body.text ?? '').trim();

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
@@ -144,18 +144,27 @@ const transcribeAudio = async (
 		signal: AbortSignal.timeout(TRANSCRIBE_TIMEOUT_MS)
 	});
 	if (!response.ok) {
-		// No body echo — this request carries a credential — but the bare status code was reaching the
-		// user as "check your API key" for EVERY failure class, including quota and bad audio. Classify
-		// by status instead: same security posture, an answer the user can actually act on.
-		const reason =
-			response.status === 401 || response.status === 403
-				? 'the API key was rejected'
-				: response.status === 429
-				? 'the rate or quota limit was hit'
-				: response.status === 400
-				? 'the audio was rejected (unsupported or empty recording)'
-				: `HTTP ${response.status} ${response.statusText}`;
-		throw new Error(`OpenAI transcription failed: ${reason}`);
+		// The bare status code was reaching the user as "check your API key" for EVERY failure class,
+		// including quota and bad audio. Classify by status so the message is actionable.
+		const credentialFailure = response.status === 401 || response.status === 403;
+		const reason = credentialFailure
+			? 'the API key was rejected'
+			: response.status === 429
+			? 'the rate or quota limit was hit'
+			: response.status === 400
+			? 'the audio was rejected (unsupported or empty recording)'
+			: `HTTP ${response.status} ${response.statusText}`;
+		// The response body is genuinely diagnostic for format/limit errors ("Invalid file format"),
+		// so it is relayed — but NEVER on a credential failure, whose body echoes the API key back
+		// ("Incorrect API key provided: sk-…"), and always redacted and truncated in case a proxy
+		// routes a secret into some other status. This error's message reaches the chat user verbatim.
+		const detail = credentialFailure
+			? ''
+			: (await response.text().catch(() => ''))
+					.replace(/sk-[A-Za-z0-9_-]+/g, 'sk-***')
+					.slice(0, 300)
+					.trim();
+		throw new Error(`OpenAI transcription failed: ${reason}${detail ? ` — ${detail}` : ''}`);
 	}
 	const body = (await response.json()) as { text?: string };
 	return (body.text ?? '').trim();

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
@@ -111,8 +111,16 @@ const transcribeAudio = async (
 	mimeType: string,
 	credentials: IAiProviderCredentials
 ): Promise<string> => {
-	const extension =
-		mimeType.includes('mp4') || mimeType.includes('mpeg') ? 'mp4' : mimeType.includes('ogg') ? 'ogg' : 'webm';
+	// `audio/mpeg` is MP3, not MP4 — lumping it in with `mp4` named MP3 bytes `dictation.mp4`, and the
+	// extension is exactly what OpenAI trusts to identify the container. MediaRecorder never produces
+	// audio/mpeg, which is why this survived: it only bites when a caller feeds a pre-recorded file.
+	const extension = mimeType.includes('mp4')
+		? 'mp4'
+		: mimeType.includes('mpeg')
+		? 'mp3'
+		: mimeType.includes('ogg')
+		? 'ogg'
+		: 'webm';
 	const form = new FormData();
 	form.append('file', new Blob([new Uint8Array(audio)], { type: mimeType }), `dictation.${extension}`);
 	form.append('model', TRANSCRIBE_MODEL);

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -69,11 +69,13 @@ describe('openAiProviderDefinition.transcribe', () => {
 
 	it.each([
 		// [browser mimeType, expected filename] — OpenAI reads the CONTAINER off the extension, so a
-		// generic name is rejected even when the bytes are valid. These are the three containers a
-		// MediaRecorder actually produces across Chrome/Firefox (webm) and Safari (mp4).
+		// generic name is rejected even when the bytes are valid. webm/mp4/ogg are what MediaRecorder
+		// actually produces across Chrome/Firefox and Safari; audio/mpeg (an MP3 fed in by a future
+		// file-upload path) must map to .mp3 — the first version of this table expected .mp4 for it,
+		// which would have told OpenAI that MP3 bytes were an MP4 container.
 		['audio/webm;codecs=opus', 'dictation.webm'],
 		['audio/mp4', 'dictation.mp4'],
-		['audio/mpeg', 'dictation.mp4'],
+		['audio/mpeg', 'dictation.mp3'],
 		['audio/ogg;codecs=opus', 'dictation.ogg'],
 		['', 'dictation.webm']
 	])('names the upload from the %s container', async (mimeType, expected) => {

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -29,11 +29,18 @@ describe('openAiProviderDefinition.transcribe', () => {
 
 	/** Capture the request the provider makes, answering with `body`. */
 	const capture = (body: unknown, init: ResponseInit = { status: 200 }) => {
-		const fetchMock = jest.fn().mockResolvedValue(
-			new Response(JSON.stringify(body), {
-				headers: { 'content-type': 'application/json' },
-				...init
-			})
+		// A FRESH Response per call: a Response body is one-shot, and `mockResolvedValue` would hand
+		// every call the same instance — the second read then rejects with undici's credential-free
+		// "Body is unusable", which made the credential-leak assertion below pass against an
+		// implementation that echoes the body. (Mutation-tested: `mockResolvedValue` let exactly that
+		// defect through.)
+		const fetchMock = jest.fn().mockImplementation(() =>
+			Promise.resolve(
+				new Response(JSON.stringify(body), {
+					headers: { 'content-type': 'application/json' },
+					...init
+				})
+			)
 		);
 		global.fetch = fetchMock as unknown as typeof fetch;
 		return fetchMock;
@@ -127,5 +134,16 @@ describe('openAiProviderDefinition.transcribe', () => {
 
 		await expect(transcribe()).rejects.toThrow(/rate or quota limit/);
 		await expect(transcribe()).rejects.not.toThrow(/API key/);
+	});
+
+	it('relays the diagnostic body for a format failure, with key-shaped tokens redacted', async () => {
+		// Non-credential failures DO include the upstream body — "Invalid file format" is the one
+		// message that tells the user what to change — but defensively redacted: a proxy that routes
+		// a secret into a 400 must not put it on screen.
+		capture({ error: { message: 'Invalid file format for sk-oops-leaked' } }, { status: 400 });
+
+		await expect(transcribe()).rejects.toThrow(/audio was rejected/);
+		await expect(transcribe()).rejects.toThrow(/Invalid file format/);
+		await expect(transcribe()).rejects.not.toThrow(/sk-oops-leaked/);
 	});
 });

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -146,4 +146,23 @@ describe('openAiProviderDefinition.transcribe', () => {
 		await expect(transcribe()).rejects.toThrow(/Invalid file format/);
 		await expect(transcribe()).rejects.not.toThrow(/sk-oops-leaked/);
 	});
+
+	it('redacts the exact key in use even when it is not sk-shaped', async () => {
+		// Custom base URLs (Azure, proxies) issue keys with no recognizable prefix, so shape-based
+		// redaction alone would relay exactly the secret it exists to protect.
+		capture({ error: { message: 'key azure-key-123 is over quota' } }, { status: 429 });
+
+		const creds = credentials({ apiKey: 'azure-key-123', baseUrl: 'https://proxy.example.com/v1' });
+		await expect(transcribe('audio/webm', creds)).rejects.toThrow(/rate or quota limit/);
+		await expect(transcribe('audio/webm', creds)).rejects.not.toThrow(/azure-key-123/);
+	});
+
+	it('never relays upstream statusText', async () => {
+		// statusText is upstream-controlled prose; with a custom base URL, upstream is whatever the
+		// tenant configured. The classified reason uses the status NUMBER only.
+		capture({ error: { message: 'teapot' } }, { status: 418, statusText: 'secret-in-status sk-via-status' });
+
+		await expect(transcribe()).rejects.toThrow(/HTTP 418/);
+		await expect(transcribe()).rejects.not.toThrow(/secret-in-status/);
+	});
 });

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -1,0 +1,114 @@
+import type { IAiProviderCredentials } from '@gauzy/plugin-ai-chat';
+import { openAiProviderDefinition } from './ai-provider-openai.provider';
+
+/**
+ * Dictation reached the user broken twice, and both defects were in the request this builds:
+ *
+ *  - `response_format: 'text'` was sent. `gpt-4o-mini-transcribe` accepts ONLY `json` and rejects
+ *    anything else outright, so every dictation failed. (whisper-1 does support `text`, which is
+ *    what made it look right.)
+ *  - the filename extension is what OpenAI uses to decide the container; a generic name is rejected
+ *    with "Invalid file format" even when the bytes are fine.
+ *
+ * Neither is visible from the call site, and neither breaks a build. They are only observable in the
+ * multipart body that goes over the wire — so that is what these tests read, by capturing the
+ * FormData handed to `fetch`.
+ */
+describe('openAiProviderDefinition.transcribe', () => {
+	const realFetch = global.fetch;
+	afterEach(() => {
+		global.fetch = realFetch;
+		jest.restoreAllMocks();
+	});
+
+	const credentials = (overrides: Partial<IAiProviderCredentials> = {}): IAiProviderCredentials => ({
+		apiKey: 'sk-test-transcribe',
+		source: 'tenant',
+		...overrides
+	});
+
+	/** Capture the request the provider makes, answering with `body`. */
+	const capture = (body: unknown, init: ResponseInit = { status: 200 }) => {
+		const fetchMock = jest.fn().mockResolvedValue(
+			new Response(JSON.stringify(body), {
+				headers: { 'content-type': 'application/json' },
+				...init
+			})
+		);
+		global.fetch = fetchMock as unknown as typeof fetch;
+		return fetchMock;
+	};
+
+	const requestOf = (fetchMock: jest.Mock) => {
+		const [url, options] = fetchMock.mock.calls[0];
+		return { url: String(url), options, form: options.body as FormData };
+	};
+
+	const transcribe = (mimeType = 'audio/webm;codecs=opus', creds = credentials()) =>
+		openAiProviderDefinition.transcribe!(Buffer.from('fake-audio-bytes'), mimeType, creds);
+
+	it('never sends response_format — the model accepts only the default', async () => {
+		// THE regression. Asking for `text` is rejected outright, so this assertion is the difference
+		// between dictation working and every attempt failing.
+		const fetchMock = capture({ text: 'hello world' });
+		await transcribe();
+
+		expect(requestOf(fetchMock).form.has('response_format')).toBe(false);
+	});
+
+	it('posts the audio to /audio/transcriptions with the key and the speech model', async () => {
+		const fetchMock = capture({ text: 'hello world' });
+		await transcribe();
+
+		const { url, options, form } = requestOf(fetchMock);
+		expect(url).toBe('https://api.openai.com/v1/audio/transcriptions');
+		expect(options.method).toBe('POST');
+		expect((options.headers as Record<string, string>).authorization).toBe('Bearer sk-test-transcribe');
+		expect(form.get('model')).toBe('gpt-4o-mini-transcribe');
+	});
+
+	it.each([
+		// [browser mimeType, expected filename] — OpenAI reads the CONTAINER off the extension, so a
+		// generic name is rejected even when the bytes are valid. These are the three containers a
+		// MediaRecorder actually produces across Chrome/Firefox (webm) and Safari (mp4).
+		['audio/webm;codecs=opus', 'dictation.webm'],
+		['audio/mp4', 'dictation.mp4'],
+		['audio/mpeg', 'dictation.mp4'],
+		['audio/ogg;codecs=opus', 'dictation.ogg'],
+		['', 'dictation.webm']
+	])('names the upload from the %s container', async (mimeType, expected) => {
+		const fetchMock = capture({ text: 'ok' });
+		await transcribe(mimeType);
+
+		const file = requestOf(fetchMock).form.get('file') as File;
+		expect(file.name).toBe(expected);
+	});
+
+	it('returns the transcript, trimmed', async () => {
+		capture({ text: '  hello world  ' });
+		await expect(transcribe()).resolves.toBe('hello world');
+	});
+
+	it('treats silence as an empty transcript rather than an error', async () => {
+		// A recording with nothing in it is a valid answer: the user pressed the mic and said nothing.
+		// Throwing here would surface as a failed dictation and send them looking at their API key.
+		capture({});
+		await expect(transcribe()).resolves.toBe('');
+	});
+
+	it('honours a custom base URL', async () => {
+		// Unlike the model catalogue, which deliberately never calls a custom endpoint: the caller
+		// configured this as their OpenAI and explicitly asked for this request.
+		const fetchMock = capture({ text: 'ok' });
+		await transcribe('audio/webm', credentials({ baseUrl: 'https://proxy.example.com/v1/' }));
+
+		expect(requestOf(fetchMock).url).toBe('https://proxy.example.com/v1/audio/transcriptions');
+	});
+
+	it('fails without echoing the upstream body, which carries the credential', async () => {
+		capture({ error: { message: 'Incorrect API key provided: sk-test-transcribe' } }, { status: 401 });
+
+		await expect(transcribe()).rejects.toThrow(/401/);
+		await expect(transcribe()).rejects.not.toThrow(/sk-test-transcribe/);
+	});
+});

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -77,6 +77,12 @@ describe('openAiProviderDefinition.transcribe', () => {
 		['audio/mp4', 'dictation.mp4'],
 		['audio/mpeg', 'dictation.mp3'],
 		['audio/ogg;codecs=opus', 'dictation.ogg'],
+		// The rest of the pre-recorded-file class: every container OpenAI accepts that a MIME type can
+		// name. Raw `audio/aac` stays on the webm fallback — OpenAI's accepted set has no extension
+		// for it, so no mapping could save it.
+		['audio/wav', 'dictation.wav'],
+		['audio/flac', 'dictation.flac'],
+		['audio/x-m4a', 'dictation.m4a'],
 		['', 'dictation.webm']
 	])('names the upload from the %s container', async (mimeType, expected) => {
 		const fetchMock = capture({ text: 'ok' });
@@ -107,10 +113,19 @@ describe('openAiProviderDefinition.transcribe', () => {
 		expect(requestOf(fetchMock).url).toBe('https://proxy.example.com/v1/audio/transcriptions');
 	});
 
-	it('fails without echoing the upstream body, which carries the credential', async () => {
+	it('classifies a failure by status without echoing the upstream body, which carries the credential', async () => {
 		capture({ error: { message: 'Incorrect API key provided: sk-test-transcribe' } }, { status: 401 });
 
-		await expect(transcribe()).rejects.toThrow(/401/);
+		// Classified, not the bare status: the chat panel shows this verbatim, and "401" told the user
+		// nothing while "check your API key" was being appended to every failure class downstream.
+		await expect(transcribe()).rejects.toThrow(/API key was rejected/);
 		await expect(transcribe()).rejects.not.toThrow(/sk-test-transcribe/);
+	});
+
+	it('does not blame the API key for a quota failure', async () => {
+		capture({ error: { message: 'Rate limit reached' } }, { status: 429 });
+
+		await expect(transcribe()).rejects.toThrow(/rate or quota limit/);
+		await expect(transcribe()).rejects.not.toThrow(/API key/);
 	});
 });


### PR DESCRIPTION
## Why

Dictation reached you broken **twice**. Both defects typechecked, built, and passed every existing test. Both were caught by review rather than by anything that runs. This adds the guards that would have caught them, and closes the hole that made one of them possible.

## The hole

`LazyFileInterceptor` calls `localOptions.storage(context)` **unconditionally**, while `MulterOptions.storage` is typed `any` and `localOptions` itself was optional. So a route could omit the factory — or pass a `StorageEngine` where a *factory* was expected — and compile, then answer **500 on every upload** with nothing pointing at the cause.

That is precisely what shipped on `/ai-chat/transcribe`. `storage` is now a required, properly typed factory. All six existing call sites already satisfy it, so nothing else changes.

## Also: `limits` was being dropped

Only `storage` and `fileFilter` were forwarded to multer. A route declaring `limits: { fileSize }` read as capped while accepting uploads of any size — the same silent-no-op shape, one step further along. The chat's size cap is enforced by hand in the service *precisely because of this*.

No caller currently declares `limits`, so this only changes what happens the next time someone reasonably expects it to work.

## Tests

Both suites were verified to **fail against the original defect**, not merely pass against the fix:

**`lazy-file-interceptor.spec.ts`** — drives real multipart bytes through the interceptor (no HTTP server; busboy just needs a Readable plus two headers): buffer population, the `ExecutionContext` handed to the factory, a missing factory, limits enforced *and* not over-enforced, `fileFilter`.
> Removing the limits forwarding fails exactly one test. ✅ verified

**`ai-provider-openai.transcribe.spec.ts`** — reads the `FormData` that actually goes over the wire: no `response_format` (`gpt-4o-mini-transcribe` accepts only the default; asking for `text` — which whisper-1 *does* support, which is what made it look right — failed every dictation), filename extension per container, trimming, silence as an empty transcript, custom base URL, and that a failure does not echo an upstream body carrying the API key.
> Re-adding `response_format: 'text'` fails exactly one test. ✅ verified

## Verification

- `packages/core` typechecks clean with the stricter signature.
- 33 tests pass in the openai plugin, 6 in core.
- cspell clean.

## What this does *not* do

It still does not prove dictation works end-to-end. Nobody has yet clicked the mic against a real OpenAI key and seen text appear — these tests pin the request shape, not the round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make missing upload storage a compile-time error and forward `limits` so `ai-chat` transcribe rejects oversize audio before buffering. Tighten OpenAI transcribe and user-facing errors to prevent silent 500s and avoid leaking secrets.

- **Bug Fixes**
  - `LazyFileInterceptor` now requires `storage: (context) => multer.StorageEngine`; missing or passing an engine fails at compile time. Removed stale optional chaining.
  - Forwards `limits` (and `fileFilter`) to `multer`; transcribe route declares `limits: { fileSize: MAX_AUDIO_BYTES }` to return 413 before memory buffering. `MAX_AUDIO_BYTES` is exported so controller and service share the same cap.
  - OpenAI transcribe: no `response_format`; correct extension by container, including `audio/mpeg`→`.mp3` plus `wav`/`flac`/`m4a` coverage.
  - Failure handling: classify by status (401/403 key rejected, 429 quota, 400 bad audio); ignore upstream `statusText`; never echo bodies on 401/403; for others read-bounded (2 KB) and redact key-shaped tokens and the exact key in use. The service relays the provider message, falls back safely on empty/non-Error throws, bounds length, and only suggests updating the key when the failure is credential-shaped.

- **Refactors**
  - Removed the unused `attempted` array in transcribe error handling; use `failures` as the single source of truth and attempt signal.

<sup>Written for commit e4ca507bf980db022f95e17439345a078774bf83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

