### PR TITLE
feat(docs): producer-only BullMQ root in the API so the Documents pipeline offloads to the worker

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,7 @@
         "predefines",
         "Slideless",
         "slidenum",
+        "snapshotted",
         "unloadable",
         "unprefixed",
         "unprioritized",

--- a/.cspell.json
+++ b/.cspell.json
@@ -45,6 +45,7 @@
         "opped",
         "regexes",
         "Runbooks",
+        "schedulable",
         "shortcodes",
         "subqueries",
         "swappable",

--- a/.env.sample
+++ b/.env.sample
@@ -765,7 +765,18 @@ AI_GATEWAY_API_KEY=
 # GAUZY_DOCS_INBOUND_WEBHOOK_SECRET=
 # GAUZY_DOCS_INBOUND_MAX_MESSAGE_BYTES=26214400
 
-# BullMQ-backed dispatch for the Documents pipeline. Off by default: only enable it in a process
-# that registers a BullMQ root connection, otherwise the API fails to boot while building the
-# queue worker. With it off the pipeline runs in-process, which is the supported default.
+# BullMQ-backed dispatch for the Documents pipeline. Defaults to ON exactly where a BullMQ root is
+# registered — i.e. REDIS_ENABLED=true and SCHEDULER_QUEUE_ENABLED not set to false. Every process
+# that loads plugins (API, `yarn seed`, worker) registers that root under the same condition, so
+# the default cannot register a @Processor without a connection. Set it explicitly to force either
+# direction; with it off the pipeline runs in-process, which stays a fully supported mode.
 # GAUZY_DOCS_QUEUE_ENABLED=false
+
+# Whether THIS process also runs the docs-processing consumer, or only enqueues. Defaults to true
+# wherever the queue is on. Set false on the API when a dedicated worker deployment exists, so the
+# extraction / OCR / embedding work happens only there.
+# GAUZY_DOCS_QUEUE_WORKER_ENABLED=false
+
+# Fleet-wide kill switch for the BullMQ root itself (API + worker + seeder). `false` removes the
+# root everywhere and puts every queue-backed pipeline back on its in-process fallback.
+# SCHEDULER_QUEUE_ENABLED=false

--- a/apps/worker/src/app/app.module.spec.ts
+++ b/apps/worker/src/app/app.module.spec.ts
@@ -29,7 +29,11 @@ jest.mock('@gauzy/scheduler', () => ({
 	SchedulerModule: {
 		forRoot: jest.fn(() => ({ module: class SchedulerModule {} })),
 		forFeature: jest.fn(() => ({ module: class SchedulerModule {} }))
-	}
+	},
+	// `worker.constants.ts` calls this at import time to decide whether this process registers a
+	// BullMQ root. It must be part of the stub or the whole suite dies on
+	// `isSchedulerQueueRootEnabled is not a function` before a single assertion runs.
+	isSchedulerQueueRootEnabled: jest.fn(() => true)
 }));
 
 jest.mock('./worker-jobs.module', () => ({ WorkerJobsModule: class WorkerJobsModule {} }));
@@ -40,6 +44,7 @@ import 'reflect-metadata';
 import { MODULE_METADATA } from '@nestjs/common/constants';
 import { ActivityLogModule, MentionModule } from '@gauzy/core';
 import { PluginModule } from '@gauzy/plugin';
+import { SchedulerModule } from '@gauzy/scheduler';
 import { AppModule } from './app.module';
 
 const imports = (): any[] => Reflect.getMetadata(MODULE_METADATA.IMPORTS, AppModule) ?? [];
@@ -57,5 +62,28 @@ describe('worker AppModule', () => {
 
 	it('imports MentionModule so plugin @mention fan-out can resolve its service', () => {
 		expect(imports()).toContain(MentionModule);
+	});
+
+	/**
+	 * The consuming side of the split introduced with the API's producer-only root. The API
+	 * registers `{ enabled: false, enableQueueing: true }`; the worker must register BOTH halves,
+	 * or the queue fills up with nothing draining it and the reconcile cron never fires.
+	 */
+	it('registers a BullMQ root with BOTH queueing and the job runner enabled', () => {
+		const [options] = (SchedulerModule.forRoot as jest.Mock).mock.calls.at(-1) ?? [];
+
+		expect(options.enableQueueing).toBe(true);
+		expect(options.enabled).toBe(true);
+	});
+
+	it('declares the scheduler root BEFORE PluginModule, so plugin queues find a root', () => {
+		// `SchedulerModule.forFeature({ queues: [...] })` inside a plugin resolves against the
+		// root registered here; Nest evaluates the decorator argument list left to right.
+		const order = imports();
+		const rootIndex = order.findIndex((imported) => imported?.module?.name === 'SchedulerModule');
+		const pluginIndex = order.findIndex((imported) => imported?.module === PluginModule);
+
+		expect(rootIndex).toBeGreaterThanOrEqual(0);
+		expect(pluginIndex).toBeGreaterThan(rootIndex);
 	});
 });

--- a/apps/worker/src/app/worker.constants.ts
+++ b/apps/worker/src/app/worker.constants.ts
@@ -1,3 +1,22 @@
+import { isSchedulerQueueRootEnabled } from '@gauzy/scheduler';
+
 export const WORKER_DEFAULT_QUEUE = process.env.WORKER_DEFAULT_QUEUE || 'worker-default';
-export const WORKER_QUEUE_ENABLED = process.env.WORKER_QUEUE_ENABLED !== 'false' && process.env.REDIS_ENABLED === 'true';
+
+/**
+ * Whether this worker registers a BullMQ root (and therefore its own queues + `@Processor` hosts).
+ *
+ * Derived from `isSchedulerQueueRootEnabled()` — the ONE predicate every process that hosts
+ * plugins evaluates — so the worker, the API and the Documents plugin's queue gate can never
+ * disagree about whether a root exists. Behaviour is unchanged from the previous inline
+ * `process.env.REDIS_ENABLED === 'true'`, except that `SCHEDULER_QUEUE_ENABLED=false` now turns
+ * queueing off fleet-wide in one move.
+ *
+ * `WORKER_QUEUE_ENABLED=false` is kept as the pre-existing worker-local opt-out, and
+ * `isSchedulerQueueRootEnabled()` reads it as well — so a plugin gate in this same process gets
+ * the same answer instead of registering a `@Processor` against a root that was never created.
+ * The `&&` below is therefore redundant today; it stays because this constant's contract is
+ * "this variable can only ever narrow", and the helper could gain other inputs later.
+ */
+export const WORKER_QUEUE_ENABLED = process.env.WORKER_QUEUE_ENABLED !== 'false' && isSchedulerQueueRootEnabled();
+
 export const WORKER_SCHEDULER_ENABLED = process.env.WORKER_SCHEDULER_ENABLED !== 'false';

--- a/packages/core/src/lib/app/app.module.ts
+++ b/packages/core/src/lib/app/app.module.ts
@@ -1,5 +1,6 @@
 import { ConfigService, environment } from '@gauzy/config';
 import { LanguagesEnum } from '@gauzy/contracts';
+import { isSchedulerQueueRootEnabled, SchedulerModule } from '@gauzy/scheduler';
 import { createKeyvNonBlocking } from '@keyv/redis';
 import { CacheModule as NestCacheModule } from '@nestjs/cache-manager';
 import { Module, OnModuleInit } from '@nestjs/common';
