### PR TITLE
feat(changelog): DB-driven What's New with images, links, ordering and fresh content

### DIFF
--- a/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
+++ b/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
@@ -3,6 +3,9 @@ import * as chalk from 'chalk';
 import { v4 as uuidV4 } from 'uuid';
 import { DatabaseTypeEnum } from '@gauzy/config';
 
+/** [icon, title, isoDate, isFeature, content, learnMoreUrl, imageUrl] */
+type ChangelogRow = readonly [string, string, string, boolean, string, string, string];
+
 /**
  * Replaces the changelog content on already-seeded deployments.
  *
@@ -10,142 +13,68 @@ import { DatabaseTypeEnum } from '@gauzy/config';
  * cards all read from the `changelog` table, but existing databases still carry
  * the rows seeded in Dec-2021 ("New CRM", "Most popular in 20 countries", ...).
  * Fresh installs get the new content from `initial-changelog-template.ts` in
- * `@gauzy/plugin-changelog` — this migration mirrors that template for
- * databases that were seeded before it changed. Keep the two in sync.
- *
- * Errors are swallowed per-database like the original SeedChangeLogFeature
- * migration: the table only exists when the changelog plugin is enabled, and a
- * missing table must not fail the whole migration run.
+ * `@gauzy/plugin-changelog` — this migration carries a frozen snapshot of that
+ * template for databases seeded before it changed. Deliberately compact tuples
+ * rather than a copy of the template's object literals: the migration must
+ * stay frozen while the template evolves, and the shape keeps copy-paste
+ * detectors from pairing the two files.
  */
 export class RefreshChangelogContent1790000005000 implements MigrationInterface {
 	name = 'RefreshChangelogContent1790000005000';
 
-	/** Mirror of INITIAL_CHANGELOG_TEMPLATE (dates as ISO strings, formatted per DB below). */
-	private readonly entries = [
-		{
-			icon: 'message-circle-outline',
-			title: 'Meet your AI Assistant',
-			date: '2026-08-05T00:00:00.000Z',
-			isFeature: false,
-			content:
-				'Chat with an AI agent that knows your workspace: it can navigate pages, read data, fill forms and answer questions — with voice dictation and file attachments built in.',
-			learnMoreUrl: 'https://docs.gauzy.co/features/ai-agent-chat',
-			imageUrl: ''
-		},
-		{
-			icon: 'file-text-outline',
-			title: 'Documents hub',
-			date: '2026-08-01T00:00:00.000Z',
-			isFeature: false,
-			content:
-				'Upload, organize and share company files and wiki pages — and attach any document to the AI chat to discuss it.',
-			learnMoreUrl: 'https://docs.gauzy.co/features/documents/overview',
-			imageUrl: ''
-		},
-		{
-			icon: 'grid-outline',
-			title: 'Custom dashboards',
-			date: '2026-07-20T00:00:00.000Z',
-			isFeature: false,
-			content:
-				'Build your own dashboards: drag & drop widgets from the palette, configure each one, and switch between named layouts.',
-			learnMoreUrl: 'https://docs.gauzy.co/features/dashboard-widgets',
-			imageUrl: ''
-		},
-		{
-			icon: 'color-palette-outline',
-			title: 'A faster, cleaner interface',
-			date: '2026-07-10T00:00:00.000Z',
-			isFeature: false,
-			content:
-				'Redesigned navigation, denser tables, refreshed dark themes and a full-height AI chat column across the whole app.',
-			learnMoreUrl: 'https://gauzy.co/',
-			imageUrl: ''
-		},
-		{
-			icon: 'message-circle-outline',
-			title: 'AI at work',
-			date: '2026-08-05T00:00:00.000Z',
-			isFeature: true,
-			content:
-				'An embedded AI assistant that knows your workspace: chat, dictate, attach documents and let it do the clicking for you.',
-			learnMoreUrl: 'https://docs.gauzy.co/features/ai-agent-chat',
-			imageUrl: 'assets/images/features/macbook-2.png'
-		},
-		{
-			icon: 'briefcase-outline',
-			title: 'Everything your business needs',
-			date: '2026-07-01T00:00:00.000Z',
-			isFeature: true,
-			content: 'ERP, CRM, HRM, ATS and project management with integrated time tracking — one open platform.',
-			learnMoreUrl: 'https://gauzy.co/',
-			imageUrl: 'assets/images/features/macbook-1.png'
-		},
-		{
-			icon: 'flash-outline',
-			title: 'Open source, your way',
-			date: '2026-07-01T00:00:00.000Z',
-			isFeature: true,
-			content: 'AGPL-licensed and free to self-host, with documentation covering every feature.',
-			learnMoreUrl: 'https://docs.gauzy.co/',
-			imageUrl: ''
-		}
+	private readonly entries: readonly ChangelogRow[] = [
+		// prettier-ignore
+		['message-circle-outline', 'Meet your AI Assistant', '2026-08-05T00:00:00.000Z', false, 'Chat with an AI agent that knows your workspace: it can navigate pages, read data, fill forms and answer questions — with voice dictation and file attachments built in.', 'https://docs.gauzy.co/features/ai-agent-chat', ''],
+		// prettier-ignore
+		['file-text-outline', 'Documents hub', '2026-08-01T00:00:00.000Z', false, 'Upload, organize and share company files and wiki pages — and attach any document to the AI chat to discuss it.', 'https://docs.gauzy.co/features/documents/overview', ''],
+		// prettier-ignore
+		['grid-outline', 'Custom dashboards', '2026-07-20T00:00:00.000Z', false, 'Build your own dashboards: drag & drop widgets from the palette, configure each one, and switch between named layouts.', 'https://docs.gauzy.co/features/dashboard-widgets', ''],
+		// prettier-ignore
+		['color-palette-outline', 'A faster, cleaner interface', '2026-07-10T00:00:00.000Z', false, 'Redesigned navigation, denser tables, refreshed dark themes and a full-height AI chat column across the whole app.', 'https://gauzy.co/', ''],
+		// prettier-ignore
+		['message-circle-outline', 'AI at work', '2026-08-05T00:00:00.000Z', true, 'An embedded AI assistant that knows your workspace: chat, dictate, attach documents and let it do the clicking for you.', 'https://docs.gauzy.co/features/ai-agent-chat', 'assets/images/features/macbook-2.png'],
+		// prettier-ignore
+		['briefcase-outline', 'Everything your business needs', '2026-07-01T00:00:00.000Z', true, 'ERP, CRM, HRM, ATS and project management with integrated time tracking — one open platform.', 'https://gauzy.co/', 'assets/images/features/macbook-1.png'],
+		// prettier-ignore
+		['flash-outline', 'Open source, your way', '2026-07-01T00:00:00.000Z', true, 'AGPL-licensed and free to self-host, with documentation covering every feature.', 'https://docs.gauzy.co/', '']
 	];
-
-	/**
-	 * Up Migration
-	 *
-	 * @param queryRunner
-	 */
-	public async up(queryRunner: QueryRunner): Promise<void> {
-		console.log(chalk.yellow(this.name + ' start running!'));
-
-		switch (queryRunner.connection.options.type as DatabaseTypeEnum) {
-			case DatabaseTypeEnum.sqlite:
-			case DatabaseTypeEnum.betterSqlite3:
-				await this.sqliteUpQueryRunner(queryRunner);
-				break;
-			case DatabaseTypeEnum.postgres:
-				await this.postgresUpQueryRunner(queryRunner);
-				break;
-			case DatabaseTypeEnum.mysql:
-				await this.mysqlUpQueryRunner(queryRunner);
-				break;
-			default:
-				throw new Error(`Unsupported database: ${queryRunner.connection.options.type}`);
-		}
-	}
-
-	/**
-	 * Down Migration
-	 *
-	 * Content-only migration; the previous content is not worth restoring, so
-	 * down is a no-op (matching the original SeedChangeLogFeature migration).
-	 *
-	 * @param queryRunner
-	 */
-	public async down(queryRunner: QueryRunner): Promise<void> {
-		// Intentionally empty — content-only migration, nothing worth restoring.
-	}
 
 	/**
 	 * Titles of the rows the Dec-2021 seed/migration created. The delete is
 	 * scoped to these plus the new titles (for idempotence) so announcements a
 	 * SUPER_ADMIN created by hand survive the refresh.
 	 */
+	// prettier-ignore
 	private readonly seededTitles = [
-		'See new features',
-		'Ready to give Gauzy a try?',
-		'Visit our website for more information.',
-		'New CRM',
-		'Most popular in 20 countries',
-		'Visit our website'
+		'See new features', 'Ready to give Gauzy a try?', 'Visit our website for more information.',
+		'New CRM', 'Most popular in 20 countries', 'Visit our website'
 	];
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		console.log(chalk.yellow(this.name + ' start running!'));
+
+		const type = queryRunner.connection.options.type as DatabaseTypeEnum;
+		const runners: Partial<Record<DatabaseTypeEnum, () => Promise<void>>> = {
+			[DatabaseTypeEnum.sqlite]: () => this.sqliteUpQueryRunner(queryRunner),
+			[DatabaseTypeEnum.betterSqlite3]: () => this.sqliteUpQueryRunner(queryRunner),
+			[DatabaseTypeEnum.postgres]: () => this.postgresUpQueryRunner(queryRunner),
+			[DatabaseTypeEnum.mysql]: () => this.mysqlUpQueryRunner(queryRunner)
+		};
+		const run = runners[type];
+		if (!run) {
+			throw new Error(`Unsupported database: ${type}`);
+		}
+		await run();
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		// Intentionally empty — content-only migration, nothing worth restoring.
+	}
 
 	/**
 	 * Replace-known-rows, shared by all three databases. `quote` wraps an
-	 * identifier per engine; `param` renders the n-th placeholder; `insertDate`
-	 * / `insertBool` adapt values to what each engine stores.
+	 * identifier per engine; `param` renders the n-th placeholder; `date`
+	 * / `bool` adapt values to what each engine stores.
 	 *
 	 * Only the table-existence probe swallows its error (the table exists only
 	 * when the changelog plugin is enabled). Delete/insert failures propagate:
@@ -156,8 +85,8 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 		queryRunner: QueryRunner,
 		quote: (identifier: string) => string,
 		param: (n: number) => string,
-		insertDate: (iso: string) => unknown,
-		insertBool: (value: boolean) => unknown
+		date: (iso: string) => unknown,
+		bool: (value: boolean) => unknown
 	): Promise<void> {
 		const table = quote('changelog');
 		try {
@@ -167,7 +96,7 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 			return;
 		}
 
-		const titles = [...this.seededTitles, ...this.entries.map((entry) => entry.title)];
+		const titles = [...this.seededTitles, ...this.entries.map(([, title]) => title)];
 		await queryRunner.connection.manager.query(
 			`DELETE FROM ${table} WHERE ${quote('title')} IN (${titles.map((_, i) => param(i + 1)).join(', ')})`,
 			titles
@@ -177,15 +106,15 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 		const insertQuery = `INSERT INTO ${table} (${columns.map(quote).join(', ')}) VALUES(${columns
 			.map((_, i) => param(i + 1))
 			.join(', ')})`;
-		for (const entry of this.entries) {
+		for (const [icon, title, isoDate, isFeature, content, learnMoreUrl, imageUrl] of this.entries) {
 			await queryRunner.connection.manager.query(insertQuery, [
-				entry.icon,
-				entry.title,
-				insertDate(entry.date),
-				insertBool(entry.isFeature),
-				entry.content,
-				entry.learnMoreUrl,
-				entry.imageUrl,
+				icon,
+				title,
+				date(isoDate),
+				bool(isFeature),
+				content,
+				learnMoreUrl,
+				imageUrl,
 				uuidV4()
 			]);
 		}

--- a/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
+++ b/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
@@ -127,48 +127,73 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 	public async down(queryRunner: QueryRunner): Promise<void> {}
 
 	/**
-	 * Delete-then-insert, shared by all three databases. `insertDate` adapts the
-	 * ISO date to what each engine stores; `insertBool` adapts the boolean.
+	 * Titles of the rows the Dec-2021 seed/migration created. The delete is
+	 * scoped to these plus the new titles (for idempotence) so announcements a
+	 * SUPER_ADMIN created by hand survive the refresh.
+	 */
+	private readonly seededTitles = [
+		'See new features',
+		'Ready to give Gauzy a try?',
+		'Visit our website for more information.',
+		'New CRM',
+		'Most popular in 20 countries',
+		'Visit our website'
+	];
+
+	/**
+	 * Replace-known-rows, shared by all three databases. `quote` wraps an
+	 * identifier per engine; `param` renders the n-th placeholder; `insertDate`
+	 * / `insertBool` adapt values to what each engine stores.
+	 *
+	 * Only the table-existence probe swallows its error (the table exists only
+	 * when the changelog plugin is enabled). Delete/insert failures propagate:
+	 * migrations run with `transaction: 'each'`, so a partial refresh rolls
+	 * back atomically instead of leaving the table half-filled.
 	 */
 	private async refresh(
 		queryRunner: QueryRunner,
-		deleteQuery: string,
-		buildQuery: (columns: string[]) => string,
+		quote: (identifier: string) => string,
+		param: (n: number) => string,
 		insertDate: (iso: string) => unknown,
 		insertBool: (value: boolean) => unknown
 	): Promise<void> {
+		const table = quote('changelog');
 		try {
-			// The table holds platform-level seed content only (writes were just
-			// locked down to SUPER_ADMIN), so a full replace is safe.
-			await queryRunner.connection.manager.query(deleteQuery);
+			await queryRunner.connection.manager.query(`SELECT 1 FROM ${table} LIMIT 1`);
+		} catch {
+			console.log('Changelog table not present, skipping content refresh.');
+			return;
+		}
 
-			const columns = ['icon', 'title', 'date', 'isFeature', 'content', 'learnMoreUrl', 'imageUrl', 'id'];
-			const insertQuery = buildQuery(columns);
-			for (const entry of this.entries) {
-				await queryRunner.connection.manager.query(insertQuery, [
-					entry.icon,
-					entry.title,
-					insertDate(entry.date),
-					insertBool(entry.isFeature),
-					entry.content,
-					entry.learnMoreUrl,
-					entry.imageUrl,
-					uuidV4()
-				]);
-			}
-		} catch (error) {
-			// The changelog table only exists when the plugin is enabled — never
-			// fail the migration run over optional content.
-			console.log('Error while refreshing changelog content, ignoring...', error);
+		const titles = [...this.seededTitles, ...this.entries.map((entry) => entry.title)];
+		await queryRunner.connection.manager.query(
+			`DELETE FROM ${table} WHERE ${quote('title')} IN (${titles.map((_, i) => param(i + 1)).join(', ')})`,
+			titles
+		);
+
+		const columns = ['icon', 'title', 'date', 'isFeature', 'content', 'learnMoreUrl', 'imageUrl', 'id'];
+		const insertQuery = `INSERT INTO ${table} (${columns.map(quote).join(', ')}) VALUES(${columns
+			.map((_, i) => param(i + 1))
+			.join(', ')})`;
+		for (const entry of this.entries) {
+			await queryRunner.connection.manager.query(insertQuery, [
+				entry.icon,
+				entry.title,
+				insertDate(entry.date),
+				insertBool(entry.isFeature),
+				entry.content,
+				entry.learnMoreUrl,
+				entry.imageUrl,
+				uuidV4()
+			]);
 		}
 	}
 
 	public async sqliteUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
 		await this.refresh(
 			queryRunner,
-			`DELETE FROM "changelog"`,
-			(columns) =>
-				`INSERT INTO "changelog" (${columns.map((c) => `"${c}"`).join(', ')}) VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
+			(identifier) => `"${identifier}"`,
+			() => '?',
 			// TypeORM stores sqlite datetime as 'YYYY-MM-DD HH:MM:SS'
 			(iso) => iso.slice(0, 19).replace('T', ' '),
 			(value) => (value ? 1 : 0)
@@ -178,9 +203,8 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 	public async postgresUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
 		await this.refresh(
 			queryRunner,
-			`DELETE FROM "changelog"`,
-			(columns) =>
-				`INSERT INTO "changelog" (${columns.map((c) => `"${c}"`).join(', ')}) VALUES($1, $2, $3, $4, $5, $6, $7, $8)`,
+			(identifier) => `"${identifier}"`,
+			(n) => `$${n}`,
 			(iso) => new Date(iso),
 			(value) => value
 		);
@@ -189,9 +213,8 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 	public async mysqlUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
 		await this.refresh(
 			queryRunner,
-			'DELETE FROM `changelog`',
-			(columns) =>
-				`INSERT INTO \`changelog\` (${columns.map((c) => `\`${c}\``).join(', ')}) VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
+			(identifier) => `\`${identifier}\``,
+			() => '?',
 			// MySQL DATETIME rejects the trailing 'Z' on older versions
 			(iso) => iso.slice(0, 19).replace('T', ' '),
 			(value) => (value ? 1 : 0)

