### PR TITLE
chore: cascade develop → stage (demo bug wave: navigation, header inset, attach pickers)

### DIFF
--- a/apps/gauzy/src/app/app.component.ts
+++ b/apps/gauzy/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { filter, map, mergeMap, take, tap } from 'rxjs';
+import { filter, map, switchMap, take, tap } from 'rxjs';
 import { pluck, union } from 'underscore';
 import { IDateRangePicker, ILanguage, LanguagesEnum } from '@gauzy/contracts';
 import { environment } from '@gauzy/ui-config';
@@ -226,8 +226,12 @@ export class AppComponent implements OnInit, AfterViewInit {
 				}),
 				// Filter for routes in the primary outlet
 				filter((route) => route.outlet === 'primary'),
-				// MergeMap to the route data
-				mergeMap((route) => route.data),
+				// switchMap, NOT mergeMap: `route.data` never completes, so mergeMap leaked one
+				// live inner subscription per navigation for the life of the app — each of which
+				// re-ran the selector/date-picker/URL writes below whenever a retained route's
+				// data re-emitted. switchMap drops the previous route's stream on every
+				// navigation, so exactly one route's data is ever live.
+				switchMap((route) => route.data),
 				/**
 				 * Set Date Range Picker Default Unit and Config
 				 */

--- a/packages/plugins/ai-chat-react-ui/src/lib/ai-chat-window.component.ts
+++ b/packages/plugins/ai-chat-react-ui/src/lib/ai-chat-window.component.ts
@@ -29,6 +29,12 @@ import { AiChatSidebarComponent } from './ai-chat-sidebar.component';
 				width: 100%;
 				min-width: 0;
 				overflow: hidden;