@@ -530,6 +531,41 @@ if (environment.THROTTLE_ENABLED) {
 		BroadcastModule,
 		OrganizationStrategicInitiativeModule,
 		PasswordHashModule,
+		/**
+		 * PRODUCER-ONLY BullMQ root for the API process.
+		 *
+		 * Why it exists: plugins that offload work (today the Documents pipeline) can only reach
+		 * BullMQ through `SchedulerQueueService`, and that provider only exists where a
+		 * `SchedulerModule.forRoot()` was imported. Until this line the API had none, so every
+		 * `extract → classify → chunk → embed → index` stage — plus OCR and thumbnails — ran
+		 * INLINE in the API process while `apps/worker` sat idle.
+		 *
+		 * The two halves are deliberately split:
+		 * - `enableQueueing: true`  → registers `BullModule.forRoot()`, i.e. the connection that
+		 *   makes `SchedulerQueueService` resolvable and lets this process ENQUEUE.
+		 * - 🛑 `enabled: false`     → the job-runner half stays OFF. `SchedulerDiscoveryService`
+		 *   still discovers `@ScheduledJob` methods but `registerSchedules()` skips every one of
+		 *   them (`if (!job.options.enabled || !this.moduleOptions.enabled) continue`), and
+		 *   `SchedulerJobRunnerService.execute()` returns immediately, which also neuters the
+		 *   `runOnStart` path. `apps/worker` owns scheduled jobs; if the API ran them too, every
+		 *   scheduled job would execute twice.
+		 * - `logRegisteredJobs: false` → discovery would otherwise log "Registered scheduled job"
+		 *   for jobs this process will never fire.
+		 *
+		 * 🛑 Conditional by design — with `REDIS_ENABLED` unset there is NO root at all and every
+		 * consumer keeps its in-process fallback (the Documents plugin dispatches stages inline).
+		 * That is the path single-container and dev setups run on and it must keep working.
+		 * `SCHEDULER_QUEUE_ENABLED=false` forces it off even where Redis is configured.
+		 */
+		...(isSchedulerQueueRootEnabled()
+			? [
+					SchedulerModule.forRoot({
+						enabled: false,
+						enableQueueing: true,
+						logRegisteredJobs: false
+					})
+			  ]
+			: []),
 		//Token cleanup scheduler is disabled by default; enable when ready
 		TokenModule.forRoot({ enableScheduler: false }),
 		AccessTokenModule,

--- a/packages/core/src/lib/core/seeds/seeder.module.ts
+++ b/packages/core/src/lib/core/seeds/seeder.module.ts
@@ -3,6 +3,7 @@ import { HeaderResolver, I18nModule } from 'nestjs-i18n';
 import * as path from 'path';
 import { ConfigModule, environment } from '@gauzy/config';
 import { getDynamicPluginsModules } from '@gauzy/plugin';
+import { isSchedulerQueueRootEnabled, SchedulerModule } from '@gauzy/scheduler';
 import { LanguagesEnum } from '@gauzy/contracts';
 import { DatabaseModule } from './../../database/database.module';
 import { ActivityLogModule } from '../../activity-log/activity-log.module';
@@ -44,6 +45,30 @@ export class SeederModule {
 				ActivityLogModule,
 				MentionModule,
 				EntitySubscriptionModule,
+				/**
+				 * 🛑 The seeder graph loads the SAME plugin list as the API (see
+				 * `getDynamicPluginsModules()` below), so it needs the SAME producer-only BullMQ root.
+				 *
+				 * A plugin decides at module-definition time whether to register its `@Processor`
+				 * host, and it can only decide that from `isSchedulerQueueRootEnabled()` — a
+				 * process-independent expression. If the API registered a root and this CLI did not,
+				 * that shared answer would be a lie here and `yarn seed` would die at `onModuleInit`
+				 * with `Worker requires a connection`, exactly the failure that crash-looped the API
+				 * earlier. Registering the root keeps the predicate honest in every process that
+				 * loads plugins: API, worker, seeder.
+				 *
+				 * `enabled: false` for the same reason as in `AppModule` — a seeding CLI must never
+				 * start cron/interval jobs.
+				 */
+				...(isSchedulerQueueRootEnabled()
+					? [
+							SchedulerModule.forRoot({
+								enabled: false,
+								enableQueueing: true,
+								logRegisteredJobs: false
+							})
+					  ]
+					: []),
 				...getDynamicPluginsModules()
 			]
 		};

