### PR TITLE
docs(theme): point the chat-column comment at the real header-inset mechanism

### DIFF
--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -119,8 +119,9 @@
 
     // Pinned to the viewport's top so the chat is a FULL-HEIGHT column with nothing above it: the
     // panel owns its own top edge (title row + icons), exactly like the nav menu owns the logo.
-    // The header is inset around it instead (see chatHeaderPad in the layout component), so header
-    // dropdowns open over the canvas, never over the chat.
+    // The header is inset around it instead (observeCanvasLeft in the layout component publishes
+    // --gz-canvas-left/right, which the fixed-header rules above consume), so header dropdowns open
+    // over the canvas, never over the chat.
     //
     // Width comes straight from `--gz-chat-width` (the user's chosen/persisted width) rather than
     // from a ResizeObserver mirroring the host: one source of truth, and nothing to go stale.


### PR DESCRIPTION
A full session audit (30 checks across 6 deliverable clusters against the stage tree) found exactly one gap — this stale comment, which still directed readers to `chatHeaderPad`, a symbol removed when header padding was replaced by insetting the fixed header band to the canvas. It now names the actual mechanism (`observeCanvasLeft` publishing `--gz-canvas-left/right`).

Comment-only change; no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update stale comment in the one-column chat layout SCSS to reference the actual header inset mechanism. Replaces `chatHeaderPad` with `observeCanvasLeft` (publishes `--gz-canvas-left/right`); no behavior change.

<sup>Written for commit 0fdf23f20c4aa18a27c324e7b2edd2098b5d70d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

