### PR TITLE
chore: promote develop to stage (webapp image build fix)

### DIFF
--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -105,7 +105,6 @@ COPY --chown=node:node packages/plugins/dashboard-time-track-angular-ui/package.
 COPY --chown=node:node packages/plugins/dashboard-time-track-react-ui/package.json ./packages/plugins/dashboard-time-track-react-ui/
 COPY --chown=node:node packages/plugins/ai-chat-react-ui/package.json ./packages/plugins/ai-chat-react-ui/
 COPY --chown=node:node packages/plugins/docs-ui/package.json ./packages/plugins/docs-ui/
-COPY --chown=node:node packages/plugins/docs/package.json ./packages/plugins/docs/
 COPY --chown=node:node packages/ui-core/package.json ./packages/ui-core/
 COPY --chown=node:node packages/ui-config/package.json ./packages/ui-config/
 COPY --chown=node:node packages/ui-auth/package.json ./packages/ui-auth/


### PR DESCRIPTION
Promotes #9943 — the webapp Docker image has failed to build since the Documents feature landed, so demo and stage frontends have not been rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the webapp Docker image build by removing the backend Documents package from the webapp image. This stops Yarn from pulling backend-only deps and unblocks demo/stage frontend rebuilds.

- **Bug Fixes**
  - Removed COPY of `packages/plugins/docs/package.json` from `.deploy/webapp/Dockerfile`; the webapp only uses `@gauzy/plugin-docs-ui`.
  - Prevents `@gauzy/plugin-docs` from being installed and requiring `@gauzy/plugin-ai-chat` and `@gauzy/scheduler`, which aren’t present in the webapp image.

<sup>Written for commit 2d1390891b87f4b7191da17c02cb9e0ce03ace80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

