### PR TITLE
fix(ci): install .NET SDK on Windows runners so Azure Trusted Signing can run

### DIFF
--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -597,6 +597,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Agent
         shell: cmd
         run: 'yarn build:agent:windows:release:gh:x64'
@@ -790,6 +799,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Agent
         shell: cmd

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -598,6 +598,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Desktop App
         shell: cmd
         run: 'yarn build:desktop:windows:release:gh:x64'
@@ -795,6 +804,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Desktop App
         shell: cmd

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -597,6 +597,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Desktop Timer App
         shell: cmd
         run: 'yarn build:desktop-timer:windows:release:gh:x64'
@@ -794,6 +803,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Desktop Timer App
         shell: cmd

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -598,6 +598,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Server
         shell: cmd
         run: 'yarn build:gauzy-api-server:windows:release:gh:x64'
@@ -791,6 +800,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Server API
         shell: cmd

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -580,6 +580,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Server
         shell: cmd
         run: 'yarn build:gauzy-mcp-server:windows:release:gh:x64'
@@ -773,6 +782,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Server MCP
         shell: cmd

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -695,6 +695,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Server
         shell: cmd
         run: 'yarn build:gauzy-server:prepare'
@@ -924,6 +933,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Server
         shell: cmd


### PR DESCRIPTION
Azure Trusted Signing shells out to `Invoke-TrustedSigning`, which installs the `sign` **dotnet global tool** at sign time. The self-hosted Windows runners have **no .NET SDK**, so that install fails and signing never happens.

Evidence from the live run (ever-gauzy stage-apps, `release-windows`):

```
Invoke-TrustedSigning -Endpoint https://eus.codesigning.azure.net/ -CertificateProfileName *** -CodeSigningAccountName ever ...
    Installing package: Microsoft.Trusted.Signing.Client 1.0.95
    Installing package: sign 0.9.1-beta.24469.1
https://aka.ms/dotnet/sdk-not-found
Failed to install package: sign 0.9.1-beta.24469.1
```

NuGet itself is reachable (`Found existing package source: https://www.nuget.org/api/v2/`) — the only thing missing is the SDK. Note the signing **configuration is already correct**: the command above carries our real endpoint, account and certificate profile.

**Fix:** add `actions/setup-dotnet@v4` (8.0.x) immediately before the Build step of each Windows job — one step per job. Provisioning it in the workflow rather than on the host keeps the requirement in Git, applies to every runner, and is trivially reversible.

Verified: exactly one step per `release-windows`/`release-windows-arm64` job, all workflows still parse as valid YAML.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks Azure Trusted Signing on Windows runners by installing the .NET SDK during CI. Previously, `Invoke-TrustedSigning` failed with "sdk-not-found" on self-hosted Windows runners and skipped signing; now `actions/setup-dotnet@v4` (8.0.x) runs before builds so the `sign` tool can install and execute.

**Review notes**
- Adds one `actions/setup-dotnet@v4` step per Windows job in these stage workflows: agent, desktop-app, desktop-timer-app, server-api, server-mcp, server.
- Placed immediately before the Build step in both `release-windows` and `release-windows-arm64` jobs.
- No changes to signing config; this only supplies the missing SDK prerequisite.
- Side effect: slight increase in job time; kept in Git so it applies to all runners and is easy to revert.

**Rollout**
- No migrations required.
- Verify Windows artifacts are signed in the next stage runs.

<sup>Written for commit 10adc8358d0fbfd15f297bf289ad6546724a167a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

