### PR TITLE
Release: router-owned URL param writes + the faster build gate

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,6 +31,7 @@
         "investigable",
         "Njcmlwd",
         "parameterizing",
+        "macrotask",
         "predefines",
         "rects",
         "Slideless",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,22 @@ name: Build
 # which exceeds the 60-minute job cap — so the cache was never written and every run started cold.
 # Self-hosted runners have no such cap.
 #
-# Job names and the commands they run mirror .circleci/config.yml one-for-one so PR-time build
-# coverage is unchanged.
+# LATENCY IS A CORRECTNESS PROPERTY OF THIS GATE. The 2026-08-13 template-error incident was not
+# a coverage gap — build-web caught the error — but its verdict landed 74 minutes AFTER the PR
+# had been merged on a still-pending check (~3h19m push-to-verdict). Two structural causes fixed
+# here:
+#   1. `build-libs` is its own job: `build:package:all` is where every LIBRARY's strict template
+#      check runs (each lib's tsconfig sets strictTemplates — the app tsconfig is lax in every
+#      configuration), so the verdict that catches template errors now reports as its own named
+#      check ~install+~20min after push instead of at the end of the longest job. Treat a
+#      pending/cancelled `build-libs`/`build-web` as a red: NEVER merge on yellow — the PR
+#      concurrency group cancels superseded runs, so "no failure" often just means "never ran".
+#   2. The `needs: build-monorepo-root` edges are gone: that job produces nothing the others
+#      consume (each re-installs from scratch), so the edge only added its full ~90 minutes as
+#      serial latency in front of every build.
+# The dev-config "Build packages" pre-step was removed from build-api/build-web: the app builds
+# rebuild their dependency libraries themselves (Nx `dependsOn: ^build`, production config), and
+# the strict library verdict lives in `build-libs`.
 
 on:
   pull_request:
@@ -51,9 +65,12 @@ jobs:
       - name: Run postinstall manually
         run: yarn postinstall.manual
 
-  build-api:
-    name: build-api
-    needs: build-monorepo-root
+  # The strict library verdict, as its own early-reporting check: this is the task set whose
+  # per-library `strictTemplates` tsconfigs catch template type errors (the class that broke the
+  # demo webapp image). It has no `needs` edge and no app build behind it, so it reports as soon
+  # as install + the 71 library builds finish.
+  build-libs:
+    name: build-libs
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 180
     steps:
@@ -72,13 +89,30 @@ jobs:
 
       - name: Build packages
         run: yarn build:package:all
+
+  build-api:
+    name: build-api
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
+
+      - name: Run postinstall manually
+        run: yarn postinstall.manual
 
       - name: Build API
         run: yarn build:api:prod:ci
 
   build-web:
     name: build-web
-    needs: build-monorepo-root
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 180
     steps:
@@ -95,15 +129,11 @@ jobs:
       - name: Run postinstall manually
         run: yarn postinstall.manual
 
-      - name: Build packages
-        run: yarn build:package:all
-
       - name: Build web
         run: yarn build:gauzy:prod:ci
 
   build-desktop:
     name: build-desktop
-    needs: build-monorepo-root
     # Matches the CircleCI branch filter: desktop was never built on ordinary PR branches.
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/stage' || github.ref == 'refs/heads/master'
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}

--- a/apps/gauzy/src/app/app.component.ts
+++ b/apps/gauzy/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { filter, map, switchMap, take, tap } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap, take, tap } from 'rxjs';
 import { pluck, union } from 'underscore';
 import { IDateRangePicker, ILanguage, LanguagesEnum } from '@gauzy/contracts';
 import { environment } from '@gauzy/ui-config';
