### PR TITLE
fix(ci): work around app-builder-lib macOS keychain bug blocking all mac signing

### DIFF
--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -423,6 +423,35 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
+
       - name: Build Agent
         run: 'yarn build:agent:mac:release'
         env:
@@ -441,7 +470,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK_BASE64 }}
+          # CSC_LINK deliberately NOT set: that is what makes electron-builder build its own
+          # (broken) keychain. Point it at the one imported above instead.
+          CSC_KEYCHAIN: ${{ runner.temp }}/ever-signing.keychain-db
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -424,6 +424,35 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
+
       - name: Build Desktop App
         run: 'yarn build:desktop:mac:release'
         env:
@@ -442,7 +471,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK_BASE64 }}
+          # CSC_LINK deliberately NOT set: that is what makes electron-builder build its own
+          # (broken) keychain. Point it at the one imported above instead.
+          CSC_KEYCHAIN: ${{ runner.temp }}/ever-signing.keychain-db
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -423,6 +423,35 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
+
       - name: Build Desktop Timer App
         run: 'yarn build:desktop-timer:mac:release'
         env:
@@ -441,7 +470,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK_BASE64 }}
+          # CSC_LINK deliberately NOT set: that is what makes electron-builder build its own
+          # (broken) keychain. Point it at the one imported above instead.
+          CSC_KEYCHAIN: ${{ runner.temp }}/ever-signing.keychain-db
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -424,6 +424,35 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
+
       - name: Build Server
         run: 'yarn build:gauzy-api-server:mac:release'
         env:
@@ -442,7 +471,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK_BASE64 }}
+          # CSC_LINK deliberately NOT set: that is what makes electron-builder build its own
+          # (broken) keychain. Point it at the one imported above instead.
+          CSC_KEYCHAIN: ${{ runner.temp }}/ever-signing.keychain-db
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -406,6 +406,35 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
+
       - name: Build Server
         run: 'yarn build:gauzy-mcp-server:mac:release'
         env:
@@ -424,7 +453,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK_BASE64 }}
+          # CSC_LINK deliberately NOT set: that is what makes electron-builder build its own
+          # (broken) keychain. Point it at the one imported above instead.
+          CSC_KEYCHAIN: ${{ runner.temp }}/ever-signing.keychain-db
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -489,6 +489,35 @@ jobs:
         shell: bash
         run: mkdir -p dist/packages
 
+      # macOS signing: build the keychain ourselves instead of letting electron-builder do it.
+      # app-builder-lib passes the p12 password to `security set-key-partition-list -k`, which
+      # expects the KEYCHAIN password — fatal on the current runner image, and still unfixed in
+      # the latest release. With CSC_LINK unset, electron-builder skips its own keychain code and
+      # uses CSC_KEYCHAIN (macPackager.js:25-48), so this sidesteps the bug without patching deps.
+      - name: Import Apple signing certificate into a keychain
+        env:
+          CSC_LINK_BASE64: ${{ secrets.CSC_LINK_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ever-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/ever-signing-cert.p12"
+          printf '%s' "$CSC_LINK_BASE64" | base64 --decode > "$CERT"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/security
+          # The KEYCHAIN password here — this is the exact call app-builder-lib gets wrong.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | xargs)
+          rm -f "$CERT"
+          # Fail loudly here rather than silently shipping an unsigned app later.
+          security find-identity -v -p codesigning "$KEYCHAIN" | tee /tmp/identities.txt
+          grep -q "Developer ID Application" /tmp/identities.txt
+
       - name: Build Server
         run: 'yarn build:gauzy-server:prepare'
         env:
@@ -539,7 +568,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_APP_PASSWORD: ${{ secrets.APPLE_ID_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.CSC_LINK_BASE64 }}
+          # CSC_LINK deliberately NOT set: that is what makes electron-builder build its own
+          # (broken) keychain. Point it at the one imported above instead.
+          CSC_KEYCHAIN: ${{ runner.temp }}/ever-signing.keychain-db
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}


### PR DESCRIPTION
## The bug

`electron-builder` `createKeychain()` creates a temp keychain with a **random** password, then calls:

```
security set-key-partition-list -S apple-tool:,apple: -s -k <p12 password> <keychain>
```

`-k` expects the **keychain** password, not the p12 export password (`macCodeSign.js`: `keychainPassword` vs `keyPasswords[i]`). On the current macOS runner image this hard-fails:

```
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

Every macOS release job dies during packaging. **Present in 26.0.3, 26.8.1 and the latest 26.15.3** — upgrading does not fix it.

## The fix — no dependency patching

`macPackager.js:25-48`: when `CSC_LINK` is **not** set, electron-builder skips `createKeychain()` and uses `process.env.CSC_KEYCHAIN` for identity lookup. So each `release-mac` job now:

1. imports the certificate itself, passing the **keychain** password to `set-key-partition-list` (the call app-builder-lib gets wrong),
2. hands the keychain over via `CSC_KEYCHAIN`,
3. ends with `security find-identity -v -p codesigning | grep -q "Developer ID Application"` — so a missing identity **fails loudly** instead of silently shipping an unsigned app.

## Verification

Every `release-mac` job checked programmatically: import step present, `CSC_KEYCHAIN` set, **no bare `CSC_LINK`** surviving (that would re-enable the broken path), and `CSC_IDENTITY_AUTO_DISCOVERY` not `false` (which would stop the imported identity being found). All workflows valid YAML.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Work around a `app-builder-lib` macOS keychain bug blocking all code signing by importing the cert into a CI-managed keychain and directing `electron-builder` to it via `CSC_KEYCHAIN`. Old behavior set `CSC_LINK`, letting `electron-builder` create a keychain and pass the wrong password to `security set-key-partition-list`, causing packaging failures; new behavior unsets `CSC_LINK`, creates the keychain in `$RUNNER_TEMP`, calls `set-key-partition-list` with the keychain password, and verifies the signing identity, failing fast if missing.

- Applies the same change to six stage workflows: agent, desktop app, desktop timer app, server, server-api, and server-mcp.
- Uses `CSC_LINK_BASE64` and `CSC_KEY_PASSWORD` to import the p12, sets `CSC_KEYCHAIN`, and intentionally does not set `CSC_LINK` to bypass `electron-builder` keychain creation.
- Adds a `security find-identity -p codesigning` check to ensure “Developer ID Application” is present; jobs fail loudly if not.
- No dependency or lockfile changes; only workflow YAML updates.

<sup>Written for commit b3dd1045b029f2142895d6029286f61e70b3b0b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

