### PR TITLE
fix(ui-core): stop $gauzy-density being shadowed off the Sass load path

### DIFF
--- a/packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss
+++ b/packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss
@@ -1,6 +1,14 @@
 // Forward themes so files importing this also get nb-theme() etc.
 @forward 'themes';
 @use 'themes' as *;
+// `themes` above is a BARE url: there is no `gauzy/_themes.scss`, so Sass falls through to the
+// build's load paths and takes the first match. Targets that put an app's own styles dir ahead of
+// `packages/ui-core/static/styles` (e.g. `gauzy-api-server`, `desktop`) therefore bind it to the
+// legacy per-app `themes.scss` fork, which predates the theme maps and does NOT forward them —
+// so `$gauzy-density` below is silently out of scope and the build fails with "Undefined variable".
+// Pull the maps in by an EXPLICIT relative url, which no load path can shadow. Same idiom as
+// `material/_material-dark.scss`. Imports only Sass variables, so this emits no CSS.
+@use '../gauzy-theme-maps' as *;
 @use 'sass:list';
 @use 'sass:map';
 @use 'rich-text-editor' as *;


### PR DESCRIPTION
Desktop builds of **`desktop`** and **`gauzy-api-server`** have been failing on **every platform** with:

```
packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss 46:38
Error: Undefined variable.  $gauzy-density
```

## Root cause — Sass load-path shadowing, not a missing definition

`_gauzy-overrides.scss` imports `themes` by a **bare** url. There is no `gauzy/_themes.scss`, so Sass falls through to `stylePreprocessorOptions.includePaths` and takes the **first** match. `gauzy-api-server` and `desktop` list the app's own styles dir **before** `packages/ui-core/static/styles`, so the name binds to the legacy per-app `themes.scss` fork — which predates the theme maps and forwards only Nebular theming, with no `$gauzy-density`. `nb-theme()` still resolves (both forward the same Nebular module), so the file compiles right up to line 46 — the first member that exists **only** in ui-core's graph.

**Why CI looked healthy:** `apps/gauzy` declares a *single* load path, so `themes` can only resolve to the correct file. The web build compiles the very same stylesheet and passes. That asymmetry is why this hid.

## Fix

Import the maps by an **explicit relative** url, which no load path can shadow — the same idiom `material/_material-dark.scss` already uses. Line 46 is untouched, nothing is duplicated, and `_gauzy-theme-maps.scss` is variables-only so **no CSS is emitted** — output is byte-identical wherever builds already succeeded.

## Verification

dart-sass against a reproduction of the CI topology, with a **known-broken control** so a pass can't be vacuous:

| case | result |
|---|---|
| broken prelude + app-first load paths (control) | ❌ fails with the exact error |
| broken prelude + web's single load path | ✅ compiles — reproduces the asymmetry |
| **fixed** prelude + app-first load paths | ✅ compiles |
| **fixed** prelude + web's single load path | ✅ compiles |

All passing cases emit identical CSS (`padding: 0.4375rem`).

## Scope

Became fatal only when `$gauzy-density` entered this file (#9854); the latent bare-`themes` binding is far older. **Production is unaffected** — `master` predates this code and doesn't contain the partial; app/api.gauzy.co are the web app, immune by construction.

Unblocks the desktop pipeline, which is a prerequisite for producing an Azure-signed installer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Sass load-path shadowing that made `$gauzy-density` undefined in desktop builds by importing the theme maps via an explicit relative path. Previously `_gauzy-overrides.scss` used a bare `themes` import that could bind to a legacy per-app `themes.scss` in `desktop` and `gauzy-api-server`; the web app was unaffected due to a single load path.

**Review notes**
- Add `@use '../gauzy-theme-maps' as *;` to `packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss` to load the map variables explicitly.
- Keep the existing `@forward 'themes'` and `@use 'themes'` for Nebular APIs; only the map source changes.
- Prevents the legacy `themes.scss` from shadowing on app-first load paths; builds now succeed across targets.
- Imports variables only; emits no CSS. Output remains byte-identical where builds already passed.
- No app changes or migrations required.

<sup>Written for commit 54d676f66b145fb8dcc7bdf315f3a6be4f2a52d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

