### PR TITLE
release(stage): Documents — AI, OCR and inbound email default ON

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -701,9 +701,12 @@ AI_GATEWAY_API_KEY=
 # after an AI provider is configured (see the AI chat section above; Documents reuses those providers
 # and honors per-tenant BYOK keys).
 
-# Master switch for AI classification, summaries and embeddings in Documents.
-# When false, uploads still extract text and stay fully searchable (lexical search only).
-# GAUZY_DOCS_AI_ENABLED=false
+# Master switch for AI classification, summaries and embeddings in Documents. ON by default.
+# It is safe to leave on with no AI provider configured: the AI stages are additionally gated on a
+# provider having credentials, so with none registered the pipeline skips them and uploads still
+# extract text and stay fully searchable (lexical search only). Set to false to keep the AI stages
+# off even where a provider IS configured.
+# GAUZY_DOCS_AI_ENABLED=true
 
 # Model overrides. Classification falls back to the AI chat default model when unset.
 # GAUZY_DOCS_CLASSIFY_MODEL=
@@ -714,10 +717,12 @@ AI_GATEWAY_API_KEY=
 
 # Text recognition (OCR) for scanned PDFs and image uploads, using the same AI provider (and the same
 # per-tenant BYOK keys) as classification — no separate OCR service is involved. Off by default because
-# it costs one model call per page. While off, a PDF with no text layer and an image upload both fail
-# with a clear "OCR is not available" message and land in the review queue, exactly as before.
+# it costs one model call per page. ON by default, but doubly gated — it needs GAUZY_DOCS_AI_ENABLED
+# *and* a provider with credentials, so a deployment with no AI configured never transcribes anything.
+# While unavailable, a PDF with no text layer and an image upload both fail with a clear "OCR is not
+# available" message and land in the review queue.
 # OCR'd documents are always flagged for review: a transcription can drop or garble text silently.
-# GAUZY_DOCS_OCR_ENABLED=false
+# GAUZY_DOCS_OCR_ENABLED=true
 # GAUZY_DOCS_OCR_MAX_PAGES=20
 
 # Vector store used for semantic retrieval. 'pgvector' requires PostgreSQL with the vector extension;
@@ -751,9 +756,11 @@ AI_GATEWAY_API_KEY=
 # GAUZY_DOCS_RETRIEVAL_LOG_ENABLED=true
 
 # Inbound email capture: documents emailed to a per-organization address land in Documents for review.
-# Disabled unless explicitly enabled AND a webhook secret is set. Captured documents are never added to
+# ON by default, but the route still accepts NOTHING until GAUZY_DOCS_INBOUND_WEBHOOK_SECRET is set:
+# signature verification fails closed on a missing secret, and also enforces a timestamp tolerance, a
+# constant-time compare and single-use replay consumption. Captured documents are never added to
 # AI knowledge automatically — they always go through review first.
-# GAUZY_DOCS_INBOUND_EMAIL_ENABLED=false
+# GAUZY_DOCS_INBOUND_EMAIL_ENABLED=true
 # GAUZY_DOCS_INBOUND_DOMAIN=
 # GAUZY_DOCS_INBOUND_WEBHOOK_SECRET=
 # GAUZY_DOCS_INBOUND_MAX_MESSAGE_BYTES=26214400

