### PR TITLE
fix(ci): gate Windows signing off for ARM64 (no ARM64 Trusted Signing tooling)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
         "GHSA-[A-Za-z0-9-]+"
     ],
     "words": [
+        "dlib",
         "codesign",
         "codesigning",
         "CSPRNG",

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -795,11 +795,12 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.agent(false))
         env:
-          # Windows signing config must be visible to the BUMP step: this script writes build.win.azureSignOptions into package.json, which electron-builder reads later.
-          WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
-          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
+          # Windows signing is deliberately NOT configured for ARM64. Azure Trusted Signing
+          # ships no ARM64 tooling (Microsoft.Trusted.Signing.Client 1.0.95 contains only
+          # bin/x64 and bin/x86), so Invoke-TrustedSigning loads the x64 dlib and fails with
+          # "SignTool failed with exit code 3", taking the whole build down. Without
+          # WINDOWS_PUBLISHER_NAME the bump script emits no signer, so ARM64 builds
+          # unsigned and succeeds; electron-updater verification stays off for it. x64 signs.
           GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           AGENT_APP_NAME: 'gauzy-agent'

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -800,11 +800,12 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktop(false))
         env:
-          # Windows signing config must be visible to the BUMP step: this script writes build.win.azureSignOptions into package.json, which electron-builder reads later.
-          WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
-          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
+          # Windows signing is deliberately NOT configured for ARM64. Azure Trusted Signing
+          # ships no ARM64 tooling (Microsoft.Trusted.Signing.Client 1.0.95 contains only
+          # bin/x64 and bin/x86), so Invoke-TrustedSigning loads the x64 dlib and fails with
+          # "SignTool failed with exit code 3", taking the whole build down. Without
+          # WINDOWS_PUBLISHER_NAME the bump script emits no signer, so ARM64 builds
+          # unsigned and succeeds; electron-updater verification stays off for it. x64 signs.
           GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_APP_NAME: 'gauzy-desktop'

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -799,11 +799,12 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.desktopTimer(false))
         env:
-          # Windows signing config must be visible to the BUMP step: this script writes build.win.azureSignOptions into package.json, which electron-builder reads later.
-          WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
-          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
+          # Windows signing is deliberately NOT configured for ARM64. Azure Trusted Signing
+          # ships no ARM64 tooling (Microsoft.Trusted.Signing.Client 1.0.95 contains only
+          # bin/x64 and bin/x86), so Invoke-TrustedSigning loads the x64 dlib and fails with
+          # "SignTool failed with exit code 3", taking the whole build down. Without
+          # WINDOWS_PUBLISHER_NAME the bump script emits no signer, so ARM64 builds
+          # unsigned and succeeds; electron-updater verification stays off for it. x64 signs.
           GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_TIMER_APP_NAME: 'gauzy-desktop-timer'

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -796,11 +796,12 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.serverapi(false))
         env:
-          # Windows signing config must be visible to the BUMP step: this script writes build.win.azureSignOptions into package.json, which electron-builder reads later.
-          WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
-          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
+          # Windows signing is deliberately NOT configured for ARM64. Azure Trusted Signing
+          # ships no ARM64 tooling (Microsoft.Trusted.Signing.Client 1.0.95 contains only
+          # bin/x64 and bin/x86), so Invoke-TrustedSigning loads the x64 dlib and fails with
+          # "SignTool failed with exit code 3", taking the whole build down. Without
+          # WINDOWS_PUBLISHER_NAME the bump script emits no signer, so ARM64 builds
+          # unsigned and succeeds; electron-updater verification stays off for it. x64 signs.
           GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_API_SERVER_APP_NAME: 'gauzy-api-server'

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -778,11 +778,12 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.servermcp(false))
         env:
-          # Windows signing config must be visible to the BUMP step: this script writes build.win.azureSignOptions into package.json, which electron-builder reads later.
-          WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
-          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
+          # Windows signing is deliberately NOT configured for ARM64. Azure Trusted Signing
+          # ships no ARM64 tooling (Microsoft.Trusted.Signing.Client 1.0.95 contains only
+          # bin/x64 and bin/x86), so Invoke-TrustedSigning loads the x64 dlib and fails with
+          # "SignTool failed with exit code 3", taking the whole build down. Without
+          # WINDOWS_PUBLISHER_NAME the bump script emits no signer, so ARM64 builds
+          # unsigned and succeeds; electron-updater verification stays off for it. x64 signs.
           GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_MCP_SERVER_APP_NAME: 'gauzy-mcp-server'

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -929,11 +929,12 @@ jobs:
             const script = require('./.scripts/bump-version-electron.js')
             console.log(script.server(false))
         env:
