### PR TITLE
fix(ci): make the Windows ARM64 VC toolset step resilient to Chocolatey outages

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,8 +6,13 @@
         "GHSA-[A-Za-z0-9-]+"
     ],
     "words": [
+        "codesign",
+        "codesigning",
         "CSPRNG",
+        "keychains",
         "NXDOMAIN",
+        "pipefail",
+        "productbuild",
         "unrepresentable",
         "ababa",
         "APAC",
@@ -678,6 +683,7 @@
         "OTLP",
         "oversampled",
         "oxsecurity",
+        "vswhere",
         "ɵcmp",
         "ɵcreate",
         "ɵmod",

--- a/.cspell.json
+++ b/.cspell.json
@@ -9,6 +9,7 @@
         "codesign",
         "codesigning",
         "CSPRNG",
+        "LASTEXITCODE",
         "keychains",
         "NXDOMAIN",
         "pipefail",

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -719,7 +719,27 @@ jobs:
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
         shell: powershell
         run: |
-          choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+          # The runner image normally ships VS with the VC ARM64 toolset. Only reach for
+          # Chocolatey if it is genuinely missing — community.chocolatey.org returning 504
+          # has failed this job before ("Chocolatey installed 0/0 packages"), and installing
+          # something already present costs ~6 min for nothing.
+          $ErrorActionPreference = "Continue"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $have = $false
+          if (Test-Path $vswhere) {
+            $found = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath 2>$null
+            if ($found) { $have = $true; Write-Host "VC ARM64 toolset already present: $found" }
+          }
+          if (-not $have) {
+            Write-Host "VC ARM64 toolset not found - installing via Chocolatey"
+            choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+            if ($LASTEXITCODE -ne 0) {
+              # Do not fail the job on a Chocolatey feed outage; the next step (msvc-dev-cmd)
+              # will either find a usable toolchain or fail with an unambiguous message.
+              Write-Warning "Chocolatey install failed (exit $LASTEXITCODE) - continuing; the MSVC setup step will report definitively."
+            }
+          }
+          exit 0
 
       - name: Configure node-gyp to use VS 2022
         shell: powershell

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -724,7 +724,27 @@ jobs:
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
         shell: powershell
         run: |
-          choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+          # The runner image normally ships VS with the VC ARM64 toolset. Only reach for
+          # Chocolatey if it is genuinely missing — community.chocolatey.org returning 504
+          # has failed this job before ("Chocolatey installed 0/0 packages"), and installing
+          # something already present costs ~6 min for nothing.
+          $ErrorActionPreference = "Continue"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $have = $false
+          if (Test-Path $vswhere) {
+            $found = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath 2>$null
+            if ($found) { $have = $true; Write-Host "VC ARM64 toolset already present: $found" }
+          }
+          if (-not $have) {
+            Write-Host "VC ARM64 toolset not found - installing via Chocolatey"
+            choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+            if ($LASTEXITCODE -ne 0) {
+              # Do not fail the job on a Chocolatey feed outage; the next step (msvc-dev-cmd)
+              # will either find a usable toolchain or fail with an unambiguous message.
+              Write-Warning "Chocolatey install failed (exit $LASTEXITCODE) - continuing; the MSVC setup step will report definitively."
+            }
+          }
+          exit 0
 
       - name: Configure node-gyp to use VS 2022
         shell: powershell

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -723,7 +723,27 @@ jobs:
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
         shell: powershell
         run: |
-          choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+          # The runner image normally ships VS with the VC ARM64 toolset. Only reach for
+          # Chocolatey if it is genuinely missing — community.chocolatey.org returning 504
+          # has failed this job before ("Chocolatey installed 0/0 packages"), and installing
+          # something already present costs ~6 min for nothing.
+          $ErrorActionPreference = "Continue"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $have = $false
+          if (Test-Path $vswhere) {
+            $found = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath 2>$null
+            if ($found) { $have = $true; Write-Host "VC ARM64 toolset already present: $found" }
+          }
+          if (-not $have) {
+            Write-Host "VC ARM64 toolset not found - installing via Chocolatey"
+            choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+            if ($LASTEXITCODE -ne 0) {
+              # Do not fail the job on a Chocolatey feed outage; the next step (msvc-dev-cmd)
+              # will either find a usable toolchain or fail with an unambiguous message.
+              Write-Warning "Chocolatey install failed (exit $LASTEXITCODE) - continuing; the MSVC setup step will report definitively."
+            }
+          }
+          exit 0
 
       - name: Configure node-gyp to use VS 2022
         shell: powershell

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -720,7 +720,27 @@ jobs:
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
         shell: powershell
         run: |
-          choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+          # The runner image normally ships VS with the VC ARM64 toolset. Only reach for
+          # Chocolatey if it is genuinely missing — community.chocolatey.org returning 504
+          # has failed this job before ("Chocolatey installed 0/0 packages"), and installing
+          # something already present costs ~6 min for nothing.
+          $ErrorActionPreference = "Continue"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $have = $false
+          if (Test-Path $vswhere) {
+            $found = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath 2>$null
+            if ($found) { $have = $true; Write-Host "VC ARM64 toolset already present: $found" }
+          }
+          if (-not $have) {
+            Write-Host "VC ARM64 toolset not found - installing via Chocolatey"
+            choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+            if ($LASTEXITCODE -ne 0) {
+              # Do not fail the job on a Chocolatey feed outage; the next step (msvc-dev-cmd)
+              # will either find a usable toolchain or fail with an unambiguous message.
+              Write-Warning "Chocolatey install failed (exit $LASTEXITCODE) - continuing; the MSVC setup step will report definitively."
+            }
+          }
+          exit 0
 
       - name: Configure node-gyp to use VS 2022
         shell: powershell

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -702,7 +702,27 @@ jobs:
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
         shell: powershell
         run: |
-          choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+          # The runner image normally ships VS with the VC ARM64 toolset. Only reach for
+          # Chocolatey if it is genuinely missing — community.chocolatey.org returning 504
+          # has failed this job before ("Chocolatey installed 0/0 packages"), and installing
+          # something already present costs ~6 min for nothing.
+          $ErrorActionPreference = "Continue"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $have = $false
+          if (Test-Path $vswhere) {
+            $found = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath 2>$null
+            if ($found) { $have = $true; Write-Host "VC ARM64 toolset already present: $found" }
+          }
+          if (-not $have) {
+            Write-Host "VC ARM64 toolset not found - installing via Chocolatey"
+            choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+            if ($LASTEXITCODE -ne 0) {
+              # Do not fail the job on a Chocolatey feed outage; the next step (msvc-dev-cmd)
+              # will either find a usable toolchain or fail with an unambiguous message.
+              Write-Warning "Chocolatey install failed (exit $LASTEXITCODE) - continuing; the MSVC setup step will report definitively."
+            }
+          }
+          exit 0
 
       - name: Configure node-gyp to use VS 2022
         shell: powershell

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -853,7 +853,27 @@ jobs:
       - name: Install Visual Studio 2022 Build Tools (VCTools with ARM64)
         shell: powershell
         run: |
-          choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+          # The runner image normally ships VS with the VC ARM64 toolset. Only reach for
+          # Chocolatey if it is genuinely missing — community.chocolatey.org returning 504
+          # has failed this job before ("Chocolatey installed 0/0 packages"), and installing
+          # something already present costs ~6 min for nothing.
+          $ErrorActionPreference = "Continue"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $have = $false
+          if (Test-Path $vswhere) {
+            $found = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath 2>$null
+            if ($found) { $have = $true; Write-Host "VC ARM64 toolset already present: $found" }
+          }
+          if (-not $have) {
+            Write-Host "VC ARM64 toolset not found - installing via Chocolatey"
+            choco install -y visualstudio2022buildtools --execution-timeout=21600 --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --passive --norestart"
+            if ($LASTEXITCODE -ne 0) {
+              # Do not fail the job on a Chocolatey feed outage; the next step (msvc-dev-cmd)
+              # will either find a usable toolchain or fail with an unambiguous message.
+              Write-Warning "Chocolatey install failed (exit $LASTEXITCODE) - continuing; the MSVC setup step will report definitively."
+            }
+          }
+          exit 0
 
       - name: Configure node-gyp to use VS 2022
         shell: powershell


### PR DESCRIPTION
`release-windows-arm64` fails whenever community.chocolatey.org is unhealthy. From the 2026-08-14 run (job 94892461391):

```
Failed to fetch results from V2 feed at 'https://community.chocolatey.org/api/v2/Packages(
Id='chocolatey-dotnetfx.extension',Version='1.0.1')' ... 504 (Gateway Timeout)
Chocolatey installed 0/0 packages.
```

**This is not an ARM64 incompatibility and not a bad component id.** The identical command succeeded on ARM64 on 2026-06-18 and is succeeding again today. `vs_buildtools.exe` never ran — ~110 s was spent retrying the feed before the step exited 1.

## Fix

`windows-11-arm` already ships VS with `Microsoft.VisualStudio.Component.VC.Tools.ARM64`, so the install is usually redundant. The step now:

1. probes with **vswhere** and skips Chocolatey entirely when the toolset is present — removing the network dependency and ~6 min from every ARM64 build;
2. downgrades a Chocolatey failure to a **warning**, letting `ilammy/msvc-dev-cmd` either succeed against the preinstalled toolchain or fail with an unambiguous message.

**Gated, not removed** — the `choco install` still runs verbatim on any runner that genuinely lacks the toolset, so this is additive and reversible.

## Verification

- All six workflows parse as valid YAML.
- The generated PowerShell parses with **zero errors** via `System.Management.Automation.Language.Parser`.
- The `vswhere` path expression resolves correctly on a real Windows machine.

The same step exists in the six `*-prod.yml` workflows and is equally exposed; left untouched to keep this change scoped to stage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Windows ARM64 VC toolset step resilient to Chocolatey outages. Previously we always installed `visualstudio2022buildtools` via Chocolatey and failed on feed errors; now we probe with `vswhere`, skip Chocolatey when the ARM64 toolset exists, and downgrade Chocolatey failures to warnings so the job can proceed to `ilammy/msvc-dev-cmd`.

- Stage workflows only; prod workflows are unchanged to limit blast radius.
- Removes a network dependency and saves ~6 minutes on `windows-11-arm`; `ilammy/msvc-dev-cmd` validates the toolchain and fails clearly if missing.
- Adds `vswhere` and `LASTEXITCODE` to `.cspell.json` to keep spellcheck green.

<sup>Written for commit 96203fbb6d6a70301a82d23b79d8d48791f32147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

