### PR TITLE
feat(ai-chat): id-first file attach into Documents + attachment chips in the transcript

### DIFF
--- a/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
@@ -34,7 +34,7 @@ import { chatTheme } from '../chat-theme';
  * which must not be pulled into the browser bundle.
  */
 interface IDocsUploadResponseSlice {
-	results?: { document?: { id?: string; name?: string } }[];
+	results?: { document?: { id?: string; name?: string; kind?: string } }[];
 	rejected?: { fileName?: string; message?: string }[];
 	message?: string;
 }
@@ -370,14 +370,26 @@ export function AiChatPanel() {
 					if (document?.id) {
 						setAttachments((current) => [
 							...current,
-							{ documentId: document.id, name: document.name || file.name }
+							{
+								documentId: document.id,
+								name: document.name || file.name,
+								...(document.kind === 'PAGE' ? { kind: 'PAGE' as const } : {})
+							}
 						]);
 						return;
 					}
-					// A 2xx with no accepted document means the file itself was rejected (type/size)
-					// — surface the server's reason instead of staging a chip for a file that does
-					// not exist anywhere.
-					throw new Error(body?.rejected?.[0]?.message || `'${file.name}' was rejected.`);
+					// Three distinct 2xx outcomes, told apart so the user is never told "rejected"
+					// about a file the server may in fact have created:
+					// a genuine per-file rejection carries the server's reason; a body that did not
+					// parse, or one with no readable document id, is a response-shape problem — the
+					// document may exist, so point at the Documents page rather than blaming the file.
+					const rejection = body?.rejected?.[0];
+					if (rejection) {
+						throw new Error(rejection.message || `'${file.name}' was rejected.`);
+					}
+					throw new Error(
+						`The upload response for '${file.name}' could not be read — check the Documents page before retrying.`
+					);
 				}
 
 				// Not-found / forbidden = the Documents feature is not available to this user or
@@ -419,8 +431,17 @@ export function AiChatPanel() {
 	);
 
 	/** Attach an existing document by id — what makes `docs_read` able to open exactly that one. */
