### PR TITLE
ci: split the strict lib verdict into its own early check; drop the gate's dead latency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,22 @@ name: Build
 # which exceeds the 60-minute job cap — so the cache was never written and every run started cold.
 # Self-hosted runners have no such cap.
 #
-# Job names and the commands they run mirror .circleci/config.yml one-for-one so PR-time build
-# coverage is unchanged.
+# LATENCY IS A CORRECTNESS PROPERTY OF THIS GATE. The 2026-08-13 template-error incident was not
+# a coverage gap — build-web caught the error — but its verdict landed 74 minutes AFTER the PR
+# had been merged on a still-pending check (~3h19m push-to-verdict). Two structural causes fixed
+# here:
+#   1. `build-libs` is its own job: `build:package:all` is where every LIBRARY's strict template
+#      check runs (each lib's tsconfig sets strictTemplates — the app tsconfig is lax in every
+#      configuration), so the verdict that catches template errors now reports as its own named
+#      check ~install+~20min after push instead of at the end of the longest job. Treat a
+#      pending/cancelled `build-libs`/`build-web` as a red: NEVER merge on yellow — the PR
+#      concurrency group cancels superseded runs, so "no failure" often just means "never ran".
+#   2. The `needs: build-monorepo-root` edges are gone: that job produces nothing the others
+#      consume (each re-installs from scratch), so the edge only added its full ~90 minutes as
+#      serial latency in front of every build.
+# The dev-config "Build packages" pre-step was removed from build-api/build-web: the app builds
+# rebuild their dependency libraries themselves (Nx `dependsOn: ^build`, production config), and
+# the strict library verdict lives in `build-libs`.
 
 on:
   pull_request:
@@ -51,9 +65,12 @@ jobs:
       - name: Run postinstall manually
         run: yarn postinstall.manual
 
-  build-api:
-    name: build-api
-    needs: build-monorepo-root
+  # The strict library verdict, as its own early-reporting check: this is the task set whose
+  # per-library `strictTemplates` tsconfigs catch template type errors (the class that broke the
+  # demo webapp image). It has no `needs` edge and no app build behind it, so it reports as soon
+  # as install + the 71 library builds finish.
+  build-libs:
+    name: build-libs
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 180
     steps:
@@ -72,13 +89,30 @@ jobs:
 
       - name: Build packages
         run: yarn build:package:all
+
+  build-api:
+    name: build-api
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
+
+      - name: Run postinstall manually
+        run: yarn postinstall.manual
 
       - name: Build API
         run: yarn build:api:prod:ci
 
   build-web:
     name: build-web
-    needs: build-monorepo-root
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 180
     steps:
@@ -95,15 +129,11 @@ jobs:
       - name: Run postinstall manually
         run: yarn postinstall.manual
 
-      - name: Build packages
-        run: yarn build:package:all
-
       - name: Build web
         run: yarn build:gauzy:prod:ci
 
   build-desktop:
     name: build-desktop
-    needs: build-monorepo-root
     # Matches the CircleCI branch filter: desktop was never built on ordinary PR branches.
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/stage' || github.ref == 'refs/heads/master'
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}


### PR DESCRIPTION
## The incident this fixes (corrected record)

The 2026-08-13 template error that broke the demo webapp image was NOT a gate coverage gap — \uild-web\ caught the exact error (TS2339 in \plugin-docs-ui:build:development\, run 31690030494/31694707026) — **it reported 74 minutes after the PR had been merged on a still-pending check**. Push-to-verdict was ~3h19m: ~96-min cold yarn install per job, plus a serial \
eeds: build-monorepo-root\ edge that contributes nothing (each job re-installs from scratch), with the PR concurrency group cancelling superseded runs so no completed verdict ever existed for the offending commits.

## Changes

1. **\uild-libs\ is a new first-class check**: \yarn build:package:all\ — the step where every library's own \strictTemplates\ tsconfig runs (the app tsconfig is lax in every configuration; libraries are where template errors get caught) — now reports on its own, ~install+20min after push instead of at the end of the longest job.
2. **Dead \
eeds: build-monorepo-root\ edges removed** from build-api / build-web / build-desktop: the root job stays as its own install+postinstall check, but no longer serializes ~90 minutes in front of every build.
3. **Redundant dev-config packages pre-step dropped** from build-api/build-web: their app builds rebuild dependency libraries themselves (Nx \dependsOn: ^build\, production configs), so the pre-step only duplicated compute; the strict verdict lives in \uild-libs\.

Net effect: same total compute or less, the template-catching verdict lands ~90-100 minutes earlier, and build-web's own end moves up by roughly the same.

## Process rule that goes with this (recorded in the workspace knowledge base)

Never merge while \uild-libs\/\uild-web\ is pending or cancelled — require a COMPLETED green for the exact head SHA. A 'settled' checks snapshot lies when the concurrency group cancels and recreates runs.

## Deferred follow-ups (documented, out of scope)

- \packages/ui-core\ has \strictTemplates: false\ and is strict-checked nowhere (lib and app both lax) — the largest remaining hole of this class; needs a burn-down.
- A strict compile-only app configuration would extend coverage to \pps/gauzy\'s own templates; blocked on the same legacy burn-down.
- node_modules caching on the ARC pods would cut the dominant ~96-min installs; separate risk profile.

This PR's own run demonstrates the new shape: \uild-libs\ should report first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the strict library build into its own early CI check and removes dead serial dependencies to reduce gate latency. Previously, template errors surfaced only at the end of `build-web`; now `build-libs` reports ~90–100 minutes earlier with the same or less compute.

- Adds `build-libs` job that runs `yarn build:package:all` with no `needs`, surfacing per-library `strictTemplates` failures early.
- Removes `needs: build-monorepo-root` from `build-api`, `build-web`, and `build-desktop`; the root job remains standalone.
- Drops the redundant "Build packages" pre-step from `build-api`/`build-web` (apps rebuild deps via Nx `dependsOn: ^build` in prod).
- Keeps `build-desktop` branch filter; otherwise unchanged.

- Merge only after green `build-libs` and `build-web` on the exact head SHA. Treat pending/cancelled as red due to PR concurrency cancellations.

<sup>Written for commit f36f0799bf1a0a6da5616e27f7e735913d27a31c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