--- a/packages/plugins/docs-ui/src/lib/docs-ui.module.effects-manager.spec.ts
+++ b/packages/plugins/docs-ui/src/lib/docs-ui.module.effects-manager.spec.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * 🛑 Regression guard for the /pages/documents main-thread hang.
+ *
+ * `@ngneat/effects-ng`'s `provideEffectsManager()` is documented "Must be called at the root
+ * level": it runs `initEffects()`, which creates the effects manager and subscribes it to the
+ * GLOBAL `actions` stream. The app root already provides it
+ * (apps/gauzy/src/app/bootstrap.module.ts). When `DocsUiModule` — a LAZY-loaded module — provided
+ * it a SECOND time, first navigation to the hub stood up a second manager on the same global
+ * stream and re-entered synchronously, pegging the main thread. The route wedged BEFORE any HTTP
+ * (before the guards' `/api/auth/permissions` call), so every unit test passed while the feature
+ * was completely unreachable in a browser.
+ *
+ * A feature module must contribute only its effects via `provideEffects()`. This test asserts the
+ * module source never reintroduces the root-only call. It is a source-level invariant on purpose:
+ * the providers are opaque `EnvironmentProviders`, and `initEffects()` mutates global singleton
+ * state, so the defect cannot be observed cleanly through TestBed without leaking across specs —
+ * whereas the one thing that must never come back is textual and unambiguous.
+ */
+describe('DocsUiModule effects wiring', () => {
+	const source = readFileSync(join(__dirname, 'docs-ui.module.ts'), 'utf8');
+
+	// Strip block and line comments so the explanatory note above the providers (which names the
+	// forbidden call) does not count as a usage.
+	const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+	it('does NOT call provideEffectsManager() — that is the app root\'s job', () => {
+		expect(code).not.toMatch(/provideEffectsManager\s*\(/);
+	});
+
+	it('does NOT import provideEffectsManager from @ngneat/effects-ng', () => {
+		expect(code).not.toMatch(/provideEffectsManager/);
+	});
+
+	it('still registers its own effects via provideEffects(DocumentsEffects)', () => {
+		expect(code).toMatch(/provideEffects\s*\(\s*DocumentsEffects\s*\)/);
+	});
+});

--- a/packages/plugins/docs-ui/src/lib/docs-ui.module.ts
+++ b/packages/plugins/docs-ui/src/lib/docs-ui.module.ts
@@ -21,7 +21,7 @@ import {
 	NbToggleModule,
 	NbTooltipModule
 } from '@nebular/theme';
-import { provideEffects, provideEffectsManager } from '@ngneat/effects-ng';
+import { provideEffects } from '@ngneat/effects-ng';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxPermissionsModule } from 'ngx-permissions';
 import {
@@ -182,7 +182,15 @@ import { UploadQueueService } from './services/upload-queue.service';
 			deps: [PageRouteRegistryService],
 			multi: true
 		},
-		provideEffectsManager(),
+		// 🛑 Do NOT call provideEffectsManager() here. `@ngneat/effects-ng` documents it as
+		// "Must be called at the root level" — it runs `initEffects()`, which creates the effects
+		// manager and subscribes it to the GLOBAL `actions` stream. The app root already provides
+		// it (apps/gauzy/src/app/bootstrap.module.ts). Providing it again in this LAZY-loaded
+		// module stood up a SECOND manager on the same global stream, and on first navigation to
+		// /pages/documents that re-entered synchronously and pegged the main thread — the route
+		// wedged before any HTTP (before the guards' /api/auth/permissions call even fired), so
+		// every unit test passed while the hub was unreachable in a browser. A feature module must
+		// contribute ONLY its effects via provideEffects(); the manager is the root's job.
 		provideEffects(DocumentsEffects),
 		DocumentsStore,
 		DocumentsQuery,

--- a/packages/plugins/docs/README.md
+++ b/packages/plugins/docs/README.md
@@ -33,7 +33,8 @@ error, not a silent DOM fallback.
 | `GAUZY_DOCS_CLASSIFY_MODEL` | *(chat default)* | Classification model id |
 | `GAUZY_DOCS_VERSION_DEBOUNCE_MINUTES` | `10` | Server-side debounce window for PAGE version snapshots |
 | `GAUZY_DOCS_QUEUE_CONCURRENCY` | `2` | `docs-processing` worker concurrency per process (queued mode only) |
-| `GAUZY_DOCS_QUEUE_ENABLED` | *(follows `REDIS_ENABLED`)* | Register the BullMQ queue + worker host. Off ⇒ the pipeline runs **inline** |
+| `GAUZY_DOCS_QUEUE_ENABLED` | *(follows `isSchedulerQueueRootEnabled()`)* | Register the BullMQ queue. Off ⇒ the pipeline runs **inline** |
+| `GAUZY_DOCS_QUEUE_WORKER_ENABLED` | `true` | Also run the `docs-processing` consumer here. Set `false` on the API when a dedicated `apps/worker` is deployed |
 
 ## Pipeline dispatch: queued vs inline
 
@@ -41,11 +42,16 @@ The `extract → classify → chunk → embed → index` pipeline has **one** de
 (`DocsPipelineService`) and **two** dispatchers:
 
 - **Queued** — `DocsProcessingWorker`, the BullMQ worker host. Requires a `@gauzy/scheduler` root
-  (`SchedulerModule.forRoot({ enableQueueing: true })`) in the process, which today only
-  `apps/worker` imports. Jobs get `attempts: 3` with exponential backoff from a 120 s base and a
-  deterministic `docs:<stage>:<documentId>` job id, so duplicate triggers coalesce in Redis.
+  (`SchedulerModule.forRoot({ enableQueueing: true })`) in the process. Every process that loads
+  the plugin list registers one under the same condition — `@gauzy/core`'s `AppModule` (the API)
+  and `SeederModule.forPlugins()` (the `yarn seed` CLI) register a **producer-only** root
+  (`{ enabled: false, enableQueueing: true }` — queueing on, cron off), and `apps/worker`
+  registers both halves because it also consumes. Jobs get `attempts: 3` with exponential backoff
+  from a 120 s base and a deterministic `docs:<stage>:<documentId>` job id, so duplicate triggers
+  coalesce in Redis.
 - **Inline** — `DocsQueueService` runs the same stage handlers **in-process on a background task**
-  when no scheduler root is present (the API), so the HTTP request is never blocked. Inline runs get
+  when no scheduler root is present (any deployment without Redis: single-container, dev, or
+  `SCHEDULER_QUEUE_ENABLED=false`), so the HTTP request is never blocked. Inline runs get
   a single immediate attempt; a failure dead-letters onto the document row (`FAILED` +
   `statusMessage`) exactly like the queue's final attempt, and an in-flight guard keyed on
   `docs:<stage>:<documentId>` stops a duplicate trigger from running the same stage twice at once.
@@ -53,6 +59,13 @@ The `extract → classify → chunk → embed → index` pipeline has **one** de
 `SchedulerQueueService` is injected `@Optional()` for exactly this reason — a required dependency
 made the whole API fail to bootstrap the moment this plugin was registered. The active mode is
 logged once at startup by `DocsQueueService` (`docs-processing dispatch mode: QUEUED|INLINE`).
+
+### Turning it off
+
+`SCHEDULER_QUEUE_ENABLED=false` removes the BullMQ root from every process at once and puts the
+whole fleet back on the inline path; `GAUZY_DOCS_QUEUE_ENABLED=false` does the same for this
+plugin alone. Either is a safe, reversible rollback — inline dispatch is a supported mode, not a
+degraded one.
 
 ## Building
 

--- a/packages/plugins/docs/src/lib/docs.config.defaults.spec.ts
+++ b/packages/plugins/docs/src/lib/docs.config.defaults.spec.ts
@@ -64,14 +64,14 @@ describe('Documents sub-feature defaults', () => {
 	});
 
 	describe('explicit opt-out still wins', () => {
-		it.each([
+		it.each<[string, 'aiEnabled' | 'ocrEnabled' | 'inboundEmailEnabled']>([
 			[ENV_GAUZY_DOCS_AI_ENABLED, 'aiEnabled'],
 			[ENV_GAUZY_DOCS_OCR_ENABLED, 'ocrEnabled'],
 			[ENV_GAUZY_DOCS_INBOUND_EMAIL_ENABLED, 'inboundEmailEnabled']
-		])('%s=false turns %s off', (key: string, field: string) => {
+		])('%s=false turns %s off', (key, field) => {
 			process.env[key] = 'false';
 
-			expect(getDocsConfig()[field as 'aiEnabled']).toBe(false);
+			expect(getDocsConfig()[field]).toBe(false);
 		});
 
 		it('GAUZY_DOCS_QUEUE_ENABLED=true is still honoured for a process that really has a Bull root', () => {

--- a/packages/plugins/docs/src/lib/docs.config.queue-gate.spec.ts
+++ b/packages/plugins/docs/src/lib/docs.config.queue-gate.spec.ts
@@ -1,4 +1,4 @@
-import { isDocsQueueEnabled } from './docs.config';
+import { isDocsQueueEnabled, isDocsQueueWorkerEnabled } from './docs.config';
 
 /**
  * The queue gate decides whether `DocsModule` registers the `docs-processing` BullMQ queue and
@@ -8,12 +8,29 @@ import { isDocsQueueEnabled } from './docs.config';
  * whole API down. `@nestjs/bullmq`'s registrar builds a `Worker` for every `@Processor` during
  * `onModuleInit`, and with no `BullModule.forRoot()` connection in the process that constructor
  * throws `Worker requires a connection`, failing the Nest bootstrap. That is exactly what
- * happened when the default was `REDIS_ENABLED === 'true'`: Redis was reachable in the deployed
- * environments, but no process that loads the plugin list registers a Bull root, so the API
- * crash-looped.
+ * happened when the default was a bare `REDIS_ENABLED === 'true'`: Redis was reachable in the
+ * deployed environments, but no process that loaded the plugin list registered a Bull root, so
+ * the API crash-looped.
+ *
+ * The default is now derived from `isSchedulerQueueRootEnabled()` — the SAME expression that
+ * `@gauzy/core`'s `AppModule`, its `SeederModule.forPlugins()` and `apps/worker`'s `AppModule`
+ * each evaluate to decide whether to register a root. The distinction the old comment protected
+ * is therefore intact: the gate still answers "does a root exist in this process?", it just has
+ * a truthful way to answer it now instead of defaulting to "no".
  */
 describe('isDocsQueueEnabled', () => {
 	const ORIGINAL = { ...process.env };
+
+	// 🛑 Nx feeds `.env` / `.env.local` into every task, so a developer's own
+	// `WORKER_QUEUE_ENABLED=false` (or `REDIS_ENABLED`) reaches jest and silently flips this gate.
+	// Start from a clean slate; each test then states the environment it asserts about.
+	beforeEach(() => {
+		delete process.env['REDIS_ENABLED'];
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+		delete process.env['WORKER_QUEUE_ENABLED'];
+		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		delete process.env['GAUZY_DOCS_QUEUE_WORKER_ENABLED'];
+	});
 
 	afterEach(() => {
 		process.env = { ...ORIGINAL };
@@ -21,21 +38,48 @@ describe('isDocsQueueEnabled', () => {
 
 	it('is OFF when nothing is configured, so the pipeline dispatches inline', () => {
 		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
 		delete process.env['REDIS_ENABLED'];
 
 		expect(isDocsQueueEnabled()).toBe(false);
 	});
 
-	it('stays OFF when Redis is enabled — reachable Redis is not a Bull root', () => {
+	it('turns ON when Redis is enabled, because that is when a root is registered', () => {
 		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
 		process.env['REDIS_ENABLED'] = 'true';
 
-		// The regression: this returning true registered a @Processor in an API process with no
-		// Bull root, and every API pod crash-looped on `Worker requires a connection`.
+		// Safe now, and ONLY because every module that builds a plugin-hosting graph registers
+		// `SchedulerModule.forRoot({ enableQueueing: true })` under this very same condition.
+		expect(isDocsQueueEnabled()).toBe(true);
+	});
+
+	it('stays OFF when the shared root switch is off, even with Redis enabled', () => {
+		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		process.env['SCHEDULER_QUEUE_ENABLED'] = 'false';
+		process.env['REDIS_ENABLED'] = 'true';
+
+		// No root is registered in this configuration, so a `@Processor` here would be the
+		// `Worker requires a connection` crash all over again.
 		expect(isDocsQueueEnabled()).toBe(false);
 	});
 
-	it('turns ON only when explicitly opted in', () => {
+	/**
+	 * REGRESSION — this configuration crash-looped a real worker boot during verification: the
+	 * worker registered no root (its `WORKER_QUEUE_ENABLED=false`) while this gate still said
+	 * "queued", and `SchedulerJobRegistryService` refused the docs reconcile job with
+	 * `targets queue "docs-processing" but queueing is disabled`.
+	 */
+	it('stays OFF when the worker-local WORKER_QUEUE_ENABLED removes the root', () => {
+		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+		process.env['REDIS_ENABLED'] = 'true';
+		process.env['WORKER_QUEUE_ENABLED'] = 'false';
+
+		expect(isDocsQueueEnabled()).toBe(false);
+	});
+
+	it('an explicit true wins where no root would otherwise exist', () => {
 		process.env['GAUZY_DOCS_QUEUE_ENABLED'] = 'true';
 		delete process.env['REDIS_ENABLED'];
 
@@ -47,5 +91,60 @@ describe('isDocsQueueEnabled', () => {
 		process.env['REDIS_ENABLED'] = 'true';
 
 		expect(isDocsQueueEnabled()).toBe(false);
+	});
+});
+
+/**
+ * The consumer half. It exists so the API can enqueue without also executing the stages, which
+ * is the entire point of deploying `apps/worker`.
+ */
+describe('isDocsQueueWorkerEnabled', () => {
+	const ORIGINAL = { ...process.env };
+
+	// 🛑 Nx feeds `.env` / `.env.local` into every task, so a developer's own
+	// `WORKER_QUEUE_ENABLED=false` (or `REDIS_ENABLED`) reaches jest and silently flips this gate.
+	// Start from a clean slate; each test then states the environment it asserts about.
+	beforeEach(() => {
+		delete process.env['REDIS_ENABLED'];
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+		delete process.env['WORKER_QUEUE_ENABLED'];
+		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		delete process.env['GAUZY_DOCS_QUEUE_WORKER_ENABLED'];
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL };
+	});
+
+	it('follows the queue gate by default, so a single-process deployment drains its own queue', () => {
+		delete process.env['GAUZY_DOCS_QUEUE_WORKER_ENABLED'];
+		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		process.env['REDIS_ENABLED'] = 'true';
+
+		expect(isDocsQueueWorkerEnabled()).toBe(true);
+	});
+
+	it('can be turned off on its own to make a process a pure producer', () => {
+		process.env['GAUZY_DOCS_QUEUE_WORKER_ENABLED'] = 'false';
+		process.env['REDIS_ENABLED'] = 'true';
+
+		expect(isDocsQueueEnabled()).toBe(true);
+		expect(isDocsQueueWorkerEnabled()).toBe(false);
+	});
+
+	it('is never ON without the queue — a @Processor without a root fails the bootstrap', () => {
+		process.env['GAUZY_DOCS_QUEUE_WORKER_ENABLED'] = 'true';
+		process.env['GAUZY_DOCS_QUEUE_ENABLED'] = 'false';
+		process.env['REDIS_ENABLED'] = 'true';
+
+		expect(isDocsQueueWorkerEnabled()).toBe(false);
+	});
+
+	it('is OFF wherever no root exists at all', () => {
+		delete process.env['GAUZY_DOCS_QUEUE_WORKER_ENABLED'];
+		delete process.env['GAUZY_DOCS_QUEUE_ENABLED'];
+		delete process.env['REDIS_ENABLED'];
+
+		expect(isDocsQueueWorkerEnabled()).toBe(false);
 	});
 });

--- a/packages/plugins/docs/src/lib/docs.config.ts
+++ b/packages/plugins/docs/src/lib/docs.config.ts
@@ -41,6 +41,7 @@ import {
 	ENV_GAUZY_DOCS_ORG_QUOTA_BYTES,
 	ENV_GAUZY_DOCS_QUEUE_CONCURRENCY,
 	ENV_GAUZY_DOCS_QUEUE_ENABLED,
+	ENV_GAUZY_DOCS_QUEUE_WORKER_ENABLED,
 	ENV_GAUZY_DOCS_RETRIEVAL_LOG_ENABLED,
 	ENV_GAUZY_DOCS_RETRIEVAL_TOPK_MAX,
 	ENV_GAUZY_DOCS_SEARCH_RATE_LIMIT,
@@ -49,6 +50,7 @@ import {
 	ENV_GAUZY_DOCS_VECTOR_STORE,
 	ENV_GAUZY_DOCS_VERSION_DEBOUNCE_MINUTES
 } from './docs.constants';
+import { isSchedulerQueueRootEnabled } from '@gauzy/scheduler';
 
 /**
  * Typed configuration object parsed from the `GAUZY_DOCS_*` environment variables.
@@ -257,18 +259,61 @@ export const docsRateLimit = (limit: number) => ({
  * Read at module-definition time by `DocsModule` (Nest module metadata is static), which is
  * why it is a standalone helper rather than a field of {@link IDocsConfig}.
  *
- * 🛑 Defaults to FALSE, and the precondition is NOT "Redis is reachable" — it is "a
- * `BullModule.forRoot()` connection is registered in THIS process". Those are different, and
- * conflating them takes the API down: `@nestjs/bullmq`'s registrar builds a `Worker` for every
- * `@Processor` at `onModuleInit`, and with no root it throws `Worker requires a connection`,
- * which fails the whole Nest bootstrap. `SchedulerModule.forRoot()` is imported only by
- * `apps/worker`, and that app does not load the plugin list — so no process that loads this
- * plugin has a root today, whatever `REDIS_ENABLED` says.
+ * 🛑 The precondition is NOT "Redis is reachable" — it is "a `BullModule.forRoot()` connection
+ * is registered in THIS process". Those are different questions, and conflating them takes the
+ * API down: `@nestjs/bullmq`'s registrar builds a `Worker` for every `@Processor` at
+ * `onModuleInit`, and with no root it throws `Worker requires a connection`, which fails the
+ * whole Nest bootstrap. That is precisely what crash-looped demo and stage when the default was
+ * a bare `REDIS_ENABLED === 'true'`: Redis was reachable everywhere, but NO process that loaded
+ * this plugin had a root.
  *
- * Leave it off unless you have added a Bull root to the process you are enabling it in; the
- * plugin dispatches every stage inline instead, which is the supported path — see
+ * That second question is now answerable, which is why the default is no longer a flat `false`.
+ * `isSchedulerQueueRootEnabled()` is the ONE expression that decides whether a root is
+ * registered, and every process that loads the plugin list imports it:
+ *
+ * - `@gauzy/core` `AppModule`               → the API (producer-only: queueing on, cron off)
+ * - `@gauzy/core` `SeederModule.forPlugins()` → the `yarn seed` CLI (same producer-only shape)
+ * - `apps/worker` `AppModule`               → the worker (queueing AND cron on; it consumes)
+ *
+ * So the distinction survives: this does not ask "is Redis on?", it asks "did the modules that
+ * build this process's graph register a root?" — and it answers by evaluating the very same
+ * predicate they did, rather than by trusting a second env var an operator has to keep in sync.
+ * With no root anywhere (`REDIS_ENABLED` unset, or `SCHEDULER_QUEUE_ENABLED=false`) this returns
+ * false and the plugin dispatches every stage inline, which stays a fully supported path — see
  * `DocsQueueService`.
+ *
+ * `GAUZY_DOCS_QUEUE_ENABLED` remains the explicit per-deployment override in BOTH directions and
+ * still wins outright.
+ *
+ * ⚠️ `apps/worker` also narrows its own root with the older `WORKER_QUEUE_ENABLED`. That flag is
+ * read INSIDE `isSchedulerQueueRootEnabled()` for exactly this reason — a verification boot with
+ * `WORKER_QUEUE_ENABLED=false` and Redis on produced a worker with no root while this gate still
+ * said "queued", and the process died on
+ * `Job "docs-reconcile-schedule" targets queue "docs-processing" but queueing is disabled.`
+ * Both sides now read both flags, so they cannot disagree.
  *
  * @returns True when the queue + worker host should be registered.
  */
-export const isDocsQueueEnabled = (): boolean => parseBoolEnv(ENV_GAUZY_DOCS_QUEUE_ENABLED, false);
+export const isDocsQueueEnabled = (): boolean =>
+	parseBoolEnv(ENV_GAUZY_DOCS_QUEUE_ENABLED, isSchedulerQueueRootEnabled());
+
+/**
+ * Whether this process should additionally run the `docs-processing` CONSUMER — the
+ * `DocsProcessingWorker` `@Processor` host that actually executes the stages.
+ *
+ * Defaults to ON wherever {@link isDocsQueueEnabled} is on, and that default is deliberate:
+ * turning it off by default would mean a deployment that enables the queue but runs no separate
+ * worker enqueues jobs nothing ever picks up, and documents would sit in `UPLOADED` forever —
+ * strictly worse than the inline fallback. Producing without consuming must be an explicit choice.
+ *
+ * Set `GAUZY_DOCS_QUEUE_WORKER_ENABLED=false` on the API deployment (and leave it unset on
+ * `apps/worker`) to make the API a pure PRODUCER, which is the point of running a dedicated
+ * worker: the heavy extraction, OCR and embedding work then happens only there.
+ *
+ * 🛑 Never true without {@link isDocsQueueEnabled} — `DocsModule` ANDs the two. A `@Processor`
+ * registered without a queue/root is the `Worker requires a connection` crash.
+ *
+ * @returns True when the `DocsProcessingWorker` host should be registered.
+ */
+export const isDocsQueueWorkerEnabled = (): boolean =>
+	isDocsQueueEnabled() && parseBoolEnv(ENV_GAUZY_DOCS_QUEUE_WORKER_ENABLED, true);

--- a/packages/plugins/docs/src/lib/docs.constants.ts
+++ b/packages/plugins/docs/src/lib/docs.constants.ts
@@ -67,14 +67,26 @@ export const ENV_GAUZY_DOCS_CLASSIFY_MODEL = 'GAUZY_DOCS_CLASSIFY_MODEL';
 export const ENV_GAUZY_DOCS_VERSION_DEBOUNCE_MINUTES = 'GAUZY_DOCS_VERSION_DEBOUNCE_MINUTES';
 export const ENV_GAUZY_DOCS_QUEUE_CONCURRENCY = 'GAUZY_DOCS_QUEUE_CONCURRENCY';
 /**
- * Master switch for BullMQ-backed pipeline dispatch. Off unless explicitly set.
+ * Master switch for BullMQ-backed pipeline dispatch. Defaults to whatever
+ * `isSchedulerQueueRootEnabled()` says — i.e. ON exactly where a `SchedulerModule.forRoot()`
+ * BullMQ root is registered (`REDIS_ENABLED=true` and `SCHEDULER_QUEUE_ENABLED` not `false`).
+ * Set it explicitly to force either direction; an explicit value always wins.
  *
- * 🛑 Only turn this on in a process that registers a `BullModule.forRoot()` connection — Redis
- * being reachable is not enough. Without a root, `@nestjs/bullmq` throws
+ * 🛑 Only turn this on by hand in a process that registers a `BullModule.forRoot()` connection —
+ * Redis being reachable is not enough. Without a root, `@nestjs/bullmq` throws
  * `Worker requires a connection` while building the `@Processor` and the whole API fails to
  * boot. When off, the pipeline runs inline (see `DocsQueueService`).
  */
 export const ENV_GAUZY_DOCS_QUEUE_ENABLED = 'GAUZY_DOCS_QUEUE_ENABLED';
+
+/**
+ * Consumer half of the queue gate: whether THIS process runs the `DocsProcessingWorker`
+ * `@Processor` in addition to enqueueing. Defaults to true wherever
+ * `GAUZY_DOCS_QUEUE_ENABLED` resolves on, so a single-process deployment still drains its own
+ * queue. Set to `false` on the API when a dedicated `apps/worker` is deployed — that makes the
+ * API a pure producer and moves extraction/OCR/embedding off the request-serving pods.
+ */
+export const ENV_GAUZY_DOCS_QUEUE_WORKER_ENABLED = 'GAUZY_DOCS_QUEUE_WORKER_ENABLED';
 export const ENV_GAUZY_DOCS_MAX_EXTRACTED_CHARS = 'GAUZY_DOCS_MAX_EXTRACTED_CHARS';
 export const ENV_GAUZY_DOCS_STUCK_THRESHOLD_MINUTES = 'GAUZY_DOCS_STUCK_THRESHOLD_MINUTES';
 export const ENV_GAUZY_DOCS_EMBEDDING_DIMS = 'GAUZY_DOCS_EMBEDDING_DIMS';

--- a/packages/plugins/docs/src/lib/docs.module.ts
+++ b/packages/plugins/docs/src/lib/docs.module.ts
@@ -6,7 +6,7 @@ import { EventBusModule, FeatureModule, RolePermissionModule, TenantSettingModul
 import { SchedulerModule } from '@gauzy/scheduler';
 import { DocumentActivityLogSubscriber } from './activity/document-activity-log.subscriber';
 import { ChatCaptureSubscriber } from './capture/chat-capture.subscriber';
-import { isDocsQueueEnabled } from './docs.config';
+import { isDocsQueueEnabled, isDocsQueueWorkerEnabled } from './docs.config';
 import { GenericSignedWebhookAdapter } from './capture/generic-signed-webhook.adapter';
 import { InboundEmailController } from './capture/inbound-email.controller';
 import { InboundEmailService } from './capture/inbound-email.service';
@@ -57,12 +57,25 @@ const KnowledgeProviders = [
  *
  * Evaluated once, at module-definition time, because Nest module metadata is static.
  *
- * 🛑 The BullMQ pieces are GATED, not unconditional: `SchedulerModule.forRoot()` is imported
- * only by `apps/worker`, so in an API process there is no Bull root — `registerQueue()` would
- * still build a `Queue`/`Worker` pair against BullMQ's default `localhost:6379` and retry that
- * connection forever. `DocsQueueService` covers the gap by running stages in-process.
+ * 🛑 The BullMQ pieces are GATED, not unconditional. Where no `SchedulerModule.forRoot()` was
+ * imported there is no Bull root, and `registerQueue()` would still build a `Queue`/`Worker`
+ * pair against BullMQ's default `localhost:6379` and retry that connection forever — while the
+ * `@Processor` host would throw `Worker requires a connection` outright and fail the bootstrap.
+ * `DocsQueueService` covers the gap by running stages in-process.
+ *
+ * The gate is derived, not guessed: `isDocsQueueEnabled()` evaluates the SAME predicate the
+ * modules that build this process's graph used to decide whether to register a root — see the
+ * long note on it in `docs.config.ts`.
  */
 const QUEUE_ENABLED = isDocsQueueEnabled();
+
+/**
+ * Whether this process also CONSUMES (`DocsProcessingWorker`), or only enqueues.
+ *
+ * Always a subset of {@link QUEUE_ENABLED} — `isDocsQueueWorkerEnabled()` ANDs the two, so a
+ * `@Processor` can never be registered without the queue it reads from.
+ */
+const QUEUE_WORKER_ENABLED = isDocsQueueWorkerEnabled();
 
 @Module({
 	imports: [
@@ -106,8 +119,12 @@ const QUEUE_ENABLED = isDocsQueueEnabled();
 		// would be a DI (and CommonJS require) cycle.
 		{ provide: DOCS_PIPELINE_RUNNER, useExisting: DocsPipelineService },
 		// Only meaningful with a BullMQ root — a `@Processor` registered without one opens a
-		// stray Redis worker connection in every API process.
-		...(QUEUE_ENABLED ? [DocsProcessingWorker] : []),
+		// stray Redis worker connection in every API process (and throws
+		// `Worker requires a connection` at `onModuleInit`).
+		// Separately gated from the queue itself so a deployment running a dedicated
+		// `apps/worker` can set `GAUZY_DOCS_QUEUE_WORKER_ENABLED=false` here and keep the API a
+		// pure producer.
+		...(QUEUE_WORKER_ENABLED ? [DocsProcessingWorker] : []),
 		DocsRecoveryService,
 		// M4 consolidation: reads the legacy Organization-Documents / Help-Center tables
 		// (from @gauzy/core and @gauzy/plugin-knowledge-base) strictly read-only.

--- a/packages/plugins/videos-ui/src/lib/video-ui.module.effects-manager.spec.ts
+++ b/packages/plugins/videos-ui/src/lib/video-ui.module.effects-manager.spec.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * 🛑 Regression guard for the lazy-module effects-manager hang.
+ *
+ * `@ngneat/effects-ng`'s `provideEffectsManager()` is documented "Must be called at the root
+ * level": it runs `initEffects()`, which creates the effects manager and subscribes it to the
+ * GLOBAL `actions` stream. The app root already provides it
+ * (apps/gauzy/src/app/bootstrap.module.ts). `VideoUiModule` is lazy-loaded via `loadChildren`
+ * (apps/gauzy .../employees/activity/activity.module.ts); providing the manager again stood up a
+ * second manager on the same global stream, which re-entered synchronously on first navigation to
+ * the videos route and pegged the main thread — before any HTTP, so unit tests passed while the
+ * route was unreachable in a browser. Same defect as `@gauzy/plugin-docs-ui`.
+ *
+ * Source-level invariant on purpose: the providers are opaque `EnvironmentProviders` and
+ * `initEffects()` mutates global singleton state, so the one thing that must never return is
+ * asserted textually.
+ */
+describe('VideoUiModule effects wiring', () => {
+	const source = readFileSync(join(__dirname, 'video-ui.module.ts'), 'utf8');
+	const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+	it('does NOT call provideEffectsManager() — that is the app root\'s job', () => {
+		expect(code).not.toMatch(/provideEffectsManager\s*\(/);
+	});
+
+	it('does NOT import provideEffectsManager from @ngneat/effects-ng', () => {
+		expect(code).not.toMatch(/provideEffectsManager/);
+	});
+
+	it('still registers its own effects via provideEffects(...)', () => {
+		expect(code).toMatch(/provideEffects\s*\(\s*VideoEffects/);
+	});
+});

--- a/packages/plugins/videos-ui/src/lib/video-ui.module.ts
+++ b/packages/plugins/videos-ui/src/lib/video-ui.module.ts
@@ -16,7 +16,7 @@ import {
 	NbSpinnerModule,
 	NbTabsetModule
 } from '@nebular/theme';
-import { provideEffects, provideEffectsManager } from '@ngneat/effects-ng';
+import { provideEffects } from '@ngneat/effects-ng';
 import { TranslateModule } from '@ngx-translate/core';
 import { MomentModule } from 'ngx-moment';
 import { VideoEffects } from './+state/video.effect';
@@ -98,7 +98,16 @@ import { SoundshotPlayerSkeletonComponent } from './shared/ui/soundshot/soundsho
 		NgOptimizedImage
 	],
 	providers: [
-		provideEffectsManager(),
+		// 🛑 Do NOT call provideEffectsManager() here. `@ngneat/effects-ng` documents it as
+		// "Must be called at the root level" — it runs `initEffects()`, which creates the effects
+		// manager and subscribes it to the GLOBAL `actions` stream. The app root already provides
+		// it (apps/gauzy/src/app/bootstrap.module.ts). This module is lazy-loaded via
+		// `loadChildren` (apps/gauzy .../employees/activity/activity.module.ts), so providing the
+		// manager again stood up a SECOND manager on the same stream that re-entered synchronously
+		// on first navigation to the videos route and pegged the main thread — before any HTTP, so
+		// every unit test passed while the route was unreachable in a browser. A feature module
+		// contributes ONLY its effects via provideEffects(); the manager is the root's job. This is
+		// the same defect fixed in @gauzy/plugin-docs-ui (see docs-ui.module.effects-manager.spec.ts).
 		provideEffects(VideoEffects, CamshotEffects, SoundshotEffects),
 		VideoQuery,
 		VideoStore,

--- a/packages/scheduler/jest.config.ts
+++ b/packages/scheduler/jest.config.ts
@@ -1,0 +1,10 @@
+module.exports = {
+	displayName: 'scheduler',
+	preset: '../../jest.preset.js',
+	testEnvironment: 'node',
+	transform: {
+		'^.+\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }]
+	},
+	moduleFileExtensions: ['ts', 'js', 'html'],
+	coverageDirectory: '../../coverage/packages/scheduler'
+};

--- a/packages/scheduler/jest.config.ts
+++ b/packages/scheduler/jest.config.ts
@@ -3,7 +3,7 @@ module.exports = {
 	preset: '../../jest.preset.js',
 	testEnvironment: 'node',
 	transform: {
-		'^.+\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }]
+		'^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }]
 	},
 	moduleFileExtensions: ['ts', 'js', 'html'],
 	coverageDirectory: '../../coverage/packages/scheduler'

--- a/packages/scheduler/project.json
+++ b/packages/scheduler/project.json
@@ -23,6 +23,13 @@
 				"assets": ["packages/scheduler/*.md"]
 			}
 		},
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "packages/scheduler/jest.config.ts"
+			}
+		},
 		"nx-release-publish": {
 			"options": {
 				"packageRoot": "dist/{projectRoot}"

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -9,5 +9,6 @@ export * from './lib/interfaces/scheduler-job-descriptor.interface';
 export * from './lib/interfaces/scheduler-module-options.interface';
 export * from './lib/interfaces/scheduler-queue-job.interface';
 export * from './lib/hosts/queue-worker.host';
+export * from './lib/utils/is-queue-root-enabled';
 export * from './lib/services/scheduler-queue.service';
 export * from './lib/services/scheduler.service';

--- a/packages/scheduler/src/lib/interfaces/discovered-scheduled-job.interface.ts
+++ b/packages/scheduler/src/lib/interfaces/discovered-scheduled-job.interface.ts
@@ -15,6 +15,16 @@ export interface ResolvedScheduledJobOptions {
 	queueName?: string;
 	queueJobName?: string;
 	queueJobOptions?: JobsOptions;
+	/**
+	 * Set when the job is well-formed but cannot be scheduled in THIS process — today only when it
+	 * fans out to a queue and this process has no queueing. The job is still registered (so it
+	 * remains introspectable and manually runnable); `registerSchedules()` skips it and warns.
+	 *
+	 * This exists so one plugin's optional scheduled fan-out cannot stop a whole process from
+	 * booting. It used to `throw` here, which meant `apps/worker` could not start at all whenever
+	 * `REDIS_ENABLED` was not `true`.
+	 */
+	unschedulableReason?: string;
 }
 
 export interface DiscoveredScheduledJob {

--- a/packages/scheduler/src/lib/scheduler.module.producer-only.spec.ts
+++ b/packages/scheduler/src/lib/scheduler.module.producer-only.spec.ts
@@ -1,0 +1,187 @@
+import 'reflect-metadata';
+import { getQueueToken } from '@nestjs/bullmq';
+import { DynamicModule } from '@nestjs/common';
+import { SchedulerModule } from './scheduler.module';
+import { SCHEDULER_MODULE_OPTIONS } from './constants/scheduler.constants';
+import { ResolvedSchedulerModuleOptions } from './interfaces/scheduler-module-options.interface';
+import { isSchedulerQueueRootEnabled } from './utils/is-queue-root-enabled';
+
+/**
+ * `SchedulerModule.forRoot()` has TWO independent halves, and the API depends on being able to
+ * take exactly one of them:
+ *
+ * - `enableQueueing` gates `BullModule.forRoot()` — the connection that makes this process able
+ *   to ENQUEUE (and the reason `SchedulerQueueService` resolves at all).
+ * - `enabled` gates the job-runner half: `SchedulerDiscoveryService.registerSchedules()` skips
+ *   every discovered job when it is false, and `SchedulerJobRunnerService.execute()` returns
+ *   before doing anything — which also neutralizes `onApplicationBootstrap`'s `runOnStart` path.
+ *
+ * `{ enabled: false, enableQueueing: true }` is therefore "producer-only", and these tests pin
+ * that, because getting it wrong is silent: with `enabled` left at its default the API would run
+ * every scheduled job a second time alongside `apps/worker`.
+ */
+const optionsOf = (module: DynamicModule): ResolvedSchedulerModuleOptions => {
+	const provider = (module.providers ?? []).find(
+		(candidate) => (candidate as { provide?: unknown }).provide === SCHEDULER_MODULE_OPTIONS
+	) as { useValue: ResolvedSchedulerModuleOptions };
+	return provider.useValue;
+};
+
+/**
+ * A `BullModule.forRoot()` import is the only thing that provides the shared `BULLMQ_CONFIG(...)`
+ * token — the connection every `Queue`/`Worker` in the process is built from. Its presence IS
+ * "this process has a Bull root".
+ */
+const hasBullRoot = (module: DynamicModule): boolean =>
+	(module.imports ?? []).some((imported) =>
+		((imported as DynamicModule)?.providers ?? []).some((provider) =>
+			String((provider as { provide?: unknown }).provide ?? '').startsWith('BULLMQ_CONFIG')
+		)
+	);
+
+describe('SchedulerModule.forRoot — producer-only shape', () => {
+	const ORIGINAL = { ...process.env };
+
+	// 🛑 Nx feeds `.env` / `.env.local` into every task, so the developer's own
+	// `WORKER_QUEUE_ENABLED=false` reaches jest and silently flips this gate. Start from a clean
+	// slate and let each test state the environment it is actually asserting about.
+	beforeEach(() => {
+		delete process.env['REDIS_ENABLED'];
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+		delete process.env['WORKER_QUEUE_ENABLED'];
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL };
+	});
+
+	it('registers a BullMQ root when queueing is enabled', () => {
+		const module = SchedulerModule.forRoot({ enabled: false, enableQueueing: true });
+
+		expect(optionsOf(module).enableQueueing).toBe(true);
+		expect(hasBullRoot(module)).toBe(true);
+	});
+
+	it('keeps the job-runner half OFF so scheduled jobs do not run twice', () => {
+		const module = SchedulerModule.forRoot({ enabled: false, enableQueueing: true });
+
+		// `SchedulerDiscoveryService.registerSchedules()` and `SchedulerJobRunnerService.execute()`
+		// both bail on this flag — no cron is created, no interval is created, no `runOnStart`.
+		expect(optionsOf(module).enabled).toBe(false);
+	});
+
+	it('still exports the queue service, which is what makes the process a producer', () => {
+		const module = SchedulerModule.forRoot({ enabled: false, enableQueueing: true });
+
+		expect(module.exports).toEqual(expect.arrayContaining([expect.anything()]));
+		expect((module.providers ?? []).length).toBeGreaterThan(0);
+	});
+
+	it('registers NO Bull root when queueing is disabled, so a root-less process stays root-less', () => {
+		const module = SchedulerModule.forRoot({ enabled: false, enableQueueing: false });
+
+		expect(optionsOf(module).enableQueueing).toBe(false);
+		expect(hasBullRoot(module)).toBe(false);
+	});
+
+	it('drops queue registrations when queueing is off — no Queue token can leak in', () => {
+		const module = SchedulerModule.forRoot({ enableQueueing: false, queues: ['docs-processing'] });
+
+		expect(optionsOf(module).queues).toEqual([]);
+		const tokens = (module.imports ?? []).flatMap((imported) =>
+			((imported as DynamicModule)?.providers ?? []).map((provider) =>
+				String((provider as { provide?: unknown }).provide ?? '')
+			)
+		);
+		expect(tokens).not.toContain(String(getQueueToken('docs-processing')));
+	});
+
+	/**
+	 * 🛑 The reason every caller passes `enableQueueing` EXPLICITLY instead of leaning on the
+	 * default: `normalizeSchedulerModuleOptions`'s `DEFAULT_MODULE_OPTIONS` is a module-level
+	 * const, so `REDIS_ENABLED` is snapshotted the first time `@gauzy/scheduler` is required.
+	 * Anything that mutates the environment after that (a test, a late `dotenv` load) is invisible
+	 * to the default. `isSchedulerQueueRootEnabled()` is a FUNCTION precisely so the apps and the
+	 * plugin gates read the environment at the moment they build their metadata.
+	 */
+	it('does not re-read REDIS_ENABLED at call time — hence the explicit option everywhere', () => {
+		process.env['REDIS_ENABLED'] = 'true';
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+
+		// The helper is live...
+		expect(isSchedulerQueueRootEnabled()).toBe(true);
+		// ...the built-in default is not; it froze at import time (false in the test process).
+		expect(optionsOf(SchedulerModule.forRoot({})).enableQueueing).toBe(false);
+		// Which is why passing it explicitly is the contract the apps use.
+		expect(
+			optionsOf(SchedulerModule.forRoot({ enableQueueing: isSchedulerQueueRootEnabled() })).enableQueueing
+		).toBe(true);
+	});
+
+	it('is declared global so plugin modules can resolve the queue service without importing it', () => {
+		expect(SchedulerModule.forRoot({ enableQueueing: true }).global).toBe(true);
+	});
+});
+
+describe('isSchedulerQueueRootEnabled', () => {
+	const ORIGINAL = { ...process.env };
+
+	// 🛑 Nx feeds `.env` / `.env.local` into every task, so the developer's own
+	// `WORKER_QUEUE_ENABLED=false` reaches jest and silently flips this gate. Start from a clean
+	// slate and let each test state the environment it is actually asserting about.
+	beforeEach(() => {
+		delete process.env['REDIS_ENABLED'];
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+		delete process.env['WORKER_QUEUE_ENABLED'];
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL };
+	});
+
+	it('is off when Redis is not explicitly enabled', () => {
+		delete process.env['REDIS_ENABLED'];
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+
+		expect(isSchedulerQueueRootEnabled()).toBe(false);
+	});
+
+	it('is on when Redis is enabled', () => {
+		process.env['REDIS_ENABLED'] = 'true';
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+
+		expect(isSchedulerQueueRootEnabled()).toBe(true);
+	});
+
+	it('honours the explicit kill-switch over Redis being enabled', () => {
+		process.env['REDIS_ENABLED'] = 'true';
+		process.env['SCHEDULER_QUEUE_ENABLED'] = 'false';
+
+		expect(isSchedulerQueueRootEnabled()).toBe(false);
+	});
+
+	/**
+	 * REGRESSION. `apps/worker` narrows its own root with the older `WORKER_QUEUE_ENABLED`. When
+	 * only the worker read that flag, a worker booted with `WORKER_QUEUE_ENABLED=false` and Redis
+	 * on had NO root, while the Documents gate — which cannot tell which process it is in — still
+	 * answered "queued". The worker then died at `onModuleInit` with
+	 * `Job "docs-reconcile-schedule" targets queue "docs-processing" but queueing is disabled.`
+	 *
+	 * Reading it here can only ever remove a root, i.e. degrade to the in-process fallback.
+	 */
+	it('honours the worker-local WORKER_QUEUE_ENABLED so plugin gates cannot disagree with it', () => {
+		process.env['REDIS_ENABLED'] = 'true';
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+		process.env['WORKER_QUEUE_ENABLED'] = 'false';
+
+		expect(isSchedulerQueueRootEnabled()).toBe(false);
+	});
+
+	it('is unaffected by WORKER_QUEUE_ENABLED when it is not an explicit false', () => {
+		process.env['REDIS_ENABLED'] = 'true';
+		delete process.env['SCHEDULER_QUEUE_ENABLED'];
+		process.env['WORKER_QUEUE_ENABLED'] = 'true';
+
+		expect(isSchedulerQueueRootEnabled()).toBe(true);
+	});
+});

--- a/packages/scheduler/src/lib/services/scheduler-discovery.service.ts
+++ b/packages/scheduler/src/lib/services/scheduler-discovery.service.ts
@@ -111,6 +111,20 @@ export class SchedulerDiscoveryService implements OnModuleInit, OnApplicationBoo
 				continue;
 			}
 
+			/**
+			 * Well-formed but not schedulable here — today only "fans out to a queue, but this
+			 * process has no queueing". Warn rather than schedule it: the handler would run and
+			 * then die at enqueue on every tick. WARN, not debug, because the job silently not
+			 * running is a real behaviour change for whoever configured it.
+			 */
+			if (job.options.unschedulableReason) {
+				this.logger.warn(
+					`Scheduled job "${job.id}" NOT scheduled — it ${job.options.unschedulableReason}. ` +
+						`Enable queueing in this process (REDIS_ENABLED=true) to run it here, or run it in a process that has it.`
+				);
+				continue;
+			}
+
 			if (job.options.cron) {
 				this.registerCronJob(job);
 				continue;

--- a/packages/scheduler/src/lib/services/scheduler-job-registry.queue-gate.spec.ts
+++ b/packages/scheduler/src/lib/services/scheduler-job-registry.queue-gate.spec.ts
@@ -1,0 +1,110 @@
+import 'reflect-metadata';
+import { SchedulerJobRegistryService } from './scheduler-job-registry.service';
+import { ResolvedSchedulerModuleOptions } from '../interfaces/scheduler-module-options.interface';
+import { ScheduledJobOptions } from '../interfaces/scheduled-job-options.interface';
+
+/**
+ * A `@ScheduledJob({ queueName })` that lands in a process WITHOUT queueing used to throw from
+ * `resolveJobOptions`, and that throw ran inside `SchedulerDiscoveryService.onModuleInit` — so it
+ * aborted the whole Nest bootstrap.
+ *
+ * 🛑 The consequence was not theoretical: `apps/worker` could not boot AT ALL whenever
+ * `REDIS_ENABLED` was not `true` (or `WORKER_QUEUE_ENABLED=false`), because
+ * `@gauzy/plugin-docs`'s `DocsRecoveryService` is registered unconditionally — correctly, since it
+ * also owns a startup recovery scan that needs no queue — and carries
+ * `@ScheduledJob({ name: 'docs-reconcile-schedule', queueName: 'docs-processing' })`. One plugin's
+ * optional scheduled fan-out could stop an entire process from starting. It threw even when the
+ * job runner itself was disabled and the job provably could never fire.
+ *
+ * The job is now REGISTERED and marked unschedulable; `registerSchedules()` skips it with a
+ * warning. The property that actually mattered is preserved: the job never fires and then dies at
+ * enqueue, because it never fires.
+ */
+describe('SchedulerJobRegistryService — queue-targeting jobs where queueing is unavailable', () => {
+	const moduleOptions = (overrides: Partial<ResolvedSchedulerModuleOptions> = {}): ResolvedSchedulerModuleOptions =>
+		({
+			enabled: true,
+			enableQueueing: false,
+			defaultQueueName: 'default-queue',
+			logRegisteredJobs: false,
+			defaultJobOptions: {
+				enabled: true,
+				preventOverlap: true,
+				retries: 0,
+				retryDelayMs: 0,
+				maxRandomDelayMs: 0
+			},
+			...overrides
+		} as ResolvedSchedulerModuleOptions);
+
+	const register = (metadata: ScheduledJobOptions, options?: Partial<ResolvedSchedulerModuleOptions>) => {
+		const registry = new SchedulerJobRegistryService(moduleOptions(options));
+		return registry.register({
+			providerName: 'DocsRecoveryService',
+			methodName: 'reconcile',
+			metadata,
+			handler: async () => undefined
+		});
+	};
+
+	/** The exact shape that broke `apps/worker`. */
+	const RECONCILE: ScheduledJobOptions = {
+		name: 'docs-reconcile-schedule',
+		cron: '*/10 * * * *',
+		queueName: 'docs-processing'
+	};
+
+	describe('the regression', () => {
+		it('registers instead of throwing when the job runner is ON but queueing is off', () => {
+			expect(() => register(RECONCILE)).not.toThrow();
+
+			const job = register(RECONCILE);
+			expect(job.id).toBe('docs-reconcile-schedule');
+			expect(job.options.unschedulableReason).toContain('docs-processing');
+			expect(job.options.unschedulableReason).toContain('queueing is disabled');
+		});
+
+		it('registers instead of throwing when the job runner is OFF as well', () => {
+			// This is the case that is provably harmless: nothing schedules anything at all.
+			expect(() => register(RECONCILE, { enabled: false })).not.toThrow();
+			expect(register(RECONCILE, { enabled: false }).options.unschedulableReason).toBeDefined();
+		});
+
+		it('keeps the job introspectable rather than dropping it on the floor', () => {
+			const job = register(RECONCILE);
+
+			expect(job.options.enabled).toBe(true);
+			expect(job.options.cron).toBe('*/10 * * * *');
+			expect(job.options.queueName).toBe('docs-processing');
+		});
+	});
+
+	describe('cases that must NOT be marked unschedulable', () => {
+		it('a queue-targeting job in a process that HAS queueing', () => {
+			expect(register(RECONCILE, { enableQueueing: true }).options.unschedulableReason).toBeUndefined();
+		});
+
+		it('a job that targets no queue at all', () => {
+			const job = register({ name: 'plain', cron: '* * * * *' });
+
+			expect(job.options.queueName).toBeUndefined();
+			expect(job.options.unschedulableReason).toBeUndefined();
+		});
+
+		it('a job the author disabled — it is already off, the queue is irrelevant', () => {
+			expect(register({ ...RECONCILE, enabled: false }).options.unschedulableReason).toBeUndefined();
+		});
+	});
+
+	describe('unrelated validation still fails fast', () => {
+		it('rejects a job defining both cron and intervalMs', () => {
+			expect(() => register({ name: 'both', cron: '* * * * *', intervalMs: 1000 })).toThrow(
+				/cannot define both/
+			);
+		});
+
+		it('rejects an invalid intervalMs', () => {
+			expect(() => register({ name: 'bad-interval', intervalMs: 0 })).toThrow(/invalid "intervalMs"/);
+		});
+	});
+});

--- a/packages/scheduler/src/lib/services/scheduler-job-registry.service.ts
+++ b/packages/scheduler/src/lib/services/scheduler-job-registry.service.ts
@@ -72,9 +72,25 @@ export class SchedulerJobRegistryService {
 			throw new Error(`Job "${jobId}" has invalid "intervalMs" value "${intervalMs}".`);
 		}
 
-		if (enabled && queueName && !this.moduleOptions.enableQueueing) {
-			throw new Error(`Job "${jobId}" targets queue "${queueName}" but queueing is disabled.`);
-		}
+		/**
+		 * A job that fans out to a queue in a process that has no queueing is a real problem, but
+		 * it is NOT a reason to abort the whole bootstrap — which is what throwing here did.
+		 *
+		 * `@ScheduledJob({ queueName })` is discovered in EVERY process that has a scheduler root,
+		 * including ones that legitimately have no Redis. `DocsRecoveryService` is the case that
+		 * exposed it: it is registered unconditionally (correctly — it also owns a startup recovery
+		 * scan that needs no queue), so `apps/worker` could not boot at all whenever `REDIS_ENABLED`
+		 * was not `true`. It threw even when `moduleOptions.enabled` was false and the job provably
+		 * could never fire.
+		 *
+		 * Marking it unschedulable instead keeps the guarantee that mattered — the job never fires
+		 * and then dies at enqueue — while letting the process start. `registerSchedules()` skips it
+		 * with a warning naming the job and queue, so it is loud, not silent.
+		 */
+		const unschedulableReason =
+			enabled && queueName && !this.moduleOptions.enableQueueing
+				? `targets queue "${queueName}" but queueing is disabled in this process`
+				: undefined;
 
 		const retries = this.toNonNegativeInteger(metadata.retries ?? this.moduleOptions.defaultJobOptions.retries, 'retries', jobId);
 		const retryDelayMs = this.toNonNegativeInteger(
@@ -105,7 +121,8 @@ export class SchedulerJobRegistryService {
 			maxRandomDelayMs,
 			queueName,
 			queueJobName: queueJobName && queueJobName.length > 0 ? queueJobName : undefined,
-			queueJobOptions: metadata.queueJobOptions
+			queueJobOptions: metadata.queueJobOptions,
+			unschedulableReason
 		};
 	}
 

--- a/packages/scheduler/src/lib/utils/is-queue-root-enabled.ts
+++ b/packages/scheduler/src/lib/utils/is-queue-root-enabled.ts
@@ -1,0 +1,56 @@
+/**
+ * Environment override for the BullMQ **root** registration (`SchedulerModule.forRoot()` with
+ * `enableQueueing: true`). Set it to `'false'` to force every process back to root-less operation
+ * even where Redis is configured — the reversible kill-switch for this whole mechanism.
+ */
+export const ENV_SCHEDULER_QUEUE_ENABLED = 'SCHEDULER_QUEUE_ENABLED';
+
+/**
+ * The pre-existing, worker-local narrowing of the same decision (`apps/worker`'s
+ * `WORKER_QUEUE_ENABLED`). It is read HERE, not only there, because a plugin gate cannot tell
+ * which process it is running in — see the note in {@link isSchedulerQueueRootEnabled}.
+ */
+export const ENV_WORKER_QUEUE_ENABLED = 'WORKER_QUEUE_ENABLED';
+
+/**
+ * The single predicate deciding whether a process registers a BullMQ **root**
+ * (`BullModule.forRoot()`, via `SchedulerModule.forRoot({ enableQueueing: true })`).
+ *
+ * 🛑 Why this exists as a shared helper rather than an inline `process.env` check in each app:
+ * "Redis is enabled" and "a Bull root exists in THIS process" are DIFFERENT questions, and
+ * conflating them crash-loops the API. `@nestjs/bullmq`'s registrar builds a `Worker` for every
+ * `@Processor` at `onModuleInit`; with no root in the process that constructor throws
+ * `Worker requires a connection` and the whole Nest bootstrap fails.
+ *
+ * The distinction is only safe to *derive* while every process that loads the plugin list agrees
+ * on the answer. That is what this helper buys: it is the one expression imported by every module
+ * that registers a root — `@gauzy/core`'s `AppModule` (the API), its `SeederModule.forPlugins()`
+ * (the `yarn seed` CLI), and `apps/worker` — AND by the consumers that must know whether a root
+ * will be there (e.g. the Documents plugin's queue gate). One expression, one answer, no drift.
+ *
+ * A process that does NOT register a root keeps working: `SchedulerQueueService` is simply absent
+ * and callers fall back to their in-process path.
+ *
+ * @returns True when this deployment wants a BullMQ root in every plugin-hosting process.
+ */
+export function isSchedulerQueueRootEnabled(): boolean {
+	// An explicit opt-out always wins, so an operator can disable queueing without touching Redis.
+	if (process.env[ENV_SCHEDULER_QUEUE_ENABLED] === 'false') {
+		return false;
+	}
+	// 🛑 `WORKER_QUEUE_ENABLED` is honoured here too, not just inside `apps/worker`. It predates
+	// this helper and narrows the worker's own root; if only the worker read it, a worker started
+	// with `WORKER_QUEUE_ENABLED=false` would have NO root while a plugin gate — which cannot tell
+	// which process it is in — still answered "a root exists", and the plugin would register a
+	// `@Processor`/queue-targeted job against a connection that was never created. That is not
+	// hypothetical: it crash-looped a real worker boot during verification with
+	// `Job "docs-reconcile-schedule" targets queue "docs-processing" but queueing is disabled.`
+	// Reading it globally can only ever REMOVE a root, which degrades to the in-process fallback —
+	// never to a crash.
+	if (process.env[ENV_WORKER_QUEUE_ENABLED] === 'false') {
+		return false;
+	}
+	// Same convention as `apps/worker/src/app/worker.constants.ts`: a root needs a real connection,
+	// so nothing is registered unless Redis is explicitly switched on for the deployment.
+	return process.env['REDIS_ENABLED'] === 'true';
+}

--- a/packages/scheduler/tsconfig.json
+++ b/packages/scheduler/tsconfig.json
@@ -15,6 +15,9 @@
 	"references": [
 		{
 			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
 		}
 	]
 }

--- a/packages/scheduler/tsconfig.lib.json
+++ b/packages/scheduler/tsconfig.lib.json
@@ -13,5 +13,6 @@
 		"forceConsistentCasingInFileNames": true,
 		"noFallthroughCasesInSwitch": true
 	},
-	"include": ["src/**/*.ts"]
+	"include": ["src/**/*.ts"],
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/scheduler/tsconfig.spec.json
+++ b/packages/scheduler/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["jest", "node"],
+		"experimentalDecorators": true,
+		"emitDecoratorMetadata": true
+	},
+	"include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
BullMQ and Redis were **already live** — `apps/worker` registers a scheduler root, loads plugins via `PluginModule.init()`, and is running jobs right now. But `GAUZY_DOCS_QUEUE_ENABLED` defaulted false everywhere, so the docs queue was never registered in either process: **the worker idled and the API did every extract / classify / embed / OCR / thumbnail stage inline** — exactly the outcome the worker module's own comment warns about.

The API couldn't simply turn it on: it had **no** `SchedulerModule.forRoot()` in its graph, and a `@Processor` without a connection throws `Worker requires a connection` at `onModuleInit` — which is what crash-looped demo and stage earlier today.

### What this adds

- **`isSchedulerQueueRootEnabled()`** in `@gauzy/scheduler` — one predicate every plugin-hosting process evaluates, so "does a Bull root exist in *this* process" is derived, not two env vars an operator must keep in sync.
- **A producer-only root in the API** (`enabled: false, enableQueueing: true`). `enableQueueing` is what registers `BullModule.forRoot`; `enabled: false` stops `registerSchedules()` and short-circuits the job runner, so the API can enqueue but can **never** fire the cron jobs the worker already owns.
- **The same root in `SeederModule`** — `forPlugins()` loads the same plugin list, so `yarn seed` would otherwise be the one plugin-hosting process where the derived gate lied.
- **`isDocsQueueWorkerEnabled()`** gates the consumer as a strict subset of the queue, so a `@Processor` can never outlive its queue.

The consumer **defaults ON** deliberately: a deployment with no worker must still process its own documents. Producing without consuming would leave them in `UPLOADED` forever — strictly worse than inline. Set `GAUZY_DOCS_QUEUE_WORKER_ENABLED=false` on the API to make it a pure producer once a worker runs.

### Verified by booting, not building

A green build proves nothing for this defect class, so every state was booted:

| State | Result |
|---|---|
| No Redis | no root, dispatch **INLINE**, boots clean |
| Redis up | queue + consumer REGISTERED, dispatch **QUEUED** |
| Producer-only override | queue REGISTERED, consumer absent (by design) |
| `apps/worker` + Redis | queue + consumer REGISTERED; `bull:docs-processing:meta` present in Redis |
| 🛑 **Redis enabled but UNREACHABLE** | **bootstrap completes in 24ms**, producer token present |

That last row is the one nobody had covered and the one that matters — it's every deployment where Redis is configured but momentarily down. The root doesn't block boot, and `enqueue()` already degrades to the inline runner when the enqueue itself fails, so an outage can't strand a document either.

### A real defect the boots caught

This workstation's `.env.local` sets `WORKER_QUEUE_ENABLED=false`, so the worker had no root while a Redis-only gate still said "queued" — it died on `Job "docs-reconcile-schedule" targets queue "docs-processing" but queueing is disabled`. Instead of documenting that two variables must agree, `WORKER_QUEUE_ENABLED` now feeds the shared predicate, where it can only ever **remove** a root and degrade to inline.

### Tests

plugin-docs **570** (43 suites), scheduler **12** (new project), worker **6**.

🛑 `nx test worker` reported EXIT=0 while its suite was failing to **load**. The worker numbers above come from running jest directly; the spec's `@gauzy/scheduler` mock was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a producer-only BullMQ root to the API and seeder so the Documents pipeline enqueues to the worker by default, with a safe inline fallback. Also fixes the Documents and Videos UI hangs by removing a root-only effects manager from lazy modules.

- **New Features**
  - Added `isSchedulerQueueRootEnabled()` in `@gauzy/scheduler` and use it across the API, `yarn seed`, worker, and the docs plugin.
  - API and seeder register a producer-only root when enabled: `SchedulerModule.forRoot({ enabled: false, enableQueueing: true, logRegisteredJobs: false })`.
  - Docs plugin gates:
    - `isDocsQueueEnabled()` now derives from the shared root predicate.
    - New `isDocsQueueWorkerEnabled()` (defaults true with the queue) gates the consumer; never registers without the queue.
  - Worker ensures both halves are on (queueing + job runner) and declares the root before `PluginModule`.
  - Scheduler no longer aborts bootstrap for queue-targeted jobs when queueing is off; marks them unschedulable and warns.
  - Env/docs updates: `.env.sample` documents `SCHEDULER_QUEUE_ENABLED` (fleet kill switch) and `GAUZY_DOCS_QUEUE_WORKER_ENABLED`; README updated; exported the helper and added scheduler/spec coverage.
  - Fix: removed `provideEffectsManager()` from `@gauzy/plugin-docs-ui` and `@gauzy/plugin-videos-ui` lazy modules to stop main-thread hangs; added regression tests.

- **Migration**
  - If a dedicated `apps/worker` is deployed, set `GAUZY_DOCS_QUEUE_WORKER_ENABLED=false` on the API to make it a pure producer.
  - Use `SCHEDULER_QUEUE_ENABLED=false` to disable the BullMQ root fleet‑wide and fall back to inline.
  - No changes needed for single‑process or dev setups; they keep inline or drain locally by default.

<sup>Written for commit 5dccd93b21fd27e704a4baa09a37351c911a1070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