-	const handlePickDocument = useCallback((document: { id: string; name: string }) => {
-		setAttachments((current) => [...current, { documentId: document.id, name: document.name }]);
+	const handlePickDocument = useCallback((document: { id: string; name: string; kind?: string }) => {
+		setAttachments((current) => [
+			...current,
+			{
+				documentId: document.id,
+				name: document.name,
+				// Carried so the chip (and the one rebuilt from history) links a PAGE to its page
+				// editor route rather than the file browser.
+				...(document.kind === 'PAGE' ? { kind: 'PAGE' as const } : {})
+			}
+		]);
 		setShowAttachPicker(false);
 	}, []);
 

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
@@ -25,40 +25,18 @@ import { ChatInput } from './ChatInput';
 import { ChatWelcome } from './ChatWelcome';
 import { ChatHistoryPanel, type IChatHistoryItem } from './ChatHistoryPanel';
 import { DocsAttachPicker } from './DocsAttachPicker';
+import { buildAttachmentPreamble, type IStagedAttachment } from './attachment-preamble';
 import { chatTheme } from '../chat-theme';
 
-/** One attachment staged for the next message. */
-interface IStagedAttachment {
-	/** Set when the user picked an EXISTING document — the handle `docs_read` takes. */
-	documentId?: string;
-	/** Display name, and the only handle an uploaded file has until capture finishes. */
-	name: string;
-}
-
 /**
- * The preamble that tells the assistant what the user attached.
- *
- * Attachments travel as ordinary message text on purpose. The tool surface the assistant has is
- * `docs_read(documentId)` / `docs_search(query)`, so naming the ids is precisely what makes an
- * attachment actionable; a side channel the model never sees would be decoration.
- *
- * An uploaded file has no id yet — capture into Documents happens asynchronously on the server —
- * so it is named instead, with an explicit instruction to search for it rather than to claim it
- * cannot be found.
- *
- * @param attachments The staged attachments.
- * @returns The preamble, or an empty string when nothing is attached.
+ * What the docs upload endpoint answers with (the slice this panel reads).
+ * Mirrored rather than imported: `IDocumentUploadResponse` lives in the backend docs plugin,
+ * which must not be pulled into the browser bundle.
  */
-function buildAttachmentPreamble(attachments: IStagedAttachment[]): string {
-	if (!attachments.length) {
-		return '';
-	}
-	const lines = attachments.map((attachment) =>
-		attachment.documentId
-			? `- "${attachment.name}" (document id: ${attachment.documentId}) — read it with docs_read.`
-			: `- "${attachment.name}" — just uploaded to Documents; find it with docs_search (processing may still be in flight).`
-	);
-	return ['Attached documents for this message:', ...lines].join('\n');
+interface IDocsUploadResponseSlice {
+	results?: { document?: { id?: string; name?: string } }[];
+	rejected?: { fileName?: string; message?: string }[];
+	message?: string;
 }
 
 /**
@@ -355,20 +333,63 @@ export function AiChatPanel() {
 	);
 
 	/**
-	 * Upload a file the user picked and attach it to this conversation.
+	 * Upload a file the user picked and attach it to this conversation — ID FIRST.
+	 *
+	 * The upload goes straight to the Documents feature (`source: CHAT`), which answers
+	 * synchronously with the created document — so the chip carries a `documentId` and the
+	 * assistant can `docs_read` the file in the very message it was attached to. The previous
+	 * design uploaded to chat-local storage and relied on the Documents plugin capturing an
+	 * event LATER: the chip was name-only, and the preamble sent the assistant to `docs_search`
+	 * — which can never find a chat capture (they are deliberately never auto-indexed), and a
+	 * file the sniffer rejected got a chip anyway while the capture silently dropped it.
+	 *
+	 * The chat-local endpoint remains as the FALLBACK for installs where Documents is absent,
+	 * disabled, or the user lacks `DOCS_CREATE` (403/404 from the docs route) — there the docs
+	 * tools do not exist either, so a name-only mention is the honest ceiling.
 	 *
 	 * `FormData` deliberately WITHOUT a Content-Type header — the browser has to set it, because
 	 * only it knows the multipart boundary (the same rule as dictation above).
-	 *
-	 * The server stores the bytes and publishes `AiChatAttachmentSavedEvent`; the Documents
-	 * plugin captures that into a `Document { source: CHAT }` and runs extraction. That is
-	 * ASYNCHRONOUS, so the attachment is carried by name — the assistant finds it with
-	 * `docs_search` once processing finishes, which the preamble tells it to do.
 	 */
 	const handleAttachFile = useCallback(
 		async (file: File): Promise<void> => {
 			setIsAttaching(true);
+			setAttachmentError(null);
 			try {
+				const docsForm = new FormData();
+				docsForm.append('files', file, file.name);
+				docsForm.append('source', 'CHAT');
+				const docsResponse = await fetch(`${environment.API_BASE_URL}/api/plugins/docs/documents/upload`, {
+					method: 'POST',
+					headers: authHeaders(),
+					body: docsForm
+				});
+
+				if (docsResponse.ok) {
+					const body = (await docsResponse.json().catch(() => null)) as IDocsUploadResponseSlice | null;
+					const document = body?.results?.[0]?.document;
+					if (document?.id) {
+						setAttachments((current) => [
+							...current,
+							{ documentId: document.id, name: document.name || file.name }
+						]);
+						return;
+					}
+					// A 2xx with no accepted document means the file itself was rejected (type/size)
+					// — surface the server's reason instead of staging a chip for a file that does
+					// not exist anywhere.
+					throw new Error(body?.rejected?.[0]?.message || `'${file.name}' was rejected.`);
+				}
+
+				// Not-found / forbidden = the Documents feature is not available to this user or
+				// install — fall back to chat-local storage. Anything else is a real failure.
+				if (docsResponse.status !== 403 && docsResponse.status !== 404) {
+					const detail = await docsResponse
+						.json()
+						.then((body: { message?: string }) => body?.message)
+						.catch(() => undefined);
+					throw new Error(detail || `Attachment failed (HTTP ${docsResponse.status})`);
+				}
+
 				const form = new FormData();
 				form.append('file', file, file.name);
 				if (conversationIdRef.current) {

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
@@ -385,10 +385,15 @@ export function AiChatPanel() {
 					// document may exist, so point at the Documents page rather than blaming the file.
 					const rejection = body?.rejected?.[0];
 					if (rejection) {
-						throw new Error(rejection.message || `'${file.name}' was rejected.`);
+						throw new Error(
+							rejection.message || `${t('AI_ASSISTANT.ATTACH_REJECTED', 'The file was rejected')}: ${file.name}`
+						);
 					}
 					throw new Error(
-						`The upload response for '${file.name}' could not be read — check the Documents page before retrying.`
+						`${t(
+							'AI_ASSISTANT.ATTACH_RESPONSE_UNREADABLE',
+							'The upload response could not be read — check the Documents page before retrying'
+						)}: ${file.name}`
 					);
 				}
 

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/ChatMessageItem.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/ChatMessageItem.tsx
@@ -21,11 +21,14 @@ import { chatTheme } from '../chat-theme';
  */
 function UserAttachmentChips({
 	attachments,
-	onOpen
+	onOpen,
+	translate
 }: {
 	attachments: IStagedAttachment[];
 	onOpen?: (citation: IDocsCitation) => void;
+	translate?: (key: string, fallback: string) => string;
 }) {
+	const t = translate ?? ((_key: string, fallback: string) => fallback);
 	const chipStyle: CSSProperties = {
 		display: 'inline-flex',
 		alignItems: 'center',
@@ -51,10 +54,16 @@ function UserAttachmentChips({
 						type="button"
 						style={{ ...chipStyle, cursor: 'pointer', font: 'inherit', fontSize: chatTheme.fontSizeSmall }}
 						title={attachment.name}
+						aria-label={t('AI_ASSISTANT.ATTACH_OPEN', 'Open attached document') + `: ${attachment.name}`}
 						onClick={() =>
 							onOpen({
 								documentId: attachment.documentId!,
-								url: `/pages/documents?id=${attachment.documentId}`,
+								// Same deep-link split the server's citation chips use: a PAGE opens
+								// at its editor route, everything else in the file browser.
+								url:
+									attachment.kind === 'PAGE'
+										? `/pages/documents/page/${attachment.documentId}`
+										: `/pages/documents?id=${attachment.documentId}`,
 								name: attachment.name
 							})
 						}
@@ -142,6 +151,7 @@ export function ChatMessageItem({
 									<UserAttachmentChips
 										attachments={attachmentView.attachments}
 										{...(onOpenCitation ? { onOpen: onOpenCitation } : {})}
+										{...(translate ? { translate } : {})}
 									/>
 									{attachmentView.text ? (
 										<span style={{ whiteSpace: 'pre-wrap' }}>{attachmentView.text}</span>

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/ChatMessageItem.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/ChatMessageItem.tsx
@@ -8,7 +8,68 @@ import {
 	type IDocsCitation,
 	type IDocsCitationsData
 } from './DocsCitationChips';
+import { parseAttachmentPreamble, type IStagedAttachment } from './attachment-preamble';
 import { chatTheme } from '../chat-theme';
+
+/**
+ * The attachment chips shown on a USER message in place of the raw preamble text.
+ *
+ * A chip with a `documentId` deep-links into the Documents hub through the same bridge the
+ * assistant's citation chips use — and through the same shape (`IDocsCitation` is `{documentId,
+ * url, …}`), so the panel's existing `onOpenCitation` handler serves both. A name-only chip
+ * (Documents unavailable on this install) has nowhere to link and renders inert.
+ */
+function UserAttachmentChips({
+	attachments,
+	onOpen
+}: {
+	attachments: IStagedAttachment[];
+	onOpen?: (citation: IDocsCitation) => void;
+}) {
+	const chipStyle: CSSProperties = {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: 4,
+		maxWidth: '100%',
+		padding: '2px 8px',
+		borderRadius: 999,
+		border: '1px solid rgba(255, 255, 255, 0.35)',
+		backgroundColor: 'rgba(255, 255, 255, 0.15)',
+		color: 'inherit',
+		fontSize: chatTheme.fontSizeSmall,
+		lineHeight: 1.4,
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap'
+	};
+	return (
+		<span style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+			{attachments.map((attachment, chipIndex) =>
+				attachment.documentId && onOpen ? (
+					<button
+						key={`${attachment.documentId}-${chipIndex}`}
+						type="button"
+						style={{ ...chipStyle, cursor: 'pointer', font: 'inherit', fontSize: chatTheme.fontSizeSmall }}
+						title={attachment.name}
+						onClick={() =>
+							onOpen({
+								documentId: attachment.documentId!,
+								url: `/pages/documents?id=${attachment.documentId}`,
+								name: attachment.name
+							})
+						}
+					>
+						📎 {attachment.name}
+					</button>
+				) : (
+					<span key={`${attachment.name}-${chipIndex}`} style={chipStyle} title={attachment.name}>
+						📎 {attachment.name}
+					</span>
+				)
+			)}
+		</span>
+	);
+}
 
 export interface ChatMessageItemProps {
 	message: UIMessage;
@@ -68,6 +129,27 @@ export function ChatMessageItem({
 			{message.parts.map((part, index) => {
 				if (part.type === 'text') {
 					if (!part.text) return null;
+					// A user message that carries attachments starts with the preamble the panel
+					// composed. The MODEL needs that text (it is what makes `docs_read` actionable
+					// and keeps the attachment context alive across turns); the READER does not —
+					// render chips + the user's own words instead. Display-only: the message text
+					// is never altered.
+					const attachmentView = isUser ? parseAttachmentPreamble(part.text) : null;
+					if (attachmentView) {
+						return (
+							<div style={rowStyle} key={`${message.id}-${index}`}>
+								<div style={{ ...bubbleStyle, display: 'flex', flexDirection: 'column', gap: 6 }}>
+									<UserAttachmentChips
+										attachments={attachmentView.attachments}
+										{...(onOpenCitation ? { onOpen: onOpenCitation } : {})}
+									/>
+									{attachmentView.text ? (
+										<span style={{ whiteSpace: 'pre-wrap' }}>{attachmentView.text}</span>
+									) : null}
+								</div>
+							</div>
+						);
+					}
 					return (
 						<div style={rowStyle} key={`${message.id}-${index}`}>
 							<div style={bubbleStyle}>

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/attachment-preamble.spec.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/attachment-preamble.spec.ts
@@ -1,0 +1,76 @@
+import { buildAttachmentPreamble, parseAttachmentPreamble } from './attachment-preamble';
+
+/**
+ * The preamble is the attachment MECHANISM — the message text is what makes attachments
+ * actionable and durable across turns — and the parser is what keeps that mechanism invisible
+ * in the transcript. A drift between the two silently regresses the UI to showing raw preamble
+ * lines in the user's bubble, which is exactly the state this pair was built to remove. So the
+ * round trip is pinned, and so is the legacy wording older conversations still carry.
+ */
+describe('attachment preamble', () => {
+	const DOC_ID = '3f8a2b1c-9d4e-4f6a-8b7c-1d2e3f4a5b6c';
+
+	it('round-trips id and name-only attachments through build → parse', () => {
+		const attachments = [
+			{ documentId: DOC_ID, name: 'Q3 report.pdf' },
+			{ name: 'notes.txt' }
+		];
+		const message = `${buildAttachmentPreamble(attachments)}\n\nWhat changed vs Q2?`;
+
+		const parsed = parseAttachmentPreamble(message);
+		expect(parsed).not.toBeNull();
+		expect(parsed!.attachments).toEqual(attachments);
+		expect(parsed!.text).toBe('What changed vs Q2?');
+	});
+
+	it('parses a preamble-only message to empty user text', () => {
+		const message = buildAttachmentPreamble([{ documentId: DOC_ID, name: 'a.pdf' }]);
+		const parsed = parseAttachmentPreamble(message);
+		expect(parsed!.attachments).toHaveLength(1);
+		expect(parsed!.text).toBe('');
+	});
+
+	it('parses the LEGACY name-only wording older conversations carry', () => {
+		// Verbatim what earlier builds emitted — the docs_search instruction that could never
+		// succeed (chat captures are not auto-indexed). Old history must still render as chips.
+		const message =
+			'Attached documents for this message:\n' +
+			'- "scan.png" — just uploaded to Documents; find it with docs_search (processing may still be in flight).\n' +
+			'\n' +
+			'What does this say?';
+
+		const parsed = parseAttachmentPreamble(message);
+		expect(parsed!.attachments).toEqual([{ name: 'scan.png' }]);
+		expect(parsed!.text).toBe('What does this say?');
+	});
+
+	it('keeps embedded quotes in names intact', () => {
+		const name = 'the "final" draft (v2).docx';
+		const message = `${buildAttachmentPreamble([{ documentId: DOC_ID, name }])}\n\nok`;
+		expect(parseAttachmentPreamble(message)!.attachments[0]).toEqual({ documentId: DOC_ID, name });
+	});
+
+	it('preserves blank lines the user typed themselves', () => {
+		const message = `${buildAttachmentPreamble([{ name: 'x.csv' }])}\n\n\nfirst\n\nsecond`;
+		// One separator blank line belongs to the builder; everything after is the user's.
+		expect(parseAttachmentPreamble(message)!.text).toBe('\nfirst\n\nsecond');
+	});
+
+	it('returns null for plain text, even when it merely resembles a preamble', () => {
+		expect(parseAttachmentPreamble('What changed vs Q2?')).toBeNull();
+		// Header with no attachment line after it is not a preamble.
+		expect(parseAttachmentPreamble('Attached documents for this message:\nnothing here')).toBeNull();
+		// Header must be the FIRST line.
+		expect(parseAttachmentPreamble('intro\nAttached documents for this message:\n- "a" — attached to this conversation.')).toBeNull();
+	});
+
+	it('emits no docs_search instruction for name-only attachments', () => {
+		// The old wording sent the assistant to a tool that cannot find chat captures (they are
+		// never auto-indexed) and does not even exist on installs where the name-only path runs.
+		expect(buildAttachmentPreamble([{ name: 'a.bin' }])).not.toContain('docs_search');
+	});
+
+	it('builds an empty string for no attachments', () => {
+		expect(buildAttachmentPreamble([])).toBe('');
+	});
+});

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/attachment-preamble.spec.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/attachment-preamble.spec.ts
@@ -64,6 +64,36 @@ describe('attachment preamble', () => {
 		expect(parseAttachmentPreamble('intro\nAttached documents for this message:\n- "a" — attached to this conversation.')).toBeNull();
 	});
 
+	it('round-trips a PAGE document with its kind, so history chips link to the page route', () => {
+		const attachments = [{ documentId: DOC_ID, name: 'Handbook', kind: 'PAGE' as const }];
+		const message = `${buildAttachmentPreamble(attachments)}\n\nSummarize it.`;
+
+		const parsed = parseAttachmentPreamble(message);
+		expect(parsed!.attachments).toEqual(attachments);
+	});
+
+	it('flattens line breaks in names so they cannot fabricate preamble lines', () => {
+		// A name with \n would break the one-attachment-per-line format: the parser stops early and
+		// the transcript falls back to showing the raw preamble.
+		const message = `${buildAttachmentPreamble([
+			{ documentId: DOC_ID, name: 'annual\r\n  report.pdf' }
+		])}\n\nthoughts?`;
+
+		const parsed = parseAttachmentPreamble(message);
+		expect(parsed!.attachments).toEqual([{ documentId: DOC_ID, name: 'annual report.pdf' }]);
+		expect(parsed!.text).toBe('thoughts?');
+	});
+
+	it('parses quote-heavy hostile lines correctly (the parser is single-pass, not backtracking)', () => {
+		// CodeQL flagged the previous regex parser as polynomial on exactly this shape: many
+		// repetitions of `a" — ` inside an attachment line. The line is still a VALID name-only
+		// attachment (longest-name semantics), and parsing it must be linear work.
+		const hostile = `- "${'a" — '.repeat(500)}tail" — attached to this conversation.`;
+		const parsed = parseAttachmentPreamble(`Attached documents for this message:\n${hostile}`);
+		expect(parsed!.attachments).toHaveLength(1);
+		expect(parsed!.attachments[0].name.endsWith('tail')).toBe(true);
+	});
+
 	it('emits no docs_search instruction for name-only attachments', () => {
 		// The old wording sent the assistant to a tool that cannot find chat captures (they are
 		// never auto-indexed) and does not even exist on installs where the name-only path runs.

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/attachment-preamble.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/attachment-preamble.ts
@@ -14,7 +14,9 @@
  * format {@link buildAttachmentPreamble} emits (plus the legacy wording earlier builds produced)
  * and renders chips + the user's own words. Parsing only ever affects DISPLAY — the model always
  * sees the full text — so a user hand-typing something preamble-shaped merely gets it rendered
- * as chips, which is harmless.
+ * as chips, which is harmless. Parsing is deliberately regex-free on the name segment: the input
+ * is uncontrolled message text, and a backtracking quantifier over embedded quotes is exactly the
+ * polynomial-ReDoS shape CodeQL flags. Everything here is single-pass `indexOf` work.
  */
 
 /** One attachment staged on the next message. */
@@ -23,10 +25,37 @@ export interface IStagedAttachment {
 	documentId?: string;
 	/** Display name, and the only handle an attachment has when Documents is unavailable. */
 	name: string;
+	/**
+	 * `PAGE` when the attachment is a Documents PAGE (a written page opens at its editor route,
+	 * not the file browser). Anything else — including absent, as in all legacy history — is
+	 * treated as a file for linking purposes.
+	 */
+	kind?: 'FILE' | 'PAGE';
 }
 
 /** First line of every preamble. EXACT — parsing keys on it, and old history carries it. */
 const PREAMBLE_HEADER = 'Attached documents for this message:';
+
+/** `(document id: …` opener on an attachment line — after the name's closing quote. */
+const ID_MARKER = '" (document id: ';
+
+/** Name/instruction separator on a name-only attachment line. */
+const NAME_MARKER = '" — ';
+
+/** Marks a PAGE document inside the id parenthetical, so history chips link to the right route. */
+const PAGE_SUFFIX = ', page';
+
+/** Anchored, fixed-length UUID check — linear, unlike a quantified group over user text. */
+const UUID_SHAPE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * A name flattened to one line, so it cannot break the one-attachment-per-line format.
+ *
+ * Document names normally have no line breaks, but the type does not forbid them — and a name
+ * with `\n` would fabricate extra preamble lines: the parser then stops early and the transcript
+ * falls back to showing the raw preamble.
+ */
+const flattenName = (name: string): string => name.replace(/[\r\n]+[ \t]*/g, ' ').trim();
 
 /**
  * Build the preamble for the staged attachments.
@@ -34,7 +63,9 @@ const PREAMBLE_HEADER = 'Attached documents for this message:';
  * Two line shapes:
  * - With an id — the document is in Documents (picked from the library, or uploaded id-first):
  *   the assistant is told to read exactly that document. `docs_read` itself explains the
- *   still-processing state for a fresh upload, so no hedging is needed here.
+ *   still-processing state for a fresh upload, so no hedging is needed here. PAGE documents get
+ *   a `, page` marker inside the parenthetical so a chip rebuilt from history can link to the
+ *   page editor rather than the file browser; the model reads straight past it.
  * - Without an id — Documents is unavailable on this install (the id-first upload fell back to
  *   plain chat storage), which also means the `docs_*` tools are not registered. The line only
  *   STATES the attachment; earlier builds told the assistant to `docs_search` for it, which
@@ -48,11 +79,14 @@ export function buildAttachmentPreamble(attachments: IStagedAttachment[]): strin
 	if (!attachments.length) {
 		return '';
 	}
-	const lines = attachments.map((attachment) =>
-		attachment.documentId
-			? `- "${attachment.name}" (document id: ${attachment.documentId}) — read it with docs_read.`
-			: `- "${attachment.name}" — attached to this conversation.`
-	);
+	const lines = attachments.map((attachment) => {
+		const name = flattenName(attachment.name);
+		if (!attachment.documentId) {
+			return `- "${name}" — attached to this conversation.`;
+		}
+		const pageMarker = attachment.kind === 'PAGE' ? PAGE_SUFFIX : '';
+		return `- "${name}" (document id: ${attachment.documentId}${pageMarker}) — read it with docs_read.`;
+	});
 	return [PREAMBLE_HEADER, ...lines].join('\n');
 }
 
@@ -65,13 +99,43 @@ export interface IParsedAttachmentPreamble {
 }
 
 /**
- * Attachment line, both shapes. Name first (greedy, so embedded quotes survive), then the
- * optional `(document id: …)` suffix, then the em-dash instruction — which is deliberately
- * unanchored beyond its shape: it differs between the current and legacy builders, and pinning
- * the wording would silently stop old history from rendering as chips.
+ * Parse one attachment line, or return `null` when the line is not one.
+ *
+ * Mirrors the builder's two shapes, tolerant on the instruction wording (it differs between the
+ * current and legacy builders, and pinning it would silently stop old history from rendering as
+ * chips). The name is recovered with `lastIndexOf` — the same longest-name semantics a greedy
+ * quantifier would give, without the backtracking.
  */
-const ID_LINE = /^- "(.+)" \(document id: ([0-9a-fA-F-]{36})\) — .+$/;
-const NAME_LINE = /^- "(.+)" — .+$/;
+function parseAttachmentLine(line: string): IStagedAttachment | null {
+	if (!line.startsWith('- "')) {
+		return null;
+	}
+
+	// Id shape: - "NAME" (document id: UUID[, page]) — instruction
+	const idAt = line.lastIndexOf(ID_MARKER);
+	if (idAt > 3) {
+		const parenthetical = line.slice(idAt + ID_MARKER.length);
+		const close = parenthetical.indexOf(') — ');
+		if (close > 0 && parenthetical.length > close + ') — '.length) {
+			let idPart = parenthetical.slice(0, close);
+			let kind: IStagedAttachment['kind'];
+			if (idPart.endsWith(PAGE_SUFFIX)) {
+				kind = 'PAGE';
+				idPart = idPart.slice(0, -PAGE_SUFFIX.length);
+			}
+			if (UUID_SHAPE.test(idPart)) {
+				return { name: line.slice(3, idAt), documentId: idPart, ...(kind ? { kind } : {}) };
+			}
+		}
+	}
+
+	// Name-only shape: - "NAME" — instruction
+	const nameAt = line.lastIndexOf(NAME_MARKER);
+	if (nameAt > 3 && line.length > nameAt + NAME_MARKER.length) {
+		return { name: line.slice(3, nameAt) };
+	}
+	return null;
+}
 
 /**
  * Recognize a message that starts with an attachment preamble.
@@ -91,18 +155,11 @@ export function parseAttachmentPreamble(messageText: string): IParsedAttachmentP
 	const attachments: IStagedAttachment[] = [];
 	let index = 1;
 	for (; index < lines.length; index++) {
-		const line = lines[index];
-		const withId = ID_LINE.exec(line);
-		if (withId) {
-			attachments.push({ name: withId[1], documentId: withId[2] });
-			continue;
+		const attachment = parseAttachmentLine(lines[index]);
+		if (!attachment) {
+			break;
 		}
-		const nameOnly = NAME_LINE.exec(line);
-		if (nameOnly) {
-			attachments.push({ name: nameOnly[1] });
-			continue;
-		}
-		break;
+		attachments.push(attachment);
 	}
 	if (!attachments.length) {
 		return null;

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/attachment-preamble.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/attachment-preamble.ts
@@ -1,0 +1,117 @@
+/**
+ * The attachment preamble: how staged attachments travel inside the user's message text,
+ * and how the transcript UI recognizes them again to render chips instead of raw lines.
+ *
+ * Attachments ride as ordinary message TEXT on purpose. The tool surface the assistant has is
+ * `docs_read(documentId)` / `docs_search(query)`, so naming the ids in the message is precisely
+ * what makes an attachment actionable — and because the text is part of the message history, the
+ * attachment context survives every later turn and conversation reload with zero extra plumbing.
+ * A side channel the model never sees (metadata, data parts) would be decoration: AI SDK data
+ * parts are not model-visible in converted history.
+ *
+ * The cost of that mechanism is that the raw preamble would show inside the user's own bubble.
+ * {@link parseAttachmentPreamble} is the display-side answer: the transcript recognizes the exact
+ * format {@link buildAttachmentPreamble} emits (plus the legacy wording earlier builds produced)
+ * and renders chips + the user's own words. Parsing only ever affects DISPLAY — the model always
+ * sees the full text — so a user hand-typing something preamble-shaped merely gets it rendered
+ * as chips, which is harmless.
+ */
+
+/** One attachment staged on the next message. */
+export interface IStagedAttachment {
+	/** Set when the document exists in Documents — the handle `docs_read` takes. */
+	documentId?: string;
+	/** Display name, and the only handle an attachment has when Documents is unavailable. */
+	name: string;
+}
+
+/** First line of every preamble. EXACT — parsing keys on it, and old history carries it. */
+const PREAMBLE_HEADER = 'Attached documents for this message:';
+
+/**
+ * Build the preamble for the staged attachments.
+ *
+ * Two line shapes:
+ * - With an id — the document is in Documents (picked from the library, or uploaded id-first):
+ *   the assistant is told to read exactly that document. `docs_read` itself explains the
+ *   still-processing state for a fresh upload, so no hedging is needed here.
+ * - Without an id — Documents is unavailable on this install (the id-first upload fell back to
+ *   plain chat storage), which also means the `docs_*` tools are not registered. The line only
+ *   STATES the attachment; earlier builds told the assistant to `docs_search` for it, which
+ *   could never succeed — chat-captured documents are not auto-indexed, and on fallback
+ *   installs the tool does not even exist.
+ *
+ * @param attachments The staged attachments.
+ * @returns The preamble, or an empty string when nothing is attached.
+ */
+export function buildAttachmentPreamble(attachments: IStagedAttachment[]): string {
+	if (!attachments.length) {
+		return '';
+	}
+	const lines = attachments.map((attachment) =>
+		attachment.documentId
+			? `- "${attachment.name}" (document id: ${attachment.documentId}) — read it with docs_read.`
+			: `- "${attachment.name}" — attached to this conversation.`
+	);
+	return [PREAMBLE_HEADER, ...lines].join('\n');
+}
+
+/** What {@link parseAttachmentPreamble} recovers from a message's text. */
+export interface IParsedAttachmentPreamble {
+	/** The attachments named by the preamble, in order. */
+	attachments: IStagedAttachment[];
+	/** The user's own message text, with the preamble removed. May be empty. */
+	text: string;
+}
+
+/**
+ * Attachment line, both shapes. Name first (greedy, so embedded quotes survive), then the
+ * optional `(document id: …)` suffix, then the em-dash instruction — which is deliberately
+ * unanchored beyond its shape: it differs between the current and legacy builders, and pinning
+ * the wording would silently stop old history from rendering as chips.
+ */
+const ID_LINE = /^- "(.+)" \(document id: ([0-9a-fA-F-]{36})\) — .+$/;
+const NAME_LINE = /^- "(.+)" — .+$/;
+
+/**
+ * Recognize a message that starts with an attachment preamble.
+ *
+ * Strict on the load-bearing parts (exact header as the FIRST line, at least one attachment
+ * line immediately after) and tolerant on the instruction wording, so both current and legacy
+ * messages parse. Returns `null` for anything else — the caller then renders the text as-is.
+ *
+ * @param messageText The full text of a user message part.
+ * @returns The parsed attachments + remaining user text, or `null` when there is no preamble.
+ */
+export function parseAttachmentPreamble(messageText: string): IParsedAttachmentPreamble | null {
+	if (!messageText.startsWith(PREAMBLE_HEADER + '\n')) {
+		return null;
+	}
+	const lines = messageText.split('\n');
+	const attachments: IStagedAttachment[] = [];
+	let index = 1;
+	for (; index < lines.length; index++) {
+		const line = lines[index];
+		const withId = ID_LINE.exec(line);
+		if (withId) {
+			attachments.push({ name: withId[1], documentId: withId[2] });
+			continue;
+		}
+		const nameOnly = NAME_LINE.exec(line);
+		if (nameOnly) {
+			attachments.push({ name: nameOnly[1] });
+			continue;
+		}
+		break;
+	}
+	if (!attachments.length) {
+		return null;
+	}
+	// The builder joins preamble and user text with a blank line; strip that one separator but
+	// preserve any further leading whitespace the user typed themselves.
+	let rest = lines.slice(index).join('\n');
+	if (rest.startsWith('\n')) {
+		rest = rest.slice(1);
+	}
+	return { attachments, text: rest };
+}

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -4107,6 +4107,7 @@
 		"LIBRARY_SOON": "Choose from the file library (coming soon)",
 		"ATTACH": "Attach a file",
 		"ATTACH_FROM_DOCUMENTS": "Attach from Documents",
+		"ATTACH_OPEN": "Open attached document",
 		"ATTACH_SEARCH": "Search documents…",
 		"ATTACH_NO_RESULTS": "No matching documents.",
 		"ATTACH_UNAVAILABLE": "Documents are not available in this workspace.",

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -4108,6 +4108,8 @@
 		"ATTACH": "Attach a file",
 		"ATTACH_FROM_DOCUMENTS": "Attach from Documents",
 		"ATTACH_OPEN": "Open attached document",
+		"ATTACH_REJECTED": "The file was rejected",
+		"ATTACH_RESPONSE_UNREADABLE": "The upload response could not be read — check the Documents page before retrying",
 		"ATTACH_SEARCH": "Search documents…",
 		"ATTACH_NO_RESULTS": "No matching documents.",
 		"ATTACH_UNAVAILABLE": "Documents are not available in this workspace.",


### PR DESCRIPTION
## What this closes

The attach + library pickers shipped with the Documents hub, but two gaps separated them from **"attach a file and discuss it right away"**:

### 1. A fresh upload could never actually be discussed

The upload went to chat-local storage; the Documents plugin captured it **asynchronously** via `AiChatAttachmentSavedEvent`. So the chip was name-only, and the preamble told the assistant to *"find it with docs_search"* — an instruction that can **never succeed**: chat captures land with `knowledgeStatus: NONE` and are deliberately never auto-indexed, so semantic search cannot see them. Worse, a file the magic-byte sniffer rejected got a chip anyway while the capture silently dropped it — the assistant was sent hunting for a file that does not exist.

**Now**: the upload goes straight to `POST /api/plugins/docs/documents/upload` with `source: CHAT` (a value that endpoint already accepts), which answers **synchronously** with the created document. The chip carries a `documentId`, the preamble says `docs_read` — and `docs_read` itself handles the still-extracting state with an explicit "processing" answer the assistant can relay. Rejections surface the server's reason immediately. The chat-local endpoint remains as the **fallback** on 403/404 (Documents absent/disabled/no `DOCS_CREATE`) — installs where the docs tools don't exist either, so a name-only mention is the honest ceiling.

### 2. The raw preamble rendered in the user's own bubble

The preamble is the *mechanism* — attachments ride as message text because that is what makes `docs_read` actionable and keeps attachment context alive across turns and conversation reloads with zero server plumbing. But the reader shouldn't see it. The transcript now parses it back (current **and** legacy wording, so old history upgrades too) and renders 📎 chips — id chips deep-link into the Documents hub through the same `onOpenCitation` bridge and `IDocsCitation` shape the citation chips already use — plus the user's own words. Display-only: the model always sees the full text.

## Verification

- `attachment-preamble.ts` extracts the build/parse pair as pure functions with an 8-test spec: round trip, preamble-only messages, the legacy `docs_search` wording, embedded quotes in names, user blank-line preservation, lookalike rejection, and a pin that the impossible `docs_search` instruction stays gone.
- 18/18 tests pass in the package; `tsc` error count identical to develop (20, all pre-existing in other packages' tiptap/NodeJS types).
- No backend changes: the docs upload endpoint already validates and accepts `source: CHAT`, and the permission ceiling holds by construction — the upload runs from the browser with the user's own JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uploads now go to Documents with an id-first flow so the assistant can read attachments in the same message, and the transcript shows paperclip chips instead of the raw preamble. The parser is hardened, PAGE chips deep-link to the page editor, and attachment error messages are localized.

- **New Features**
  - Send uploads to `POST /api/plugins/docs/documents/upload` with `source: CHAT`; stage chips with `documentId` (PAGE kind preserved). Fall back to chat-local storage on 403/404.
  - Parse the preamble in user messages and render attachment chips; id chips deep-link to Documents (PAGE chips open the page editor). Legacy wording is supported; the model still sees the full text.
  - Surface server rejection messages and drop phantom chips; remove the old `docs_search` instruction. `docs_read` covers “processing” state.

- **Bug Fixes**
  - Rewrote preamble parsing to linear string scans to avoid ReDoS on quote-heavy lines.
  - Flatten newline characters in names so chips don’t break back to raw text.
  - Distinguish true rejections from unreadable 2xx bodies; show accurate errors and point to Documents when response shape is unclear; route strings through `t()` with new keys `AI_ASSISTANT.ATTACH_REJECTED` and `AI_ASSISTANT.ATTACH_RESPONSE_UNREADABLE`.
  - Added chip aria label; new i18n key `AI_ASSISTANT.ATTACH_OPEN`.

<sup>Written for commit bdb87538d12f752a946393cdffa0d645cf7f093b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

