### PR TITLE
chore: cascade develop → stage (session-audit comment fix)

### DIFF
--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -119,8 +119,9 @@
 
     // Pinned to the viewport's top so the chat is a FULL-HEIGHT column with nothing above it: the
     // panel owns its own top edge (title row + icons), exactly like the nav menu owns the logo.
-    // The header is inset around it instead (see chatHeaderPad in the layout component), so header
-    // dropdowns open over the canvas, never over the chat.
+    // The header is inset around it instead (observeCanvasLeft in the layout component publishes
+    // --gz-canvas-left/right, which the fixed-header rules above consume), so header dropdowns open
+    // over the canvas, never over the chat.
     //
     // Width comes straight from `--gz-chat-width` (the user's chosen/persisted width) rather than
     // from a ResizeObserver mirroring the host: one source of truth, and nothing to go stale.


### PR DESCRIPTION
Promotes develop to stage: PR #9957 — the single finding from the full session audit (30 checks across 6 deliverable clusters): a comment-only fix pointing the chat-column note at the real header-inset mechanism instead of the removed `chatHeaderPad`.

**Merge with a MERGE COMMIT** (release-gate requirement).

CodeQL/Sonar/Codacy fail on every develop→stage cascade by construction; expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `develop` to `stage` and fixes a stale SCSS comment in the one-column layout. The comment now references `observeCanvasLeft` publishing `--gz-canvas-left/right` (real header inset) instead of removed `chatHeaderPad`; no runtime changes.

<sup>Written for commit e9b833568645ec479e4f130b6222477157a96b0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

