### PR TITLE
fix(docs): stop the webapp image pulling the backend Documents package

### DIFF
--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -105,7 +105,6 @@ COPY --chown=node:node packages/plugins/dashboard-time-track-angular-ui/package.
 COPY --chown=node:node packages/plugins/dashboard-time-track-react-ui/package.json ./packages/plugins/dashboard-time-track-react-ui/
 COPY --chown=node:node packages/plugins/ai-chat-react-ui/package.json ./packages/plugins/ai-chat-react-ui/
 COPY --chown=node:node packages/plugins/docs-ui/package.json ./packages/plugins/docs-ui/
-COPY --chown=node:node packages/plugins/docs/package.json ./packages/plugins/docs/
 COPY --chown=node:node packages/ui-core/package.json ./packages/ui-core/
 COPY --chown=node:node packages/ui-config/package.json ./packages/ui-config/
 COPY --chown=node:node packages/ui-auth/package.json ./packages/ui-auth/


### PR DESCRIPTION
**Every webapp image build has failed since the Documents feature landed** — demo and stage frontends have not been rebuilt since.

The webapp Dockerfile copied `packages/plugins/docs/package.json`, but the web app only consumes `@gauzy/plugin-docs-ui`, which does not depend on it. That put `@gauzy/plugin-docs` into the install graph without its own workspace dependencies (`@gauzy/plugin-ai-chat` and `@gauzy/scheduler` are not copied into the webapp image), so yarn fell through to the public registry:

```
Couldn't find package "@gauzy/plugin-ai-chat@^0.1.0" required by "@gauzy/plugin-docs@0.1.0" on the "npm" registry
Couldn't find package "@gauzy/scheduler@^0.1.0" required by "@gauzy/plugin-docs@0.1.0"
```

One line removed. The api and worker images keep the copy — they actually run the backend plugin and already copy both of its dependencies, which is why those two images have been building fine all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix webapp Docker builds by removing the copy of `packages/plugins/docs/package.json` so the image no longer pulls the backend `@gauzy/plugin-docs`. The webapp now installs only `@gauzy/plugin-docs-ui` dependencies, avoiding missing workspace packages (`@gauzy/plugin-ai-chat`, `@gauzy/scheduler`); API/worker images are unchanged.

<sup>Written for commit 91b85256dc2d29709058bcb66f7336bddb18c7a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