@@ -232,6 +232,21 @@ export class AppComponent implements OnInit, AfterViewInit {
 				// data re-emitted. switchMap drops the previous route's stream on every
 				// navigation, so exactly one route's data is ever live.
 				switchMap((route) => route.data),
+				// A query-param-only navigation (every picker/selector write now issued
+				// through NavigationService terminates in NavigationEnd — replaceState
+				// never did) does NOT re-run resolvers: `route.data` replays the SAME
+				// object resolved for the last full navigation, stale relative to the
+				// URL just written. Re-applying it stomped `dates$` back to the
+				// pre-arrow range, and the picker's org-roundtrip derivation then
+				// rewrote the OLD range into the URL (~500ms later), overwriting the
+				// user's choice. Reference equality is exact here: the router only
+				// next()s `route.data` when a resolver actually re-ran
+				// (advanceActivatedRoute's shallowEqual guard), so this applies route
+				// data once per RESOLUTION — the same cadence the replaceState world
+				// had. Deliberately NOT the JSON-deep distinctUntilChange(): two
+				// different routes can resolve value-identical data, and suppressing
+				// that transition would skip the new route's bookmark restore.
+				distinctUntilChanged(),
 				/**
 				 * Set Date Range Picker Default Unit and Config
 				 */

--- a/packages/ui-core/core/src/lib/services/navigation/navigation.service.spec.ts
+++ b/packages/ui-core/core/src/lib/services/navigation/navigation.service.spec.ts
@@ -1,0 +1,119 @@
+import { Subject } from 'rxjs';
+import { NavigationEnd, NavigationSkipped, Params, Router } from '@angular/router';
+import { NavigationService } from './navigation.service';
+
+/**
+ * Constructed directly — no `TestBed` (the ui-core barrel pulls the whole app
+ * graph). The router double records `navigate()` calls and lets each test
+ * control the two inputs the service's scheduling depends on: the in-flight
+ * navigation (`getCurrentNavigation`) and the settle events stream.
+ */
+interface RecordedNavigate {
+	commands: unknown[];
+	extras: { queryParams?: Params; queryParamsHandling?: string; replaceUrl?: boolean };
+}
+
+function createService(overrides: { currentNavigation?: () => unknown } = {}) {
+	const events$ = new Subject<unknown>();
+	const navigations: RecordedNavigate[] = [];
+	const router = {
+		events: events$.asObservable(),
+		getCurrentNavigation: overrides.currentNavigation ?? (() => null),
+		navigate: jest.fn(async (commands: unknown[], extras: RecordedNavigate['extras']) => {
+			navigations.push({ commands, extras });
+			return true;
+		})
+	} as unknown as Router;
+	const activatedRoute = {} as never;
+	const destroyRef = { onDestroy: () => () => {} } as never;
+
+	const service = new NavigationService(router, activatedRoute, destroyRef);
+	return { service, router, events$, navigations };
+}
+
+/** The flush is a macrotask — one real timer tick lets it run. */
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve));
+
+describe('NavigationService — router-owned query-param writes', () => {
+	it('writes through router.navigate with merge + replaceUrl (no history entry, tree stays in sync)', async () => {
+		const { service, navigations } = createService();
+
+		await service.updateQueryParams({ date: '2026-08-01', unit_of_time: 'month' });
+
+		expect(navigations).toHaveLength(1);
+		expect(navigations[0].commands).toEqual([]);
+		expect(navigations[0].extras.queryParamsHandling).toBe('merge');
+		expect(navigations[0].extras.replaceUrl).toBe(true);
+		expect(navigations[0].extras.queryParams).toEqual({ date: '2026-08-01', unit_of_time: 'month' });
+	});
+
+	it("maps '' and empty arrays to null — the router's removal — so 'All Teams' still removes ?teamId", async () => {
+		const { service, navigations } = createService();
+
+		await service.updateQueryParams({ teamId: '', tags: [], archived: false });
+
+		expect(navigations[0].extras.queryParams).toEqual({ teamId: null, tags: null, archived: false });
+	});
+
+	it('deduplicates array values (the old buildQueryString contract)', async () => {
+		const { service, navigations } = createService();
+
+		await service.updateQueryParams({ tags: ['a', 'b', 'a'] });
+
+		expect(navigations[0].extras.queryParams).toEqual({ tags: ['a', 'b'] });
+	});
+
+	it('coalesces a same-tick burst into ONE navigation, last value per key wins', async () => {
+		const { service, navigations } = createService();
+
+		const first = service.updateQueryParams({ teamId: '', projectId: 'p1' });
+		const second = service.updateQueryParams({ teamId: 't2' });
+		await Promise.all([first, second]);
+
+		expect(navigations).toHaveLength(1);
+		expect(navigations[0].extras.queryParams).toEqual({ teamId: 't2', projectId: 'p1' });
+	});
+
+	it('parks the patch while a navigation is in flight and retries once it settles — never mid-flight', async () => {
+		let inFlight: unknown = { id: 1 };
+		const { service, events$, navigations } = createService({ currentNavigation: () => inFlight });
+
+		const write = service.updateQueryParams({ date: '2026-08-01' });
+		await tick();
+		// Still in flight at flush time: nothing written, nothing lost.
+		expect(navigations).toHaveLength(0);
+
+		inFlight = null;
+		events$.next(new NavigationEnd(1, '/pages/x', '/pages/x'));
+		await write;
+
+		expect(navigations).toHaveLength(1);
+		expect(navigations[0].extras.queryParams).toEqual({ date: '2026-08-01' });
+	});
+
+	it('a NavigationSkipped settle also releases parked patches (idempotent re-write loop terminator)', async () => {
+		let inFlight: unknown = { id: 1 };
+		const { service, events$, navigations } = createService({ currentNavigation: () => inFlight });
+
+		const write = service.updateQueryParams({ organizationId: 'org-1' });
+		await tick();
+		expect(navigations).toHaveLength(0);
+
+		inFlight = null;
+		events$.next(new NavigationSkipped(1, '/pages/x', 'ignored'));
+		await write;
+
+		expect(navigations).toHaveLength(1);
+	});
+
+	it('a non-merge patch replaces the pending accumulation wholesale', async () => {
+		const { service, navigations } = createService();
+
+		const first = service.updateQueryParams({ keepMe: 'no' });
+		const second = service.updateQueryParams({ onlyMe: 'yes' }, '');
+		await Promise.all([first, second]);
+
+		expect(navigations).toHaveLength(1);
+		expect(navigations[0].extras.queryParams).toEqual({ onlyMe: 'yes' });
+	});
+});

