### PR TITLE
fix(docs): never register the pipeline queue without a BullMQ root (demo/stage API down)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -757,3 +757,8 @@ AI_GATEWAY_API_KEY=
 # GAUZY_DOCS_INBOUND_DOMAIN=
 # GAUZY_DOCS_INBOUND_WEBHOOK_SECRET=
 # GAUZY_DOCS_INBOUND_MAX_MESSAGE_BYTES=26214400
+
+# BullMQ-backed dispatch for the Documents pipeline. Off by default: only enable it in a process
+# that registers a BullMQ root connection, otherwise the API fails to boot while building the
+# queue worker. With it off the pipeline runs in-process, which is the supported default.
+# GAUZY_DOCS_QUEUE_ENABLED=false

--- a/packages/plugins/docs/src/lib/docs.config.queue-gate.spec.ts
+++ b/packages/plugins/docs/src/lib/docs.config.queue-gate.spec.ts
@@ -1,0 +1,51 @@
+import { isDocsQueueEnabled } from './docs.config';
+
+/**
+ * The queue gate decides whether `DocsModule` registers the `docs-processing` BullMQ queue and
+ * the `DocsProcessingWorker` `@Processor`.
+ *
+ * It is covered on its own because getting it wrong does not degrade a feature — it takes the
+ * whole API down. `@nestjs/bullmq`'s registrar builds a `Worker` for every `@Processor` during
+ * `onModuleInit`, and with no `BullModule.forRoot()` connection in the process that constructor
+ * throws `Worker requires a connection`, failing the Nest bootstrap. That is exactly what
+ * happened when the default was `REDIS_ENABLED === 'true'`: Redis was reachable in the deployed
+ * environments, but no process that loads the plugin list registers a Bull root, so the API
+ * crash-looped.
+ */
+describe('isDocsQueueEnabled', () => {
+	const ORIGINAL = { ...process.env };
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL };
+	});
+
+	it('is OFF when nothing is configured, so the pipeline dispatches inline', () => {
+		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		delete process.env['REDIS_ENABLED'];
+
+		expect(isDocsQueueEnabled()).toBe(false);
+	});
+
+	it('stays OFF when Redis is enabled — reachable Redis is not a Bull root', () => {
+		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		process.env['REDIS_ENABLED'] = 'true';
+
+		// The regression: this returning true registered a @Processor in an API process with no
+		// Bull root, and every API pod crash-looped on `Worker requires a connection`.
+		expect(isDocsQueueEnabled()).toBe(false);
+	});
+
+	it('turns ON only when explicitly opted in', () => {
+		process.env['GAUZY_DOCS_QUEUE_ENABLED'] = 'true';
+		delete process.env['REDIS_ENABLED'];
+
+		expect(isDocsQueueEnabled()).toBe(true);
+	});
+
+	it('an explicit false wins over anything else in the environment', () => {
+		process.env['GAUZY_DOCS_QUEUE_ENABLED'] = 'false';
+		process.env['REDIS_ENABLED'] = 'true';
+
+		expect(isDocsQueueEnabled()).toBe(false);
+	});
+});

