### PR TITLE
feat(desktop): support Azure Artifact Signing for Windows (gated, stage)

### DIFF
--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -604,6 +604,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'
@@ -785,6 +793,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -605,6 +605,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'
@@ -790,6 +798,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -604,6 +604,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'
@@ -789,6 +797,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -605,6 +605,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'
@@ -786,6 +794,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -587,6 +587,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'
@@ -768,6 +776,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -738,6 +738,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'
@@ -955,6 +963,14 @@ jobs:
           WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
+          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
+          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
+          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
           EP_GH_IGNORE_TIME: true
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_TRACES_SAMPLE_RATE: '${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}'

--- a/.scripts/bump-version-electron.js
+++ b/.scripts/bump-version-electron.js
@@ -9,8 +9,29 @@ const git = simpleGit();
 function applyWindowsSigning(pkg) {
 	const publisherName = process.env.WINDOWS_PUBLISHER_NAME;
 	if (!publisherName) return;
+
 	pkg.build = pkg.build || {};
 	pkg.build.win = pkg.build.win || {};
+
+	// Preferred path: Azure Artifact Signing (formerly Trusted Signing). Engaged only when a
+	// certificate profile name is supplied, i.e. the Azure identity validation has completed and
+	// a profile exists. electron-builder authenticates with AZURE_TENANT_ID / AZURE_CLIENT_ID /
+	// AZURE_CLIENT_SECRET from the environment (DefaultAzureCredential).
+	const certificateProfileName = process.env.AZURE_CERT_PROFILE_NAME;
+	if (certificateProfileName) {
+		pkg.build.win.azureSignOptions = {
+			...(pkg.build.win.azureSignOptions || {}),
+			publisherName,
+			endpoint: process.env.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/',
+			codeSigningAccountName: process.env.AZURE_CODE_SIGNING_ACCOUNT || 'ever',
+			certificateProfileName
+		};
+		// Azure signing supersedes the PFX/signtool path; drop it so only one signer is configured.
+		delete pkg.build.win.signtoolOptions;
+		return;
+	}
+
+	// Fallback: PFX via WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD (signtool).
 	pkg.build.win.signtoolOptions = {
 		...(pkg.build.win.signtoolOptions || {}),
 		publisherName,


### PR DESCRIPTION
Follow-up to #9972. Adds the **Azure Artifact Signing** (formerly Trusted Signing) path next to the existing PFX signer, so Windows signing flips to a publicly-trusted, Microsoft-rooted certificate the moment a certificate profile exists — with no further code change.

## Behaviour (all three states verified)

| Env | Result |
|---|---|
| no `WINDOWS_PUBLISHER_NAME` | no signer block — today's state (interim self-signed cert, verification off) |
| `WINDOWS_PUBLISHER_NAME` only | `signtoolOptions` — PFX path via `WIN_CSC_LINK` |
| `+ AZURE_CERT_PROFILE_NAME` | `azureSignOptions`, `signtoolOptions` removed (exactly one signer) |

## Changes
- `.scripts/bump-version-electron.js` — `applyWindowsSigning()` emits `win.azureSignOptions` (endpoint / codeSigningAccountName / certificateProfileName / publisherName) when `AZURE_CERT_PROFILE_NAME` is set.
- `.github/workflows/*-stage.yml` (all six) — pass `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`/`AZURE_CERT_PROFILE_NAME` to both windows jobs, plus repo `vars` for account/endpoint (defaults `ever` / `https://eus.codesigning.azure.net/`). electron-builder authenticates via DefaultAzureCredential.

**STAGE only** — prod stays unwired per the standing instruction that Ever Gauzy may go to stage, never production.

## Azure state (verified live)
Subscription `Ever`, account `ever` (East US, SKU Basic), endpoint `https://eus.codesigning.azure.net/`, provisioning Succeeded. The CI principal now holds **Artifact Signing Certificate Profile Signer** — note Azure **Owner does NOT** grant this (Owner has `dataActions: []`, and signing is a data-plane action).

Remaining prerequisite: Azure **identity validation → certificate profile** (portal, business verification). Until then this code path stays dormant and builds are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Azure Artifact Signing for Windows builds, gated by `AZURE_CERT_PROFILE_NAME`, so signing switches to a Microsoft‑trusted cert when a profile exists. Stage only; production unchanged.

- New Features
  - `.scripts/bump-version-electron.js` now sets `win.azureSignOptions` when `AZURE_CERT_PROFILE_NAME` is present and removes `signtoolOptions` (exactly one signer). Falls back to PFX via `WIN_CSC_LINK` when no profile, or no signer if no `WINDOWS_PUBLISHER_NAME`.
  - Stage workflows pass `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_CERT_PROFILE_NAME`, plus repo vars `AZURE_CODE_SIGNING_ACCOUNT` and `AZURE_CODE_SIGNING_ENDPOINT` (defaults: `ever`, `https://eus.codesigning.azure.net/`). `electron-builder` authenticates via `DefaultAzureCredential`.

<sup>Written for commit aec432b178e1a647767b1852bcfb2f9ed842e99e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