--- a/packages/ui-core/core/src/lib/services/navigation/navigation.service.ts
+++ b/packages/ui-core/core/src/lib/services/navigation/navigation.service.ts
@@ -1,17 +1,59 @@
-import { Injectable } from '@angular/core';
-import { ActivatedRoute, QueryParamsHandling, Router } from '@angular/router';
-import { Location } from '@angular/common';
-import { isNotNullOrUndefinedOrEmpty } from '@gauzy/ui-core/common';
+import { DestroyRef, Injectable } from '@angular/core';
+import {
+	ActivatedRoute,
+	NavigationCancel,
+	NavigationEnd,
+	NavigationError,
+	NavigationSkipped,
+	Params,
+	QueryParamsHandling,
+	Router
+} from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { filter } from 'rxjs/operators';
 
 @Injectable({
 	providedIn: 'root'
 })
 export class NavigationService {
+	/**
+	 * Query-param patches accumulated between flushes. Writes COALESCE: a burst
+	 * (e.g. an organization switch cascading into team/project rewrites) merges
+	 * into one router navigation, last value per key wins — the same end state
+	 * the old synchronous `location.replaceState` produced, without issuing one
+	 * navigation per write.
+	 */
+	private _pending: Params | null = null;
+	/** Callers awaiting the flush that will carry their patch. */
+	private _pendingResolvers: Array<() => void> = [];
+	private _flushScheduled = false;
+
 	constructor(
 		private readonly _router: Router,
 		private readonly _activatedRoute: ActivatedRoute,
-		private readonly _location: Location
-	) {}
+		private readonly _destroyRef: DestroyRef
+	) {
+		// A flush attempt that found a navigation in flight parks the patch and
+		// retries once that navigation SETTLES — never mid-flight, where a
+		// same-tick `navigate()` supersedes the user's navigation into a silent
+		// NavigationSkipped (the 536fa7fced bug class this service must never
+		// reintroduce). All four terminal events count as settled; Skipped is
+		// what our own idempotent re-writes produce.
+		this._router.events
+			.pipe(
+				filter(
+					(event) =>
+						event instanceof NavigationEnd ||
+						event instanceof NavigationCancel ||
+						event instanceof NavigationError ||
+						event instanceof NavigationSkipped
+				),
+				takeUntilDestroyed(this._destroyRef)
+			)
+			.subscribe(() => {
+				if (this._pending) this._scheduleFlush();
+			});
+	}
 
 	/**
 	 * Navigates to the current route with specified query parameters, while preserving existing ones.
@@ -31,77 +73,105 @@ export class NavigationService {
 	}
 
 	/**
-	 * Updates the query parameters of the current route without navigating away.
+	 * Updates the query parameters of the current route without a history entry.
+	 *
+	 * THE ROUTER OWNS THE WRITE. This used to build the URL by hand and call
+	 * `location.replaceState`, which the router cannot see: `currentUrlTree`
+	 * never contained the written params, so the first cancelled or failed
+	 * navigation had `resetUrlToCurrentUrlTree` rewrite the URL WITHOUT them —
+	 * the date-range/organization params silently vanished (observed live on
+	 * demo). `router.navigate` keeps tree and URL in agreement.
+	 *
+	 * The write is DEFERRED (macrotask) and RETRIED after any in-flight
+	 * navigation settles, never issued mid-flight:
+	 * - deferred, because callers like the app component's bookmark writer run
+	 *   synchronously inside NavigationEnd — where `getCurrentNavigation()` is
+	 *   still non-null (it is nulled only in the router's `finalize`), so a
+	 *   naive "skip while navigating" guard would drop that write on every
+	 *   navigation, and `route.data` never re-emits to heal it;
+	 * - retried (not dropped), because some writes are one-shot (the
+	 *   organization selector's startup write) — a dropped patch here would
+	 *   not self-heal.
+	 *
+	 * Removal semantics are preserved exactly: `''`, `null`, `undefined` and
+	 * empty arrays all REMOVE a param (the team/project selectors pass `''`
+	 * meaning "All" — under plain router merge that would survive as
+	 * `?teamId=`), while `false` and `0` are kept. Arrays are deduplicated.
 	 *
 	 * @param queryParams The query parameters to be updated.
 	 * @param queryParamsHandling The strategy to handle the query parameters (default is 'merge').
+	 *                            Every current caller merges; a non-merge patch replaces the
+	 *                            pending accumulation wholesale.
 	 */
 	async updateQueryParams(
 		queryParams: { [key: string]: string | string[] | boolean },
 		queryParamsHandling: QueryParamsHandling = 'merge'
 	): Promise<void> {
-		const currentUrl = this._location.path();
-		const [currentUrlTree, currentQueryParamsString] = currentUrl.split('?'); // Split current URL to get the path and query params
+		const normalized = this._normalize(queryParams);
+		this._pending = queryParamsHandling === 'merge' ? { ...(this._pending ?? {}), ...normalized } : normalized;
 
-		let existingQueryParams: { [key: string]: string | string[] | boolean } = {};
-
-		if (currentQueryParamsString) {
-			// Parse existing query params from current URL
-			const urlSearchParams = new URLSearchParams(currentQueryParamsString);
-			urlSearchParams.forEach((value, key) => {
-				if (existingQueryParams[key]) {
-					if (Array.isArray(existingQueryParams[key])) {
-						(existingQueryParams[key] as string[]).push(value);
-					} else {
-						existingQueryParams[key] = [existingQueryParams[key] as string, value];
-					}
-				} else {
-					existingQueryParams[key] = value;
-				}
-			});
-		}
-
-		//
-		const mergeQueryParams = { ...existingQueryParams, ...queryParams };
-
-		// Merge existing query params with new query params if handling is 'merge'
-		const finalQueryParams = queryParamsHandling === 'merge' ? mergeQueryParams : queryParams;
-
-		// Ensure the query parameters are unique
-		const uniqueQueryParams: { [key: string]: string | string[] | boolean } = {};
-		for (const key in finalQueryParams) {
-			const value = finalQueryParams[key];
-			if (isNotNullOrUndefinedOrEmpty(value)) {
-				if (Array.isArray(value)) {
-					uniqueQueryParams[key] = Array.from(new Set(value));
-				} else {
-					uniqueQueryParams[key] = value;
-				}
-			}
-		}
-
-		const queryParamsString = this.buildQueryString(uniqueQueryParams); // Convert query params object to string
-		const newUrl = [currentUrlTree, queryParamsString].filter(Boolean).join('?'); // Combine current URL with updated query params
-
-		// Replace the browser's URL without triggering navigation
-		this._location.replaceState(newUrl);
+		const flushed = new Promise<void>((resolve) => this._pendingResolvers.push(resolve));
+		this._scheduleFlush();
+		await flushed;
 	}
 
 	/**
-	 * Creates a query parameters string from an object of query parameters.
-	 * @param queryParams An object containing query parameters.
-	 * @returns A string representation of the query parameters.
+	 * Maps the service's historical "empty means remove" contract onto the
+	 * router's: `createUrlTree` merge removes `null`/`undefined` but keeps `''`
+	 * (serialized as `?key=`) and empty arrays, so both become `null` here.
 	 */