--- a/packages/plugins/docs/src/lib/docs.config.defaults.spec.ts
+++ b/packages/plugins/docs/src/lib/docs.config.defaults.spec.ts
@@ -1,0 +1,83 @@
+import {
+	ENV_GAUZY_DOCS_AI_ENABLED,
+	ENV_GAUZY_DOCS_INBOUND_EMAIL_ENABLED,
+	ENV_GAUZY_DOCS_OCR_ENABLED,
+	ENV_GAUZY_DOCS_QUEUE_ENABLED
+} from './docs.constants';
+import { getDocsConfig, isDocsQueueEnabled } from './docs.config';
+
+/**
+ * Pins the ON/OFF defaults of the optional Documents sub-features (owner decision, 2026-08-09).
+ *
+ * These are not arbitrary. Each default is safe only because a second gate exists downstream, and
+ * that pairing is what this suite protects — flipping a default without its gate is how a
+ * deployment with no AI configured starts failing every upload, or an unsigned webhook starts
+ * accepting documents.
+ */
+describe('Documents sub-feature defaults', () => {
+	const KEYS = [
+		ENV_GAUZY_DOCS_AI_ENABLED,
+		ENV_GAUZY_DOCS_OCR_ENABLED,
+		ENV_GAUZY_DOCS_INBOUND_EMAIL_ENABLED,
+		ENV_GAUZY_DOCS_QUEUE_ENABLED
+	];
+
+	const saved: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of KEYS) {
+			saved[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of KEYS) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+	});
+
+	describe('with nothing configured', () => {
+		it('enables AI, OCR and inbound email', () => {
+			const config = getDocsConfig();
+
+			expect(config.aiEnabled).toBe(true);
+			expect(config.ocrEnabled).toBe(true);
+			expect(config.inboundEmailEnabled).toBe(true);
+		});
+
+		/**
+		 * 🛑 The one that must stay OFF. Enabling the BullMQ queue without a Bull root connection in
+		 * the process registers a `@Processor` with no connection, which throws
+		 * `Worker requires a connection` during `onModuleInit` and takes the whole API down — it
+		 * crash-looped demo and stage for hours. With it off the pipeline runs inline and works.
+		 */
+		it('leaves the queue OFF', () => {
+			expect(isDocsQueueEnabled()).toBe(false);
+		});
+
+		/** Safe-by-default: no secret means the inbound route accepts nothing, however "enabled" it is. */
+		it('ships no inbound webhook secret, so the route can accept nothing', () => {
+			expect(getDocsConfig().inboundWebhookSecret).toBeUndefined();
+		});
+	});
+
+	describe('explicit opt-out still wins', () => {
+		it.each([
+			[ENV_GAUZY_DOCS_AI_ENABLED, 'aiEnabled'],
+			[ENV_GAUZY_DOCS_OCR_ENABLED, 'ocrEnabled'],
+			[ENV_GAUZY_DOCS_INBOUND_EMAIL_ENABLED, 'inboundEmailEnabled']
+		])('%s=false turns %s off', (key: string, field: string) => {
+			process.env[key] = 'false';
+
+			expect(getDocsConfig()[field as 'aiEnabled']).toBe(false);
+		});
+
+		it('GAUZY_DOCS_QUEUE_ENABLED=true is still honoured for a process that really has a Bull root', () => {
+			process.env[ENV_GAUZY_DOCS_QUEUE_ENABLED] = 'true';
+
+			expect(isDocsQueueEnabled()).toBe(true);
+		});
+	});
+});