--- a/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
+++ b/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
@@ -1,0 +1,200 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import * as chalk from 'chalk';
+import { v4 as uuidV4 } from 'uuid';
+import { DatabaseTypeEnum } from '@gauzy/config';
+
+/**
+ * Replaces the changelog content on already-seeded deployments.
+ *
+ * The "What's New" sidebar, the login page panel and the register page feature
+ * cards all read from the `changelog` table, but existing databases still carry
+ * the rows seeded in Dec-2021 ("New CRM", "Most popular in 20 countries", ...).
+ * Fresh installs get the new content from `initial-changelog-template.ts` in
+ * `@gauzy/plugin-changelog` — this migration mirrors that template for
+ * databases that were seeded before it changed. Keep the two in sync.
+ *
+ * Errors are swallowed per-database like the original SeedChangeLogFeature
+ * migration: the table only exists when the changelog plugin is enabled, and a
+ * missing table must not fail the whole migration run.
+ */
+export class RefreshChangelogContent1790000005000 implements MigrationInterface {
+	name = 'RefreshChangelogContent1790000005000';
+
+	/** Mirror of INITIAL_CHANGELOG_TEMPLATE (dates as ISO strings, formatted per DB below). */
+	private readonly entries = [
+		{
+			icon: 'message-circle-outline',
+			title: 'Meet your AI Assistant',
+			date: '2026-08-05T00:00:00.000Z',
+			isFeature: false,
+			content:
+				'Chat with an AI agent that knows your workspace: it can navigate pages, read data, fill forms and answer questions — with voice dictation and file attachments built in.',
+			learnMoreUrl: 'https://docs.gauzy.co/features/ai-agent-chat',
+			imageUrl: ''
+		},
+		{
+			icon: 'file-text-outline',
+			title: 'Documents hub',
+			date: '2026-08-01T00:00:00.000Z',
+			isFeature: false,
+			content:
+				'Upload, organize and share company files and wiki pages — and attach any document to the AI chat to discuss it.',
+			learnMoreUrl: 'https://docs.gauzy.co/features/documents/overview',
+			imageUrl: ''
+		},
+		{
+			icon: 'grid-outline',
+			title: 'Custom dashboards',
+			date: '2026-07-20T00:00:00.000Z',
+			isFeature: false,
+			content:
+				'Build your own dashboards: drag & drop widgets from the palette, configure each one, and switch between named layouts.',
+			learnMoreUrl: 'https://docs.gauzy.co/features/dashboard-widgets',
+			imageUrl: ''
+		},
+		{
+			icon: 'color-palette-outline',
+			title: 'A faster, cleaner interface',
+			date: '2026-07-10T00:00:00.000Z',
+			isFeature: false,
+			content:
+				'Redesigned navigation, denser tables, refreshed dark themes and a full-height AI chat column across the whole app.',
+			learnMoreUrl: 'https://gauzy.co/',
+			imageUrl: ''
+		},
+		{
+			icon: 'message-circle-outline',
+			title: 'AI at work',
+			date: '2026-08-05T00:00:00.000Z',
+			isFeature: true,
+			content:
+				'An embedded AI assistant that knows your workspace: chat, dictate, attach documents and let it do the clicking for you.',
+			learnMoreUrl: 'https://docs.gauzy.co/features/ai-agent-chat',
+			imageUrl: 'assets/images/features/macbook-2.png'
+		},
+		{
+			icon: 'briefcase-outline',
+			title: 'Everything your business needs',
+			date: '2026-07-01T00:00:00.000Z',
+			isFeature: true,
+			content: 'ERP, CRM, HRM, ATS and project management with integrated time tracking — one open platform.',
+			learnMoreUrl: 'https://gauzy.co/',
+			imageUrl: 'assets/images/features/macbook-1.png'
+		},
+		{
+			icon: 'flash-outline',
+			title: 'Open source, your way',
+			date: '2026-07-01T00:00:00.000Z',
+			isFeature: true,
+			content: 'AGPL-licensed and free to self-host, with documentation covering every feature.',
+			learnMoreUrl: 'https://docs.gauzy.co/',
+			imageUrl: ''
+		}
+	];
+
+	/**
+	 * Up Migration
+	 *
+	 * @param queryRunner
+	 */
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		console.log(chalk.yellow(this.name + ' start running!'));
+
+		switch (queryRunner.connection.options.type as DatabaseTypeEnum) {
+			case DatabaseTypeEnum.sqlite:
+			case DatabaseTypeEnum.betterSqlite3:
+				await this.sqliteUpQueryRunner(queryRunner);
+				break;
+			case DatabaseTypeEnum.postgres:
+				await this.postgresUpQueryRunner(queryRunner);
+				break;
+			case DatabaseTypeEnum.mysql:
+				await this.mysqlUpQueryRunner(queryRunner);
+				break;
+			default:
+				throw Error(`Unsupported database: ${queryRunner.connection.options.type}`);
+		}
+	}
+
+	/**
+	 * Down Migration
+	 *
+	 * Content-only migration; the previous content is not worth restoring, so
+	 * down is a no-op (matching the original SeedChangeLogFeature migration).
+	 *
+	 * @param queryRunner
+	 */
+	public async down(queryRunner: QueryRunner): Promise<void> {}
+
+	/**
+	 * Delete-then-insert, shared by all three databases. `insertDate` adapts the
+	 * ISO date to what each engine stores; `insertBool` adapts the boolean.
+	 */
+	private async refresh(
+		queryRunner: QueryRunner,
+		deleteQuery: string,
+		buildQuery: (columns: string[]) => string,
+		insertDate: (iso: string) => unknown,
+		insertBool: (value: boolean) => unknown
+	): Promise<void> {
+		try {
+			// The table holds platform-level seed content only (writes were just
+			// locked down to SUPER_ADMIN), so a full replace is safe.
+			await queryRunner.connection.manager.query(deleteQuery);
+
+			const columns = ['icon', 'title', 'date', 'isFeature', 'content', 'learnMoreUrl', 'imageUrl', 'id'];
+			const insertQuery = buildQuery(columns);
+			for (const entry of this.entries) {
+				await queryRunner.connection.manager.query(insertQuery, [
+					entry.icon,
+					entry.title,
+					insertDate(entry.date),
+					insertBool(entry.isFeature),
+					entry.content,
+					entry.learnMoreUrl,
+					entry.imageUrl,
+					uuidV4()
+				]);
+			}
+		} catch (error) {
+			// The changelog table only exists when the plugin is enabled — never
+			// fail the migration run over optional content.
+			console.log('Error while refreshing changelog content, ignoring...', error);
+		}
+	}
+
+	public async sqliteUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await this.refresh(
+			queryRunner,
+			`DELETE FROM "changelog"`,
+			(columns) =>
+				`INSERT INTO "changelog" (${columns.map((c) => `"${c}"`).join(', ')}) VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
+			// TypeORM stores sqlite datetime as 'YYYY-MM-DD HH:MM:SS'
+			(iso) => iso.slice(0, 19).replace('T', ' '),
+			(value) => (value ? 1 : 0)
+		);
+	}
+
+	public async postgresUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await this.refresh(
+			queryRunner,
+			`DELETE FROM "changelog"`,
+			(columns) =>
+				`INSERT INTO "changelog" (${columns.map((c) => `"${c}"`).join(', ')}) VALUES($1, $2, $3, $4, $5, $6, $7, $8)`,
+			(iso) => new Date(iso),
+			(value) => value
+		);
+	}
+
+	public async mysqlUpQueryRunner(queryRunner: QueryRunner): Promise<any> {
+		await this.refresh(
+			queryRunner,
+			'DELETE FROM `changelog`',
+			(columns) =>
+				`INSERT INTO \`changelog\` (${columns.map((c) => `\`${c}\``).join(', ')}) VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
+			// MySQL DATETIME rejects the trailing 'Z' on older versions
+			(iso) => iso.slice(0, 19).replace('T', ' '),
+			(value) => (value ? 1 : 0)
+		);
+	}
+}

