### PR TITLE
Stage

### DIFF
--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -597,6 +597,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Agent
         shell: cmd
         run: 'yarn build:agent:windows:release:gh:x64'
@@ -790,6 +799,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Agent
         shell: cmd

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -598,6 +598,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Desktop App
         shell: cmd
         run: 'yarn build:desktop:windows:release:gh:x64'
@@ -795,6 +804,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Desktop App
         shell: cmd

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -597,6 +597,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Desktop Timer App
         shell: cmd
         run: 'yarn build:desktop-timer:windows:release:gh:x64'
@@ -794,6 +803,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Desktop Timer App
         shell: cmd

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -598,6 +598,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Server
         shell: cmd
         run: 'yarn build:gauzy-api-server:windows:release:gh:x64'
@@ -791,6 +800,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Server API
         shell: cmd

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -580,6 +580,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Server
         shell: cmd
         run: 'yarn build:gauzy-mcp-server:windows:release:gh:x64'
@@ -773,6 +782,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Server MCP
         shell: cmd

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -695,6 +695,15 @@ jobs:
         shell: powershell
         run: npx nx reset
 
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Server
         shell: cmd
         run: 'yarn build:gauzy-server:prepare'
@@ -924,6 +933,15 @@ jobs:
           "UV_THREADPOOL_SIZE=32" | Out-File -FilePath $env:GITHUB_ENV -Append
           # Patch graceful-fs to retry EMFILE errors with backoff
           node -e "try { var gfs = require('graceful-fs'); gfs.gracefulify(require('fs')); console.log('graceful-fs patched'); } catch(e) { console.log('graceful-fs not available, skipping'); }"
+
+      # Azure Trusted Signing runs Invoke-TrustedSigning, which installs the `sign` dotnet
+      # global tool. The self-hosted Windows runners have no .NET SDK, so that install fails
+      # ("sdk-not-found") and signing is skipped. Provision it here rather than on the host,
+      # so the requirement lives in Git and applies to every runner.
+      - name: Install .NET SDK (required by Azure Trusted Signing)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Build Server
         shell: cmd

--- a/packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss
+++ b/packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss
@@ -1,6 +1,14 @@
 // Forward themes so files importing this also get nb-theme() etc.
 @forward 'themes';
 @use 'themes' as *;
+// `themes` above is a BARE url: there is no `gauzy/_themes.scss`, so Sass falls through to the
+// build's load paths and takes the first match. Targets that put an app's own styles dir ahead of
+// `packages/ui-core/static/styles` (e.g. `gauzy-api-server`, `desktop`) therefore bind it to the
+// legacy per-app `themes.scss` fork, which predates the theme maps and does NOT forward them —
+// so `$gauzy-density` below is silently out of scope and the build fails with "Undefined variable".
+// Pull the maps in by an EXPLICIT relative url, which no load path can shadow. Same idiom as
+// `material/_material-dark.scss`. Imports only Sass variables, so this emits no CSS.
+@use '../gauzy-theme-maps' as *;
 @use 'sass:list';
 @use 'sass:map';
 @use 'rich-text-editor' as *;


### PR DESCRIPTION
# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs the .NET SDK in all stage Windows workflows so Azure Trusted Signing runs, and fixes Sass load-path shadowing that broke desktop builds. Previously, signing was skipped on self-hosted Windows runners and `$gauzy-density` failed to resolve in desktop builds; now signing executes and Sass variables resolve consistently without changing CSS output.

- CI (Windows stage workflows): add `actions/setup-dotnet@v4` (8.0.x) before Build so Azure Trusted Signing can install the `sign` tool and run. Old: SDK missing → signing silently skipped. New: SDK present → signing runs on every self-hosted Windows runner.
- UI core Sass: replace bare `@use 'themes'` with `@use '../gauzy-theme-maps'` in `packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss` to avoid resolving the legacy per-app theme file. Old: `$gauzy-density` undefined in `desktop` and `gauzy-api-server` builds; web unaffected by configuration. New: variables resolve everywhere; no CSS output change.

<sup>Written for commit 82b63ad85b0af6eaf51a1739ff0fe3f1a2dd754e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

