### PR TITLE
fix(ci): complete the ARM64 signing gate (drop WIN_CSC_LINK on ARM64)

### DIFF
--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -868,13 +868,12 @@ jobs:
           USE_HARD_LINKS: false
           ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\.cache\electron-builder
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          # Windows Authenticode signing (electron-builder auto-signs when WIN_CSC_LINK is set;
-          # empty secret => skipped). Verification engages only when WINDOWS_PUBLISHER_NAME is set.
-          WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          # WIN_CSC_LINK is deliberately NOT passed on ARM64. electron-builder auto-signs
+          # whenever it is set, independently of azureSignOptions, and then spawns a signtool
+          # that does not exist for ARM64 in its bundled winCodeSign package:
+          #   spawn ...\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
+          # ARM64 therefore ships unsigned (see the Bump step). x64 still signs via Azure.
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
-          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -873,13 +873,12 @@ jobs:
           USE_HARD_LINKS: false
           ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\.cache\electron-builder
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          # Windows Authenticode signing (electron-builder auto-signs when WIN_CSC_LINK is set;
-          # empty secret => skipped). Verification engages only when WINDOWS_PUBLISHER_NAME is set.
-          WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          # WIN_CSC_LINK is deliberately NOT passed on ARM64. electron-builder auto-signs
+          # whenever it is set, independently of azureSignOptions, and then spawns a signtool
+          # that does not exist for ARM64 in its bundled winCodeSign package:
+          #   spawn ...\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
+          # ARM64 therefore ships unsigned (see the Bump step). x64 still signs via Azure.
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
-          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -872,13 +872,12 @@ jobs:
           USE_HARD_LINKS: false
           ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\.cache\electron-builder
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          # Windows Authenticode signing (electron-builder auto-signs when WIN_CSC_LINK is set;
-          # empty secret => skipped). Verification engages only when WINDOWS_PUBLISHER_NAME is set.
-          WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          # WIN_CSC_LINK is deliberately NOT passed on ARM64. electron-builder auto-signs
+          # whenever it is set, independently of azureSignOptions, and then spawns a signtool
+          # that does not exist for ARM64 in its bundled winCodeSign package:
+          #   spawn ...\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
+          # ARM64 therefore ships unsigned (see the Bump step). x64 still signs via Azure.
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
-          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -869,13 +869,12 @@ jobs:
           USE_HARD_LINKS: false
           ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\.cache\electron-builder
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          # Windows Authenticode signing (electron-builder auto-signs when WIN_CSC_LINK is set;
-          # empty secret => skipped). Verification engages only when WINDOWS_PUBLISHER_NAME is set.
-          WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          # WIN_CSC_LINK is deliberately NOT passed on ARM64. electron-builder auto-signs
+          # whenever it is set, independently of azureSignOptions, and then spawns a signtool
+          # that does not exist for ARM64 in its bundled winCodeSign package:
+          #   spawn ...\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
+          # ARM64 therefore ships unsigned (see the Bump step). x64 still signs via Azure.
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
-          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -851,13 +851,12 @@ jobs:
           USE_HARD_LINKS: false
           ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\.cache\electron-builder
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          # Windows Authenticode signing (electron-builder auto-signs when WIN_CSC_LINK is set;
-          # empty secret => skipped). Verification engages only when WINDOWS_PUBLISHER_NAME is set.
-          WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          # WIN_CSC_LINK is deliberately NOT passed on ARM64. electron-builder auto-signs
+          # whenever it is set, independently of azureSignOptions, and then spawns a signtool
+          # that does not exist for ARM64 in its bundled winCodeSign package:
+          #   spawn ...\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
+          # ARM64 therefore ships unsigned (see the Bump step). x64 still signs via Azure.
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
-          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -1038,13 +1038,12 @@ jobs:
           USE_HARD_LINKS: false
           ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\.cache\electron-builder
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          # Windows Authenticode signing (electron-builder auto-signs when WIN_CSC_LINK is set;
-          # empty secret => skipped). Verification engages only when WINDOWS_PUBLISHER_NAME is set.
-          WIN_CSC_LINK: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+          # WIN_CSC_LINK is deliberately NOT passed on ARM64. electron-builder auto-signs
+          # whenever it is set, independently of azureSignOptions, and then spawns a signtool
+          # that does not exist for ARM64 in its bundled winCodeSign package:
+          #   spawn ...\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
+          # ARM64 therefore ships unsigned (see the Bump step). x64 still signs via Azure.
           WINDOWS_PUBLISHER_NAME: ${{ secrets.WINDOWS_PUBLISHER_NAME }}
-          # Azure Artifact Signing (preferred once a certificate profile exists). Engaged only when
-          # AZURE_CERT_PROFILE_NAME is set; otherwise the PFX path above is used.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
Follow-up to the ARM64 signing gate. That change stopped `azureSignOptions` being written, but ARM64 still failed:

```
Exit code: ENOENT. spawn
...\.cache\electron-builder\winCodeSign\winCodeSign-2.6.0\windows-10\arm64\signtool.exe ENOENT
```

**There were two independent signing triggers, and I only closed one.** electron-builder v26 auto-signs whenever `WIN_CSC_LINK` is in the environment (`windowsSignToolManager: getCscLink("WIN_CSC_LINK")`) regardless of `azureSignOptions` — and on ARM64 it reaches for a signtool that does not ship in its bundled `winCodeSign` package.

**Fix:** drop `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` from the ARM64 Build step. ARM64 now builds **unsigned and succeeds**; x64 keeps both and still signs via Azure.

The first gate did work as far as it went — the log confirms `SignTool failed with exit code 3` is gone and Azure signing is no longer attempted on ARM64.

**Verified** per job with the YAML parser: every `release-windows` Build step still carries both PFX vars; every `release-windows-arm64` Build step carries neither.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops ARM64 Windows builds from failing by removing `WIN_CSC_LINK`/`WIN_CSC_KEY_PASSWORD` so `electron-builder` no longer auto-signs with a missing ARM64 signtool. Previously, Azure signing was gated off but the PFX env still triggered auto-signing and ENOENT; now ARM64 builds unsigned and succeeds, while x64 continues to sign via Azure.

- `release-windows-arm64` Build steps no longer export the PFX env vars; `release-windows` (x64) still do.
- `AZURE_*` secrets remain; only x64 uses them for signing.
- Comments updated to document the ARM64 omission and rationale.

<sup>Written for commit ab17b10411370b481521af4de8ad7a9e43f2509c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