-          # Windows signing config must be visible to the BUMP step: this script writes build.win.azureSignOptions into package.json, which electron-builder reads later.
-          WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          AZURE_CODE_SIGNING_ACCOUNT: ${{ vars.AZURE_CODE_SIGNING_ACCOUNT || 'ever' }}
-          AZURE_CODE_SIGNING_ENDPOINT: ${{ vars.AZURE_CODE_SIGNING_ENDPOINT || 'https://eus.codesigning.azure.net/' }}
+          # Windows signing is deliberately NOT configured for ARM64. Azure Trusted Signing
+          # ships no ARM64 tooling (Microsoft.Trusted.Signing.Client 1.0.95 contains only
+          # bin/x64 and bin/x86), so Invoke-TrustedSigning loads the x64 dlib and fails with
+          # "SignTool failed with exit code 3", taking the whole build down. Without
+          # WINDOWS_PUBLISHER_NAME the bump script emits no signer, so ARM64 builds
+          # unsigned and succeeds; electron-updater verification stays off for it. x64 signs.
           GAUZY_RELEASE_TAG: ${{ needs.check-release-tag.outputs.tag }}
           PROJECT_REPO: 'https://github.com/ever-co/ever-gauzy.git'
           DESKTOP_SERVER_APP_NAME: 'gauzy-server'


### PR DESCRIPTION
`release-windows-arm64` fails during packaging:

```
Trusted signing package installed: False
Executing signtool.exe: ...\Microsoft.Windows.SDK.BuildTools\...\bin\10.0.26100.0\x64\signtool.exe
  /dlib ...\Microsoft.Trusted.Signing.Client.1.0.95\bin\x64\Azure.CodeSigning.Dlib.dll
Exception: SignTool failed with exit code 3
```

## Verified: Microsoft ships no ARM64 tooling

Downloaded and inspected the published package:

```
Architecture folders in Microsoft.Trusted.Signing.Client 1.0.95:  bin/x64, bin/x86
ARM64 entries in the entire package:                              0
Latest published version:                                         1.0.95  (none newer)
```

On an ARM64 runner `Invoke-TrustedSigning` therefore loads the **x64** signtool + **x64** dlib, cannot initialise, and fails the whole build after 3 retries. **Not our configuration** — x64 signs fine (40 binaries across 5 apps in the same run).

## Fix

The bump script only emits a signer when `WINDOWS_PUBLISHER_NAME` is set, so removing the signing config from the **ARM64 Bump step** makes ARM64:

- **build unsigned but succeed** (instead of failing outright), and
- correctly leave electron-updater verification **disabled** for those artifacts — with no `publisherName`, the verifier skips rather than failing closed.

**x64 is untouched and still signs.** Verified per job via the YAML parser: x64 bump step keeps all four signing vars, ARM64 has none.

Revisit if Microsoft ships an ARM64 client; the alternative is signing ARM64 artifacts on an x64 machine in a separate step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Azure Trusted Signing for Windows ARM64 builds to unblock CI. Previously ARM64 attempted signing with x64 tooling and failed; now ARM64 artifacts build unsigned, while x64 signing is unchanged.

- Remove signing env vars from the ARM64 Bump step in stage workflows: agent, desktop, desktop-timer, server, server-api, server-mcp, server.
- The bump script only emits a signer when `WINDOWS_PUBLISHER_NAME` is set; without it, no `build.win.azureSignOptions` is written for ARM64. `electron-updater` verification stays off for ARM64; `electron-builder` behavior for x64 is unaffected.
- Cause: `Microsoft.Trusted.Signing.Client` ships no ARM64 binaries; `Invoke-TrustedSigning` loads x64 `signtool`/`Azure.CodeSigning.Dlib.dll` and exits 3.
- Add `dlib` to `.cspell.json` to allow the `Azure.CodeSigning.Dlib` reference in logs.

<sup>Written for commit ea3bd3cb2f6d3666e58f57cb67e11b385f38cca7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