--- a/packages/plugins/docs/src/lib/docs.config.ts
+++ b/packages/plugins/docs/src/lib/docs.config.ts
@@ -170,7 +170,11 @@ const parseBoolEnv = (key: string, fallback: boolean): boolean => {
 export const getDocsConfig = (): IDocsConfig => ({
 	maxFileSize: parseIntEnv(ENV_GAUZY_DOCS_MAX_FILE_SIZE, DEFAULT_DOCS_MAX_FILE_SIZE),
 	maxBinaryBytes: parseIntEnv(ENV_GAUZY_DOCS_MAX_BINARY_BYTES, DEFAULT_DOCS_MAX_BINARY_BYTES),
-	aiEnabled: parseBoolEnv(ENV_GAUZY_DOCS_AI_ENABLED, false),
+	// Default ON (owner, 2026-08-09). Safe without any AI configuration: `DocsAiService.isAiAvailable()`
+	// is `aiEnabled && registryList().length > 0`, so with no provider registered the pipeline simply
+	// skips the classify/embed stages and extraction + search keep working. Set to `false` to keep the
+	// AI stages off even where a provider IS configured.
+	aiEnabled: parseBoolEnv(ENV_GAUZY_DOCS_AI_ENABLED, true),
 	embeddingModel: process.env[ENV_GAUZY_DOCS_EMBEDDING_MODEL] || DEFAULT_DOCS_EMBEDDING_MODEL,
 	classifyModel: process.env[ENV_GAUZY_DOCS_CLASSIFY_MODEL] || undefined,
 	versionDebounceMinutes: parseIntEnv(ENV_GAUZY_DOCS_VERSION_DEBOUNCE_MINUTES, DEFAULT_DOCS_VERSION_DEBOUNCE_MINUTES),
@@ -189,14 +193,22 @@ export const getDocsConfig = (): IDocsConfig => ({
 	// 0 must survive as "unlimited" — hence the non-negative parser.
 	orgQuotaBytes: parseNonNegativeIntEnv(ENV_GAUZY_DOCS_ORG_QUOTA_BYTES, DEFAULT_DOCS_ORG_QUOTA_BYTES),
 	retrievalLogEnabled: parseBoolEnv(ENV_GAUZY_DOCS_RETRIEVAL_LOG_ENABLED, true),
-	inboundEmailEnabled: parseBoolEnv(ENV_GAUZY_DOCS_INBOUND_EMAIL_ENABLED, false),
+	// Default ON (owner, 2026-08-09). Safe without a secret: `GenericSignedWebhookAdapter.verifySignature()`
+	// FAILS CLOSED when `inboundWebhookSecret` is unset — it logs and rejects, so the route accepts nothing
+	// until a secret is configured. It also enforces a timestamp tolerance, a constant-time compare and
+	// replay consumption.
+	inboundEmailEnabled: parseBoolEnv(ENV_GAUZY_DOCS_INBOUND_EMAIL_ENABLED, true),
 	inboundWebhookSecret: process.env[ENV_GAUZY_DOCS_INBOUND_WEBHOOK_SECRET] || undefined,
 	inboundMaxMessageBytes: parseIntEnv(
 		ENV_GAUZY_DOCS_INBOUND_MAX_MESSAGE_BYTES,
 		DEFAULT_DOCS_INBOUND_MAX_MESSAGE_BYTES
 	),
 	inboundDomain: process.env[ENV_GAUZY_DOCS_INBOUND_DOMAIN] || undefined,
-	ocrEnabled: parseBoolEnv(ENV_GAUZY_DOCS_OCR_ENABLED, false),
+	// Default ON (owner, 2026-08-09). Doubly gated: `resolveVisionModel()` returns null unless BOTH
+	// `aiEnabled` and `ocrEnabled` are set AND a provider has credentials, so a deployment with no AI
+	// configured never transcribes anything. Capped by `ocrMaxPages`; transcribed text is marked
+	// OCR-derived and routed to review, because it is a machine reading rather than an authored document.
+	ocrEnabled: parseBoolEnv(ENV_GAUZY_DOCS_OCR_ENABLED, true),
 	ocrMaxPages: parseIntEnv(ENV_GAUZY_DOCS_OCR_MAX_PAGES, DEFAULT_DOCS_OCR_MAX_PAGES),
 	uploadRateLimit: parseIntEnv(ENV_GAUZY_DOCS_UPLOAD_RATE_LIMIT, DEFAULT_DOCS_UPLOAD_RATE_LIMIT),
 	searchRateLimit: parseIntEnv(ENV_GAUZY_DOCS_SEARCH_RATE_LIMIT, DEFAULT_DOCS_SEARCH_RATE_LIMIT),


### PR DESCRIPTION
Cascades `develop` → `stage`. Carries #9954.

`GAUZY_DOCS_{AI,OCR,INBOUND_EMAIL}_ENABLED` now default to `true`. Each is safe on by default because of a second gate: AI and OCR additionally require a provider with credentials (so a deployment with no AI configured skips those stages rather than failing), and the inbound webhook **fails closed** with no secret configured.

🛑 `GAUZY_DOCS_QUEUE_ENABLED` deliberately stays `false` — enabling it without a BullMQ root is what crash-looped demo and stage earlier today.

`FEATURE_DOCUMENTS` itself was already default-on and needed no change.

Verified: plugin-docs 43 suites / 564 tests; all 17 CI checks green including CodeQL (0 alerts), SonarCloud and DeepScan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Documents AI, OCR, and inbound email by default with safety gates so unconfigured deployments stay safe. The processing queue remains off to prevent crash loops; defaults and docs updated, plus tests added to pin these choices.

- **New Features**
  - `GAUZY_DOCS_AI_ENABLED`, `GAUZY_DOCS_OCR_ENABLED`, and `GAUZY_DOCS_INBOUND_EMAIL_ENABLED` default to `true`; `GAUZY_DOCS_QUEUE_ENABLED` stays `false`.
  - Safety gates: AI/OCR only run when a provider with credentials exists; inbound email accepts nothing without `GAUZY_DOCS_INBOUND_WEBHOOK_SECRET` (signature check fails closed).

- **Migration**
  - No action needed; to opt out set the three env vars to `false`.
  - Set `GAUZY_DOCS_INBOUND_WEBHOOK_SECRET` before using inbound email.
  - Only enable `GAUZY_DOCS_QUEUE_ENABLED=true` if a `BullMQ` root connection is configured.

<sup>Written for commit a753a20c1b51db7bbed38ab81a4311354eca3cec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

