### PR TITLE
fix(ui): stop the docs URL-writer cancelling every navigation; unstick the header inset

### DIFF
--- a/apps/gauzy/src/app/app.component.ts
+++ b/apps/gauzy/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { filter, map, mergeMap, take, tap } from 'rxjs';
+import { filter, map, switchMap, take, tap } from 'rxjs';
 import { pluck, union } from 'underscore';
 import { IDateRangePicker, ILanguage, LanguagesEnum } from '@gauzy/contracts';
 import { environment } from '@gauzy/ui-config';
@@ -226,8 +226,12 @@ export class AppComponent implements OnInit, AfterViewInit {
 				}),
 				// Filter for routes in the primary outlet
 				filter((route) => route.outlet === 'primary'),
-				// MergeMap to the route data
-				mergeMap((route) => route.data),
+				// switchMap, NOT mergeMap: `route.data` never completes, so mergeMap leaked one
+				// live inner subscription per navigation for the life of the app — each of which
+				// re-ran the selector/date-picker/URL writes below whenever a retained route's
+				// data re-emitted. switchMap drops the previous route's stream on every
+				// navigation, so exactly one route's data is ever live.
+				switchMap((route) => route.data),
 				/**
 				 * Set Date Range Picker Default Unit and Config
 				 */

--- a/packages/plugins/docs-ui/src/lib/+state/documents.effects.ts
+++ b/packages/plugins/docs-ui/src/lib/+state/documents.effects.ts
@@ -436,6 +436,27 @@ export class DocumentsEffects {
 	}
 
 	private mergeUrlParams(params: Params): void {
+		// `navigate([], …)` targets the CURRENT url — and these effects live on the GLOBAL effects
+		// manager, so once the lazy Documents module has loaded they run for the rest of the
+		// session, on every page, on debounced timers. Two guards keep that from hijacking the
+		// router:
+		//
+		// 1. Only write while the Documents page is the ACTIVE route. After the user leaves, the
+		//    URL belongs to whatever page they navigated to — a background docs write there is
+		//    state leakage at best.
+		// 2. Never write while ANOTHER navigation is in flight. A same-URL navigate issued
+		//    mid-navigation silently SUPERSEDES it (NavigationCancel → NavigationSkipped, no
+		//    error, no URL change) — which is exactly how every sidebar click on demo died the
+		//    moment the docs module had loaded: the click's imperative navigation was cancelled
+		//    by this funnel, while popstate/hash navigations (already past the URL change) kept
+		//    working. The dropped write is safe: every effect that lands here re-derives the full
+		//    param set from the store, so the next write carries the complete state anyway.
+		if (!this.router.url.startsWith('/pages/documents')) {
+			return;
+		}
+		if (this.router.getCurrentNavigation()) {
+			return;
+		}
 		this.router.navigate([], {
 			queryParams: params,
 			queryParamsHandling: 'merge',

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -55,9 +55,10 @@
   // (Menu | Chat | Canvas, or Menu | Canvas | Chat when docked right).
   // The HOST stays in the flex flow and reserves the width; Nebular's
   // .main-container is position:fixed in windowMode, so it is pinned to the
-  // full viewport height (top 0 → nothing above or below it) and follows the
-  // host's flex-computed width via --gz-chat-live-width (set by the layout's
-  // ResizeObserver — covers normal, user-resized, maximized and collapsed).
+  // full viewport height (top 0 → nothing above or below it). Host and panel
+  // BOTH size from --gz-chat-width (the persisted user width, bound inline on
+  // the host by the layout template) with the same 24rem fallback — one source
+  // of truth, and the two can never disagree.
   nb-sidebar.chat-sidebar {
     order: 0 !important;
     align-self: stretch;

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
@@ -101,6 +101,7 @@ export class OneColumnLayoutComponent {
 			this.navigationBuilderService.clearActionBars();
 			this.headerResizeObserver?.disconnect();
 			this.canvasResizeObserver?.disconnect();
+			this.chatClassObserver?.disconnect();
 			if (this.canvasLeftOnResize) window.removeEventListener('resize', this.canvasLeftOnResize);
 		});
 	}
@@ -158,9 +159,11 @@ export class OneColumnLayoutComponent {
 	 */
 	private observeCanvasLeft(): void {
 		if (typeof ResizeObserver === 'undefined' || typeof document === 'undefined') return;
-		const column = document.querySelector('nb-layout-column') as HTMLElement | null;
-		if (!column) return;
 		const apply = () => {
+			// Queried FRESH on every call — a captured node can go stale across layout re-renders,
+			// and a stale node measures its old box while looking perfectly alive.
+			const column = document.querySelector('nb-layout-column') as HTMLElement | null;
+			if (!column) return;
 			const rect = column.getBoundingClientRect();
 			const root = document.documentElement.style;
 			root.setProperty('--gz-canvas-left', `${Math.round(rect.left)}px`);
@@ -170,8 +173,20 @@ export class OneColumnLayoutComponent {
 			// which is the regression this whole change exists to remove.
 			root.setProperty('--gz-canvas-right', `${Math.round(window.innerWidth - rect.right)}px`);
 		};
-		this.canvasResizeObserver = new ResizeObserver(apply);
-		this.canvasResizeObserver.observe(column);
+		// The chat panel animates its width (0.2s transition), so a single measurement lands
+		// mid-animation and freezes the header at a stale inset. Settle over the transition:
+		// idempotent style writes make the extra ticks free.
+		const applySettled = () => {
+			requestAnimationFrame(apply);
+			setTimeout(apply, 120);
+			setTimeout(apply, 400);
+		};
+
+		const column = document.querySelector('nb-layout-column') as HTMLElement | null;
+		if (column) {
+			this.canvasResizeObserver = new ResizeObserver(apply);
+			this.canvasResizeObserver.observe(column);
+		}
 		// The column's own box does not change when the window does, so track that too.
 		window.addEventListener('resize', apply);
 		this.canvasLeftOnResize = apply;
@@ -186,13 +201,26 @@ export class OneColumnLayoutComponent {
 				this.chatSidebarService.expanded();
 				this.chatSidebarService.maximized();
 				this.chatSidebarService.width();
-				// After the layout has actually reflowed, not during this microtask.
-				requestAnimationFrame(apply);
+				applySettled();
 			},
 			{ injector: this.injector }
 		);
+
+		// DOM-level belt-and-braces, deliberately independent of Angular's reactive machinery:
+		// measured LIVE on demo, expanding the chat moved the column (256 → 640) while neither the
+		// effect above nor the ResizeObserver ever refreshed the vars — the header stayed pinned
+		// under the chat until an unrelated window resize. Nebular stamps expanded/collapsed onto
+		// the sidebar host as CLASSES, so a MutationObserver on that attribute fires on every
+		// state change no matter which observer mechanism is having a bad day.
+		const chatHost = document.querySelector('nb-sidebar.chat-sidebar');
+		if (chatHost && typeof MutationObserver !== 'undefined') {
+			this.chatClassObserver = new MutationObserver(applySettled);
+			this.chatClassObserver.observe(chatHost, { attributes: true, attributeFilter: ['class'] });
+		}
 		apply();
 	}
+
+	private chatClassObserver?: MutationObserver;
 
 	private canvasLeftOnResize?: () => void;
 


### PR DESCRIPTION
Both P0s from today's demo report, **reproduced live in a browser session on demo before touching code**, with the mechanism pinned by measurement.

## 1. Every sidebar click silently did nothing

Live evidence: the click reaches the link and `navigateByUrl` runs — then nothing. No console error, URL unchanged. Setting `location.hash` directly navigates fine. That asymmetry (imperative dies, popstate passes) is the signature of a **superseding same-URL navigation**.

The canceller: `DocumentsEffects.mergeUrlParams` issues `router.navigate([], {queryParamsHandling: 'merge', replaceUrl: true})` from **debounced effects registered on the global effects manager** — once the lazy Documents module loads (e.g. by *clicking Documents once*), they run for the rest of the session on every page. Any write landing while a click's navigation is in flight cancels it into a `NavigationSkipped`: silent by construction.

**Fix**: the funnel writes only while the Documents route is active, and never while another navigation is in flight (safe to drop — every caller re-derives the full param set from the store on its next write). A systematic sweep found the other four `navigate([], …)` callers in docs-ui are click-driven on the docs page itself.

Bonus from the same hunt: the app component's `NavigationEnd` pipeline used `mergeMap(route => route.data)` — `route.data` never completes, so it leaked one live inner subscription **per navigation, forever**, each re-running selector/date-picker/URL writes on any retained route's data re-emit. Now `switchMap`.

## 2. Chat over the canvas header (the long-standing complaint)

Live measurement on current demo: expanding the chat moves the layout column (256 → 640) but **neither the reactive effect nor the ResizeObserver ever refreshed `--gz-canvas-left`** — the header stayed pinned under the chat until an unrelated window resize, at which point it snapped to the right place (proving `apply()` itself was always correct).

**Fix — belt and braces so no single broken observer can ever strand the header again**:
- elements queried fresh on every apply (captured nodes can go stale invisibly)
- measurements settle across the panel's 0.2 s width transition (rAF + 120 ms + 400 ms ticks, idempotent writes)
- a DOM-level `MutationObserver` on the chat host's `class` attribute fires on every expand/collapse, independent of Angular's reactive machinery entirely

## Verification

- docs-ui `tsc` error count identical with the change stashed (all 53 pre-existing, none in these files); cspell clean.
- The definitive verification is on demo after deploy: click sidebar items with the docs module loaded, and expand/collapse the chat watching the header band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two P0s: sidebar clicks were cancelled after visiting Documents, and the canvas header stayed stuck under the chat panel. Restores reliable navigation and keeps the header inset in sync when chat expands or collapses.

- **Bug Fixes**
  - Navigation: `DocumentsEffects` now writes URL params only on the Documents route and never during another navigation. This stops same-URL `navigate([], { queryParamsHandling: 'merge' })` calls from superseding sidebar clicks.
  - Routing pipeline: switched `mergeMap` to `switchMap` on `route.data` in `AppComponent` to drop old streams and prevent repeated selector/date-picker/URL writes.
  - Header inset: reliably updates `--gz-canvas-left/right` by re-querying elements on each apply, settling over the chat’s 0.2s width transition (rAF + 120 ms + 400 ms), and observing `nb-sidebar.chat-sidebar` class changes with a `MutationObserver`.
  - SCSS/layout: unified chat width via `--gz-chat-width` for both host and panel; removed the stale `--gz-chat-live-width` reference.

<sup>Written for commit 536fa7fcedb3fcb0230546e6eb729716dea54495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

