### PR TITLE
fix(ai-chat): make the attach pickers work against the real Documents API

### DIFF
--- a/packages/plugins/ai-chat-react-ui/src/lib/ai-chat-window.component.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/ai-chat-window.component.ts
@@ -29,6 +29,12 @@ import { AiChatSidebarComponent } from './ai-chat-sidebar.component';
 				width: 100%;
 				min-width: 0;
 				overflow: hidden;
+				/* The docked chat gets --gz-chat-surface from its nb-sidebar wrapper (the layout
+				   publishes the themed sidebar background there). This window has no wrapper, so
+				   without a value the panel's overlays (history, attach picker) fall back to a
+				   blur over a transparent surface — readable-ish, but the conversation bleeds
+				   through. Publish the page background this window already renders on. */
+				--gz-chat-surface: var(--background-basic-color-1, Canvas);
 			}
 		`
 	],

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
@@ -104,6 +104,21 @@ export function AiChatPanel() {
 	);
 
 	/**
+	 * The tenant/organization scope the Documents endpoints require IN THE REQUEST ITSELF —
+	 * `where[organizationId]` on the list, an `organizationId` part in the upload body. The
+	 * Tenant-Id/Organization-Id HEADERS do not satisfy those DTO validators
+	 * (`TenantOrganizationBaseDTO`), which is exactly how the picker first shipped broken:
+	 * every request answered 400 and the UI misread it as "Documents unavailable".
+	 */
+	const attachScope = useCallback(
+		(): { organizationId?: string; tenantId?: string } => ({
+			...(store.organizationId ? { organizationId: store.organizationId } : {}),
+			...(store.tenantId ? { tenantId: store.tenantId } : {})
+		}),
+		[store]
+	);
+
+	/**
 	 * May this user open the AI Providers settings page?
 	 *
 	 * Chat only requires AI_CHAT_ACCESS, but the settings route is guarded by AI_CHAT_SETTINGS — so
@@ -358,6 +373,11 @@ export function AiChatPanel() {
 				const docsForm = new FormData();
 				docsForm.append('files', file, file.name);
 				docsForm.append('source', 'CHAT');
+				// Required by UploadDocumentsDTO (TenantOrganizationBaseDTO): the org must be in the
+				// BODY — headers alone fail validation with "organizationId must be a UUID".
+				const scope = attachScope();
+				if (scope.organizationId) docsForm.append('organizationId', scope.organizationId);
+				if (scope.tenantId) docsForm.append('tenantId', scope.tenantId);
 				const docsResponse = await fetch(`${environment.API_BASE_URL}/api/plugins/docs/documents/upload`, {
 					method: 'POST',
 					headers: authHeaders(),
@@ -432,7 +452,7 @@ export function AiChatPanel() {
 				setIsAttaching(false);
 			}
 		},
-		[authHeaders]
+		[authHeaders, attachScope]
 	);
 
 	/** Attach an existing document by id — what makes `docs_read` able to open exactly that one. */
@@ -612,7 +632,10 @@ export function AiChatPanel() {
 		display: 'flex',
 		flexDirection: 'column',
 		overflow: 'hidden',
-		minWidth: 0
+		minWidth: 0,
+		// The positioning context for the history and attach-picker overlays: `inset: 0` must
+		// resolve against the BODY, so an overlay can never cover the panel's own header row.
+		position: 'relative'
 	};
 
 	const resizeHandleStyle: CSSProperties = {
@@ -929,32 +952,34 @@ export function AiChatPanel() {
 				</span>
 			</div>
 
-			{/* Conversation history overlay */}
-			{showHistory && (
-				<ChatHistoryPanel
-					items={history}
-					loading={historyLoading}
-					activeId={activeConversationId}
-					translate={t}
-					onSelect={handleSelectConversation}
-					onDelete={handleDeleteConversation}
-					onClose={() => setShowHistory(false)}
-				/>
-			)}
-
-			{/* "Attach from Documents" overlay — same full-panel treatment as history. */}
-			{showAttachPicker && (
-				<DocsAttachPicker
-					apiBaseUrl={environment.API_BASE_URL}
-					headers={authHeaders}
-					translate={t}
-					onPick={handlePickDocument}
-					onClose={() => setShowAttachPicker(false)}
-				/>
-			)}
-
-			{/* Chat body — fills remaining height */}
+			{/* Chat body — fills remaining height. The overlays mount INSIDE it so they cover the
+			    conversation area only, never the panel's own header (which stays operable — the
+			    user can still collapse/detach while a picker is open). */}
 			<div style={bodyStyle}>
+				{/* Conversation history overlay */}
+				{showHistory && (
+					<ChatHistoryPanel
+						items={history}
+						loading={historyLoading}
+						activeId={activeConversationId}
+						translate={t}
+						onSelect={handleSelectConversation}
+						onDelete={handleDeleteConversation}
+						onClose={() => setShowHistory(false)}
+					/>
+				)}
+
+				{/* "Attach from Documents" overlay */}
+				{showAttachPicker && (
+					<DocsAttachPicker
+						apiBaseUrl={environment.API_BASE_URL}
+						headers={authHeaders}
+						scope={attachScope}
+						translate={t}
+						onPick={handlePickDocument}
+						onClose={() => setShowAttachPicker(false)}
+					/>
+				)}
 				{hasMessages ? (
 					<ChatMessageList
 						messages={messages}

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/ChatHistoryPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/ChatHistoryPanel.tsx
@@ -36,13 +36,18 @@ export function ChatHistoryPanel({
 	onClose
 }: ChatHistoryPanelProps) {
 	const containerStyle: CSSProperties = {
+		// Fills the chat BODY (the panel mounts this inside its position:relative body container),
+		// so the panel's own header row stays visible and operable above it.
 		position: 'absolute',
 		inset: 0,
 		display: 'flex',
 		flexDirection: 'column',
 		zIndex: 5,
-		backdropFilter: 'blur(2px)',
-		background: 'inherit'
+		// `inherit` resolved to transparent (the parent paints no background), so the conversation
+		// bled through. The layout publishes its sidebar surface as --gz-chat-surface; the blur is
+		// the fallback for hosts that do not (detached window).
+		backdropFilter: 'blur(12px)',
+		background: 'var(--gz-chat-surface, transparent)'
 	};
 
 	const headerStyle: CSSProperties = {

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/DocsAttachPicker.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/DocsAttachPicker.tsx
@@ -21,6 +21,14 @@ export interface DocsAttachPickerProps {
 	apiBaseUrl: string;
 	/** Auth + tenant headers for the request (the panel already builds these for every call). */
 	headers: () => Record<string, string>;
+	/**
+	 * Tenant/organization scope for the QUERY. The docs list endpoint validates a `where` object
+	 * (`where[organizationId]` is required) — the Tenant-Id/Organization-Id headers do not satisfy
+	 * it, and flat `organizationId` params are whitelisted away. Without this the endpoint answers
+	 * 400 for every request, which the first version of this picker misreported as "Documents are
+	 * not available in this workspace".
+	 */
+	scope: () => { organizationId?: string; tenantId?: string };
 	/** The user chose a document. */
 	onPick: (document: IAttachableDocument) => void;
 	/** Dismiss without choosing. */
@@ -44,12 +52,12 @@ export interface DocsAttachPickerProps {
  * tool takes a document id, so the assistant can open exactly what the user pointed at rather
  * than searching for something with a similar name.
  */
-export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, translate }: DocsAttachPickerProps) {
+export function DocsAttachPicker({ apiBaseUrl, headers, scope, onPick, onClose, translate }: DocsAttachPickerProps) {
 	const t = translate ?? ((_key: string, fallback: string) => fallback);
 	const [query, setQuery] = useState('');
 	const [documents, setDocuments] = useState<IAttachableDocument[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
-	const [failed, setFailed] = useState(false);
+	const [failure, setFailure] = useState<'unavailable' | 'error' | null>(null);
 	const searchRef = useRef<HTMLInputElement>(null);
 	// Bumped on every request so a slow earlier response can never overwrite a newer one.
 	const requestSeq = useRef(0);
@@ -62,9 +70,14 @@ export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, transla
 		(search: string) => {
 			const seq = ++requestSeq.current;
 			setIsLoading(true);
-			setFailed(false);
+			setFailure(null);
 
 			const params = new URLSearchParams({ take: String(PAGE_SIZE), sort: 'updatedAt', sortOrder: 'DESC' });
+			// The endpoint's DTO requires the scope inside a `where` object (bracket syntax — the
+			// API's extended query parser reassembles it into the nested shape the validator wants).
+			const { organizationId, tenantId } = scope();
+			if (organizationId) params.set('where[organizationId]', organizationId);
+			if (tenantId) params.set('where[tenantId]', tenantId);
 			// Folders hold no readable content — offering one would attach nothing.
 			params.set('kind', 'FILE,PAGE');
 			if (search.trim()) {
@@ -77,18 +90,22 @@ export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, transla
 					if (seq !== requestSeq.current) return;
 					setDocuments(Array.isArray(page?.items) ? page.items : []);
 				})
-				.catch(() => {
+				.catch((error: unknown) => {
 					if (seq !== requestSeq.current) return;
-					// The Documents plugin may not be installed at all, in which case this 404s.
-					// Either way the honest answer is "nothing to offer", not a broken list.
 					setDocuments([]);
-					setFailed(true);
+					// Only "the feature is not here for you" statuses may claim unavailability:
+					// 404 = docs plugin not installed, 403 = no DOCS_READ / feature disabled.
+					// Anything else is a FAILURE and must say so — the first version showed
+					// "Documents are not available" for its own 400s, hiding a plain bug behind
+					// a message that blamed the workspace.
+					const status = error instanceof Error ? error.message : '';
+					setFailure(status === '403' || status === '404' ? 'unavailable' : 'error');
 				})
 				.finally(() => {
 					if (seq === requestSeq.current) setIsLoading(false);
 				});
 		},
-		[apiBaseUrl, headers]
+		[apiBaseUrl, headers, scope]
 	);
 
 	useEffect(() => {
@@ -97,12 +114,19 @@ export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, transla
 	}, [query, load]);
 
 	const overlayStyle: CSSProperties = {
+		// Fills the chat BODY (the panel mounts this inside its position:relative body container),
+		// so the panel's own header row stays visible and operable above it.
 		position: 'absolute',
 		inset: 0,
 		zIndex: 6,
 		display: 'flex',
 		flexDirection: 'column',
-		backgroundColor: chatTheme.surface,
+		// The chat theme has no opaque surface token (surfaces are currentColor tints over
+		// transparent — the Angular layout paints the real background), so a tint alone let the
+		// conversation show through the picker. The layout publishes its sidebar surface as
+		// --gz-chat-surface; the blur is the fallback for hosts that do not (detached window).
+		backgroundColor: 'var(--gz-chat-surface, transparent)',
+		backdropFilter: 'blur(12px)',
 		animation: 'fadeIn 0.15s ease'
 	};
 
@@ -198,8 +222,10 @@ export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, transla
 
 				{!isLoading && !documents.length && (
 					<div style={emptyStyle}>
-						{failed
+						{failure === 'unavailable'
 							? t('AI_ASSISTANT.ATTACH_UNAVAILABLE', 'Documents are not available in this workspace.')
+							: failure === 'error'
+							? t('AI_ASSISTANT.ATTACH_LOAD_FAILED', 'The document list could not be loaded — please try again.')
 							: t('AI_ASSISTANT.ATTACH_NO_RESULTS', 'No matching documents.')}
 					</div>
 				)}

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/DocsAttachPicker.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/DocsAttachPicker.tsx
@@ -85,7 +85,12 @@ export function DocsAttachPicker({ apiBaseUrl, headers, scope, onPick, onClose, 
 			}
 
 			fetch(`${apiBaseUrl}/api/plugins/docs/documents?${params.toString()}`, { headers: headers() })
-				.then((response) => (response.ok ? response.json() : Promise.reject(new Error(String(response.status)))))
+				.then((response) => {
+					if (response.ok) return response.json();
+					// The status rides the rejection as a typed field — classifying on a
+					// stringified message would couple the catch to this throw-site's wording.
+					return Promise.reject(Object.assign(new Error(`docs list failed (${response.status})`), { status: response.status }));
+				})
 				.then((page: { items?: IAttachableDocument[] }) => {
 					if (seq !== requestSeq.current) return;
 					setDocuments(Array.isArray(page?.items) ? page.items : []);
@@ -98,8 +103,8 @@ export function DocsAttachPicker({ apiBaseUrl, headers, scope, onPick, onClose, 
 					// Anything else is a FAILURE and must say so — the first version showed
 					// "Documents are not available" for its own 400s, hiding a plain bug behind
 					// a message that blamed the workspace.
-					const status = error instanceof Error ? error.message : '';
-					setFailure(status === '403' || status === '404' ? 'unavailable' : 'error');
+					const status = (error as { status?: number })?.status;
+					setFailure(status === 403 || status === 404 ? 'unavailable' : 'error');
 				})
 				.finally(() => {
 					if (seq === requestSeq.current) setIsLoading(false);

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -4112,6 +4112,7 @@
 		"ATTACH_RESPONSE_UNREADABLE": "The upload response could not be read — check the Documents page before retrying",
 		"ATTACH_SEARCH": "Search documents…",
 		"ATTACH_NO_RESULTS": "No matching documents.",
+		"ATTACH_LOAD_FAILED": "The document list could not be loaded — please try again.",
 		"ATTACH_UNAVAILABLE": "Documents are not available in this workspace.",
 		"ATTACH_REMOVE": "Remove attachment",
 		"CITATIONS": {

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -143,6 +143,10 @@
         // Same surface as the nav menu sidebar; the chat panel's design
         // tokens derive from currentColor, so set the themed text color here.
         background: nb-theme(gauzy-sidebar-background-2);
+        // Published as a CSS var so the React panel's overlays (history, attach picker) can paint
+        // an OPAQUE surface: the chat theme's own surface tokens are currentColor tints over
+        // transparent, and an overlay using them lets the conversation bleed through.
+        --gz-chat-surface: #{nb-theme(gauzy-sidebar-background-2)};
         color: nb-theme(text-basic-color);
         border-right: 1px solid nb-theme(divider-color);
       }


### PR DESCRIPTION
Reproduced live on demo (develop tip) with the exact server responses captured in the browser.

## The three functional defects

1. **Picker list 400'd on every request** — `["where should not be empty"]`. The docs list DTO requires the scope inside a `where` object (`where[organizationId]=…` bracket syntax); flat params are whitelisted away and headers don't count. The panel now passes a `scope()` callback and the picker sends the shape the endpoint validates.
2. **Upload 400'd** — `["organization must be an object","organizationId must be a UUID"]` (the error the user hit). `UploadDocumentsDTO` extends `TenantOrganizationBaseDTO`: the org id must be a **body** part. Now appended.
3. **Every failure claimed "Documents are not available in this workspace"** — including the picker's own 400s. Only 403/404 (no permission / plugin absent) may claim unavailability now; anything else says the list could not be loaded (new i18n key `ATTACH_LOAD_FAILED`).

## The overlay collision (user's screenshot)

Both the attach picker and the history overlay used `inset: 0` against the **panel root** — covering the chat's own header — with `chatTheme.surface`, a 96%-transparent `color-mix` tint that let everything bleed through. Fixes:
- Overlays now mount **inside the body** (`position: relative` added), so the header stays visible and operable.
- They paint an **opaque** themed surface via a new `--gz-chat-surface` custom property the one-column layout publishes from `nb-theme(gauzy-sidebar-background-2)` (Sass tokens aren't readable from React); `backdrop-filter: blur(12px)` is the fallback for the detached window, which has no sidebar wrapper.

## Verification

21/21 tests; tsc error count identical to develop. The DTO shapes were verified against the live demo API and the docs plugin source (`escapeQueryWithParameters` transform, extended query parser, whitelist pipes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat attach pickers to work with the real Documents API and moves overlays inside the chat body with an opaque surface so the header stays usable. Also switches error handling to typed HTTP status and makes the detached window provide the same opaque surface.

- **Bug Fixes**
  - Docs list: send `where[organizationId]`/`where[tenantId]` in query to stop 400s.
  - Uploads: include `organizationId`/`tenantId` in multipart body to match DTOs.
  - Errors: classify by typed status; show “Documents are not available” only for 403/404, use `ATTACH_LOAD_FAILED` otherwise.

- **UI Improvements**
  - Mount history and attach overlays inside the chat body (`position: relative`) so the header stays operable.
  - Use an opaque surface via `--gz-chat-surface`; the one-column layout publishes it, and the detached window now sets it too (fallback to blur/Canvas when unavailable).

<sup>Written for commit ce42092a36fad03d5a3c3ca051c16abc29545ed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