-	private buildQueryString(queryParams: { [key: string]: string | string[] | boolean }): string {
-		return Object.keys(queryParams)
-			.map((key) => {
-				const value = queryParams[key];
-				if (Array.isArray(value)) {
-					return value.map((v) => `${encodeURIComponent(key)}=${encodeURIComponent(v)}`).join('&');
-				} else {
-					return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
-				}
-			})
-			.join('&');
+	private _normalize(queryParams: { [key: string]: string | string[] | boolean }): Params {
+		const normalized: Params = {};
+		for (const key of Object.keys(queryParams ?? {})) {
+			const value = queryParams[key];
+			if (value === '' || value === null || value === undefined) {
+				normalized[key] = null;
+			} else if (Array.isArray(value)) {
+				const unique = Array.from(new Set(value));
+				normalized[key] = unique.length ? unique : null;
+			} else {
+				normalized[key] = value;
+			}
+		}
+		return normalized;
+	}
+
+	/**
+	 * Schedules a flush on a MACROTASK. A microtask is not enough: a write made
+	 * synchronously during NavigationEnd would flush before the router's
+	 * `finalize` clears `currentNavigation`, see `updateQueryParams`.
+	 */
+	private _scheduleFlush(): void {
+		if (this._flushScheduled) return;
+		this._flushScheduled = true;
+		setTimeout(() => {
+			this._flushScheduled = false;
+			void this._flush();
+		});
+	}
+
+	private async _flush(): Promise<void> {
+		if (!this._pending) return;
+		// A navigation is in flight — park the patch; the settle listener in the
+		// constructor re-schedules. Writing NOW would supersede that navigation.
+		if (this._router.getCurrentNavigation()) return;
+
+		const queryParams = this._pending;
+		const resolvers = this._pendingResolvers;
+		this._pending = null;
+		this._pendingResolvers = [];
+		try {
+			// `replaceUrl` keeps parity with the old `replaceState` (no history
+			// entry). An idempotent re-write (same resulting tree) terminates as
+			// NavigationSkipped — that is what bounds the NavigationEnd →
+			// bookmark-writer → NavigationEnd loop to a single extra round.
+			await this._router.navigate([], {
+				queryParams,
+				queryParamsHandling: 'merge',
+				replaceUrl: true
+			});
+		} finally {
+			resolvers.forEach((resolve) => resolve());
+		}
 	}
 }

