### PR TITLE
fix(ai-chat): stop telling placeholder-provider users to save an API key

### DIFF
--- a/packages/contracts/src/lib/ai-chat.model.ts
+++ b/packages/contracts/src/lib/ai-chat.model.ts
@@ -101,6 +101,13 @@ export interface IAiChatProvider {
 	 * i.e. a tenant (BYOK) credential or a server env credential exists.
 	 */
 	configured: boolean;
+	/**
+	 * `false` when the provider is a registered PLACEHOLDER whose chat routing is not implemented yet
+	 * (its `createModel` still throws). Distinct from `configured`, which conflates "no credential"
+	 * with "not capable": the settings UI needs to tell those apart, because the remedy it suggests
+	 * for one — "save an API key" — is a lie for the other. Absent means capable.
+	 */
+	chatCapable?: boolean;
 	/** Where the active credential comes from. */
 	credentialSource?: AiCredentialSource;
 	/** Display ordering (ascending) in provider lists/catalogs. */

--- a/packages/plugins/ai-chat-react-ui/src/i18n/en.json
+++ b/packages/plugins/ai-chat-react-ui/src/i18n/en.json
@@ -48,6 +48,7 @@
 			"MODELS_CURATED_NO_KEY": "Showing known models. Save an API key to load everything this provider offers.",
 			"MODELS_CURATED_UNAVAILABLE": "Showing known models — the provider's full list could not be loaded just now.",
 			"MODELS_STALE": "Showing the last known list — the provider's catalogue could not be refreshed.",
+			"MODELS_NOT_CHAT_CAPABLE": "Chat through this provider is not available yet — pick another provider to chat. A key saved here takes effect once support ships.",
 			"ENABLED": "Enabled",
 			"USE_AS_DEFAULT": "Use as default provider",
 			"GET_KEY": "Get API key"

--- a/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.ts
@@ -620,6 +620,14 @@ export class AiChatSettingsComponent implements OnInit {
 	 * live and complete (the ordinary case needs no explanation).
 	 */
 	modelSourceKey(provider: IAiChatProvider): string | null {
+		// Before anything catalogue-shaped: a placeholder provider (chat routing not implemented; its
+		// catalogue is deliberately empty) must not fall through to the 'curated' advice below, which
+		// tells the user to save an API key — the one remedy that cannot help here. Checked first and
+		// independent of the fetch, because the provider is a placeholder whether or not the catalogue
+		// has arrived.
+		if (provider.chatCapable === false) {
+			return 'AI_CHAT_UI.SETTINGS.FORM.MODELS_NOT_CHAT_CAPABLE';
+		}
 		const catalogue = this.modelCatalogues().get(provider.id);
 		if (!catalogue) {
 			return null;

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.capability.spec.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.capability.spec.ts
@@ -39,6 +39,9 @@ describe('AiChatService chatCapable boundary', () => {
 		models: [],
 		defaultModel: '',
 		chatCapable: false,
+		// Sorts FIRST, like the real placeholder (gauzy-ai is order 10): the outage this file guards
+		// against depended on exactly that — the placeholder winning default selection by sort order.
+		order: 10,
 		async createModel(): Promise<never> {
 			throw new Error('raw not-implemented error that must never reach a user');
 		}
@@ -50,6 +53,7 @@ describe('AiChatService chatCapable boundary', () => {
 		apiKeyEnvVars: ['TEST_CAPABLE_API_KEY'],
 		models: [{ id: 'test-model', label: 'Test Model', providerId: 'test-capable' }],
 		defaultModel: 'test-model',
+		order: 50,
 		async createModel() {
 			return {} as never;
 		}
@@ -104,5 +108,21 @@ describe('AiChatService chatCapable boundary', () => {
 
 		expect(byId.get('test-placeholder')?.configured).toBe(false);
 		expect(byId.get('test-capable')?.configured).toBe(true);
+	});
+
+	it('never DEFAULTS to a placeholder — the filter whose absence was a live outage', async () => {
+		// The placeholder sorts first and has a resolvable credential, i.e. the exact state that once
+		// made every chat turn fail: default selection picked it by sort order, and its createModel
+		// threw unconditionally while /config advertised a healthy default. The other tests would all
+		// still pass if the `chatCapable !== false` filter in the default path were reverted — this
+		// one fails on that revert (the placeholder's raw error replaces the resolved capable model).
+		const instance = service();
+		(instance as unknown as { resolveDefaultProvider: unknown }).resolveDefaultProvider = async () => null;
+
+		const resolved = await (
+			instance as unknown as { resolveModel(providerId?: string): Promise<{ providerId: string }> }
+		).resolveModel();
+
+		expect(resolved.providerId).toBe('test-capable');
 	});
 });

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.capability.spec.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.capability.spec.ts
@@ -1,0 +1,108 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+
+// The service module's import graph is why no service spec existed before this one: @gauzy/core pulls
+// the whole bootstrap (config, database, an ESM package jest cannot parse), and the tool builders pull
+// the ESM-only `ai` SDK. None of that is on the code paths under test, so it is stubbed AT THE MODULE
+// BOUNDARY — hoisted above the imports — leaving the real service, registry and capability logic live.
+jest.mock('@gauzy/core', () => ({ RequestContext: class {} }));
+jest.mock('./esm-loader', () => ({ loadAiSdk: jest.fn() }));
+jest.mock('./tools/gauzy-api-client', () => ({ GauzyApiClient: class {} }));
+jest.mock('./tools/gauzy-tools', () => ({ buildGauzyTools: jest.fn(), GAUZY_TOOLS_REQUIRING_APPROVAL: [] }));
+jest.mock('./tools/client-tools', () => ({ buildClientTools: jest.fn(), CLIENT_TOOLS_REQUIRING_APPROVAL: [] }));
+jest.mock('./tools/mcp-tools', () => ({ createMcpTools: jest.fn() }));
+jest.mock('./credentials/ai-provider-credential.service', () => ({ AiProviderCredentialService: class {} }));
+jest.mock('./conversations/ai-chat-conversation.service', () => ({ AiChatConversationService: class {} }));
+
+import { AiProviderRegistry } from './provider-registry';
+import { AiChatService } from './ai-chat.service';
+import { IAiChatProviderDefinition } from './provider.types';
+
+/**
+ * The `chatCapable` contract, pinned from the backend side — the side that emits it.
+ *
+ * A placeholder provider (its `createModel` still throws) is registered so it SHOWS in the UI, and
+ * everything else about it is opt-out: it must never be defaulted to, never be selectable, and —
+ * covered here because it was the gap review found — never reachable by NAMING it explicitly, which
+ * any client can do the moment `/config` advertises the id. Without the boundary check the request
+ * sailed through to `createModel()` and surfaced the provider's raw not-implemented error as a
+ * failed turn.
+ *
+ * The serialization rule matters as much as the gate: the UI treats ABSENT as capable and exactly
+ * `false` as placeholder, so a change that starts emitting `true` (or dropping the field for
+ * placeholders) silently flips the settings guidance. Both directions are asserted.
+ */
+describe('AiChatService chatCapable boundary', () => {
+	const placeholder: IAiChatProviderDefinition = {
+		id: 'test-placeholder',
+		label: 'Test Placeholder',
+		apiKeyEnvVars: [],
+		models: [],
+		defaultModel: '',
+		chatCapable: false,
+		async createModel(): Promise<never> {
+			throw new Error('raw not-implemented error that must never reach a user');
+		}
+	};
+
+	const capable: IAiChatProviderDefinition = {
+		id: 'test-capable',
+		label: 'Test Capable',
+		apiKeyEnvVars: ['TEST_CAPABLE_API_KEY'],
+		models: [{ id: 'test-model', label: 'Test Model', providerId: 'test-capable' }],
+		defaultModel: 'test-model',
+		async createModel() {
+			return {} as never;
+		}
+	};
+
+	/** Service with the DB-touching privates stubbed — the capability logic is what's under test. */
+	const service = (): AiChatService => {
+		const instance = new AiChatService(null as never, null as never);
+		(instance as unknown as { getTenantCredential: unknown }).getTenantCredential = async () => ({
+			// A SAVED tenant key for every provider, placeholder included: the boundary must hold
+			// even when credentials resolve, because tenant BYOK is resolved first and emptying the
+			// placeholder's env vars cannot close that route.
+			apiKey: 'tenant-key',
+			enabled: true
+		});
+		(instance as unknown as { resolveDefaultProvider: unknown }).resolveDefaultProvider = async () => ({});
+		return instance;
+	};
+
+	beforeEach(() => {
+		AiProviderRegistry.clear();
+		AiProviderRegistry.register(placeholder);
+		AiProviderRegistry.register(capable);
+	});
+
+	afterAll(() => {
+		AiProviderRegistry.clear();
+	});
+
+	it('rejects an EXPLICIT request for a placeholder with a controlled 503, not the raw provider error', async () => {
+		const resolve = (service() as unknown as { resolveModel(p?: string, m?: string): Promise<unknown> }).resolveModel(
+			'test-placeholder'
+		);
+
+		await expect(resolve).rejects.toBeInstanceOf(ServiceUnavailableException);
+		await expect(resolve).rejects.toThrow(/cannot serve chat yet/);
+		await expect(resolve).rejects.not.toThrow(/raw not-implemented/);
+	});
+
+	it('emits chatCapable exactly false for a placeholder and OMITS it for a capable provider', async () => {
+		const config = await service().getConfig();
+		const byId = new Map(config.providers.map((provider) => [provider.id, provider]));
+
+		expect(byId.get('test-placeholder')?.chatCapable).toBe(false);
+		// Omitted, not true: absent-means-capable is the wire contract the settings UI branches on.
+		expect('chatCapable' in (byId.get('test-capable') ?? {})).toBe(false);
+	});
+
+	it('keeps a placeholder with a saved credential out of the configured set', async () => {
+		const config = await service().getConfig();
+		const byId = new Map(config.providers.map((provider) => [provider.id, provider]));
+
+		expect(byId.get('test-placeholder')?.configured).toBe(false);
+		expect(byId.get('test-capable')?.configured).toBe(true);
+	});
+});

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -287,6 +287,16 @@ export class AiChatService {
 			if (!definition) {
 				throw new BadRequestException(`Unknown AI provider '${requestedProviderId}'.`);
 			}
+			// The capability gate must hold on the EXPLICIT path too, not only when defaulting. The
+			// default path below filters placeholders out, but a request that names one directly —
+			// easy to send once /config advertises the provider, and reachable whenever a tenant has
+			// saved a BYOK key for it — would sail through to createModel() and surface its raw
+			// not-implemented error as a failed turn. Same controlled 503 either way.
+			if (definition.chatCapable === false) {
+				throw new ServiceUnavailableException(
+					`AI provider '${definition.label}' cannot serve chat yet — select another provider.`
+				);
+			}
 		} else {
 			// Only a provider that actually HAS credentials may be defaulted to.
 			//

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -229,6 +229,10 @@ export class AiChatService {
 				// however many credentials resolve for it — otherwise /config advertises it, the
 				// settings UI shows it as ready, and it can be chosen as the tenant default.
 				configured: credentials !== null && definition.chatCapable !== false,
+				// Surfaced separately from `configured` so the UI can distinguish "save a key" (fixable
+				// by the user) from "chat is not implemented for this provider yet" (not fixable by any
+				// key). Only ever emitted as false — absent means capable.
+				...(definition.chatCapable === false ? { chatCapable: false } : {}),
 				...(credentials ? { credentialSource: credentials.source } : {}),
 				...(definition.order !== undefined ? { order: definition.order } : {}),
 				...(definition.websiteUrl ? { websiteUrl: definition.websiteUrl } : {}),


### PR DESCRIPTION
## The lie

For a provider registered as a placeholder (`chatCapable: false` — today Gauzy AI, whose `createModel` still throws), the settings model picker showed the generic curated-list note:

> *Showing known models. Save an API key to load everything this provider offers.*

In front of a deliberately **empty** dropdown, for a provider where saving a key changes **nothing** — both halves of that sentence are wrong. Worse, it kept saying "save an API key" even when a key *was* already saved, because `configured` is forced false for placeholders.

## Why the UI couldn't tell

`configured` conflates "no credential" with "not capable" **on purpose** — a placeholder must never be selectable. But that left the settings page unable to distinguish the two situations, and the remedy it suggests for one ("save an API key", fixable by the user) is a lie for the other (not fixable by any key).

## The fix

- `IAiChatProvider` now carries `chatCapable?: boolean`, emitted only as `false` for placeholders (absent means capable).
- `modelSourceKey`'s **first** branch — checked before any catalogue state, because the provider is a placeholder whether or not the fetch has resolved — returns a truthful note:

> *Chat through this provider is not available yet — pick another provider to chat. A key saved here takes effect once support ships.*

## Verification

- `@gauzy/plugin-ai-chat` and `@gauzy/plugin-ai-chat-react-ui` both typecheck clean.
- The i18n diff is exactly one line, key order preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misleading AI Chat settings for placeholder providers and fully enforces capability checks across explicit and default selection paths. The UI now says chat isn’t available, and the service returns a controlled 503 or avoids defaulting to placeholders.

- **Bug Fixes**
  - Added `chatCapable?: boolean` to providers; `@gauzy/plugin-ai-chat` emits `chatCapable: false` only for placeholders (absent means capable).
  - `@gauzy/plugin-ai-chat-react-ui` checks `chatCapable === false` first and shows `MODELS_NOT_CHAT_CAPABLE` instead of “save an API key”.
  - Backend enforcement: placeholders stay unconfigured; explicit placeholder requests return 503; default selection filters out placeholders even with saved BYOK. Tests added to pin these behaviors and the absent-means-capable contract.

<sup>Written for commit 89dcd4a6b143ec2c4a68720bb3f9f24bb2a723da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