+				/* The docked chat gets --gz-chat-surface from its nb-sidebar wrapper (the layout
+				   publishes the themed sidebar background there). This window has no wrapper, so
+				   without a value the panel's overlays (history, attach picker) fall back to a
+				   blur over a transparent surface — readable-ish, but the conversation bleeds
+				   through. Publish the page background this window already renders on. */
+				--gz-chat-surface: var(--background-basic-color-1, Canvas);
 			}
 		`
 	],

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/AiChatPanel.tsx
@@ -104,6 +104,21 @@ export function AiChatPanel() {
 	);
 
 	/**
+	 * The tenant/organization scope the Documents endpoints require IN THE REQUEST ITSELF —
+	 * `where[organizationId]` on the list, an `organizationId` part in the upload body. The
+	 * Tenant-Id/Organization-Id HEADERS do not satisfy those DTO validators
+	 * (`TenantOrganizationBaseDTO`), which is exactly how the picker first shipped broken:
+	 * every request answered 400 and the UI misread it as "Documents unavailable".
+	 */
+	const attachScope = useCallback(
+		(): { organizationId?: string; tenantId?: string } => ({
+			...(store.organizationId ? { organizationId: store.organizationId } : {}),
+			...(store.tenantId ? { tenantId: store.tenantId } : {})
+		}),
+		[store]
+	);
+
+	/**
 	 * May this user open the AI Providers settings page?
 	 *
 	 * Chat only requires AI_CHAT_ACCESS, but the settings route is guarded by AI_CHAT_SETTINGS — so
@@ -358,6 +373,11 @@ export function AiChatPanel() {
 				const docsForm = new FormData();
 				docsForm.append('files', file, file.name);
 				docsForm.append('source', 'CHAT');
+				// Required by UploadDocumentsDTO (TenantOrganizationBaseDTO): the org must be in the
+				// BODY — headers alone fail validation with "organizationId must be a UUID".
+				const scope = attachScope();
+				if (scope.organizationId) docsForm.append('organizationId', scope.organizationId);
+				if (scope.tenantId) docsForm.append('tenantId', scope.tenantId);
 				const docsResponse = await fetch(`${environment.API_BASE_URL}/api/plugins/docs/documents/upload`, {
 					method: 'POST',
 					headers: authHeaders(),
@@ -432,7 +452,7 @@ export function AiChatPanel() {
 				setIsAttaching(false);
 			}
 		},
-		[authHeaders]
+		[authHeaders, attachScope]
 	);
 
 	/** Attach an existing document by id — what makes `docs_read` able to open exactly that one. */
@@ -612,7 +632,10 @@ export function AiChatPanel() {
 		display: 'flex',
 		flexDirection: 'column',
 		overflow: 'hidden',
-		minWidth: 0
+		minWidth: 0,
+		// The positioning context for the history and attach-picker overlays: `inset: 0` must
+		// resolve against the BODY, so an overlay can never cover the panel's own header row.
+		position: 'relative'
 	};
 
 	const resizeHandleStyle: CSSProperties = {
@@ -929,32 +952,34 @@ export function AiChatPanel() {
 				</span>
 			</div>
 
-			{/* Conversation history overlay */}
-			{showHistory && (
-				<ChatHistoryPanel
-					items={history}
-					loading={historyLoading}
-					activeId={activeConversationId}
-					translate={t}
-					onSelect={handleSelectConversation}
-					onDelete={handleDeleteConversation}
-					onClose={() => setShowHistory(false)}
-				/>
-			)}
-
-			{/* "Attach from Documents" overlay — same full-panel treatment as history. */}
-			{showAttachPicker && (
-				<DocsAttachPicker
-					apiBaseUrl={environment.API_BASE_URL}
-					headers={authHeaders}
-					translate={t}
-					onPick={handlePickDocument}
-					onClose={() => setShowAttachPicker(false)}
-				/>
-			)}
-
-			{/* Chat body — fills remaining height */}
+			{/* Chat body — fills remaining height. The overlays mount INSIDE it so they cover the
+			    conversation area only, never the panel's own header (which stays operable — the
+			    user can still collapse/detach while a picker is open). */}
 			<div style={bodyStyle}>
+				{/* Conversation history overlay */}
+				{showHistory && (
+					<ChatHistoryPanel
+						items={history}
+						loading={historyLoading}
+						activeId={activeConversationId}
+						translate={t}
+						onSelect={handleSelectConversation}
+						onDelete={handleDeleteConversation}
+						onClose={() => setShowHistory(false)}
+					/>
+				)}
+
+				{/* "Attach from Documents" overlay */}
+				{showAttachPicker && (
+					<DocsAttachPicker
+						apiBaseUrl={environment.API_BASE_URL}
+						headers={authHeaders}
+						scope={attachScope}
+						translate={t}
+						onPick={handlePickDocument}
+						onClose={() => setShowAttachPicker(false)}
+					/>
+				)}
 				{hasMessages ? (
 					<ChatMessageList
 						messages={messages}

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/ChatHistoryPanel.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/ChatHistoryPanel.tsx
@@ -36,13 +36,18 @@ export function ChatHistoryPanel({
 	onClose
 }: ChatHistoryPanelProps) {
 	const containerStyle: CSSProperties = {
+		// Fills the chat BODY (the panel mounts this inside its position:relative body container),
+		// so the panel's own header row stays visible and operable above it.
 		position: 'absolute',
 		inset: 0,
 		display: 'flex',
 		flexDirection: 'column',
 		zIndex: 5,
-		backdropFilter: 'blur(2px)',
-		background: 'inherit'
+		// `inherit` resolved to transparent (the parent paints no background), so the conversation
+		// bled through. The layout publishes its sidebar surface as --gz-chat-surface; the blur is
+		// the fallback for hosts that do not (detached window).
+		backdropFilter: 'blur(12px)',
+		background: 'var(--gz-chat-surface, transparent)'
 	};
 
 	const headerStyle: CSSProperties = {

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/DocsAttachPicker.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/DocsAttachPicker.tsx
@@ -21,6 +21,14 @@ export interface DocsAttachPickerProps {
 	apiBaseUrl: string;
 	/** Auth + tenant headers for the request (the panel already builds these for every call). */
 	headers: () => Record<string, string>;
+	/**
+	 * Tenant/organization scope for the QUERY. The docs list endpoint validates a `where` object
+	 * (`where[organizationId]` is required) — the Tenant-Id/Organization-Id headers do not satisfy
+	 * it, and flat `organizationId` params are whitelisted away. Without this the endpoint answers
+	 * 400 for every request, which the first version of this picker misreported as "Documents are
+	 * not available in this workspace".
+	 */
+	scope: () => { organizationId?: string; tenantId?: string };
 	/** The user chose a document. */
 	onPick: (document: IAttachableDocument) => void;
 	/** Dismiss without choosing. */
@@ -44,12 +52,12 @@ export interface DocsAttachPickerProps {
  * tool takes a document id, so the assistant can open exactly what the user pointed at rather
  * than searching for something with a similar name.
  */
-export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, translate }: DocsAttachPickerProps) {
+export function DocsAttachPicker({ apiBaseUrl, headers, scope, onPick, onClose, translate }: DocsAttachPickerProps) {
 	const t = translate ?? ((_key: string, fallback: string) => fallback);
 	const [query, setQuery] = useState('');
 	const [documents, setDocuments] = useState<IAttachableDocument[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
-	const [failed, setFailed] = useState(false);
+	const [failure, setFailure] = useState<'unavailable' | 'error' | null>(null);
 	const searchRef = useRef<HTMLInputElement>(null);
 	// Bumped on every request so a slow earlier response can never overwrite a newer one.
 	const requestSeq = useRef(0);
@@ -62,9 +70,14 @@ export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, transla
 		(search: string) => {
 			const seq = ++requestSeq.current;
 			setIsLoading(true);
-			setFailed(false);
+			setFailure(null);
 
 			const params = new URLSearchParams({ take: String(PAGE_SIZE), sort: 'updatedAt', sortOrder: 'DESC' });
+			// The endpoint's DTO requires the scope inside a `where` object (bracket syntax — the
+			// API's extended query parser reassembles it into the nested shape the validator wants).
+			const { organizationId, tenantId } = scope();
+			if (organizationId) params.set('where[organizationId]', organizationId);
+			if (tenantId) params.set('where[tenantId]', tenantId);
 			// Folders hold no readable content — offering one would attach nothing.
 			params.set('kind', 'FILE,PAGE');
 			if (search.trim()) {
@@ -77,18 +90,22 @@ export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, transla
 					if (seq !== requestSeq.current) return;
 					setDocuments(Array.isArray(page?.items) ? page.items : []);
 				})
-				.catch(() => {
+				.catch((error: unknown) => {
 					if (seq !== requestSeq.current) return;
-					// The Documents plugin may not be installed at all, in which case this 404s.
-					// Either way the honest answer is "nothing to offer", not a broken list.
 					setDocuments([]);
-					setFailed(true);
+					// Only "the feature is not here for you" statuses may claim unavailability:
+					// 404 = docs plugin not installed, 403 = no DOCS_READ / feature disabled.
+					// Anything else is a FAILURE and must say so — the first version showed
+					// "Documents are not available" for its own 400s, hiding a plain bug behind
+					// a message that blamed the workspace.
+					const status = error instanceof Error ? error.message : '';
+					setFailure(status === '403' || status === '404' ? 'unavailable' : 'error');
 				})
 				.finally(() => {
 					if (seq === requestSeq.current) setIsLoading(false);
 				});
 		},
-		[apiBaseUrl, headers]
+		[apiBaseUrl, headers, scope]
 	);
 
 	useEffect(() => {
@@ -97,12 +114,19 @@ export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, transla
 	}, [query, load]);
 
 	const overlayStyle: CSSProperties = {
+		// Fills the chat BODY (the panel mounts this inside its position:relative body container),
+		// so the panel's own header row stays visible and operable above it.
 		position: 'absolute',
 		inset: 0,
 		zIndex: 6,
 		display: 'flex',
 		flexDirection: 'column',
-		backgroundColor: chatTheme.surface,
+		// The chat theme has no opaque surface token (surfaces are currentColor tints over
+		// transparent — the Angular layout paints the real background), so a tint alone let the
+		// conversation show through the picker. The layout publishes its sidebar surface as
+		// --gz-chat-surface; the blur is the fallback for hosts that do not (detached window).
+		backgroundColor: 'var(--gz-chat-surface, transparent)',
+		backdropFilter: 'blur(12px)',
 		animation: 'fadeIn 0.15s ease'
 	};
 
@@ -198,8 +222,10 @@ export function DocsAttachPicker({ apiBaseUrl, headers, onPick, onClose, transla
 
 				{!isLoading && !documents.length && (
 					<div style={emptyStyle}>
-						{failed
+						{failure === 'unavailable'
 							? t('AI_ASSISTANT.ATTACH_UNAVAILABLE', 'Documents are not available in this workspace.')
+							: failure === 'error'
+							? t('AI_ASSISTANT.ATTACH_LOAD_FAILED', 'The document list could not be loaded — please try again.')
 							: t('AI_ASSISTANT.ATTACH_NO_RESULTS', 'No matching documents.')}
 					</div>
 				)}

--- a/packages/plugins/ai-chat-react-ui/src/lib/components/DocsAttachPicker.tsx
+++ b/packages/plugins/ai-chat-react-ui/src/lib/components/DocsAttachPicker.tsx
@@ -85,7 +85,12 @@ export function DocsAttachPicker({ apiBaseUrl, headers, scope, onPick, onClose, 
 			}
 
 			fetch(`${apiBaseUrl}/api/plugins/docs/documents?${params.toString()}`, { headers: headers() })
-				.then((response) => (response.ok ? response.json() : Promise.reject(new Error(String(response.status)))))
+				.then((response) => {
+					if (response.ok) return response.json();
+					// The status rides the rejection as a typed field — classifying on a
+					// stringified message would couple the catch to this throw-site's wording.
+					return Promise.reject(Object.assign(new Error(`docs list failed (${response.status})`), { status: response.status }));
+				})
 				.then((page: { items?: IAttachableDocument[] }) => {
 					if (seq !== requestSeq.current) return;
 					setDocuments(Array.isArray(page?.items) ? page.items : []);
@@ -98,8 +103,8 @@ export function DocsAttachPicker({ apiBaseUrl, headers, scope, onPick, onClose, 
 					// Anything else is a FAILURE and must say so — the first version showed
 					// "Documents are not available" for its own 400s, hiding a plain bug behind
 					// a message that blamed the workspace.
-					const status = error instanceof Error ? error.message : '';
-					setFailure(status === '403' || status === '404' ? 'unavailable' : 'error');
+					const status = (error as { status?: number })?.status;
+					setFailure(status === 403 || status === 404 ? 'unavailable' : 'error');
 				})
 				.finally(() => {
 					if (seq === requestSeq.current) setIsLoading(false);

--- a/packages/plugins/docs-ui/src/lib/+state/documents.effects.ts
+++ b/packages/plugins/docs-ui/src/lib/+state/documents.effects.ts
@@ -436,6 +436,27 @@ export class DocumentsEffects {
 	}
 
 	private mergeUrlParams(params: Params): void {
+		// `navigate([], …)` targets the CURRENT url — and these effects live on the GLOBAL effects
+		// manager, so once the lazy Documents module has loaded they run for the rest of the
+		// session, on every page, on debounced timers. Two guards keep that from hijacking the
+		// router:
+		//
+		// 1. Only write while the Documents page is the ACTIVE route. After the user leaves, the
+		//    URL belongs to whatever page they navigated to — a background docs write there is
+		//    state leakage at best.
+		// 2. Never write while ANOTHER navigation is in flight. A same-URL navigate issued
+		//    mid-navigation silently SUPERSEDES it (NavigationCancel → NavigationSkipped, no
+		//    error, no URL change) — which is exactly how every sidebar click on demo died the
+		//    moment the docs module had loaded: the click's imperative navigation was cancelled
+		//    by this funnel, while popstate/hash navigations (already past the URL change) kept
+		//    working. The dropped write is safe: every effect that lands here re-derives the full
+		//    param set from the store, so the next write carries the complete state anyway.
+		if (!this.router.url.startsWith('/pages/documents')) {
+			return;
+		}
+		if (this.router.getCurrentNavigation()) {
+			return;
+		}
 		this.router.navigate([], {
 			queryParams: params,
 			queryParamsHandling: 'merge',

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -4112,6 +4112,7 @@
 		"ATTACH_RESPONSE_UNREADABLE": "The upload response could not be read — check the Documents page before retrying",
 		"ATTACH_SEARCH": "Search documents…",
 		"ATTACH_NO_RESULTS": "No matching documents.",
+		"ATTACH_LOAD_FAILED": "The document list could not be loaded — please try again.",
 		"ATTACH_UNAVAILABLE": "Documents are not available in this workspace.",
 		"ATTACH_REMOVE": "Remove attachment",
 		"CITATIONS": {

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -143,6 +143,10 @@
         // Same surface as the nav menu sidebar; the chat panel's design
         // tokens derive from currentColor, so set the themed text color here.
         background: nb-theme(gauzy-sidebar-background-2);
+        // Published as a CSS var so the React panel's overlays (history, attach picker) can paint
+        // an OPAQUE surface: the chat theme's own surface tokens are currentColor tints over
+        // transparent, and an overlay using them lets the conversation bleed through.
+        --gz-chat-surface: #{nb-theme(gauzy-sidebar-background-2)};
         color: nb-theme(text-basic-color);
         border-right: 1px solid nb-theme(divider-color);
       }

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -55,9 +55,10 @@
   // (Menu | Chat | Canvas, or Menu | Canvas | Chat when docked right).
   // The HOST stays in the flex flow and reserves the width; Nebular's
   // .main-container is position:fixed in windowMode, so it is pinned to the
-  // full viewport height (top 0 → nothing above or below it) and follows the
-  // host's flex-computed width via --gz-chat-live-width (set by the layout's
-  // ResizeObserver — covers normal, user-resized, maximized and collapsed).
+  // full viewport height (top 0 → nothing above or below it). Host and panel
+  // BOTH size from --gz-chat-width (the persisted user width, bound inline on
+  // the host by the layout template) with the same 24rem fallback — one source
+  // of truth, and the two can never disagree.
   nb-sidebar.chat-sidebar {
     order: 0 !important;
     align-self: stretch;

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.ts
@@ -101,6 +101,7 @@ export class OneColumnLayoutComponent {
 			this.navigationBuilderService.clearActionBars();
 			this.headerResizeObserver?.disconnect();
 			this.canvasResizeObserver?.disconnect();
+			this.chatClassObserver?.disconnect();
 			if (this.canvasLeftOnResize) window.removeEventListener('resize', this.canvasLeftOnResize);
 		});
 	}
@@ -158,9 +159,11 @@ export class OneColumnLayoutComponent {
 	 */
 	private observeCanvasLeft(): void {
 		if (typeof ResizeObserver === 'undefined' || typeof document === 'undefined') return;
-		const column = document.querySelector('nb-layout-column') as HTMLElement | null;
-		if (!column) return;
 		const apply = () => {
+			// Queried FRESH on every call — a captured node can go stale across layout re-renders,
+			// and a stale node measures its old box while looking perfectly alive.
+			const column = document.querySelector('nb-layout-column') as HTMLElement | null;
+			if (!column) return;
 			const rect = column.getBoundingClientRect();
 			const root = document.documentElement.style;
 			root.setProperty('--gz-canvas-left', `${Math.round(rect.left)}px`);
@@ -170,8 +173,20 @@ export class OneColumnLayoutComponent {
 			// which is the regression this whole change exists to remove.
 			root.setProperty('--gz-canvas-right', `${Math.round(window.innerWidth - rect.right)}px`);
 		};
-		this.canvasResizeObserver = new ResizeObserver(apply);
-		this.canvasResizeObserver.observe(column);
+		// The chat panel animates its width (0.2s transition), so a single measurement lands
+		// mid-animation and freezes the header at a stale inset. Settle over the transition:
+		// idempotent style writes make the extra ticks free.
+		const applySettled = () => {
+			requestAnimationFrame(apply);
+			setTimeout(apply, 120);
+			setTimeout(apply, 400);
+		};
+
+		const column = document.querySelector('nb-layout-column') as HTMLElement | null;
+		if (column) {
+			this.canvasResizeObserver = new ResizeObserver(apply);
+			this.canvasResizeObserver.observe(column);
+		}
 		// The column's own box does not change when the window does, so track that too.
 		window.addEventListener('resize', apply);
 		this.canvasLeftOnResize = apply;
@@ -186,13 +201,26 @@ export class OneColumnLayoutComponent {
 				this.chatSidebarService.expanded();
 				this.chatSidebarService.maximized();
 				this.chatSidebarService.width();
-				// After the layout has actually reflowed, not during this microtask.
-				requestAnimationFrame(apply);
+				applySettled();
 			},
 			{ injector: this.injector }
 		);
+
+		// DOM-level belt-and-braces, deliberately independent of Angular's reactive machinery:
+		// measured LIVE on demo, expanding the chat moved the column (256 → 640) while neither the
+		// effect above nor the ResizeObserver ever refreshed the vars — the header stayed pinned
+		// under the chat until an unrelated window resize. Nebular stamps expanded/collapsed onto
+		// the sidebar host as CLASSES, so a MutationObserver on that attribute fires on every
+		// state change no matter which observer mechanism is having a bad day.
+		const chatHost = document.querySelector('nb-sidebar.chat-sidebar');
+		if (chatHost && typeof MutationObserver !== 'undefined') {
+			this.chatClassObserver = new MutationObserver(applySettled);
+			this.chatClassObserver.observe(chatHost, { attributes: true, attributeFilter: ['class'] });
+		}
 		apply();
 	}
+
+	private chatClassObserver?: MutationObserver;
 
 	private canvasLeftOnResize?: () => void;
 


### PR DESCRIPTION
Promotes develop to stage — the demo bug-wave fixes, each root-caused live on demo first:

- **#9965**: the Documents URL-writer silently cancelled every sidebar navigation once the docs module had loaded (global effects manager + same-URL merge navigate); now route-scoped and in-flight-aware. Plus the NavigationEnd subscription leak (mergeMap over never-completing route.data) and the stranded header inset — the chat/header overlap — now updated via fresh queries, transition-settled measurements, and a DOM-level MutationObserver.
- **#9964**: the attach/library pickers actually work against the Documents API (where[organizationId] on the list, organizationId in the upload body — both 400'd before), honest failure classification, and overlays that sit below the chat header on an opaque surface.

**Merge with a MERGE COMMIT** (release gate). CodeQL/Sonar/Codacy fail on every cascade by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken sidebar navigation and header overlap, and makes the chat document attach pickers work with the real Documents API. Also tightens route subscriptions and makes overlays readable without covering the panel header.

- **Bug Fixes**
  - Prevented global Documents URL writes from running outside the Documents route and during in‑flight navigations, so sidebar clicks no longer get silently canceled.
  - Switched `mergeMap` to `switchMap` over `route.data` to avoid leaking subscriptions on each navigation.
  - Kept the chat/header from overlapping by re-measuring the canvas inset with fresh DOM queries, settled timing (rAF + timers), and a `MutationObserver` on sidebar class changes.
  - Made attach pickers work with the Documents API: send `where[organizationId]`/`where[tenantId]` on list queries and include `organizationId`/`tenantId` in upload bodies; classify 403/404 as unavailable, others as load failures (added `ATTACH_LOAD_FAILED` i18n key).
  - Mounted history and attach overlays inside the panel body and rendered them on an opaque surface via `--gz-chat-surface` (published by the layout; detached window sets its own), so the conversation doesn’t bleed through and the panel header remains usable.

<sup>Written for commit 211fa68b7b2f09da47697aa876a52c45a57d9c7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