--- a/packages/ui-core/shared/src/lib/selectors/date-range-picker/date-range-picker.component.ts
+++ b/packages/ui-core/shared/src/lib/selectors/date-range-picker/date-range-picker.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, AfterViewInit, Input, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { BehaviorSubject, combineLatest, of, Subject, switchMap, take } from 'rxjs';
-import { filter, tap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
 	DaterangepickerComponent as NgxDateRangePickerComponent,
@@ -239,7 +239,15 @@ export class DateRangePickerComponent extends TranslationBaseComponent implement
 	ngOnInit(): void {
 		const storeOrganization$ = this._store.selectedOrganization$;
 		const storeDatePickerConfig$ = this._dateRangePickerBuilderService.datePickerConfig$;
-		const queryParams$ = this._route.queryParams;
+		// This pipeline consumes ONLY `unit_of_time` from the query string. The raw
+		// queryParams stream re-emits on every date/org/team write the picker itself
+		// issues through the router (replaceState never made it emit), and each
+		// emission costs an organization round-trip plus a re-derivation — narrow +
+		// distinct so only an actual unit change (or the first load) wakes it.
+		const queryParamsUnitOfTime$ = this._route.queryParams.pipe(
+			map((params) => params['unit_of_time'] as moment.unitOfTime.Base | undefined),
+			distinctUntilChanged()
+		);
 
 		// Subscribe to the timeZone$ observable
 		const timeZone$ = this._timeZoneService.timeZone$.pipe(
@@ -256,10 +264,10 @@ export class DateRangePickerComponent extends TranslationBaseComponent implement
 			})
 		);
 