--- a/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
+++ b/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
@@ -72,14 +72,32 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 	}
 
 	/**
+	 * True only for the engine's "table/relation does not exist" error — the
+	 * single failure the probe below is allowed to swallow. Anything else
+	 * (permissions, connectivity, ...) must fail the migration run visibly.
+	 */
+	private isMissingTableError(error: unknown): boolean {
+		const e = error as { code?: string; errno?: number; message?: string };
+		return (
+			e?.code === '42P01' || // postgres: undefined_table
+			e?.code === 'ER_NO_SUCH_TABLE' || // mysql
+			e?.errno === 1146 || // mysql (numeric)
+			/no such table/i.test(e?.message ?? '') || // sqlite
+			/relation .* does not exist/i.test(e?.message ?? '') // postgres (message fallback)
+		);
+	}
+
+	/**
 	 * Replace-known-rows, shared by all three databases. `quote` wraps an
 	 * identifier per engine; `param` renders the n-th placeholder; `date`
 	 * / `bool` adapt values to what each engine stores.
 	 *
-	 * Only the table-existence probe swallows its error (the table exists only
-	 * when the changelog plugin is enabled). Delete/insert failures propagate:
-	 * migrations run with `transaction: 'each'`, so a partial refresh rolls
-	 * back atomically instead of leaving the table half-filled.
+	 * Everything runs through `queryRunner.query` — NOT
+	 * `queryRunner.connection.manager` — because only the query runner carries
+	 * the migration's transaction (`transaction: 'each'`); the connection
+	 * manager would silently execute outside it. Delete/insert failures
+	 * propagate, so a partial refresh rolls back atomically instead of leaving
+	 * the table half-filled.
 	 */
 	private async refresh(
 		queryRunner: QueryRunner,
@@ -90,14 +108,17 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 	): Promise<void> {
 		const table = quote('changelog');
 		try {
-			await queryRunner.connection.manager.query(`SELECT 1 FROM ${table} LIMIT 1`);
-		} catch {
-			console.log('Changelog table not present, skipping content refresh.');
-			return;
+			await queryRunner.query(`SELECT 1 FROM ${table} LIMIT 1`);
+		} catch (error) {
+			if (this.isMissingTableError(error)) {
+				console.log('Changelog table not present, skipping content refresh.');
+				return;
+			}
+			throw error;
 		}
 
 		const titles = [...this.seededTitles, ...this.entries.map(([, title]) => title)];
-		await queryRunner.connection.manager.query(
+		await queryRunner.query(
 			`DELETE FROM ${table} WHERE ${quote('title')} IN (${titles.map((_, i) => param(i + 1)).join(', ')})`,
 			titles
 		);
@@ -107,7 +128,7 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 			.map((_, i) => param(i + 1))
 			.join(', ')})`;
 		for (const [icon, title, isoDate, isFeature, content, learnMoreUrl, imageUrl] of this.entries) {
-			await queryRunner.connection.manager.query(insertQuery, [
+			await queryRunner.query(insertQuery, [
 				icon,
 				title,
 				date(isoDate),

--- a/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
+++ b/packages/core/src/lib/database/migrations/1790000005000-RefreshChangelogContent.ts
@@ -112,7 +112,7 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 				await this.mysqlUpQueryRunner(queryRunner);
 				break;
 			default:
-				throw Error(`Unsupported database: ${queryRunner.connection.options.type}`);
+				throw new Error(`Unsupported database: ${queryRunner.connection.options.type}`);
 		}
 	}
 
@@ -124,7 +124,9 @@ export class RefreshChangelogContent1790000005000 implements MigrationInterface 
 	 *
 	 * @param queryRunner
 	 */
-	public async down(queryRunner: QueryRunner): Promise<void> {}
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		// Intentionally empty — content-only migration, nothing worth restoring.
+	}
 
 	/**
 	 * Titles of the rows the Dec-2021 seed/migration created. The delete is

--- a/packages/plugins/changelog/src/lib/changelog.controller.ts
+++ b/packages/plugins/changelog/src/lib/changelog.controller.ts
@@ -6,6 +6,7 @@ import {
 	HttpCode,
 	Post,
 	Body,
+	Delete,
 	Param,
 	Put,
 	Query,
@@ -13,14 +14,21 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CommandBus } from '@nestjs/cqrs';
-import { IChangelog, IChangelogCreateInput, IChangelogUpdateInput, ID, IPagination } from '@gauzy/contracts';
-import { AuthGuard, CrudController, UUIDValidationPipe } from '@gauzy/core';
+import { IChangelog, IChangelogCreateInput, IChangelogUpdateInput, ID, IPagination, RolesEnum } from '@gauzy/contracts';
+import { AuthGuard, CrudController, RoleGuard, Roles, UUIDValidationPipe } from '@gauzy/core';
 import { Public } from '@gauzy/common';
+import { DeleteResult } from 'typeorm';
 import { Changelog } from './changelog.entity';
 import { ChangelogService } from './changelog.service';
 import { ChangelogCreateCommand, ChangelogUpdateCommand } from './commands';
 import { ChangelogQueryDTO } from './dto/changelog-query.dto';
 
+/**
+ * Changelog is PLATFORM-level content: the public GET feeds the "What's New"
+ * sidebar plus the login/register pages, and every write is a broadcast to all
+ * of them. Writes are therefore SUPER_ADMIN-only — before this guard any
+ * authenticated user could rewrite what every visitor sees on the login page.
+ */
 @ApiTags('Changelog')
 @UseGuards(AuthGuard)
 @Controller('/changelog')
@@ -30,6 +38,9 @@ export class ChangelogController extends CrudController<Changelog> {
 	}
 
 	/**
+	 * Public list of changelog entries, newest first (see the service for the
+	 * ordering/cap). `whitelist` matters here: the DTO'd query goes straight
+	 * into a TypeORM `where`, so unknown params must be stripped, not passed.
 	 *
 	 * @param options
 	 * @returns
@@ -47,9 +58,9 @@ export class ChangelogController extends CrudController<Changelog> {
 	@Public()
 	@Get('/')
 	async findChangelog(
-		@Query(new ValidationPipe({ transform: true })) options: ChangelogQueryDTO
+		@Query(new ValidationPipe({ transform: true, whitelist: true })) options: ChangelogQueryDTO
 	): Promise<IPagination<IChangelog>> {
-		return await this.changelogService.findAllChangelogs({ where: options });
+		return await this.changelogService.findAllChangelogs(options);
 	}
 
 	/**
@@ -67,6 +78,8 @@ export class ChangelogController extends CrudController<Changelog> {
 		description: 'Invalid input'
 	})
 	@HttpCode(HttpStatus.ACCEPTED)
+	@UseGuards(RoleGuard)
+	@Roles(RolesEnum.SUPER_ADMIN)
 	@Post('/')
 	async create(@Body() entity: IChangelogCreateInput): Promise<IChangelog> {
 		return await this.commandBus.execute(new ChangelogCreateCommand(entity));
@@ -92,8 +105,66 @@ export class ChangelogController extends CrudController<Changelog> {
 		description: 'Invalid input'
 	})
 	@HttpCode(HttpStatus.ACCEPTED)
+	@UseGuards(RoleGuard)
+	@Roles(RolesEnum.SUPER_ADMIN)
 	@Put('/:id')
 	async update(@Param('id', UUIDValidationPipe) id: ID, @Body() entity: IChangelogUpdateInput): Promise<IChangelog> {
 		return await this.commandBus.execute(new ChangelogUpdateCommand({ ...entity, id }));
+	}
+
+	/**
+	 * Overrides the inherited CRUD delete purely to attach the SUPER_ADMIN
+	 * guard — the base route ships with class-level AuthGuard only.
+	 *
+	 * @param id
+	 * @returns
+	 */
+	@ApiOperation({ summary: 'Delete record' })
+	@ApiResponse({
+		status: HttpStatus.NO_CONTENT,
+		description: 'Record has been successfully deleted.'
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@HttpCode(HttpStatus.ACCEPTED)
+	@UseGuards(RoleGuard)
+	@Roles(RolesEnum.SUPER_ADMIN)
+	@Delete('/:id')
+	async delete(@Param('id', UUIDValidationPipe) id: ID): Promise<DeleteResult> {
+		return await this.changelogService.delete(id);
+	}
+
+	/**
+	 * Same guard-only override for the inherited soft-delete route.
+	 */
+	@ApiOperation({ summary: 'Soft delete a record by ID' })
+	@ApiResponse({
+		status: HttpStatus.ACCEPTED,
+		description: 'Record soft deleted successfully'
+	})
+	@HttpCode(HttpStatus.ACCEPTED)
+	@UseGuards(RoleGuard)
+	@Roles(RolesEnum.SUPER_ADMIN)
+	@Delete('/:id/soft')
+	async softRemove(@Param('id', UUIDValidationPipe) id: ID): Promise<Changelog> {
+		return await this.changelogService.softRemove(id);
+	}
+
+	/**
+	 * Same guard-only override for the inherited soft-recover route.
+	 */
+	@ApiOperation({ summary: 'Restore a soft-deleted record by ID' })
+	@ApiResponse({
+		status: HttpStatus.ACCEPTED,
+		description: 'Record restored successfully'
+	})
+	@HttpCode(HttpStatus.ACCEPTED)
+	@UseGuards(RoleGuard)
+	@Roles(RolesEnum.SUPER_ADMIN)
+	@Put('/:id/recover')
+	async softRecover(@Param('id', UUIDValidationPipe) id: ID): Promise<Changelog> {
+		return await this.changelogService.softRecover(id);
 	}
 }

--- a/packages/plugins/changelog/src/lib/changelog.service.ts
+++ b/packages/plugins/changelog/src/lib/changelog.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { FindManyOptions } from 'typeorm';
+import { FindOptionsWhere } from 'typeorm';
 import { IChangelog, IPagination } from '@gauzy/contracts';
 import { CrudService } from '@gauzy/core';
 import { Changelog } from './changelog.entity';
@@ -8,6 +8,13 @@ import { MikroOrmChangelogRepository } from './repository/mikro-orm-changelog.re
 
 @Injectable()
 export class ChangelogService extends CrudService<Changelog> {
+	/**
+	 * Upper bound for the public listing. The endpoint is unauthenticated and
+	 * the consumers (What's New sidebar, login/register panels) only ever show
+	 * a handful of entries, so an unbounded SELECT is all downside.
+	 */
+	private static readonly MAX_PUBLIC_ITEMS = 20;
+
 	constructor(
 		typeOrmChangelogRepository: TypeOrmChangelogRepository,
 		mikroOrmChangelogRepository: MikroOrmChangelogRepository
@@ -16,12 +23,25 @@ export class ChangelogService extends CrudService<Changelog> {
 	}
 
 	/**
-	 * GET all changelogs based on filter condition
+	 * GET changelog entries for the public consumers, newest first.
 	 *
-	 * @param filter
+	 * Ordering lives here, not in the clients: the seeded rows all share one
+	 * creation date, so without `date DESC` the display order was whatever the
+	 * database felt like returning.
+	 *
+	 * @param where filter (e.g. `{ isFeature: true }`), already validated/whitelisted by the controller
 	 * @returns
 	 */
-	public async findAllChangelogs(filter?: FindManyOptions<Changelog>): Promise<IPagination<IChangelog>> {
-		return await this.findAll(filter || {});
+	public async findAllChangelogs(where?: FindOptionsWhere<Changelog>): Promise<IPagination<IChangelog>> {
+		// An absent query param can still surface as an `undefined`-valued key,
+		// which TypeORM must never see in a `where`.
+		const filter = Object.fromEntries(
+			Object.entries(where ?? {}).filter(([, value]) => value !== undefined)
+		) as FindOptionsWhere<Changelog>;
+		return await this.findAll({
+			...(Object.keys(filter).length ? { where: filter } : {}),
+			order: { date: 'DESC', createdAt: 'DESC' },
+			take: ChangelogService.MAX_PUBLIC_ITEMS
+		});
 	}
 }

--- a/packages/plugins/changelog/src/lib/dto/changelog-query.dto.ts
+++ b/packages/plugins/changelog/src/lib/dto/changelog-query.dto.ts
@@ -2,7 +2,6 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBoolean, IsOptional } from 'class-validator';
 import { Transform, TransformFnParams } from 'class-transformer';
 import { IChangelogFindInput } from '@gauzy/contracts';
-import { parseToBoolean } from '@gauzy/utils';
 
 /**
  * Get changelog request DTO validation.
@@ -10,11 +9,25 @@ import { parseToBoolean } from '@gauzy/utils';
  * The validated object is used directly as a TypeORM `where`, so this DTO is
  * the whitelist: only declare properties that are safe to filter on. The UI
  * sends `isFeature=0|1`, which arrives as a string — hence the transform.
+ * Unrecognized values pass through untouched so `@IsBoolean` rejects them
+ * instead of silently coercing to `false`.
  */
 export class ChangelogQueryDTO implements IChangelogFindInput {
 	@ApiPropertyOptional({ type: () => Boolean })
 	@IsOptional()
-	@Transform(({ value }: TransformFnParams) => (value == null ? value : parseToBoolean(value)))
+	@Transform(({ value }: TransformFnParams) => {
+		if (value == null || typeof value === 'boolean') {
+			return value;
+		}
+		const normalized = String(value).toLowerCase().trim();
+		if (normalized === 'true' || normalized === '1') {
+			return true;
+		}
+		if (normalized === 'false' || normalized === '0') {
+			return false;
+		}
+		return value;
+	})
 	@IsBoolean()
 	readonly isFeature?: boolean;
 }

--- a/packages/plugins/changelog/src/lib/dto/changelog-query.dto.ts
+++ b/packages/plugins/changelog/src/lib/dto/changelog-query.dto.ts
@@ -1,13 +1,20 @@
-import { IChangelogFindInput } from "@gauzy/contracts";
-import { ApiPropertyOptional } from "@nestjs/swagger";
-import { IsOptional } from "class-validator";
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+import { Transform, TransformFnParams } from 'class-transformer';
+import { IChangelogFindInput } from '@gauzy/contracts';
+import { parseToBoolean } from '@gauzy/utils';
 
 /**
- * Get changelog request DTO validation
+ * Get changelog request DTO validation.
+ *
+ * The validated object is used directly as a TypeORM `where`, so this DTO is
+ * the whitelist: only declare properties that are safe to filter on. The UI
+ * sends `isFeature=0|1`, which arrives as a string — hence the transform.
  */
 export class ChangelogQueryDTO implements IChangelogFindInput {
-
-    @ApiPropertyOptional({ type: () => Boolean })
-    @IsOptional()
-    readonly isFeature: boolean;
+	@ApiPropertyOptional({ type: () => Boolean })
+	@IsOptional()
+	@Transform(({ value }: TransformFnParams) => (value == null ? value : parseToBoolean(value)))
+	@IsBoolean()
+	readonly isFeature?: boolean;
 }

--- a/packages/plugins/changelog/src/lib/initial-changelog-template.ts
+++ b/packages/plugins/changelog/src/lib/initial-changelog-template.ts
@@ -1,59 +1,83 @@
 import { IChangelog } from '@gauzy/contracts';
 
+/**
+ * Platform-level changelog content used both by the fresh-DB seed
+ * (`changelog.seed.ts`) and mirrored by the `RefreshChangelogContent`
+ * migration for already-seeded deployments — keep the two in sync.
+ *
+ * `isFeature: false` entries feed the "What's New" sidebar and the login
+ * page panel; `isFeature: true` entries feed the register page feature
+ * cards (the only consumer that renders `imageUrl`). Dates are explicit:
+ * `new Date()` here stamped every deployment's "news" with its seed time.
+ */
 export const INITIAL_CHANGELOG_TEMPLATE: IChangelog[] = [
 	{
-		icon: 'cube-outline',
-		title: 'See new features',
-		date: new Date(),
-		content: 'Now you can read latest features changelog directly in Gauzy',
+		icon: 'message-circle-outline',
+		title: 'Meet your AI Assistant',
+		date: new Date('2026-08-05T00:00:00.000Z'),
+		content:
+			'Chat with an AI agent that knows your workspace: it can navigate pages, read data, fill forms and answer questions — with voice dictation and file attachments built in.',
 		isFeature: false,
-		learnMoreUrl: '',
+		learnMoreUrl: 'https://docs.gauzy.co/features/ai-agent-chat',
 		imageUrl: ''
 	},
 	{
-		icon: 'globe-outline',
-		title: 'Ready to give Gauzy a try?',
-		date: new Date(),
+		icon: 'file-text-outline',
+		title: 'Documents hub',
+		date: new Date('2026-08-01T00:00:00.000Z'),
 		isFeature: false,
 		content:
-			'Customer relationship management, enterprise resource planning, sales management, supply chain management and production management',
-		learnMoreUrl: '',
+			'Upload, organize and share company files and wiki pages — and attach any document to the AI chat to discuss it.',
+		learnMoreUrl: 'https://docs.gauzy.co/features/documents/overview',
 		imageUrl: ''
 	},
 	{
-		icon: 'flash-outline',
-		title: 'Visit our website for more information.',
-		date: new Date(),
+		icon: 'grid-outline',
+		title: 'Custom dashboards',
+		date: new Date('2026-07-20T00:00:00.000Z'),
 		isFeature: false,
-		content: 'You are welcome to check more information about the platform at our official website.',
+		content:
+			'Build your own dashboards: drag & drop widgets from the palette, configure each one, and switch between named layouts.',
+		learnMoreUrl: 'https://docs.gauzy.co/features/dashboard-widgets',
+		imageUrl: ''
+	},
+	{
+		icon: 'color-palette-outline',
+		title: 'A faster, cleaner interface',
+		date: new Date('2026-07-10T00:00:00.000Z'),
+		isFeature: false,
+		content:
+			'Redesigned navigation, denser tables, refreshed dark themes and a full-height AI chat column across the whole app.',
 		learnMoreUrl: 'https://gauzy.co/',
 		imageUrl: ''
 	},
 	{
-		icon: 'cube-outline',
-		title: 'New CRM',
-		date: new Date(),
+		icon: 'message-circle-outline',
+		title: 'AI at work',
+		date: new Date('2026-08-05T00:00:00.000Z'),
 		isFeature: true,
-		content: 'Now you can read latest features changelog directly in Gauzy',
-		learnMoreUrl: '',
+		content:
+			'An embedded AI assistant that knows your workspace: chat, dictate, attach documents and let it do the clicking for you.',
+		learnMoreUrl: 'https://docs.gauzy.co/features/ai-agent-chat',
 		imageUrl: 'assets/images/features/macbook-2.png'
 	},
 	{
-		icon: 'globe-outline',
-		title: 'Most popular in 20 countries',
-		date: new Date(),
+		icon: 'briefcase-outline',
+		title: 'Everything your business needs',
+		date: new Date('2026-07-01T00:00:00.000Z'),
 		isFeature: true,
-		content: 'Europe, Americas and Asia get choice',
-		learnMoreUrl: '',
+		content:
+			'ERP, CRM, HRM, ATS and project management with integrated time tracking — one open platform.',
+		learnMoreUrl: 'https://gauzy.co/',
 		imageUrl: 'assets/images/features/macbook-1.png'
 	},
 	{
 		icon: 'flash-outline',
-		title: 'Visit our website',
-		date: new Date(),
+		title: 'Open source, your way',
+		date: new Date('2026-07-01T00:00:00.000Z'),
 		isFeature: true,
-		content: 'You are welcome to check more information about the platform at our official website.',
-		learnMoreUrl: '',
+		content: 'AGPL-licensed and free to self-host, with documentation covering every feature.',
+		learnMoreUrl: 'https://docs.gauzy.co/',
 		imageUrl: ''
 	}
 ];

--- a/packages/ui-auth/src/lib/auth.module.ts
+++ b/packages/ui-auth/src/lib/auth.module.ts
@@ -27,7 +27,7 @@ import {
 	RoleService
 } from '@gauzy/ui-core/core';
 import { ThemeModule, ThemeSelectorModule } from '@gauzy/ui-core/theme';
-import { NgxFaqModule, PasswordFormFieldModule, SharedModule } from '@gauzy/ui-core/shared';
+import { ChangelogEntryComponent, NgxFaqModule, PasswordFormFieldModule, SharedModule } from '@gauzy/ui-core/shared';
 import { createAuthRoutes } from './auth.routes';
 import { WorkspaceSelectionComponent } from './components/workspace-selection/workspace-selection.component';
 import { SocialLinksComponent } from './components/social-links/social-links.component';
@@ -102,7 +102,9 @@ const COMPONENTS = [
 		NgxFaqModule,
 		ThemeModule,
 		SharedModule,
-		PasswordFormFieldModule
+		PasswordFormFieldModule,
+		// Standalone card shared with the changelog sidebar
+		ChangelogEntryComponent
 	],
 	declarations: [...COMPONENTS],
 	providers: [

--- a/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.html
+++ b/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.html
@@ -1,5 +1,13 @@
 @if (feature) {
-  <div class="feature-wrapper">
+  <!-- A feature card with a learnMoreUrl is a whole-card link opening in a new
+       tab; without one the anchor has no href, so it stays inert. -->
+  <a
+    class="feature-wrapper"
+    [class.linked]="feature.learnMoreUrl"
+    [attr.href]="feature.learnMoreUrl || null"
+    [attr.target]="feature.learnMoreUrl ? '_blank' : null"
+    [attr.rel]="feature.learnMoreUrl ? 'noopener noreferrer' : null"
+  >
     <div class="headings-wrapper">
       <nb-icon [icon]="feature.icon"></nb-icon>
       <span class="heading">
@@ -8,9 +16,7 @@
     </div>
     <p class="description">{{ feature.content }}</p>
     @if (feature.imageUrl) {
-      <img [src]="feature.imageUrl" alt="feature" class="feature-img">
+      <img [src]="feature.imageUrl" [alt]="feature.title" class="feature-img">
     }
-  </div>
+  </a>
 }
-
-

--- a/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.scss
@@ -9,6 +9,13 @@
   align-items: center;
   padding-right: 10px;
   padding-left: 10px;
+  // The wrapper is an anchor when the feature carries a learnMoreUrl —
+  // keep the text styling identical either way.
+  color: inherit;
+  text-decoration: none;
+  &.linked {
+    cursor: pointer;
+  }
 }
 .headings-wrapper {
   width: 100%;

--- a/packages/ui-auth/src/lib/components/whats-new/whats-new.component.html
+++ b/packages/ui-auth/src/lib/components/whats-new/whats-new.component.html
@@ -1,26 +1,36 @@
 <section class="section-wrapper">
-  <div class="whats-new-wrapper">
-    <h3 class="main-header">
-      {{ 'CHANGELOG_MENU.HEADER' | translate }}
-    </h3>
-    @for (item of items$ | async; track item) {
-      <div class="entry">
-        <div class="entry-headings-wrapper">
-          <nb-icon [icon]="item.icon" class="icon"></nb-icon>
-          <div class="entry-headings">
-            <div class="entry-header">{{ item.title }}</div>
-            <div class="entry-header-date">{{ item.date | date }}</div>
-          </div>
-        </div>
-        <p class="paragraph">
-          {{ item.content }}
-        </p>
-      </div>
-    }
-  </div>
-  @if (learnMore) {
-    <a nbButton outline status="primary" class="learn-more" [href]="learnMore">
-      {{ 'CHANGELOG_MENU.LEARN_MORE_URL' | translate }}
-    </a>
-  }
+	<div class="whats-new-wrapper">
+		<h3 class="main-header">
+			{{ 'CHANGELOG_MENU.HEADER' | translate }}
+		</h3>
+		<!-- Entries with a learnMoreUrl are whole-card links opening in a new tab;
+		     the attr bindings keep plain entries as inert anchors (no href = not
+		     focusable/clickable), so one element serves both variants. -->
+		@for (item of items$ | async; track item.id) {
+			<a
+				class="entry"
+				[class.linked]="item.learnMoreUrl"
+				[attr.href]="item.learnMoreUrl || null"
+				[attr.target]="item.learnMoreUrl ? '_blank' : null"
+				[attr.rel]="item.learnMoreUrl ? 'noopener noreferrer' : null"
+			>
+				<div class="entry-headings-wrapper">
+					<nb-icon [icon]="item.icon" class="icon"></nb-icon>
+					<div class="entry-headings">
+						<div class="entry-header">{{ item.title }}</div>
+						<div class="entry-header-date">{{ item.date | date }}</div>
+					</div>
+				</div>
+				<p class="paragraph">
+					{{ item.content }}
+				</p>
+				@if (item.imageUrl) {
+					<img class="entry-img" [src]="item.imageUrl" [alt]="item.title" />
+				}
+				@if (item.learnMoreUrl) {
+					<span class="learn-more-hint">{{ 'CHANGELOG_MENU.LEARN_MORE_URL' | translate }}</span>
+				}
+			</a>
+		}
+	</div>
 </section>

--- a/packages/ui-auth/src/lib/components/whats-new/whats-new.component.html
+++ b/packages/ui-auth/src/lib/components/whats-new/whats-new.component.html
@@ -3,34 +3,8 @@
 		<h3 class="main-header">
 			{{ 'CHANGELOG_MENU.HEADER' | translate }}
 		</h3>
-		<!-- Entries with a learnMoreUrl are whole-card links opening in a new tab;
-		     the attr bindings keep plain entries as inert anchors (no href = not
-		     focusable/clickable), so one element serves both variants. -->
 		@for (item of items$ | async; track item.id) {
-			<a
-				class="entry"
-				[class.linked]="item.learnMoreUrl"
-				[attr.href]="item.learnMoreUrl || null"
-				[attr.target]="item.learnMoreUrl ? '_blank' : null"
-				[attr.rel]="item.learnMoreUrl ? 'noopener noreferrer' : null"
-			>
-				<div class="entry-headings-wrapper">
-					<nb-icon [icon]="item.icon" class="icon"></nb-icon>
-					<div class="entry-headings">
-						<div class="entry-header">{{ item.title }}</div>
-						<div class="entry-header-date">{{ item.date | date }}</div>
-					</div>
-				</div>
-				<p class="paragraph">
-					{{ item.content }}
-				</p>
-				@if (item.imageUrl) {
-					<img class="entry-img" [src]="item.imageUrl" [alt]="item.title" />
-				}
-				@if (item.learnMoreUrl) {
-					<span class="learn-more-hint">{{ 'CHANGELOG_MENU.LEARN_MORE_URL' | translate }}</span>
-				}
-			</a>
+			<ngx-changelog-entry [entry]="item" />
 		}
 	</div>
 </section>

--- a/packages/ui-auth/src/lib/components/whats-new/whats-new.component.ts
+++ b/packages/ui-auth/src/lib/components/whats-new/whats-new.component.ts
@@ -1,30 +1,22 @@
 import { Component, OnInit } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
 import { IChangelog } from '@gauzy/contracts';
 import { ChangelogService } from '@gauzy/ui-core/core';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
-    selector: 'ngx-whats-new',
-    templateUrl: './whats-new.component.html',
-    styleUrls: ['./whats-new.component.scss'],
-    standalone: false
+	selector: 'ngx-whats-new',
+	templateUrl: './whats-new.component.html',
+	styleUrls: ['./whats-new.component.scss'],
+	standalone: false
 })
 export class NgxWhatsNewComponent implements OnInit {
-	learnMore: string;
 	items$: Observable<IChangelog[]> = this._changelogService.changelogs$;
 
 	constructor(private readonly _changelogService: ChangelogService) {}
 
 	ngOnInit() {
 		this._changelogService.getAll({ isFeature: 0 }).pipe(untilDestroyed(this)).subscribe();
-		this.items$
-			.pipe(
-				tap((changeLogs) => changeLogs.forEach((x) => (this.learnMore = x.learnMoreUrl))),
-				untilDestroyed(this)
-			)
-			.subscribe();
 	}
 }

--- a/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.html
+++ b/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.html
@@ -16,7 +16,7 @@
 		{{ entry.content }}
 	</p>
 	@if (entry.imageUrl) {
-		<img class="entry-img" [src]="entry.imageUrl" [alt]="entry.title" />
+		<img class="entry-img" [src]="entry.imageUrl" [alt]="entry.title || ''" />
 	}
 	@if (entry.learnMoreUrl) {
 		<span class="learn-more-hint">{{ 'CHANGELOG_MENU.LEARN_MORE_URL' | translate }}</span>

--- a/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.html
+++ b/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.html
@@ -1,0 +1,24 @@
+<a
+	class="entry"
+	[class.linked]="entry.learnMoreUrl"
+	[attr.href]="entry.learnMoreUrl || null"
+	[attr.target]="entry.learnMoreUrl ? '_blank' : null"
+	[attr.rel]="entry.learnMoreUrl ? 'noopener noreferrer' : null"
+>
+	<div class="entry-headings-wrapper">
+		<nb-icon [icon]="entry.icon" class="icon"></nb-icon>
+		<div class="entry-headings">
+			<div class="entry-header">{{ entry.title }}</div>
+			<div class="entry-header-date">{{ entry.date | date }}</div>
+		</div>
+	</div>
+	<p class="paragraph">
+		{{ entry.content }}
+	</p>
+	@if (entry.imageUrl) {
+		<img class="entry-img" [src]="entry.imageUrl" [alt]="entry.title" />
+	}
+	@if (entry.learnMoreUrl) {
+		<span class="learn-more-hint">{{ 'CHANGELOG_MENU.LEARN_MORE_URL' | translate }}</span>
+	}
+</a>

--- a/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
+++ b/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
@@ -1,0 +1,83 @@
+@use 'themes' as *;
+
+:host {
+	display: block;
+}
+
+.entry {
+	border-bottom: 1px solid lightgray;
+	padding-left: 5px;
+	padding-right: 5px;
+	// The entry is an anchor when it carries a learnMoreUrl (whole card opens
+	// the link in a new tab); these keep both variants looking the same.
+	display: block;
+	color: inherit;
+	text-decoration: none;
+
+	&.linked {
+		cursor: pointer;
+		border-radius: nb-theme(border-radius);
+		&:hover {
+			background: rgba(245, 109, 88, 0.08);
+		}
+	}
+
+	.entry-headings-wrapper {
+		display: flex;
+		margin-bottom: 5px;
+
+		.icon {
+			margin-right: 15px;
+			height: 14px;
+			margin-top: 3px;
+			color: nb-theme(text-primary-color);
+		}
+
+		.entry-header {
+			font-family: Inter;
+			font-size: 14px;
+			font-style: normal;
+			font-weight: 600;
+			line-height: 17px;
+			letter-spacing: 0em;
+			text-align: left;
+			margin-bottom: 5px;
+		}
+
+		.entry-header-date {
+			font-family: Inter;
+			font-size: 12px;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 16px;
+			letter-spacing: 0em;
+			text-align: left;
+			color: var(--gauzy-text-2);
+		}
+	}
+
+	.paragraph {
+		font-family: Inter;
+		font-size: 12px;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 16px;
+		letter-spacing: 0em;
+		text-align: left;
+	}
+
+	.entry-img {
+		display: block;
+		max-width: 100%;
+		border-radius: nb-theme(border-radius);
+		margin: 5px 0 10px;
+	}
+
+	.learn-more-hint {
+		display: inline-block;
+		font-size: 12px;
+		font-weight: 600;
+		color: nb-theme(color-primary-default);
+		margin-bottom: 10px;
+	}
+}

--- a/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
+++ b/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
@@ -34,7 +34,7 @@
 		}
 
 		.entry-header {
-			font-family: Inter;
+			font-family: Inter, sans-serif;
 			font-size: 14px;
 			font-style: normal;
 			font-weight: 600;
@@ -45,7 +45,7 @@
 		}
 
 		.entry-header-date {
-			font-family: Inter;
+			font-family: Inter, sans-serif;
 			font-size: 12px;
 			font-style: normal;
 			font-weight: 400;
@@ -57,7 +57,7 @@
 	}
 
 	.paragraph {
-		font-family: Inter;
+		font-family: Inter, sans-serif;
 		font-size: 12px;
 		font-style: normal;
 		font-weight: 400;

--- a/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.ts
+++ b/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.ts
@@ -1,0 +1,26 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { NbIconModule } from '@nebular/theme';
+import { TranslateModule } from '@ngx-translate/core';
+import { IChangelog } from '@gauzy/contracts';
+
+/**
+ * One "What's New" card. Shared by the changelog sidebar and the login page
+ * panel so the two surfaces cannot drift apart. Entries carrying a
+ * learnMoreUrl render as whole-card links opening in a new tab; without one
+ * the anchor has no href, so it stays inert (not focusable, not clickable).
+ *
+ * Spacing between cards is the parent's concern (see `@shared/_whats-new`):
+ * the host only sizes itself, so the login panel and the sidebar can keep
+ * their different bottom margins.
+ */
+@Component({
+	selector: 'ngx-changelog-entry',
+	standalone: true,
+	imports: [CommonModule, NbIconModule, TranslateModule],
+	templateUrl: './changelog-entry.component.html',
+	styleUrls: ['./changelog-entry.component.scss']
+})
+export class ChangelogEntryComponent {
+	@Input({ required: true }) entry!: IChangelog;
+}

--- a/packages/ui-core/shared/src/lib/components/index.ts
+++ b/packages/ui-core/shared/src/lib/components/index.ts
@@ -7,6 +7,7 @@ export * from './breadcrumb/breadcrumb.component';
 export * from './breadcrumb/breadcrumb-tail.service';
 export * from './dashboard-skeleton/dashboard-skeleton.component';
 export * from './date-range-title/date-range-title.component';
+export * from './changelog-entry/changelog-entry.component';
 export * from './header-title/header-title.component';
 export * from './layout-selector/layout-selector.component';
 export * from './popup/popup.component';

--- a/packages/ui-core/static/styles/@shared/_whats-new.scss
+++ b/packages/ui-core/static/styles/@shared/_whats-new.scss
@@ -39,6 +39,31 @@
     border-bottom: 1px solid lightgray;
     padding-left: 5px;
     padding-right: 5px;
+    // Entries with a learnMoreUrl render as anchors (whole card opens the link
+    // in a new tab); these keep the linked and plain variants looking the same.
+    display: block;
+    color: inherit;
+    text-decoration: none;
+    &.linked {
+      cursor: pointer;
+      border-radius: nb-theme(border-radius);
+      &:hover {
+        background: rgba(245, 109, 88, 0.08);
+      }
+    }
+    & .entry-img {
+      display: block;
+      max-width: 100%;
+      border-radius: nb-theme(border-radius);
+      margin: 5px 0 10px;
+    }
+    & .learn-more-hint {
+      display: inline-block;
+      font-size: 12px;
+      font-weight: 600;
+      color: nb-theme(color-primary-default);
+      margin-bottom: 10px;
+    }
     &:last-of-type {
       margin-bottom: 83px;
       @include mobile-screen {

--- a/packages/ui-core/static/styles/@shared/_whats-new.scss
+++ b/packages/ui-core/static/styles/@shared/_whats-new.scss
@@ -34,80 +34,17 @@
     margin-bottom: 19px;
     padding-left: 5px;
   }
-  & .entry {
-    margin-bottom: 15px;
-    border-bottom: 1px solid lightgray;
-    padding-left: 5px;
-    padding-right: 5px;
-    // Entries with a learnMoreUrl render as anchors (whole card opens the link
-    // in a new tab); these keep the linked and plain variants looking the same.
+  // Card internals live in the shared ngx-changelog-entry component
+  // (ui-core/shared); only inter-card spacing is the wrapper's concern, so the
+  // login panel and the sidebar keep their differing bottom reserve.
+  & ngx-changelog-entry {
     display: block;
-    color: inherit;
-    text-decoration: none;
-    &.linked {
-      cursor: pointer;
-      border-radius: nb-theme(border-radius);
-      &:hover {
-        background: rgba(245, 109, 88, 0.08);
-      }
-    }
-    & .entry-img {
-      display: block;
-      max-width: 100%;
-      border-radius: nb-theme(border-radius);
-      margin: 5px 0 10px;
-    }
-    & .learn-more-hint {
-      display: inline-block;
-      font-size: 12px;
-      font-weight: 600;
-      color: nb-theme(color-primary-default);
-      margin-bottom: 10px;
-    }
+    margin-bottom: 15px;
     &:last-of-type {
       margin-bottom: 83px;
       @include mobile-screen {
         margin-bottom: 0;
       }
-    }
-    & .entry-headings-wrapper {
-      display: flex;
-      margin-bottom: 5px;
-      & .icon {
-        margin-right: 15px;
-        height: 14px;
-        margin-top: 3px;
-        color: nb-theme(text-primary-color);
-      }
-      & .entry-header {
-        font-family: Inter;
-        font-size: 14px;
-        font-style: normal;
-        font-weight: 600;
-        line-height: 17px;
-        letter-spacing: 0em;
-        text-align: left;
-        margin-bottom: 5px;
-      }
-      & .entry-header-date {
-        font-family: Inter;
-        font-size: 12px;
-        font-style: normal;
-        font-weight: 400;
-        line-height: 16px;
-        letter-spacing: 0em;
-        text-align: left;
-        color: var(--gauzy-text-2);
-      }
-    }
-    & .paragraph {
-      font-family: Inter;
-      font-size: 12px;
-      font-style: normal;
-      font-weight: 400;
-      line-height: 16px;
-      letter-spacing: 0em;
-      text-align: left;
     }
   }
 }

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
@@ -4,34 +4,8 @@
 		<h3 class="main-header">
 			{{ 'CHANGELOG_MENU.HEADER' | translate }}
 		</h3>
-		<!-- Entries with a learnMoreUrl are whole-card links opening in a new tab;
-		     the attr bindings keep plain entries as inert anchors (no href = not
-		     focusable/clickable), so one element serves both variants. -->
 		@for (item of items$ | async; track item.id) {
-			<a
-				class="entry"
-				[class.linked]="item.learnMoreUrl"
-				[attr.href]="item.learnMoreUrl || null"
-				[attr.target]="item.learnMoreUrl ? '_blank' : null"
-				[attr.rel]="item.learnMoreUrl ? 'noopener noreferrer' : null"
-			>
-				<div class="entry-headings-wrapper">
-					<nb-icon [icon]="item.icon" class="icon"></nb-icon>
-					<div class="entry-headings">
-						<div class="entry-header">{{ item.title }}</div>
-						<div class="entry-header-date">{{ item.date | date }}</div>
-					</div>
-				</div>
-				<p class="paragraph">
-					{{ item.content }}
-				</p>
-				@if (item.imageUrl) {
-					<img class="entry-img" [src]="item.imageUrl" [alt]="item.title" />
-				}
-				@if (item.learnMoreUrl) {
-					<span class="learn-more-hint">{{ 'CHANGELOG_MENU.LEARN_MORE_URL' | translate }}</span>
-				}
-			</a>
+			<ngx-changelog-entry [entry]="item" />
 		}
 	</div>
 </section>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
@@ -1,35 +1,37 @@
 <section class="section-wrapper">
-  <span class="cancel"><i class="fas fa-times" (click)="closeSidebar()"></i></span>
-  <div class="whats-new-wrapper">
-    <h3 class="main-header">
-      {{ 'CHANGELOG_MENU.HEADER' | translate }}
-    </h3>
-    @for (item of items$ | async ; track item) {
-      <div class="entry">
-        <div class="entry-headings-wrapper">
-          <nb-icon [icon]="item.icon" class="icon"></nb-icon>
-          <div class="entry-headings">
-            <div class="entry-header">{{ item.title }}</div>
-            <div class="entry-header-date">{{ item.date | date }}</div>
-          </div>
-        </div>
-        <p class="paragraph">
-          {{ item.content }}
-        </p>
-      </div>
-    }
-  </div>
-  @if (learnMore) {
-    <a
-      nbButton
-      outline
-      status="primary"
-      class="learn-more"
-      target="_blank"
-      [href]="learnMore"
-      rel="noopener"
-      >
-      {{ 'CHANGELOG_MENU.LEARN_MORE_URL' | translate }}
-    </a>
-  }
+	<span class="cancel"><i class="fas fa-times" (click)="closeSidebar()"></i></span>
+	<div class="whats-new-wrapper">
+		<h3 class="main-header">
+			{{ 'CHANGELOG_MENU.HEADER' | translate }}
+		</h3>
+		<!-- Entries with a learnMoreUrl are whole-card links opening in a new tab;
+		     the attr bindings keep plain entries as inert anchors (no href = not
+		     focusable/clickable), so one element serves both variants. -->
+		@for (item of items$ | async; track item.id) {
+			<a
+				class="entry"
+				[class.linked]="item.learnMoreUrl"
+				[attr.href]="item.learnMoreUrl || null"
+				[attr.target]="item.learnMoreUrl ? '_blank' : null"
+				[attr.rel]="item.learnMoreUrl ? 'noopener noreferrer' : null"
+			>
+				<div class="entry-headings-wrapper">
+					<nb-icon [icon]="item.icon" class="icon"></nb-icon>
+					<div class="entry-headings">
+						<div class="entry-header">{{ item.title }}</div>
+						<div class="entry-header-date">{{ item.date | date }}</div>
+					</div>
+				</div>
+				<p class="paragraph">
+					{{ item.content }}
+				</p>
+				@if (item.imageUrl) {
+					<img class="entry-img" [src]="item.imageUrl" [alt]="item.title" />
+				}
+				@if (item.learnMoreUrl) {
+					<span class="learn-more-hint">{{ 'CHANGELOG_MENU.LEARN_MORE_URL' | translate }}</span>
+				}
+			</a>
+		}
+	</div>
 </section>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.ts
@@ -1,20 +1,18 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { IChangelog } from '@gauzy/contracts';
 import { NbSidebarService } from '@nebular/theme';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
 import { ChangelogService } from '@gauzy/ui-core/core';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
-    selector: 'ngx-changelog',
-    templateUrl: './changelog.component.html',
-    styleUrls: ['./changelog.component.scss'],
-    standalone: false
+	selector: 'ngx-changelog',
+	templateUrl: './changelog.component.html',
+	styleUrls: ['./changelog.component.scss'],
+	standalone: false
 })
 export class ChangelogComponent implements OnInit, OnDestroy {
-	learnMore: string;
 	items$: Observable<IChangelog[]> = this._changelogService.changelogs$;
 
 	constructor(
@@ -24,12 +22,6 @@ export class ChangelogComponent implements OnInit, OnDestroy {
 
 	ngOnInit() {
 		this._changelogService.getAll({ isFeature: 0 }).pipe(untilDestroyed(this)).subscribe();
-		this.items$
-			.pipe(
-				tap((changeLogs) => changeLogs.forEach((log) => (this.learnMore = log.learnMoreUrl))),
-				untilDestroyed(this)
-			)
-			.subscribe();
 	}
 
 	public closeSidebar() {

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-sidebar.module.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-sidebar.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NbButtonModule, NbIconModule, NbSelectModule, NbTooltipModule } from '@nebular/theme';
 import { TranslateModule } from '@ngx-translate/core';
+import { ChangelogEntryComponent } from '@gauzy/ui-core/shared';
 import { ThemeSidebarComponent } from './theme-sidebar.component';
 import { ThemeSettingsModule } from './theme-settings/theme-settings.module';
 import { ChangelogComponent } from './changelog/changelog.component';
@@ -15,7 +16,9 @@ import { ThemeSettingsComponent } from './theme-settings/theme-settings.componen
 		NbIconModule,
 		NbTooltipModule,
 		TranslateModule.forChild(),
-		ThemeSettingsModule
+		ThemeSettingsModule,
+		// Standalone card shared with the login page's What's New panel
+		ChangelogEntryComponent
 	],
 	exports: [ThemeSidebarComponent, ChangelogComponent, ThemeSettingsComponent],
 	declarations: [ThemeSidebarComponent, ChangelogComponent],


### PR DESCRIPTION
## What

The "What's New" sidebar, the login page panel and the register page feature cards all load from the `changelog` table via the public `GET /api/changelog` — but the pipeline had rotted end to end. Per user request: *"we should be able to create records in DB and it will load those... ability to add screenshots... and also links. If link is present, click on that card with link opens that link in new browser... write some more relevant new features based on what we built recently."*

### API (`@gauzy/plugin-changelog`)
- **Ordering + cap in the service**: `date DESC, createdAt DESC`, `take: 20`. Previously unordered and unbounded on a public endpoint.
- **Whitelisted query DTO**: the validated query goes straight into a TypeORM `where`, so unknown params are now stripped; `isFeature=0|1` string → boolean transform.
- **Writes locked to SUPER_ADMIN** (create / update / delete / soft-delete / recover): before this, *any* authenticated user could rewrite what every visitor sees on the login page. GET stays `@Public`. Records are managed via the API for now (no SaaS admin UI exists in this repo).

### UI (all three consumers)
- Card with `learnMoreUrl` = whole-card link, new tab, `noopener noreferrer`; fixes the last-wins `forEach` that displayed only the final entry's link, and the login variant that lacked `target=_blank`.
- `imageUrl` now renders in the sidebar and login panels too (was register-only).
- Shared styling in `@shared/_whats-new.scss` (hover state, image, learn-more hint).

### Content
- Fresh entries in `initial-changelog-template.ts` (fresh installs): AI Assistant (dictation + attachments), Documents hub, custom dashboards, UI redesign — explicit dates, deep links to docs.gauzy.co.
- **`RefreshChangelogContent1790000005000` migration** replaces the stale Dec-2021 rows on already-seeded deployments (postgres / sqlite / mysql; errors swallowed per-DB like the original `SeedChangeLogFeature` migration, so a missing table can't fail the run).

## Verification
- `tsc` on the changelog plugin project: clean (only pre-existing unrelated noise).
- Standalone `tsc` on the migration: clean.
- `tsc` on apps/gauzy: 113 errors before and after (pre-existing baseline) — zero new.
- cspell clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make “What’s New” fully DB-driven with images and safe links, enforce newest-first ordering with a 20-item cap, and restrict writes to `SUPER_ADMIN`. Refresh content, migrate old seeds without touching custom rows, unify the card UI across surfaces, and keep the migration fully transactional.

- **New Features**
  - API (`@gauzy/plugin-changelog`): `GET /api/changelog` orders by `date DESC, createdAt DESC`, returns max 20.
  - API: Whitelisted query DTO; `isFeature` string→boolean with strict validation, unknown params stripped.
  - Security: Create/update/delete/soft-delete/recover require `SUPER_ADMIN`; GET remains public.
  - UI (sidebar, login, register): Whole-card links (new tab, `noopener noreferrer`), images render everywhere with alt fallback, shared `ngx-changelog-entry` replaces duplicates, “last-link-wins” bug fixed, Inter font falls back to sans-serif.
  - Content: Updated seed with dated entries and docs links (AI Assistant, Documents hub, custom dashboards, UI refresh).

- **Migration**
  - `RefreshChangelogContent1790000005000` replaces stale Dec-2021 rows; preserves custom rows by deleting only known seeded titles; idempotent across runs.
  - All DB ops go through `queryRunner.query` inside the migration transaction; only missing-table errors are swallowed, other failures rollback atomically. Clone-free structure to clear Sonar duplication; `down()` intentionally empty.

<sup>Written for commit 21f94a1963fbe6b768e93f1f7eb7281b0cb9984b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

