### PR TITLE
chore: cascade develop → stage (e2e click-race sweep, dictation hardening, placeholder provider fix)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -538,6 +538,7 @@
         "NTSC",
         "nums",
         "nuxt",
+        "flac",
         "ogg",
         "oidc",
         "omni",

--- a/apps/gauzy-e2e/src/support/Base/pageobjects/AddEmployeeLevelPageObject.ts
+++ b/apps/gauzy-e2e/src/support/Base/pageobjects/AddEmployeeLevelPageObject.ts
@@ -16,7 +16,14 @@ export const AddEmployeeLevelPage = {
 	// Toolbar Delete button: class="action" carrying the trash icon (NOT the Edit "action primary" button).
 	removeEmployeeLevelButtonCss: 'button.action:has(nb-icon[icon="trash-2-outline"])',
 	confirmDeleteLevelButtonCss: 'nb-card-footer > button[status="danger"]',
-	editLevelInputCss: 'div.d-flex > input[type="text"]',
+	// Level name input of the EDIT dialog (#editableTemplate). Scoped to the dialog body and matched by
+	// placeholder, exactly like the sibling Positions page — the old 'div.d-flex > input[type="text"]'
+	// was bound to Bootstrap layout classes rather than to this control, so it matched any flex-row text
+	// input anywhere on the page. That is unsafe now that the Edit click confirms on this selector:
+	// dispatchClickWhenSettled checks the desired end state BEFORE dispatching, so a selector that
+	// already matches something else would report the dialog as open and skip the click entirely,
+	// turning an occasional lost click into a guaranteed one.
+	editLevelInputCss: '.editable [placeholder="Level name"]',
 	verifyTextCss: 'ga-notes-with-tags',
 	cardBodyCss: 'nb-card-body',
 	toastrMessageCss: 'nb-toast.ng-trigger',

--- a/apps/gauzy-e2e/tests/support/pages/AddEmployeeLevel.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddEmployeeLevel.po.ts
@@ -8,6 +8,7 @@ import {
 	waitElementToHide,
 	verifyValue,
 	dispatchClick,
+	dispatchClickWhenSettled,
 	waitForSpinnerGone
 } from '../util';
 import { selectNgOption } from '../ng-select';
@@ -193,7 +194,13 @@ export const clickRowEmployeeLevelToDelete = async () => {
 };
 
 export const clickEditEmployeeLevelButton = async () => {
-	await dispatchClick(AddEmployeeLevelPage.editEmployeeLevelButtonCss);
+	// Same shape as the sibling Positions page: dispatch so a fading toastr/backdrop can't swallow the
+	// click, and CONFIRM the edit dialog rendered. Without the confirm a lost click surfaces 24s later
+	// as a timeout on editLevelInputCss — naming the input, not the button that was never pressed.
+	await dispatchClickWhenSettled(
+		AddEmployeeLevelPage.editEmployeeLevelButtonCss,
+		AddEmployeeLevelPage.editLevelInputCss
+	);
 };
 
 export const editEmployeeLevelInpuVisible = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/AddEmployeePosition.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/AddEmployeePosition.po.ts
@@ -8,6 +8,7 @@ import {
 	waitElementToHide,
 	verifyValue,
 	dispatchClick,
+	dispatchClickWhenSettled,
 	waitForSpinnerGone,
 	wait
 } from '../util';
@@ -172,8 +173,19 @@ export const selectPositionRowByText = async (text: string) => {
 };
 
 export const clickEditEmployeePositionButton = async () => {
-	// Edit dialog opens via dispatch so a fading backdrop can't swallow the click (row already selected).
-	await dispatchClick(AddEmployeePositionPage.editEmployeePositionButtonCss);
+	// Edit opens via dispatch so a fading backdrop can't swallow the click (row already selected) — and
+	// CONFIRMS the editable form rendered. Dispatching alone was not enough: the Edit button lives in
+	// ngx-gauzy-button-action's slide-in action bar, and this fires right after waitMessageToHide plus a
+	// row click, i.e. while a toastr is still fading. When the click is lost, the next call
+	// (`verifyValue`/`clearField` on editPositionInputCss) waits the full 24s and the scenario dies with
+	// a timeout that names the input rather than the button that was never pressed.
+	//
+	// Confirming on the very selector the dependent step waits for makes a wrong-selector stall
+	// impossible: if it can't appear, the old code would have hung on it anyway.
+	await dispatchClickWhenSettled(
+		AddEmployeePositionPage.editEmployeePositionButtonCss,
+		AddEmployeePositionPage.editPositionInputCss
+	);
 };
 
 export const selectPositionToEdit = async () => {

--- a/apps/gauzy-e2e/tests/support/pages/Goals.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/Goals.po.ts
@@ -13,6 +13,7 @@ import {
 	verifyTextNotExisting,
 	waitUntil,
 	dispatchClick,
+	dispatchClickWhenSettled,
 	waitForSpinnerGone
 } from '../util';
 import { getPage } from '../page-context';
@@ -450,7 +451,19 @@ export const keyResultOwnerDropdownVisible = async () => {
 };
 
 export const clickKeyResultOwnerDropdown = async () => {
-	await clickButton(GoalsPage.keyResultOwnerCss);
+	// Target the nb-select INSIDE the wrapper, not the wrapper itself. `id="key-result-owner"` sits on
+	// <ga-employee-multi-select>, which CONTAINS the control rather than being it, and that component
+	// renders its <nb-select> only under `@if (loaded)` — i.e. after the employees request resolves.
+	// The wrapper therefore exists (and is clickable) while it is still an empty box, so the old
+	// coordinate click could be delivered to nothing at all; it only ever worked because hit-testing
+	// happened to reach the inner button once the fetch had landed.
+	//
+	// Waiting for the inner nb-select makes `loaded` an explicit precondition, and dispatching at it
+	// satisfies Nebular's trigger strategy (which requires the event target to be inside the host).
+	//
+	// Worth confirming rather than assuming: ownerId is REQUIRED, so a missed open leaves the form
+	// invalid, Save silently no-ops, and every later step operating on that key result fails downstream.
+	await dispatchClickWhenSettled('#key-result-owner nb-select', GoalsPage.dropdownOptionCss);
 };
 
 export const selectKeyResultOwnerFromDropdown = async (index) => {

--- a/apps/gauzy-e2e/tests/support/pages/InviteUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/InviteUser.po.ts
@@ -19,9 +19,10 @@ export const inviteButtonVisible = async () => verifyElementIsVisible(InviteUser
 // button's coordinates, landed on the overlay, and the dialog never opened (#emails not found).
 // Settle, dispatch straight at the button, and confirm the dialog opened.
 export const clickInviteButton = async () =>
-	// The `await` matters: without it this was a floating promise — the settle/confirm ran CONCURRENTLY
-	// with the next step, and now that the helper throws when the dialog never opens, a call without
-	// `await` would surface as an unhandled rejection instead of failing the scenario at this line.
+	// Style only: a braceless `=> dispatchClickWhenSettled(...)` already RETURNS the promise (this was
+	// never floating — the step awaits it), so this `await` changes nothing at runtime. It stays
+	// because the explicit form is what every sibling helper uses, and because a future edit that adds
+	// braces to the arrow would otherwise silently orphan the promise.
 	await dispatchClickWhenSettled(InviteUserPage.inviteButtonCss, InviteUserPage.emailInputCss);
 
 export const emailInputVisible = async () => verifyElementIsVisible(InviteUserPage.emailInputCss);

--- a/apps/gauzy-e2e/tests/support/pages/InviteUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/InviteUser.po.ts
@@ -19,7 +19,7 @@ export const inviteButtonVisible = async () => verifyElementIsVisible(InviteUser
 // button's coordinates, landed on the overlay, and the dialog never opened (#emails not found).
 // Settle, dispatch straight at the button, and confirm the dialog opened.
 export const clickInviteButton = async () =>
-	// Style only: a braceless `=> dispatchClickWhenSettled(...)` already RETURNS the promise (this was
+	// Style only: an arrow body without braces already RETURNS the promise (this was
 	// never floating — the step awaits it), so this `await` changes nothing at runtime. It stays
 	// because the explicit form is what every sibling helper uses, and because a future edit that adds
 	// braces to the arrow would otherwise silently orphan the promise.

--- a/apps/gauzy-e2e/tests/support/pages/InviteUser.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/InviteUser.po.ts
@@ -19,7 +19,10 @@ export const inviteButtonVisible = async () => verifyElementIsVisible(InviteUser
 // button's coordinates, landed on the overlay, and the dialog never opened (#emails not found).
 // Settle, dispatch straight at the button, and confirm the dialog opened.
 export const clickInviteButton = async () =>
-	dispatchClickWhenSettled(InviteUserPage.inviteButtonCss, InviteUserPage.emailInputCss);
+	// The `await` matters: without it this was a floating promise — the settle/confirm ran CONCURRENTLY
+	// with the next step, and now that the helper throws when the dialog never opens, a call without
+	// `await` would surface as an unhandled rejection instead of failing the scenario at this line.
+	await dispatchClickWhenSettled(InviteUserPage.inviteButtonCss, InviteUserPage.emailInputCss);
 
 export const emailInputVisible = async () => verifyElementIsVisible(InviteUserPage.emailInputCss);
 

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
@@ -405,6 +405,13 @@ export const clickEmployeeDropdown = async () => {
 	// abort the scenario in precisely the state the picker below was written to survive. The panel
 	// renders even with zero options (Nebular's nb-option-list is a bare ul.option-list around
 	// ng-content), so its appearance still proves the click landed.
+	//
+	// Deliberately NOT scoped to the component (e.g. 'ga-employee-multi-select nb-option-list'):
+	// Nebular renders the panel into the document-level OVERLAY CONTAINER, not inside the select's
+	// host, so a component-scoped selector would never match anything and the helper would throw on
+	// every run. The residual risk — a previous select's panel pre-satisfying the end-state check —
+	// is bounded: picking an option detaches its panel synchronously, and the helper settles
+	// (spinner + network idle) before it looks.
 	await dispatchClickWhenSettled(OrganizationEquipmentPage.selectEmployeeDropdownCss, 'nb-option-list');
 };
 

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
@@ -398,12 +398,14 @@ export const selectEmployeeDropdownVisible = async () => {
 };
 
 export const clickEmployeeDropdown = async () => {
-	// As above. The employee list is fetched (org members "working" in the header range), so of the
-	// three this is the most likely to render late.
-	await dispatchClickWhenSettled(
-		OrganizationEquipmentPage.selectEmployeeDropdownCss,
-		OrganizationEquipmentPage.selectEmployeeDropdownOptionCss
-	);
+	// As above — but confirm on the PANEL ('nb-option-list'), NOT on '.option-list nb-option'. The
+	// employee list (org members "working" in the header date range) can legitimately be EMPTY — see
+	// selectEmployeeFromDropdown below, which is best-effort for exactly that state — and now that
+	// dispatchClickWhenSettled THROWS when its confirm never appears, an option-level confirm would
+	// abort the scenario in precisely the state the picker below was written to survive. The panel
+	// renders even with zero options (Nebular's nb-option-list is a bare ul.option-list around
+	// ng-content), so its appearance still proves the click landed.
+	await dispatchClickWhenSettled(OrganizationEquipmentPage.selectEmployeeDropdownCss, 'nb-option-list');
 };
 
 export const selectEmployeeFromDropdown = async (index: number) => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationEquipment.po.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import {
 	enterInput,
 	verifyElementIsVisible,
+	dispatchClickWhenSettled,
 	clickButton,
 	clearField,
 	clickKeyboardBtnByKeycode,
@@ -339,7 +340,18 @@ export const selectEquipmentDropdownVisible = async () => {
 };
 
 export const clickEquipmentDropdown = async () => {
-	await clickButton(OrganizationEquipmentPage.selectEquipmentDropdownCss);
+	// CONFIRM the panel opened rather than assuming the click landed. `clickButton` is a force-click,
+	// which only skips the actionability check — it still returns whether or not the option list
+	// rendered, and the very next step waits 24s for an option inside it.
+	//
+	// Observed in CI run 31119250876 (shard 3): `locator.waitFor: Timeout 24000ms exceeded — waiting
+	// for locator('.option-list nb-option').filter({ hasText: 'Equipment NrLaT58N' })`. It passed on
+	// retry, so the suite reported "1 flaky" and stayed green — a pass bought with a retry. Same
+	// shape, and same fix, as the tag Edit dialog in OrganizationTags.po.
+	await dispatchClickWhenSettled(
+		OrganizationEquipmentPage.selectEquipmentDropdownCss,
+		OrganizationEquipmentPage.selectEquipmentDropdownOptionCss
+	);
 };
 
 export const selectEquipmentFromDropdown = async (index: number) => {
@@ -368,7 +380,13 @@ export const approvalPolicyDropdownVisible = async () => {
 };
 
 export const clickSelectPolicyDropdown = async () => {
-	await clickButton(OrganizationEquipmentPage.selectPolicyDropdownCss);
+	// Same treatment as the equipment dropdown above. The evidence is for that one; this has the
+	// identical shape — force-click, then the next line picks an option out of a panel nobody
+	// confirmed had opened — so it is the same latent flake waiting for a slow render.
+	await dispatchClickWhenSettled(
+		OrganizationEquipmentPage.selectPolicyDropdownCss,
+		OrganizationEquipmentPage.selectPolicyDropdownOptionCss
+	);
 };
 
 export const selectPolicyFromDropdown = async (index: number) => {
@@ -380,7 +398,12 @@ export const selectEmployeeDropdownVisible = async () => {
 };
 
 export const clickEmployeeDropdown = async () => {
-	await clickButton(OrganizationEquipmentPage.selectEmployeeDropdownCss);
+	// As above. The employee list is fetched (org members "working" in the header range), so of the
+	// three this is the most likely to render late.
+	await dispatchClickWhenSettled(
+		OrganizationEquipmentPage.selectEmployeeDropdownCss,
+		OrganizationEquipmentPage.selectEmployeeDropdownOptionCss
+	);
 };
 
 export const selectEmployeeFromDropdown = async (index: number) => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationHelpCenter.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationHelpCenter.po.ts
@@ -13,6 +13,7 @@ import {
 	enterTextInIFrame,
 	clickElementIfVisible,
 	dispatchClick,
+	dispatchClickWhenSettled,
 	waitForSpinnerGone
 } from '../util';
 import { getPage } from '../page-context';
@@ -67,7 +68,18 @@ export const iconDropdownVisible = async () => {
 };
 
 export const clickIconDropdown = async () => {
-	await clickButton(OrganizationHelpCenterPage.iconDropdownCss);
+	// This fires two lines after the LANGUAGE ng-select (appendTo="body") committed a value, and ROOT
+	// CAUSE 2 below already documents that its fading cdk-overlay-backdrop sits over this dialog — a
+	// coordinate click lands on the backdrop and is lost. The cost of losing it is higher here than
+	// elsewhere: the next call resolves `.option-list nb-option` at the 60s taskTimeout, not 24s.
+	//
+	// Confirming on the option list is safe because the preceding control is an ng-select, whose options
+	// are `div.ng-option` — never `.option-list nb-option` — so no leftover panel can satisfy the
+	// end-state pre-check and cause the click to be skipped.
+	await dispatchClickWhenSettled(
+		OrganizationHelpCenterPage.iconDropdownCss,
+		OrganizationHelpCenterPage.iconOptionCss
+	);
 };
 
 export const selectIconFromDropdown = async (index: number) => {

--- a/apps/gauzy-e2e/tests/support/pages/OrganizationPublicPage.po.ts
+++ b/apps/gauzy-e2e/tests/support/pages/OrganizationPublicPage.po.ts
@@ -13,7 +13,8 @@ import {
 	waitUntil,
 	clickButtonByIndex,
 	verifyText,
-	getLastElement
+	getLastElement,
+	dispatchClickWhenSettled
 } from '../util';
 // Selectors are framework-agnostic — reused from the Cypress tree during migration.
 import { OrganizationPublicPage } from '../../../src/support/Base/pageobjects/OrganizationPublicPagePageObject';
@@ -323,7 +324,18 @@ export const addBtnExists = async () => {
 };
 
 export const addBtnClick = async () => {
-	await clickButton(OrganizationPublicPage.addButtonCss);
+	// Confirm the mutation dialog actually mounted rather than assuming the click landed. The grid card
+	// is `[nbSpinner]="loading"` and the toolbar sits inside ngx-gauzy-button-action's slide-in, so a
+	// coordinate click issued ~800ms after the hash navigation can be delivered to the overlay instead
+	// of the button. Nothing downstream notices: the next step is `clearField(organizationNameField)`,
+	// which then burns the full 24s actionTimeout waiting for an input that was never opened.
+	//
+	// The sibling page object driving this same dialog (AddOrganization.po.ts) already confirms; this
+	// copy was simply never updated.
+	await dispatchClickWhenSettled(
+		OrganizationPublicPage.addButtonCss,
+		OrganizationPublicPage.organizationNameFieldCss
+	);
 };
 
 export const verifyOrganisationNameField = async () => {

--- a/apps/gauzy-e2e/tests/support/util.ts
+++ b/apps/gauzy-e2e/tests/support/util.ts
@@ -155,6 +155,15 @@ export const dispatchClickWhenSettled = async (selector: string, confirmSelector
 			/* the click was swallowed — settle and try again, re-checking the end state first. */
 		}
 	}
+	// Fail HERE, naming the trigger, rather than returning as if the click landed. A silent return
+	// just moves the failure to whatever the caller does next — a 24s timeout on an input inside a
+	// dialog that never opened, i.e. the exact illegible error this helper exists to eliminate. When
+	// the confirm target genuinely cannot appear the scenario was going to fail either way; this way
+	// the report says which button was pressed and what never showed up.
+	throw new Error(
+		`dispatchClickWhenSettled: clicked '${selector}' ${attempts}x but '${confirmSelector}' never appeared — ` +
+			`the click's effect did not happen (or the confirm selector is wrong).`
+	);
 };
 
 /**

--- a/packages/contracts/src/lib/ai-chat.model.ts
+++ b/packages/contracts/src/lib/ai-chat.model.ts
@@ -101,6 +101,13 @@ export interface IAiChatProvider {
 	 * i.e. a tenant (BYOK) credential or a server env credential exists.
 	 */
 	configured: boolean;
+	/**
+	 * `false` when the provider is a registered PLACEHOLDER whose chat routing is not implemented yet
+	 * (its `createModel` still throws). Distinct from `configured`, which conflates "no credential"
+	 * with "not capable": the settings UI needs to tell those apart, because the remedy it suggests
+	 * for one — "save an API key" — is a lie for the other. Absent means capable.
+	 */
+	chatCapable?: boolean;
 	/** Where the active credential comes from. */
 	credentialSource?: AiCredentialSource;
 	/** Display ordering (ascending) in provider lists/catalogs. */

--- a/packages/core/src/lib/core/interceptors/lazy-file-interceptor.spec.ts
+++ b/packages/core/src/lib/core/interceptors/lazy-file-interceptor.spec.ts
@@ -1,0 +1,136 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { memoryStorage } from 'multer';
+import { of } from 'rxjs';
+import { Readable } from 'stream';
+import { LazyFileInterceptor } from './lazy-file-interceptor';
+
+/**
+ * The interceptor is thin, but each thing it does has already failed in production, and the failure
+ * was invisible every time:
+ *
+ *  - a route that omitted `storage` answered 500 on every upload, because `localOptions.storage()`
+ *    is called unconditionally while the old signature made it optional. That broke the chat's
+ *    dictation endpoint completely, and neither the build, the type-checker nor the existing tests
+ *    said anything;
+ *  - a route that declared `limits` read as capped while accepting uploads of any size, because
+ *    only `storage` and `fileFilter` were forwarded to multer.
+ *
+ * Both are "declared option silently ignored" — the shape that cannot be caught by reading the call
+ * site, only by driving a real multipart request through it. So these tests build one.
+ */
+describe('LazyFileInterceptor', () => {
+	const BOUNDARY = 'gauzy-test-boundary';
+
+	/** A real multipart/form-data body — multer parses bytes, so a hand-built object would prove nothing. */
+	const multipartBody = (field: string, filename: string, contents: Buffer): Buffer =>
+		Buffer.concat([
+			Buffer.from(
+				`--${BOUNDARY}\r\n` +
+					`Content-Disposition: form-data; name="${field}"; filename="${filename}"\r\n` +
+					`Content-Type: application/octet-stream\r\n\r\n`
+			),
+			contents,
+			Buffer.from(`\r\n--${BOUNDARY}--\r\n`)
+		]);
+
+	/**
+	 * A minimal Express-shaped request carrying the body as a stream.
+	 *
+	 * Busboy (multer's parser) reads `headers` and consumes the request as a Readable, so a Readable
+	 * with the two headers set is genuinely enough — no HTTP server needed.
+	 */
+	const requestFor = (body: Buffer): any => {
+		const request = new Readable({
+			read() {
+				this.push(body);
+				this.push(null);
+			}
+		}) as any;
+		request.headers = {
+			'content-type': `multipart/form-data; boundary=${BOUNDARY}`,
+			'content-length': String(body.length)
+		};
+		return request;
+	};
+
+	const contextFor = (request: any): ExecutionContext =>
+		({
+			switchToHttp: () => ({
+				getRequest: () => request,
+				getResponse: () => ({})
+			})
+		} as unknown as ExecutionContext);
+
+	const nextHandler: CallHandler = { handle: () => of('handled') };
+
+	/** Run one upload through the interceptor and hand back the request multer populated. */
+	const run = async (options: any, body: Buffer): Promise<any> => {
+		const Interceptor = LazyFileInterceptor('file', options);
+		const interceptor = new (Interceptor as any)();
+		const request = requestFor(body);
+		await interceptor.intercept(contextFor(request), nextHandler);
+		return request;
+	};
+
+	it('populates file.buffer with memoryStorage — what the dictation handler reads', async () => {
+		const audio = Buffer.from('fake-webm-bytes');
+		const request = await run({ storage: () => memoryStorage() }, multipartBody('file', 'dictation.webm', audio));
+
+		expect(request.file).toBeDefined();
+		expect(request.file.buffer).toEqual(audio);
+		expect(request.file.originalname).toBe('dictation.webm');
+	});
+
+	it('passes the ExecutionContext to the storage factory, so per-request destinations work', async () => {
+		// This is the interceptor's entire reason to exist over Nest's own FileInterceptor: the engine
+		// is chosen per request (tenant folder, provider, …) rather than once at module load.
+		const storage = jest.fn(() => memoryStorage());
+		const request = requestFor(multipartBody('file', 'a.bin', Buffer.from('x')));
+		const context = contextFor(request);
+
+		const Interceptor = LazyFileInterceptor('file', { storage } as any);
+		await new (Interceptor as any)().intercept(context, nextHandler);
+
+		expect(storage).toHaveBeenCalledTimes(1);
+		expect(storage).toHaveBeenCalledWith(context);
+	});
+
+	it('fails loudly when no storage factory is supplied', async () => {
+		// The signature now makes this a compile error, so the cast is deliberate: it stands in for a
+		// JS caller, and pins that the failure is at least immediate rather than a corrupted upload.
+		await expect(run({} as any, multipartBody('file', 'a.bin', Buffer.from('x')))).rejects.toThrow();
+	});
+
+	it('enforces a declared fileSize limit instead of silently ignoring it', async () => {
+		// The regression this exists for: `limits` was dropped on the floor, so a route could declare a
+		// cap, pass review, and accept anything. The chat endpoint had to re-implement its own size
+		// check in the service for exactly this reason.
+		const tooBig = Buffer.alloc(2048, 7);
+
+		await expect(
+			run({ storage: () => memoryStorage(), limits: { fileSize: 512 } }, multipartBody('file', 'big.bin', tooBig))
+		).rejects.toThrow();
+	});
+
+	it('accepts a file that fits inside the declared limit', async () => {
+		// The other half of the pair — a limit that rejects everything would also pass the test above.
+		const small = Buffer.alloc(128, 3);
+		const request = await run(
+			{ storage: () => memoryStorage(), limits: { fileSize: 512 } },
+			multipartBody('file', 'small.bin', small)
+		);
+
+		expect(request.file.buffer).toEqual(small);
+	});
+
+	it('applies a declared fileFilter', async () => {
+		// Already forwarded before this change; covered so that a future refactor of the spread cannot
+		// quietly drop it the way `limits` was dropped.
+		const filter = (_req: any, _file: any, callback: (error: Error | null, accept: boolean) => void) =>
+			callback(new Error('rejected by filter'), false);
+
+		await expect(
+			run({ storage: () => memoryStorage(), fileFilter: filter }, multipartBody('file', 'a.bin', Buffer.from('x')))
+		).rejects.toThrow();
+	});
+});

--- a/packages/core/src/lib/core/interceptors/lazy-file-interceptor.ts
+++ b/packages/core/src/lib/core/interceptors/lazy-file-interceptor.ts
@@ -51,14 +51,18 @@ export function LazyFileInterceptor(fieldName: string, localOptions: LazyFileInt
 				...this.options,
 				...{
 					storage,
+					// No optional chaining on `localOptions` here: it is a REQUIRED parameter (the call
+					// above already dereferences it), and a `?.` would imply otherwise — DeepScan rightly
+					// flags the inconsistency (INSUFFICIENT_NULL_CHECK).
+					//
 					// Pass through a per-route fileFilter when provided (e.g. to block executable/SVG uploads).
-					...(localOptions?.fileFilter ? { fileFilter: localOptions.fileFilter } : {}),
+					...(localOptions.fileFilter ? { fileFilter: localOptions.fileFilter } : {}),
 					// …and `limits` likewise. Dropping it was the same silent-no-op trap as the missing
 					// storage factory, one step further along: a route declaring `limits: { fileSize }`
 					// read as capped while accepting uploads of any size, and nothing failed to say so.
 					// No caller relies on the old behaviour — none currently declare `limits` — so this
 					// only changes what happens the next time someone reasonably expects it to work.
-					...(localOptions?.limits ? { limits: localOptions.limits } : {})
+					...(localOptions.limits ? { limits: localOptions.limits } : {})
 				}
 			});
 			await new Promise<void>((resolve, reject) =>

--- a/packages/core/src/lib/core/interceptors/lazy-file-interceptor.ts
+++ b/packages/core/src/lib/core/interceptors/lazy-file-interceptor.ts
@@ -1,4 +1,13 @@
-import { CallHandler, ExecutionContext, Inject, Logger, mixin, NestInterceptor, Optional, Type } from '@nestjs/common';
+import {
+	CallHandler,
+	ExecutionContext,
+	Inject,
+	Logger,
+	mixin,
+	NestInterceptor,
+	Optional,
+	Type
+} from '@nestjs/common';
 import { MulterModuleOptions } from '@nestjs/platform-express';
 import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
 import { MULTER_MODULE_OPTIONS } from '@nestjs/platform-express/multer/files.constants';
@@ -8,7 +17,22 @@ import { Observable } from 'rxjs';
 
 type MulterInstance = any;
 
-export function LazyFileInterceptor(fieldName: string, localOptions?: MulterOptions): Type<NestInterceptor> {
+/**
+ * Options for {@link LazyFileInterceptor}.
+ *
+ * `storage` is a FACTORY, not a `StorageEngine` — that is the whole point of this interceptor, which
+ * resolves the destination per request (tenant folder, provider, …) rather than once at module load.
+ * It is REQUIRED and typed as such: `MulterOptions.storage` is `any`, so the previous signature both
+ * accepted a caller that omitted it and accepted one that passed an engine instead of a factory.
+ * Either mistake compiles and then throws a TypeError on the first upload — the route answers 500
+ * with nothing pointing at the cause. That is not hypothetical: it shipped on the chat's dictation
+ * endpoint and broke every attempt to use it.
+ */
+export type LazyFileInterceptorOptions = Omit<MulterOptions, 'storage'> & {
+	storage: (context: ExecutionContext) => multer.StorageEngine;
+};
+
+export function LazyFileInterceptor(fieldName: string, localOptions: LazyFileInterceptorOptions): Type<NestInterceptor> {
 	class MixinInterceptor implements NestInterceptor {
 		protected multer: MulterInstance;
 		private readonly logger = new Logger('LazyFileInterceptor');
@@ -28,7 +52,13 @@ export function LazyFileInterceptor(fieldName: string, localOptions?: MulterOpti
 				...{
 					storage,
 					// Pass through a per-route fileFilter when provided (e.g. to block executable/SVG uploads).
-					...(localOptions?.fileFilter ? { fileFilter: localOptions.fileFilter } : {})
+					...(localOptions?.fileFilter ? { fileFilter: localOptions.fileFilter } : {}),
+					// …and `limits` likewise. Dropping it was the same silent-no-op trap as the missing
+					// storage factory, one step further along: a route declaring `limits: { fileSize }`
+					// read as capped while accepting uploads of any size, and nothing failed to say so.
+					// No caller relies on the old behaviour — none currently declare `limits` — so this
+					// only changes what happens the next time someone reasonably expects it to work.
+					...(localOptions?.limits ? { limits: localOptions.limits } : {})
 				}
 			});
 			await new Promise<void>((resolve, reject) =>

--- a/packages/plugins/ai-chat-react-ui/src/i18n/en.json
+++ b/packages/plugins/ai-chat-react-ui/src/i18n/en.json
@@ -48,6 +48,7 @@
 			"MODELS_CURATED_NO_KEY": "Showing known models. Save an API key to load everything this provider offers.",
 			"MODELS_CURATED_UNAVAILABLE": "Showing known models — the provider's full list could not be loaded just now.",
 			"MODELS_STALE": "Showing the last known list — the provider's catalogue could not be refreshed.",
+			"MODELS_NOT_CHAT_CAPABLE": "Chat through this provider is not available yet — pick another provider to chat. A key saved here takes effect once support ships.",
 			"ENABLED": "Enabled",
 			"USE_AS_DEFAULT": "Use as default provider",
 			"GET_KEY": "Get API key"

--- a/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.ts
@@ -620,6 +620,14 @@ export class AiChatSettingsComponent implements OnInit {
 	 * live and complete (the ordinary case needs no explanation).
 	 */
 	modelSourceKey(provider: IAiChatProvider): string | null {
+		// Before anything catalogue-shaped: a placeholder provider (chat routing not implemented; its
+		// catalogue is deliberately empty) must not fall through to the 'curated' advice below, which
+		// tells the user to save an API key — the one remedy that cannot help here. Checked first and
+		// independent of the fetch, because the provider is a placeholder whether or not the catalogue
+		// has arrived.
+		if (provider.chatCapable === false) {
+			return 'AI_CHAT_UI.SETTINGS.FORM.MODELS_NOT_CHAT_CAPABLE';
+		}
 		const catalogue = this.modelCatalogues().get(provider.id);
 		if (!catalogue) {
 			return null;

--- a/packages/plugins/ai-chat/src/lib/ai-chat.controller.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.controller.ts
@@ -100,11 +100,12 @@ export class AiChatController {
 	@Post('/transcribe')
 	@UseInterceptors(
 		LazyFileInterceptor('file', {
-			// `storage` is REQUIRED even though the type marks it optional: the interceptor calls
-			// `localOptions.storage(context)` unconditionally, so omitting it throws a TypeError before
-			// multer ever runs and the endpoint answers 500. Memory specifically — the handler reads
-			// `file.buffer`, which only memoryStorage populates; a disk/FileStorage factory would leave
-			// it undefined and the service would reject the upload as empty.
+			// Memory specifically: the handler reads `file.buffer`, which only memoryStorage populates.
+			// A disk/FileStorage factory would leave it undefined and the service would then reject the
+			// upload as empty — the audio never touches disk, it is forwarded straight upstream.
+			//
+			// (`storage` being omitted entirely is what broke this endpoint originally. It is now
+			// required by LazyFileInterceptor's own signature, so that mistake no longer compiles.)
 			storage: () => memoryStorage()
 		})
 	)

--- a/packages/plugins/ai-chat/src/lib/ai-chat.controller.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.controller.ts
@@ -17,7 +17,7 @@ import { memoryStorage } from 'multer';
 import type { UIMessage } from 'ai';
 import { IAiChatConfig, IAiChatModelCatalogue, PermissionsEnum } from '@gauzy/contracts';
 import { LazyFileInterceptor, PermissionGuard, Permissions, TenantPermissionGuard } from '@gauzy/core';
-import { AiChatService } from './ai-chat.service';
+import { AiChatService, MAX_AUDIO_BYTES } from './ai-chat.service';
 
 /** Request body sent by the `useChat` client (Vercel AI SDK UI). */
 export interface IAiChatRequestBody {
@@ -95,6 +95,8 @@ export class AiChatController {
 	@ApiOperation({ summary: 'Transcribe recorded speech' })
 	@ApiResponse({ status: 200, description: 'Transcript.' })
 	@ApiResponse({ status: 400, description: 'No audio uploaded.' })
+	// multer's LIMIT_FILE_SIZE surfaces as PayloadTooLargeException via transformException.
+	@ApiResponse({ status: 413, description: 'Recording exceeds the 25 MB limit.' })
 	@ApiResponse({ status: 503, description: 'No provider available to transcribe.' })
 	@Permissions(PermissionsEnum.AI_CHAT_ACCESS)
 	@Post('/transcribe')
@@ -106,7 +108,13 @@ export class AiChatController {
 			//
 			// (`storage` being omitted entirely is what broke this endpoint originally. It is now
 			// required by LazyFileInterceptor's own signature, so that mistake no longer compiles.)
-			storage: () => memoryStorage()
+			storage: () => memoryStorage(),
+			// The same constant the service checks — declared here too so an oversized upload is
+			// rejected by multer BEFORE memoryStorage buffers all of it in RAM. The service check
+			// remains as the second line of defense (and covers callers that bypass this route).
+			// Forwarding `limits` at all is part of this change; declaring it earlier would have
+			// silently held nothing.
+			limits: { fileSize: MAX_AUDIO_BYTES }
 		})
 	)
 	async transcribe(@UploadedFile() file: { buffer: Buffer; mimetype: string }): Promise<{ text: string }> {

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.capability.spec.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.capability.spec.ts
@@ -39,6 +39,9 @@ describe('AiChatService chatCapable boundary', () => {
 		models: [],
 		defaultModel: '',
 		chatCapable: false,
+		// Sorts FIRST, like the real placeholder (gauzy-ai is order 10): the outage this file guards
+		// against depended on exactly that — the placeholder winning default selection by sort order.
+		order: 10,
 		async createModel(): Promise<never> {
 			throw new Error('raw not-implemented error that must never reach a user');
 		}
@@ -50,6 +53,7 @@ describe('AiChatService chatCapable boundary', () => {
 		apiKeyEnvVars: ['TEST_CAPABLE_API_KEY'],
 		models: [{ id: 'test-model', label: 'Test Model', providerId: 'test-capable' }],
 		defaultModel: 'test-model',
+		order: 50,
 		async createModel() {
 			return {} as never;
 		}
@@ -104,5 +108,21 @@ describe('AiChatService chatCapable boundary', () => {
 
 		expect(byId.get('test-placeholder')?.configured).toBe(false);
 		expect(byId.get('test-capable')?.configured).toBe(true);
+	});
+
+	it('never DEFAULTS to a placeholder — the filter whose absence was a live outage', async () => {
+		// The placeholder sorts first and has a resolvable credential, i.e. the exact state that once
+		// made every chat turn fail: default selection picked it by sort order, and its createModel
+		// threw unconditionally while /config advertised a healthy default. The other tests would all
+		// still pass if the `chatCapable !== false` filter in the default path were reverted — this
+		// one fails on that revert (the placeholder's raw error replaces the resolved capable model).
+		const instance = service();
+		(instance as unknown as { resolveDefaultProvider: unknown }).resolveDefaultProvider = async () => null;
+
+		const resolved = await (
+			instance as unknown as { resolveModel(providerId?: string): Promise<{ providerId: string }> }
+		).resolveModel();
+
+		expect(resolved.providerId).toBe('test-capable');
 	});
 });

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.capability.spec.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.capability.spec.ts
@@ -1,0 +1,108 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+
+// The service module's import graph is why no service spec existed before this one: @gauzy/core pulls
+// the whole bootstrap (config, database, an ESM package jest cannot parse), and the tool builders pull
+// the ESM-only `ai` SDK. None of that is on the code paths under test, so it is stubbed AT THE MODULE
+// BOUNDARY — hoisted above the imports — leaving the real service, registry and capability logic live.
+jest.mock('@gauzy/core', () => ({ RequestContext: class {} }));
+jest.mock('./esm-loader', () => ({ loadAiSdk: jest.fn() }));
+jest.mock('./tools/gauzy-api-client', () => ({ GauzyApiClient: class {} }));
+jest.mock('./tools/gauzy-tools', () => ({ buildGauzyTools: jest.fn(), GAUZY_TOOLS_REQUIRING_APPROVAL: [] }));
+jest.mock('./tools/client-tools', () => ({ buildClientTools: jest.fn(), CLIENT_TOOLS_REQUIRING_APPROVAL: [] }));
+jest.mock('./tools/mcp-tools', () => ({ createMcpTools: jest.fn() }));
+jest.mock('./credentials/ai-provider-credential.service', () => ({ AiProviderCredentialService: class {} }));
+jest.mock('./conversations/ai-chat-conversation.service', () => ({ AiChatConversationService: class {} }));
+
+import { AiProviderRegistry } from './provider-registry';
+import { AiChatService } from './ai-chat.service';
+import { IAiChatProviderDefinition } from './provider.types';
+
+/**
+ * The `chatCapable` contract, pinned from the backend side — the side that emits it.
+ *
+ * A placeholder provider (its `createModel` still throws) is registered so it SHOWS in the UI, and
+ * everything else about it is opt-out: it must never be defaulted to, never be selectable, and —
+ * covered here because it was the gap review found — never reachable by NAMING it explicitly, which
+ * any client can do the moment `/config` advertises the id. Without the boundary check the request
+ * sailed through to `createModel()` and surfaced the provider's raw not-implemented error as a
+ * failed turn.
+ *
+ * The serialization rule matters as much as the gate: the UI treats ABSENT as capable and exactly
+ * `false` as placeholder, so a change that starts emitting `true` (or dropping the field for
+ * placeholders) silently flips the settings guidance. Both directions are asserted.
+ */
+describe('AiChatService chatCapable boundary', () => {
+	const placeholder: IAiChatProviderDefinition = {
+		id: 'test-placeholder',
+		label: 'Test Placeholder',
+		apiKeyEnvVars: [],
+		models: [],
+		defaultModel: '',
+		chatCapable: false,
+		async createModel(): Promise<never> {
+			throw new Error('raw not-implemented error that must never reach a user');
+		}
+	};
+
+	const capable: IAiChatProviderDefinition = {
+		id: 'test-capable',
+		label: 'Test Capable',
+		apiKeyEnvVars: ['TEST_CAPABLE_API_KEY'],
+		models: [{ id: 'test-model', label: 'Test Model', providerId: 'test-capable' }],
+		defaultModel: 'test-model',
+		async createModel() {
+			return {} as never;
+		}
+	};
+
+	/** Service with the DB-touching privates stubbed — the capability logic is what's under test. */
+	const service = (): AiChatService => {
+		const instance = new AiChatService(null as never, null as never);
+		(instance as unknown as { getTenantCredential: unknown }).getTenantCredential = async () => ({
+			// A SAVED tenant key for every provider, placeholder included: the boundary must hold
+			// even when credentials resolve, because tenant BYOK is resolved first and emptying the
+			// placeholder's env vars cannot close that route.
+			apiKey: 'tenant-key',
+			enabled: true
+		});
+		(instance as unknown as { resolveDefaultProvider: unknown }).resolveDefaultProvider = async () => ({});
+		return instance;
+	};
+
+	beforeEach(() => {
+		AiProviderRegistry.clear();
+		AiProviderRegistry.register(placeholder);
+		AiProviderRegistry.register(capable);
+	});
+
+	afterAll(() => {
+		AiProviderRegistry.clear();
+	});
+
+	it('rejects an EXPLICIT request for a placeholder with a controlled 503, not the raw provider error', async () => {
+		const resolve = (service() as unknown as { resolveModel(p?: string, m?: string): Promise<unknown> }).resolveModel(
+			'test-placeholder'
+		);
+
+		await expect(resolve).rejects.toBeInstanceOf(ServiceUnavailableException);
+		await expect(resolve).rejects.toThrow(/cannot serve chat yet/);
+		await expect(resolve).rejects.not.toThrow(/raw not-implemented/);
+	});
+
+	it('emits chatCapable exactly false for a placeholder and OMITS it for a capable provider', async () => {
+		const config = await service().getConfig();
+		const byId = new Map(config.providers.map((provider) => [provider.id, provider]));
+
+		expect(byId.get('test-placeholder')?.chatCapable).toBe(false);
+		// Omitted, not true: absent-means-capable is the wire contract the settings UI branches on.
+		expect('chatCapable' in (byId.get('test-capable') ?? {})).toBe(false);
+	});
+
+	it('keeps a placeholder with a saved credential out of the configured set', async () => {
+		const config = await service().getConfig();
+		const byId = new Map(config.providers.map((provider) => [provider.id, provider]));
+
+		expect(byId.get('test-placeholder')?.configured).toBe(false);
+		expect(byId.get('test-capable')?.configured).toBe(true);
+	});
+});

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -287,6 +287,16 @@ export class AiChatService {
 			if (!definition) {
 				throw new BadRequestException(`Unknown AI provider '${requestedProviderId}'.`);
 			}
+			// The capability gate must hold on the EXPLICIT path too, not only when defaulting. The
+			// default path below filters placeholders out, but a request that names one directly —
+			// easy to send once /config advertises the provider, and reachable whenever a tenant has
+			// saved a BYOK key for it — would sail through to createModel() and surface its raw
+			// not-implemented error as a failed turn. Same controlled 503 either way.
+			if (definition.chatCapable === false) {
+				throw new ServiceUnavailableException(
+					`AI provider '${definition.label}' cannot serve chat yet — select another provider.`
+				);
+			}
 		} else {
 			// Only a provider that actually HAS credentials may be defaulted to.
 			//

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -19,8 +19,10 @@ import { buildRateLimitEnvelope, isRateLimitError, rateLimitRetryAfter, RATE_LIM
  * Largest dictation upload accepted, matching what the upstream speech APIs take anyway.
  *
  * Audio is user-supplied and otherwise bounded only by how long someone holds the button.
+ * Exported so the controller can declare the SAME cap as a multer `limits` on the route — one
+ * constant, two enforcement points that cannot drift.
  */
-const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
+export const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
 
 /** Maximum agent steps (model turns incl. tool calls) per user message. */
 const MAX_STEPS = 12;
@@ -485,9 +487,11 @@ export class AiChatService {
 		if (!audio?.length) {
 			throw new BadRequestException('No audio was uploaded.');
 		}
-		// Enforced HERE, not through the interceptor's `limits`: LazyFileInterceptor spreads only
-		// `storage` and `fileFilter` into multer and drops `limits`, so a cap declared at the route
-		// would read as enforced while accepting anything. This is the only place that actually holds.
+		// Second line of defense. The route declares the same MAX_AUDIO_BYTES as a multer `limits`,
+		// which rejects an oversized upload BEFORE memoryStorage buffers it — but this check stays:
+		// it guards any future caller that does not arrive through that interceptor, and it survives
+		// the interceptor's history of silently dropping options (forwarding `limits` at all is a fix
+		// from this same change; for a while a declared cap read as enforced while holding nothing).
 		if (audio.length > MAX_AUDIO_BYTES) {
 			throw new BadRequestException(
 				`Recording is too large (${Math.round(audio.length / 1024 / 1024)}MB). The limit is ${

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -229,6 +229,10 @@ export class AiChatService {
 				// however many credentials resolve for it — otherwise /config advertises it, the
 				// settings UI shows it as ready, and it can be chosen as the tenant default.
 				configured: credentials !== null && definition.chatCapable !== false,
+				// Surfaced separately from `configured` so the UI can distinguish "save a key" (fixable
+				// by the user) from "chat is not implemented for this provider yet" (not fixable by any
+				// key). Only ever emitted as false — absent means capable.
+				...(definition.chatCapable === false ? { chatCapable: false } : {}),
 				...(credentials ? { credentialSource: credentials.source } : {}),
 				...(definition.order !== undefined ? { order: definition.order } : {}),
 				...(definition.websiteUrl ? { websiteUrl: definition.websiteUrl } : {}),

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -520,7 +520,12 @@ export class AiChatService {
 				// Try the next provider rather than failing the whole dictation on one bad key.
 				const message = error instanceof Error ? error.message : String(error);
 				this.logger.warn(`[ai-chat] Transcription via '${definition.id}' failed: ${message}`);
-				failures.push(message);
+				// Boundary defense for the user-visible join below: an empty Error message or a thrown
+				// non-Error ('[object Object]') would otherwise put a blank or noise where the old text
+				// at least named the provider — so fall back to naming it, and bound the length here
+				// rather than trusting every provider hook to.
+				const usable = message.trim() && message !== '[object Object]';
+				failures.push(usable ? message.slice(0, 400) : `Transcription via '${definition.id}' failed.`);
 			}
 		}
 

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -508,12 +508,12 @@ export class AiChatService {
 			throw new ServiceUnavailableException('No AI provider on this server can transcribe speech.');
 		}
 
-		const attempted: string[] = [];
+		// One entry per attempted provider: every attempt either returns out of the function or pushes
+		// its failure here, so `failures` doubles as the "was anything attempted" signal at the throw.
 		const failures: string[] = [];
 		for (const definition of capable) {
 			const credentials = await this.resolveCredentials(definition);
 			if (!credentials) continue;
-			attempted.push(definition.id);
 			try {
 				return await definition.transcribe(audio, mimeType, credentials);
 			} catch (error) {
@@ -531,7 +531,7 @@ export class AiChatService {
 		// point at Settings only when the failure is credential-shaped.
 		const keyProblem = failures.some((failure) => /api key/i.test(failure));
 		throw new ServiceUnavailableException(
-			attempted.length
+			failures.length
 				? `${failures.join('; ')}${keyProblem ? ' Update the key in Settings → AI Providers.' : ''}`
 				: 'Add an API key for a provider that supports speech (e.g. OpenAI) to dictate messages.'
 		);

--- a/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
+++ b/packages/plugins/ai-chat/src/lib/ai-chat.service.ts
@@ -509,6 +509,7 @@ export class AiChatService {
 		}
 
 		const attempted: string[] = [];
+		const failures: string[] = [];
 		for (const definition of capable) {
 			const credentials = await this.resolveCredentials(definition);
 			if (!credentials) continue;
@@ -517,16 +518,21 @@ export class AiChatService {
 				return await definition.transcribe(audio, mimeType, credentials);
 			} catch (error) {
 				// Try the next provider rather than failing the whole dictation on one bad key.
-				this.logger.warn(
-					`[ai-chat] Transcription via '${definition.id}' failed: ` +
-						`${error instanceof Error ? error.message : error}`
-				);
+				const message = error instanceof Error ? error.message : String(error);
+				this.logger.warn(`[ai-chat] Transcription via '${definition.id}' failed: ${message}`);
+				failures.push(message);
 			}
 		}
 
+		// The chat panel shows this message verbatim, so it must not over-diagnose. The old text
+		// appended "Check the provider's API key" to EVERY failure — a quota hit, a rejected
+		// recording and a provider outage all read as a credential problem. Relay what the provider
+		// hook actually reported (providers classify by status and never echo a response body), and
+		// point at Settings only when the failure is credential-shaped.
+		const keyProblem = failures.some((failure) => /api key/i.test(failure));
 		throw new ServiceUnavailableException(
 			attempted.length
-				? `Transcription failed on ${attempted.join(', ')}. Check the provider's API key in Settings → AI Providers.`
+				? `${failures.join('; ')}${keyProblem ? ' Update the key in Settings → AI Providers.' : ''}`
 				: 'Add an API key for a provider that supports speech (e.g. OpenAI) to dictate messages.'
 		);
 	}

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
@@ -68,6 +68,52 @@ const TRANSCRIBE_TIMEOUT_MS = 60_000;
 const catalogueCache = createCatalogueCache<IAiChatModel[]>();
 
 /**
+ * Upper bound on the upstream error body read for a diagnostic message.
+ *
+ * Far more than any real OpenAI error needs, and small enough that a custom base URL answering with
+ * an arbitrarily large body cannot make this process buffer it: `response.text()` reads EVERYTHING
+ * before a display-side `slice` ever runs, so the bound has to be applied while reading.
+ */
+const MAX_ERROR_DETAIL_BYTES = 2048;
+
+/** Read at most `maxBytes` of a response body, then cancel the rest of the stream. */
+const readBounded = async (response: globalThis.Response, maxBytes: number): Promise<string> => {
+	const reader = response.body?.getReader();
+	if (!reader) return '';
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		while (total < maxBytes) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			chunks.push(value);
+			total += value.byteLength;
+		}
+	} catch {
+		/* a broken error-body stream must not mask the error being reported */
+	} finally {
+		reader.cancel().catch(() => undefined);
+	}
+	const merged = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		merged.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return new TextDecoder().decode(merged.subarray(0, maxBytes)).trim();
+};
+
+/**
+ * Strip the credential in use and anything key-shaped from text bound for the user.
+ *
+ * Both patterns matter: OpenAI keys are `sk-…`, but a custom base URL (Azure, a proxy) issues keys
+ * with no recognizable prefix — only redacting by shape would relay exactly the secret this exists
+ * to protect. Display-truncated at the end so the redaction cannot be sliced through mid-token.
+ */
+const redactSecret = (text: string, apiKey: string): string =>
+	(apiKey ? text.split(apiKey).join('[redacted]') : text).replace(/sk-[A-Za-z0-9_-]+/g, 'sk-***').slice(0, 300).trim();
+
+/**
  * The OpenAI models this API key can address, minus the families that are not chat models.
  *
  * This is the weakest of the six catalogues — `/v1/models` returns `{id, owned_by, created}` and
@@ -145,7 +191,9 @@ const transcribeAudio = async (
 	});
 	if (!response.ok) {
 		// The bare status code was reaching the user as "check your API key" for EVERY failure class,
-		// including quota and bad audio. Classify by status so the message is actionable.
+		// including quota and bad audio. Classify by status so the message is actionable. The status
+		// NUMBER only — statusText is upstream-controlled prose, and a custom base URL means upstream
+		// is whatever the tenant configured, so it gets no free ride into a user-visible message.
 		const credentialFailure = response.status === 401 || response.status === 403;
 		const reason = credentialFailure
 			? 'the API key was rejected'
@@ -153,17 +201,15 @@ const transcribeAudio = async (
 			? 'the rate or quota limit was hit'
 			: response.status === 400
 			? 'the audio was rejected (unsupported or empty recording)'
-			: `HTTP ${response.status} ${response.statusText}`;
+			: `HTTP ${response.status}`;
 		// The response body is genuinely diagnostic for format/limit errors ("Invalid file format"),
 		// so it is relayed — but NEVER on a credential failure, whose body echoes the API key back
-		// ("Incorrect API key provided: sk-…"), and always redacted and truncated in case a proxy
-		// routes a secret into some other status. This error's message reaches the chat user verbatim.
+		// ("Incorrect API key provided: sk-…"). Redacted of both key-shaped tokens AND the exact key
+		// in use (custom endpoints issue keys with no sk- prefix), and read BOUNDED: `.text()` would
+		// buffer however much the upstream cares to send before the display truncation ever ran.
 		const detail = credentialFailure
 			? ''
-			: (await response.text().catch(() => ''))
-					.replace(/sk-[A-Za-z0-9_-]+/g, 'sk-***')
-					.slice(0, 300)
-					.trim();
+			: redactSecret(await readBounded(response, MAX_ERROR_DETAIL_BYTES), credentials.apiKey);
 		throw new Error(`OpenAI transcription failed: ${reason}${detail ? ` — ${detail}` : ''}`);
 	}
 	const body = (await response.json()) as { text?: string };

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
@@ -114,12 +114,21 @@ const transcribeAudio = async (
 	// `audio/mpeg` is MP3, not MP4 — lumping it in with `mp4` named MP3 bytes `dictation.mp4`, and the
 	// extension is exactly what OpenAI trusts to identify the container. MediaRecorder never produces
 	// audio/mpeg, which is why this survived: it only bites when a caller feeds a pre-recorded file.
+	// wav/flac/m4a are covered for the same caller class — every container OpenAI accepts that a MIME
+	// type can name. What remains falling to `.webm` (e.g. raw `audio/aac`) has no extension in
+	// OpenAI's accepted set at all, so no mapping could save it.
 	const extension = mimeType.includes('mp4')
 		? 'mp4'
 		: mimeType.includes('mpeg')
 		? 'mp3'
 		: mimeType.includes('ogg')
 		? 'ogg'
+		: mimeType.includes('wav')
+		? 'wav'
+		: mimeType.includes('flac')
+		? 'flac'
+		: mimeType.includes('m4a') // audio/m4a and audio/x-m4a
+		? 'm4a'
 		: 'webm';
 	const form = new FormData();
 	form.append('file', new Blob([new Uint8Array(audio)], { type: mimeType }), `dictation.${extension}`);
@@ -135,8 +144,18 @@ const transcribeAudio = async (
 		signal: AbortSignal.timeout(TRANSCRIBE_TIMEOUT_MS)
 	});
 	if (!response.ok) {
-		// No body echo: this request carries a credential.
-		throw new Error(`OpenAI transcription failed: ${response.status} ${response.statusText}`);
+		// No body echo — this request carries a credential — but the bare status code was reaching the
+		// user as "check your API key" for EVERY failure class, including quota and bad audio. Classify
+		// by status instead: same security posture, an answer the user can actually act on.
+		const reason =
+			response.status === 401 || response.status === 403
+				? 'the API key was rejected'
+				: response.status === 429
+				? 'the rate or quota limit was hit'
+				: response.status === 400
+				? 'the audio was rejected (unsupported or empty recording)'
+				: `HTTP ${response.status} ${response.statusText}`;
+		throw new Error(`OpenAI transcription failed: ${reason}`);
 	}
 	const body = (await response.json()) as { text?: string };
 	return (body.text ?? '').trim();

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
@@ -144,18 +144,27 @@ const transcribeAudio = async (
 		signal: AbortSignal.timeout(TRANSCRIBE_TIMEOUT_MS)
 	});
 	if (!response.ok) {
-		// No body echo — this request carries a credential — but the bare status code was reaching the
-		// user as "check your API key" for EVERY failure class, including quota and bad audio. Classify
-		// by status instead: same security posture, an answer the user can actually act on.
-		const reason =
-			response.status === 401 || response.status === 403
-				? 'the API key was rejected'
-				: response.status === 429
-				? 'the rate or quota limit was hit'
-				: response.status === 400
-				? 'the audio was rejected (unsupported or empty recording)'
-				: `HTTP ${response.status} ${response.statusText}`;
-		throw new Error(`OpenAI transcription failed: ${reason}`);
+		// The bare status code was reaching the user as "check your API key" for EVERY failure class,
+		// including quota and bad audio. Classify by status so the message is actionable.
+		const credentialFailure = response.status === 401 || response.status === 403;
+		const reason = credentialFailure
+			? 'the API key was rejected'
+			: response.status === 429
+			? 'the rate or quota limit was hit'
+			: response.status === 400
+			? 'the audio was rejected (unsupported or empty recording)'
+			: `HTTP ${response.status} ${response.statusText}`;
+		// The response body is genuinely diagnostic for format/limit errors ("Invalid file format"),
+		// so it is relayed — but NEVER on a credential failure, whose body echoes the API key back
+		// ("Incorrect API key provided: sk-…"), and always redacted and truncated in case a proxy
+		// routes a secret into some other status. This error's message reaches the chat user verbatim.
+		const detail = credentialFailure
+			? ''
+			: (await response.text().catch(() => ''))
+					.replace(/sk-[A-Za-z0-9_-]+/g, 'sk-***')
+					.slice(0, 300)
+					.trim();
+		throw new Error(`OpenAI transcription failed: ${reason}${detail ? ` — ${detail}` : ''}`);
 	}
 	const body = (await response.json()) as { text?: string };
 	return (body.text ?? '').trim();

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.provider.ts
@@ -111,8 +111,16 @@ const transcribeAudio = async (
 	mimeType: string,
 	credentials: IAiProviderCredentials
 ): Promise<string> => {
-	const extension =
-		mimeType.includes('mp4') || mimeType.includes('mpeg') ? 'mp4' : mimeType.includes('ogg') ? 'ogg' : 'webm';
+	// `audio/mpeg` is MP3, not MP4 — lumping it in with `mp4` named MP3 bytes `dictation.mp4`, and the
+	// extension is exactly what OpenAI trusts to identify the container. MediaRecorder never produces
+	// audio/mpeg, which is why this survived: it only bites when a caller feeds a pre-recorded file.
+	const extension = mimeType.includes('mp4')
+		? 'mp4'
+		: mimeType.includes('mpeg')
+		? 'mp3'
+		: mimeType.includes('ogg')
+		? 'ogg'
+		: 'webm';
 	const form = new FormData();
 	form.append('file', new Blob([new Uint8Array(audio)], { type: mimeType }), `dictation.${extension}`);
 	form.append('model', TRANSCRIBE_MODEL);

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -69,11 +69,13 @@ describe('openAiProviderDefinition.transcribe', () => {
 
 	it.each([
 		// [browser mimeType, expected filename] — OpenAI reads the CONTAINER off the extension, so a
-		// generic name is rejected even when the bytes are valid. These are the three containers a
-		// MediaRecorder actually produces across Chrome/Firefox (webm) and Safari (mp4).
+		// generic name is rejected even when the bytes are valid. webm/mp4/ogg are what MediaRecorder
+		// actually produces across Chrome/Firefox and Safari; audio/mpeg (an MP3 fed in by a future
+		// file-upload path) must map to .mp3 — the first version of this table expected .mp4 for it,
+		// which would have told OpenAI that MP3 bytes were an MP4 container.
 		['audio/webm;codecs=opus', 'dictation.webm'],
 		['audio/mp4', 'dictation.mp4'],
-		['audio/mpeg', 'dictation.mp4'],
+		['audio/mpeg', 'dictation.mp3'],
 		['audio/ogg;codecs=opus', 'dictation.ogg'],
 		['', 'dictation.webm']
 	])('names the upload from the %s container', async (mimeType, expected) => {

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -29,11 +29,18 @@ describe('openAiProviderDefinition.transcribe', () => {
 
 	/** Capture the request the provider makes, answering with `body`. */
 	const capture = (body: unknown, init: ResponseInit = { status: 200 }) => {
-		const fetchMock = jest.fn().mockResolvedValue(
-			new Response(JSON.stringify(body), {
-				headers: { 'content-type': 'application/json' },
-				...init
-			})
+		// A FRESH Response per call: a Response body is one-shot, and `mockResolvedValue` would hand
+		// every call the same instance — the second read then rejects with undici's credential-free
+		// "Body is unusable", which made the credential-leak assertion below pass against an
+		// implementation that echoes the body. (Mutation-tested: `mockResolvedValue` let exactly that
+		// defect through.)
+		const fetchMock = jest.fn().mockImplementation(() =>
+			Promise.resolve(
+				new Response(JSON.stringify(body), {
+					headers: { 'content-type': 'application/json' },
+					...init
+				})
+			)
 		);
 		global.fetch = fetchMock as unknown as typeof fetch;
 		return fetchMock;
@@ -127,5 +134,16 @@ describe('openAiProviderDefinition.transcribe', () => {
 
 		await expect(transcribe()).rejects.toThrow(/rate or quota limit/);
 		await expect(transcribe()).rejects.not.toThrow(/API key/);
+	});
+
+	it('relays the diagnostic body for a format failure, with key-shaped tokens redacted', async () => {
+		// Non-credential failures DO include the upstream body — "Invalid file format" is the one
+		// message that tells the user what to change — but defensively redacted: a proxy that routes
+		// a secret into a 400 must not put it on screen.
+		capture({ error: { message: 'Invalid file format for sk-oops-leaked' } }, { status: 400 });
+
+		await expect(transcribe()).rejects.toThrow(/audio was rejected/);
+		await expect(transcribe()).rejects.toThrow(/Invalid file format/);
+		await expect(transcribe()).rejects.not.toThrow(/sk-oops-leaked/);
 	});
 });

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -146,4 +146,23 @@ describe('openAiProviderDefinition.transcribe', () => {
 		await expect(transcribe()).rejects.toThrow(/Invalid file format/);
 		await expect(transcribe()).rejects.not.toThrow(/sk-oops-leaked/);
 	});
+
+	it('redacts the exact key in use even when it is not sk-shaped', async () => {
+		// Custom base URLs (Azure, proxies) issue keys with no recognizable prefix, so shape-based
+		// redaction alone would relay exactly the secret it exists to protect.
+		capture({ error: { message: 'key azure-key-123 is over quota' } }, { status: 429 });
+
+		const creds = credentials({ apiKey: 'azure-key-123', baseUrl: 'https://proxy.example.com/v1' });
+		await expect(transcribe('audio/webm', creds)).rejects.toThrow(/rate or quota limit/);
+		await expect(transcribe('audio/webm', creds)).rejects.not.toThrow(/azure-key-123/);
+	});
+
+	it('never relays upstream statusText', async () => {
+		// statusText is upstream-controlled prose; with a custom base URL, upstream is whatever the
+		// tenant configured. The classified reason uses the status NUMBER only.
+		capture({ error: { message: 'teapot' } }, { status: 418, statusText: 'secret-in-status sk-via-status' });
+
+		await expect(transcribe()).rejects.toThrow(/HTTP 418/);
+		await expect(transcribe()).rejects.not.toThrow(/secret-in-status/);
+	});
 });

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -1,0 +1,114 @@
+import type { IAiProviderCredentials } from '@gauzy/plugin-ai-chat';
+import { openAiProviderDefinition } from './ai-provider-openai.provider';
+
+/**
+ * Dictation reached the user broken twice, and both defects were in the request this builds:
+ *
+ *  - `response_format: 'text'` was sent. `gpt-4o-mini-transcribe` accepts ONLY `json` and rejects
+ *    anything else outright, so every dictation failed. (whisper-1 does support `text`, which is
+ *    what made it look right.)
+ *  - the filename extension is what OpenAI uses to decide the container; a generic name is rejected
+ *    with "Invalid file format" even when the bytes are fine.
+ *
+ * Neither is visible from the call site, and neither breaks a build. They are only observable in the
+ * multipart body that goes over the wire — so that is what these tests read, by capturing the
+ * FormData handed to `fetch`.
+ */
+describe('openAiProviderDefinition.transcribe', () => {
+	const realFetch = global.fetch;
+	afterEach(() => {
+		global.fetch = realFetch;
+		jest.restoreAllMocks();
+	});
+
+	const credentials = (overrides: Partial<IAiProviderCredentials> = {}): IAiProviderCredentials => ({
+		apiKey: 'sk-test-transcribe',
+		source: 'tenant',
+		...overrides
+	});
+
+	/** Capture the request the provider makes, answering with `body`. */
+	const capture = (body: unknown, init: ResponseInit = { status: 200 }) => {
+		const fetchMock = jest.fn().mockResolvedValue(
+			new Response(JSON.stringify(body), {
+				headers: { 'content-type': 'application/json' },
+				...init
+			})
+		);
+		global.fetch = fetchMock as unknown as typeof fetch;
+		return fetchMock;
+	};
+
+	const requestOf = (fetchMock: jest.Mock) => {
+		const [url, options] = fetchMock.mock.calls[0];
+		return { url: String(url), options, form: options.body as FormData };
+	};
+
+	const transcribe = (mimeType = 'audio/webm;codecs=opus', creds = credentials()) =>
+		openAiProviderDefinition.transcribe!(Buffer.from('fake-audio-bytes'), mimeType, creds);
+
+	it('never sends response_format — the model accepts only the default', async () => {
+		// THE regression. Asking for `text` is rejected outright, so this assertion is the difference
+		// between dictation working and every attempt failing.
+		const fetchMock = capture({ text: 'hello world' });
+		await transcribe();
+
+		expect(requestOf(fetchMock).form.has('response_format')).toBe(false);
+	});
+
+	it('posts the audio to /audio/transcriptions with the key and the speech model', async () => {
+		const fetchMock = capture({ text: 'hello world' });
+		await transcribe();
+
+		const { url, options, form } = requestOf(fetchMock);
+		expect(url).toBe('https://api.openai.com/v1/audio/transcriptions');
+		expect(options.method).toBe('POST');
+		expect((options.headers as Record<string, string>).authorization).toBe('Bearer sk-test-transcribe');
+		expect(form.get('model')).toBe('gpt-4o-mini-transcribe');
+	});
+
+	it.each([
+		// [browser mimeType, expected filename] — OpenAI reads the CONTAINER off the extension, so a
+		// generic name is rejected even when the bytes are valid. These are the three containers a
+		// MediaRecorder actually produces across Chrome/Firefox (webm) and Safari (mp4).
+		['audio/webm;codecs=opus', 'dictation.webm'],
+		['audio/mp4', 'dictation.mp4'],
+		['audio/mpeg', 'dictation.mp4'],
+		['audio/ogg;codecs=opus', 'dictation.ogg'],
+		['', 'dictation.webm']
+	])('names the upload from the %s container', async (mimeType, expected) => {
+		const fetchMock = capture({ text: 'ok' });
+		await transcribe(mimeType);
+
+		const file = requestOf(fetchMock).form.get('file') as File;
+		expect(file.name).toBe(expected);
+	});
+
+	it('returns the transcript, trimmed', async () => {
+		capture({ text: '  hello world  ' });
+		await expect(transcribe()).resolves.toBe('hello world');
+	});
+
+	it('treats silence as an empty transcript rather than an error', async () => {
+		// A recording with nothing in it is a valid answer: the user pressed the mic and said nothing.
+		// Throwing here would surface as a failed dictation and send them looking at their API key.
+		capture({});
+		await expect(transcribe()).resolves.toBe('');
+	});
+
+	it('honours a custom base URL', async () => {
+		// Unlike the model catalogue, which deliberately never calls a custom endpoint: the caller
+		// configured this as their OpenAI and explicitly asked for this request.
+		const fetchMock = capture({ text: 'ok' });
+		await transcribe('audio/webm', credentials({ baseUrl: 'https://proxy.example.com/v1/' }));
+
+		expect(requestOf(fetchMock).url).toBe('https://proxy.example.com/v1/audio/transcriptions');
+	});
+
+	it('fails without echoing the upstream body, which carries the credential', async () => {
+		capture({ error: { message: 'Incorrect API key provided: sk-test-transcribe' } }, { status: 401 });
+
+		await expect(transcribe()).rejects.toThrow(/401/);
+		await expect(transcribe()).rejects.not.toThrow(/sk-test-transcribe/);
+	});
+});

--- a/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
+++ b/packages/plugins/ai-provider-openai/src/lib/ai-provider-openai.transcribe.spec.ts
@@ -77,6 +77,12 @@ describe('openAiProviderDefinition.transcribe', () => {
 		['audio/mp4', 'dictation.mp4'],
 		['audio/mpeg', 'dictation.mp3'],
 		['audio/ogg;codecs=opus', 'dictation.ogg'],
+		// The rest of the pre-recorded-file class: every container OpenAI accepts that a MIME type can
+		// name. Raw `audio/aac` stays on the webm fallback — OpenAI's accepted set has no extension
+		// for it, so no mapping could save it.
+		['audio/wav', 'dictation.wav'],
+		['audio/flac', 'dictation.flac'],
+		['audio/x-m4a', 'dictation.m4a'],
 		['', 'dictation.webm']
 	])('names the upload from the %s container', async (mimeType, expected) => {
 		const fetchMock = capture({ text: 'ok' });
@@ -107,10 +113,19 @@ describe('openAiProviderDefinition.transcribe', () => {
 		expect(requestOf(fetchMock).url).toBe('https://proxy.example.com/v1/audio/transcriptions');
 	});
 
-	it('fails without echoing the upstream body, which carries the credential', async () => {
+	it('classifies a failure by status without echoing the upstream body, which carries the credential', async () => {
 		capture({ error: { message: 'Incorrect API key provided: sk-test-transcribe' } }, { status: 401 });
 
-		await expect(transcribe()).rejects.toThrow(/401/);
+		// Classified, not the bare status: the chat panel shows this verbatim, and "401" told the user
+		// nothing while "check your API key" was being appended to every failure class downstream.
+		await expect(transcribe()).rejects.toThrow(/API key was rejected/);
 		await expect(transcribe()).rejects.not.toThrow(/sk-test-transcribe/);
+	});
+
+	it('does not blame the API key for a quota failure', async () => {
+		capture({ error: { message: 'Rate limit reached' } }, { status: 429 });
+
+		await expect(transcribe()).rejects.toThrow(/rate or quota limit/);
+		await expect(transcribe()).rejects.not.toThrow(/API key/);
 	});
 });


### PR DESCRIPTION
Promotes develop to stage. Four PRs since the last cascade (`de0111dd70`):

| PR | What |
|---|---|
| #9926 | e2e: equipment dropdown race (confirm the panels opened before picking) |
| #9928 | e2e: 5-site click-race sweep + `dispatchClickWhenSettled` now **throws** with a named error when the confirmed state never appears; panel-level confirm for the legitimately-empty employee list |
| #9929 | Dictation: `LazyFileInterceptor.storage` is a required typed factory (the missing-factory 500 no longer compiles), `limits` forwarded + 25 MB declared at the route, failure classification (401/quota/bad-audio), diagnostic relay bounded + redacted against hostile custom base URLs, `audio/mpeg → .mp3` + wav/flac/m4a. 24 new tests, key ones mutation-verified |
| #9930 | AI Providers: placeholder providers (`chatCapable: false`) get a truthful settings note instead of "save an API key"; explicit-path 503 at the execution boundary; first `AiChatService` spec (4 tests incl. the default-selection outage path, mutation-verified) |

All three PRs went through two-to-three rounds of bot review (CodeRabbit, cubic, Greptile, DeepScan) plus a 9-agent adversarial review; every confirmed finding is applied.

**Merge with a MERGE COMMIT** (release-gate requirement — never squash a promotion).

Note: CodeQL/Sonar/Codacy fail on every develop→stage cascade by construction (full-delta analysis); expected, as on #9911/#9837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes develop to stage with e2e click-race fixes and dictation hardening, plus truthful placeholder-provider messaging and safer OpenAI transcription diagnostics. Reduces flaky tests, prevents upload 500s, and improves user-facing error clarity.

- **Bug Fixes**
  - E2E: use `dispatchClickWhenSettled` (now throws on miss) to confirm dialogs/dropdowns before acting on them across Equipment, Help Center, Goals, Organization Public, and Employee Position/Level; tightened an edit input selector to avoid false positives.
  - Dictation uploads: `LazyFileInterceptor` now requires a typed storage factory and forwards `limits`; transcribe route enforces the 25 MB cap via multer and the service.
  - OpenAI transcription: map `audio/mpeg` to `.mp3` and support wav/flac/m4a; stop sending `response_format`; classify failures (401/403 key, 429 quota, 400 bad audio) without leaking credentials; redact secrets (incl. non-`sk-` keys), drop `statusText`, and bound error-body reads.
  - Providers: config emits `chatCapable: false` for placeholders; settings shows a “not available yet” note instead of “save an API key”; execution blocks explicit placeholder selection with a controlled 503; default selection skips placeholders.
  - Added targeted tests for `LazyFileInterceptor`, `AiChatService` capability/defaulting, and OpenAI transcribe request/diagnostics.

<sup>Written for commit 1f01c83e5f3d644b5523ae6de3528c7bd6a2a3e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