-		combineLatest([storeOrganization$, storeDatePickerConfig$, queryParams$, timeZone$])
+		combineLatest([storeOrganization$, storeDatePickerConfig$, queryParamsUnitOfTime$, timeZone$])
 			.pipe(
 				filter(([organization, datePickerConfig]) => !!organization && !!datePickerConfig),
-				switchMap(([organization, datePickerConfig, queryParams, timeZone]) =>
+				switchMap(([organization, datePickerConfig, unitOfTimeFromQuery, timeZone]) =>
 					combineLatest([
 						this._organizationService.getById(organization.id, [], {
 							id: true,
@@ -268,11 +276,11 @@ export class DateRangePickerComponent extends TranslationBaseComponent implement
 							startWeekOn: true
 						}),
 						of(datePickerConfig),
-						of(queryParams), // Emit queryParams as part of the inner observable
+						of(unitOfTimeFromQuery), // Emit the narrowed unit as part of the inner observable
 						of(timeZone)
 					])
 				),
-				tap(([organization, datePickerConfig, queryParams, timeZone]) => {
+				tap(([organization, datePickerConfig, unitOfTimeFromQuery, timeZone]) => {
 					this.organization = organization; // Update the organization
 					this.futureDateAllowed = organization.futureDateAllowed; // Update the future date allowed
 					this.timeZone = timeZone; // Update the time zone
@@ -285,8 +293,10 @@ export class DateRangePickerComponent extends TranslationBaseComponent implement
 					this.isLockDatePicker = isLockDatePicker;
 					this.isSingleDatePicker = isSingleDatePicker;
 
-					const { unit_of_time: unitOfTime = datePickerConfig.unitOfTime } = queryParams;
-					this.unitOfTime = unitOfTime;
+					// Query-param values are `string | undefined`, never null — the explicit
+					// `??` keeps the ROUTE-CONFIG unit as the fallback (the setter's own
+					// internal fallback is the global default, wrong for month routes).
+					this.unitOfTime = unitOfTimeFromQuery ?? datePickerConfig.unitOfTime;
 				}),
 				tap(() => {
 					this.createDateRangeMenus();


### PR DESCRIPTION
Promotes the remaining develop delta to stage (the UX sweep itself was cascaded in #9979):

- **#9977** — \updateQueryParams\ writes through the router (failed/cancelled navigations can no longer strip the date/organization params — observed live on demo), with the route-data replay loop fixed at its source (reference-dedup on \oute.data\; resolvers don't re-run on query-param navigations and the stale replay was stomping the shared date store). Browser-verified: single-transition writes, coalescing, deep links, per-route re-derivation, bookmark one-shots, no-supersede.
- **#9980** — the Build gate's strict library verdict is its own early-reporting \uild-libs\ check; dead \
eeds\ edges removed (~90 serial minutes cut). Validated by its own PR run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents query‑param loss by moving writes from Location.replaceState to router-owned navigations, and makes strict library template failures report earlier. Previously failed/canceled navigations could strip date/organization params; now writes use `router.navigate([], { queryParamsHandling: 'merge', replaceUrl: true })` and emit a settle event the app handles correctly.

- **Behavior changes**
  - `NavigationService.updateQueryParams` defers to a macrotask, never writes mid‑flight, retries after navigation settles (End/Cancel/Error/Skipped), coalesces same‑tick patches, deduplicates arrays, and maps ''/empty arrays to null for removal; no history entry. Unit tests cover coalescing, in‑flight parking, and removal semantics.
  - App applies `distinctUntilChanged()` to replayed `route.data`, stopping stale resolver data from overwriting the date store on query‑only navigations.
  - Date‑range picker narrows to `unit_of_time` from `queryParams` with `distinctUntilChanged()` and keeps the route‑config fallback, reducing unnecessary re‑derivations and org round‑trips.

- **CI gate**
  - Adds `build-libs` as an early, independent check running `yarn build:package:all` (strictTemplates for all libraries); removes dead `needs` edges and redundant package builds from web/api. Treat pending/cancelled `build-libs`/`build-web` as blocking.

<sup>Written for commit a6bdfdbda7fde98c272332e228c29d57ba0dbb9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