--- a/packages/plugins/docs/src/lib/docs.config.ts
+++ b/packages/plugins/docs/src/lib/docs.config.ts
@@ -194,14 +194,18 @@ export const getDocsConfig = (): IDocsConfig => ({
  * Read at module-definition time by `DocsModule` (Nest module metadata is static), which is
  * why it is a standalone helper rather than a field of {@link IDocsConfig}.
  *
- * Defaults to `REDIS_ENABLED === 'true'`, the same signal `@gauzy/scheduler` uses for its own
- * `enableQueueing` default. That matters for more than tidiness: `BullModule.registerQueue()`
- * without a `BullModule.forRoot()` connection instantiates a `Queue` (and the explorer a
- * `Worker`) against BullMQ's default `localhost:6379`, so an API process with no Redis would
- * open a stray, endlessly-retrying connection. When this returns false the plugin dispatches
- * every stage inline instead — see `DocsQueueService`.
+ * 🛑 Defaults to FALSE, and the precondition is NOT "Redis is reachable" — it is "a
+ * `BullModule.forRoot()` connection is registered in THIS process". Those are different, and
+ * conflating them takes the API down: `@nestjs/bullmq`'s registrar builds a `Worker` for every
+ * `@Processor` at `onModuleInit`, and with no root it throws `Worker requires a connection`,
+ * which fails the whole Nest bootstrap. `SchedulerModule.forRoot()` is imported only by
+ * `apps/worker`, and that app does not load the plugin list — so no process that loads this
+ * plugin has a root today, whatever `REDIS_ENABLED` says.
+ *
+ * Leave it off unless you have added a Bull root to the process you are enabling it in; the
+ * plugin dispatches every stage inline instead, which is the supported path — see
+ * `DocsQueueService`.
  *
  * @returns True when the queue + worker host should be registered.
  */
-export const isDocsQueueEnabled = (): boolean =>
-	parseBoolEnv(ENV_GAUZY_DOCS_QUEUE_ENABLED, process.env['REDIS_ENABLED'] === 'true');
+export const isDocsQueueEnabled = (): boolean => parseBoolEnv(ENV_GAUZY_DOCS_QUEUE_ENABLED, false);

--- a/packages/plugins/docs/src/lib/docs.constants.ts
+++ b/packages/plugins/docs/src/lib/docs.constants.ts
@@ -63,10 +63,12 @@ export const ENV_GAUZY_DOCS_CLASSIFY_MODEL = 'GAUZY_DOCS_CLASSIFY_MODEL';
 export const ENV_GAUZY_DOCS_VERSION_DEBOUNCE_MINUTES = 'GAUZY_DOCS_VERSION_DEBOUNCE_MINUTES';
 export const ENV_GAUZY_DOCS_QUEUE_CONCURRENCY = 'GAUZY_DOCS_QUEUE_CONCURRENCY';
 /**
- * Master switch for BullMQ-backed pipeline dispatch. Unset, it follows `REDIS_ENABLED` —
- * the exact signal `@gauzy/scheduler` uses for its own `enableQueueing` default, so the
- * plugin registers its queue + worker host precisely when a Bull root could exist.
- * When off, the pipeline runs inline (see `DocsQueueService`).
+ * Master switch for BullMQ-backed pipeline dispatch. Off unless explicitly set.
+ *
+ * 🛑 Only turn this on in a process that registers a `BullModule.forRoot()` connection — Redis
+ * being reachable is not enough. Without a root, `@nestjs/bullmq` throws
+ * `Worker requires a connection` while building the `@Processor` and the whole API fails to
+ * boot. When off, the pipeline runs inline (see `DocsQueueService`).
  */
 export const ENV_GAUZY_DOCS_QUEUE_ENABLED = 'GAUZY_DOCS_QUEUE_ENABLED';
 export const ENV_GAUZY_DOCS_MAX_EXTRACTED_CHARS = 'GAUZY_DOCS_MAX_EXTRACTED_CHARS';


### PR DESCRIPTION
**The demo and stage APIs have been crash-looping since the Documents feature landed.** Production is unaffected — it runs a released image from master, verified 7/7 pods healthy with no restarts.

```
Error: Worker requires a connection
  at new Worker (bullmq/dist/cjs/classes/worker.js:46)
  at BullExplorer.handleProcessor (@nestjs/bullmq/dist/bull.explorer.js:135)
  at BullRegistrar.onModuleInit
```

The queue gate defaulted to `REDIS_ENABLED`, on the assumption that reachable Redis implies a usable queue. It does not. `@nestjs/bullmq` builds a `Worker` for every `@Processor` during `onModuleInit`, and that constructor requires a `BullModule.forRoot()` connection **registered in the same process**. Only `apps/worker` registers one, and that app does not load the plugin list — so no process that loads this plugin has a root, whatever `REDIS_ENABLED` says. Redis is enabled in both environments, so the worker got registered and the entire Nest bootstrap failed.

The gate is now off unless explicitly opted in, which is precisely the state the inline dispatcher was built for: uploads still extract, chunk and index, in-process.

Covered by a regression test that pins the "Redis enabled is not a Bull root" case, since the failure mode is total API boot failure rather than a degraded feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop registering the Documents pipeline BullMQ queue unless explicitly enabled to prevent API boot failures (“Worker requires a connection”). The pipeline runs inline by default; only enable the queue in a process with a `BullModule.forRoot()` connection.

- **Bug Fixes**
  - Default `isDocsQueueEnabled` to `false` and ignore `REDIS_ENABLED`; queue turns on only with `GAUZY_DOCS_QUEUE_ENABLED=true` in a process that has a Bull root.
  - Added regression test to ensure “Redis enabled” alone does not enable the queue.
  - Updated `.env.sample` with clear guidance on when to enable the queue.

<sup>Written for commit 42cda517973e2bb6843264f3273af553291278d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

