### PR TITLE
ci(uptime): free external uptime monitor for app/api.gauzy.co on GitHub-hosted runners

### DIFF
--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -28,7 +28,7 @@ name: External Uptime Monitor
 
 # Domain vocabulary and curl `-w` field names used throughout this file. `.cspell.json` runs
 # with `strict: true` on every PR to develop, so without this the Cspell check goes red.
-# cspell:ignore homelab ttfb blackhole redirs namelookup appconnect starttransfer esac
+# cspell:ignore homelab ttfb blackhole redirs namelookup appconnect starttransfer esac selftest
 
 on:
   schedule:
@@ -372,9 +372,9 @@ jobs:
               echo "::error::Could not read alert issue #${NUM}. The outage is already visible there, so skipping the comment rather than risking a duplicate."
               exit 1
             fi
-            # No pipe in a decision. Under `pipefail` a SIGPIPE'd producer can make an already-
-            # MATCHED grep report failure, which would post a redundant comment on every run of a
-            # steady outage — defeating the de-duplication exactly when it matters most.
+            # No pipe in a decision. Under `pipefail`, a producer killed by SIGPIPE can make an
+            # already-MATCHED grep report failure, which would post a redundant comment on every
+            # run of a steady outage — defeating the de-duplication exactly when it matters most.
             if grep -q "uptime-fingerprint: ${FINGERPRINT}" <<< "${LAST}"; then
               echo "State unchanged (fingerprint ${FINGERPRINT}) — not commenting, to avoid issue spam."
             else

--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -48,15 +48,17 @@ on:
     paths:
       - '.github/workflows/external-uptime-monitor.yml'
 
-# Least privilege: we only need to read the repo and write issues. GITHUB_TOKEN is provided
-# automatically — this workflow requires NO new secrets.
+# Least privilege: the workflow default is read-only. `issues: write` is granted narrowly to the
+# one job that needs it (below). GITHUB_TOKEN is provided automatically — NO new secrets required.
 permissions:
   contents: read
-  issues: write
 
 concurrency:
-  # Never let two probe runs overlap and fight over the same alert issue.
-  group: external-uptime-monitor
+  # Scheduled and manual runs share one group so two live probes never overlap and fight over the
+  # same alert issue. Pull-request self-tests get their own per-ref group, so reviewing this file
+  # can never delay or displace a real production probe.
+  group: >-
+    external-uptime-monitor-${{ github.event_name == 'pull_request' && github.ref || 'live' }}
   cancel-in-progress: false
 
 jobs:
@@ -65,6 +67,11 @@ jobs:
     # 🛑 DO NOT CHANGE — see the header block. GitHub-hosted is the whole point.
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    permissions:
+      contents: read
+      # Needed only to open/comment/close the single rolling alert issue.
+      issues: write
 
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -264,7 +271,9 @@ jobs:
           FINGERPRINT: ${{ steps.probe.outputs.fingerprint }}
           EGRESS_IP: ${{ steps.egress.outputs.ip }}
         run: |
-          set -uo pipefail
+          # -e matters here: a silent failure in this step means an outage goes unreported, or a
+          # duplicate issue is opened. Both are worse than a red run.
+          set -euo pipefail
 
           BODY="${RUNNER_TEMP}/alert.md"
           {
@@ -299,8 +308,14 @@ jobs:
             echo "<!-- uptime-fingerprint: ${FINGERPRINT} -->"
           } > "$BODY"
 
-          NUM=$(gh issue list --repo "${GITHUB_REPOSITORY}" --label "${ALERT_LABEL}" \
-                  --state open --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          # A FAILED lookup must never be mistaken for "no issue is open" — that would open a
+          # duplicate issue on every run during an API blip, which is exactly the spam that gets
+          # monitors muted. Distinguish command failure from an empty result.
+          if ! NUM=$(gh issue list --repo "${GITHUB_REPOSITORY}" --label "${ALERT_LABEL}" \
+                       --state open --limit 1 --json number --jq '.[0].number // empty'); then
+            echo "::error::Could not query existing ${ALERT_LABEL} issues. Refusing to create one, as it would likely be a duplicate."
+            exit 1
+          fi
 
           if [ -z "${NUM}" ]; then
             echo "No open alert issue — creating one."
@@ -310,8 +325,13 @@ jobs:
               --body-file "$BODY"
           else
             echo "Alert issue #${NUM} already open."
-            LAST=$(gh issue view "${NUM}" --repo "${GITHUB_REPOSITORY}" --json body,comments \
-                     --jq 'if (.comments | length) > 0 then .comments[-1].body else .body end' 2>/dev/null || true)
+            # Likewise: a failed read must not look like "the state changed", or every blip adds a
+            # comment to an already-open issue.
+            if ! LAST=$(gh issue view "${NUM}" --repo "${GITHUB_REPOSITORY}" --json body,comments \
+                          --jq 'if (.comments | length) > 0 then .comments[-1].body else .body end'); then
+              echo "::error::Could not read alert issue #${NUM}. The outage is already visible there, so skipping the comment rather than risking a duplicate."
+              exit 1
+            fi
             if printf '%s' "${LAST}" | grep -q "uptime-fingerprint: ${FINGERPRINT}"; then
               echo "State unchanged (fingerprint ${FINGERPRINT}) — not commenting, to avoid issue spam."
             else
@@ -326,10 +346,15 @@ jobs:
           FINGERPRINT: ${{ steps.probe.outputs.fingerprint }}
           EGRESS_IP: ${{ steps.egress.outputs.ip }}
         run: |
-          set -uo pipefail
+          # -e matters here too: silently failing to close a resolved alert leaves a stale red
+          # issue that trains people to ignore it.
+          set -euo pipefail
 
-          NUM=$(gh issue list --repo "${GITHUB_REPOSITORY}" --label "${ALERT_LABEL}" \
-                  --state open --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if ! NUM=$(gh issue list --repo "${GITHUB_REPOSITORY}" --label "${ALERT_LABEL}" \
+                       --state open --limit 1 --json number --jq '.[0].number // empty'); then
+            echo "::error::Could not query existing ${ALERT_LABEL} issues, so an open alert may have been left unclosed."
+            exit 1
+          fi
           if [ -z "${NUM}" ]; then
             echo "All critical endpoints healthy and no alert issue open — nothing to do."
             exit 0

--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -29,6 +29,7 @@ name: External Uptime Monitor
 # Domain vocabulary and curl `-w` field names used throughout this file. `.cspell.json` runs
 # with `strict: true` on every PR to develop, so without this the Cspell check goes red.
 # cspell:ignore homelab ttfb blackhole redirs namelookup appconnect starttransfer esac selftest
+# cspell:ignore SIGPIPE
 
 on:
   schedule:

--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -1,0 +1,363 @@
+name: External Uptime Monitor
+
+# =====================================================================================
+#  🛑 THIS WORKFLOW MUST RUN ON GITHUB-HOSTED RUNNERS. DO NOT "FIX" IT TO self-hosted.
+# =====================================================================================
+#
+#  Every other workflow in this repository deliberately targets the self-hosted ARC pool
+#  (`vars.RUNNER_LINUX_X64_4` / `_8`). This one is a DELIBERATE, DOCUMENTED EXCEPTION.
+#
+#  WHY: every existing probe of app.gauzy.co / api.gauzy.co runs INSIDE the `ever-k8s`
+#  homelab cluster. On 2026-08-15 a routing fault at the owner's ISP (Orange, Spain) made
+#  Cloudflare's 188.114.96.0/22 prefix unreachable *from the homelab only*. All gauzy.co
+#  hostnames resolve into that prefix, so every internal probe went red at once and it
+#  looked exactly like "production is down". It was not — real users were served the whole
+#  time. Hours were lost chasing a false alarm.
+#
+#  The ONLY value of this workflow is that it observes production from a vantage point
+#  OUTSIDE the homelab network. Self-hosted / ARC runners live in the homelab and share
+#  the exact same uplink, so moving this job to them would silently destroy the entire
+#  point of it while still appearing to work.
+#
+#  If you are here because a CI policy linter flagged `runs-on: ubuntu-latest`, the answer
+#  is to exempt this file, not to change it.
+#
+#  COST: ever-co/ever-gauzy is a PUBLIC repository, so GitHub-hosted minutes are free and
+#  unlimited. This costs $0. If the repo ever goes private, reduce the cron to hourly.
+# =====================================================================================
+
+on:
+  schedule:
+    # Every 15 minutes. Free on public repos. GitHub's scheduler is best-effort and can
+    # be delayed under load; treat gaps between runs as normal, not as an outage.
+    - cron: '*/15 * * * *'
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Probe the endpoints but never open, comment on, or close the alert issue'
+        type: boolean
+        default: false
+
+  # Self-test: whenever THIS file changes, run it on the pull request so the YAML is proven
+  # to parse and the probes are proven to work before it is merged. Alerting is force-disabled
+  # on pull_request events (see the "Decide alerting mode" step), so this can never spam issues.
+  # This trigger is also the only way to exercise the workflow pre-merge: `workflow_dispatch`
+  # is not available until the file exists on the default branch.
+  pull_request:
+    paths:
+      - '.github/workflows/external-uptime-monitor.yml'
+
+# Least privilege: we only need to read the repo and write issues. GITHUB_TOKEN is provided
+# automatically — this workflow requires NO new secrets.
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  # Never let two probe runs overlap and fight over the same alert issue.
+  group: external-uptime-monitor
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Probe public endpoints from outside the homelab
+    # 🛑 DO NOT CHANGE — see the header block. GitHub-hosted is the whole point.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ALERT_LABEL: uptime-alert
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      # Number of consecutive failed attempts required before a target is declared DOWN.
+      # A single transient blip must never alert.
+      ATTEMPTS: '3'
+      RETRY_SLEEP: '15'
+      CONNECT_TIMEOUT: '10'
+      MAX_TIME: '20'
+
+    steps:
+      - name: Decide alerting mode
+        id: mode
+        run: |
+          set -euo pipefail
+          # Alerting is ON for scheduled runs, and for manual runs unless dry_run was ticked.
+          # It is always OFF for pull_request events (this file's own self-test).
+          MODE=on
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            MODE=off
+            echo "pull_request event -> self-test only, issue alerting disabled."
+          elif [ "${DRY_RUN_INPUT}" = "true" ]; then
+            MODE=off
+            echo "dry_run requested -> issue alerting disabled."
+          fi
+          echo "alerting=${MODE}" >> "$GITHUB_OUTPUT"
+        env:
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+
+      - name: Record runner public egress IP
+        id: egress
+        run: |
+          set -uo pipefail
+          # Knowing WHERE the probe observed from is what separates "production is down"
+          # from "this particular network path is broken".
+          IP=""
+          for svc in https://api.ipify.org https://checkip.amazonaws.com https://ifconfig.me/ip; do
+            IP=$(curl -sS --connect-timeout 5 --max-time 10 "$svc" 2>/dev/null | tr -d '[:space:]') || IP=""
+            if [ -n "$IP" ]; then break; fi
+          done
+          if [ -z "$IP" ]; then IP="unknown"; fi
+          echo "Runner public egress IP: ${IP}"
+          echo "ip=${IP}" >> "$GITHUB_OUTPUT"
+
+      - name: Probe endpoints
+        id: probe
+        run: |
+          set -uo pipefail
+
+          # id | severity | url | body-regex (empty = no body assertion)
+          #
+          # severity=critical -> a sustained failure opens/updates the alert issue.
+          # severity=warn     -> checked and reported, but never opens an issue on its own.
+          #                      stage is WIP by fleet policy and brief downtime is expected;
+          #                      letting it flap would keep the alert issue permanently open
+          #                      and mask a real production outage.
+          TARGETS=(
+            'prod-web|critical|https://app.gauzy.co/|'
+            'prod-api|critical|https://api.gauzy.co/api/health|"status"[[:space:]]*:[[:space:]]*"ok"'
+            'marketing|warn|https://gauzy.co/|'
+            'stage-web|warn|https://stage.gauzy.co/|'
+            'stage-api|warn|https://apistage.gauzy.co/api/health|"status"[[:space:]]*:[[:space:]]*"ok"'
+          )
+
+          REPORT="${RUNNER_TEMP}/report.md"
+          : > "$REPORT"
+          FAILED_CRITICAL=""
+          FAILED_WARN=""
+
+          {
+            echo "| Target | Sev | URL | HTTP | dns | connect | tls | ttfb | total | peer | verdict |"
+            echo "|---|---|---|---|---|---|---|---|---|---|---|"
+          } >> "$REPORT"
+
+          for entry in "${TARGETS[@]}"; do
+            IFS='|' read -r id sev url expect <<< "$entry"
+
+            ok=false
+            code="000"; dns="0"; conn="0"; tls="0"; ttfb="0"; total="0"; peer="-"
+            reason=""
+
+            for attempt in $(seq 1 "${ATTEMPTS}"); do
+              body="${RUNNER_TEMP}/body_${id}.txt"
+              : > "$body"
+
+              # -L: follow redirects (the web apps redirect to their login route).
+              # The -w fields are the load-bearing diagnostic: on 2026-08-15 the whole
+              # diagnosis hinged on connect=0.000 with a healthy dns, which proves a
+              # TCP-level blackhole rather than an application error.
+              w=$(curl -sS -L --max-redirs 5 \
+                    --connect-timeout "${CONNECT_TIMEOUT}" --max-time "${MAX_TIME}" \
+                    -A 'ever-gauzy-external-uptime-monitor (+https://github.com/ever-co/ever-gauzy)' \
+                    -o "$body" \
+                    -w '%{http_code}|%{time_namelookup}|%{time_connect}|%{time_appconnect}|%{time_starttransfer}|%{time_total}|%{remote_ip}' \
+                    "$url" 2>/dev/null) || true
+
+              if [ -n "$w" ]; then
+                IFS='|' read -r code dns conn tls ttfb total peer <<< "$w"
+              else
+                code="000"; dns="0"; conn="0"; tls="0"; ttfb="0"; total="0"; peer="-"
+              fi
+              [ -n "${peer:-}" ] || peer="-"
+
+              case "$code" in
+                2*) http_ok=true ;;
+                *)  http_ok=false ;;
+              esac
+
+              body_ok=true
+              if [ -n "$expect" ]; then
+                # Assert on the BODY, not just the status code: a 200 with a broken payload
+                # is still an outage.
+                if ! grep -Eq "$expect" "$body" 2>/dev/null; then
+                  body_ok=false
+                fi
+              fi
+
+              if [ "$http_ok" = true ] && [ "$body_ok" = true ]; then
+                ok=true
+                reason=""
+                break
+              fi
+
+              if [ "$http_ok" != true ]; then
+                reason="HTTP ${code}"
+              else
+                reason="body assertion failed (HTTP ${code}, expected /${expect}/)"
+              fi
+              echo "::warning::${id} attempt ${attempt}/${ATTEMPTS} failed: ${reason} (${url})"
+
+              if [ "$attempt" -lt "${ATTEMPTS}" ]; then
+                sleep "${RETRY_SLEEP}"
+              fi
+            done
+
+            if [ "$ok" = true ]; then
+              verdict="✅ up"
+            else
+              verdict="❌ DOWN — ${reason}"
+              if [ "$sev" = "critical" ]; then
+                FAILED_CRITICAL="${FAILED_CRITICAL}${id} "
+              else
+                FAILED_WARN="${FAILED_WARN}${id} "
+              fi
+            fi
+
+            echo "| \`${id}\` | ${sev} | ${url} | ${code} | ${dns} | ${conn} | ${tls} | ${ttfb} | ${total} | ${peer} | ${verdict} |" >> "$REPORT"
+
+            # Show a little of the health payload so the body assertion is auditable.
+            if [ -n "$expect" ]; then
+              snippet=$(head -c 200 "${RUNNER_TEMP}/body_${id}.txt" 2>/dev/null | tr -d '\r\n' || true)
+              echo "::notice::${id} body[0:200]=${snippet}"
+            fi
+          done
+
+          FAILED_CRITICAL=$(echo "$FAILED_CRITICAL" | xargs || true)
+          FAILED_WARN=$(echo "$FAILED_WARN" | xargs || true)
+
+          # Fingerprint of the exact failing set, so a sustained outage does not produce a
+          # comment every 15 minutes — we only comment when the situation actually changes.
+          FP=$(printf '%s|%s' "$FAILED_CRITICAL" "$FAILED_WARN" | sha256sum | cut -c1-12)
+
+          {
+            echo "failed_critical=${FAILED_CRITICAL}"
+            echo "failed_warn=${FAILED_WARN}"
+            echo "fingerprint=${FP}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### External uptime probe"
+            echo
+            echo "Observed from GitHub-hosted runner egress IP \`${EGRESS_IP}\` (outside the homelab)."
+            echo
+            cat "$REPORT"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "failed_critical='${FAILED_CRITICAL}' failed_warn='${FAILED_WARN}' fp=${FP}"
+        env:
+          EGRESS_IP: ${{ steps.egress.outputs.ip }}
+
+      - name: Ensure alert label exists
+        if: steps.mode.outputs.alerting == 'on'
+        run: |
+          set -uo pipefail
+          gh label create "${ALERT_LABEL}" \
+            --color B60205 \
+            --description 'Automated external uptime probe alert' \
+            --repo "${GITHUB_REPOSITORY}" 2>/dev/null || true
+
+      - name: Open or update the alert issue
+        if: steps.mode.outputs.alerting == 'on' && steps.probe.outputs.failed_critical != ''
+        env:
+          FAILED_CRITICAL: ${{ steps.probe.outputs.failed_critical }}
+          FAILED_WARN: ${{ steps.probe.outputs.failed_warn }}
+          FINGERPRINT: ${{ steps.probe.outputs.fingerprint }}
+          EGRESS_IP: ${{ steps.egress.outputs.ip }}
+        run: |
+          set -uo pipefail
+
+          BODY="${RUNNER_TEMP}/alert.md"
+          {
+            echo "## 🔴 Production unreachable from OUTSIDE the homelab"
+            echo
+            echo "A GitHub-hosted runner — which is **not** on the homelab network or the owner's"
+            echo "ISP uplink — could not reach the endpoint(s) below on **${ATTEMPTS} consecutive**"
+            echo "attempts, ${RETRY_SLEEP}s apart."
+            echo
+            echo "Because this vantage point is external, this is evidence of a **real, user-facing**"
+            echo "problem rather than a homelab routing fault."
+            echo
+            echo "- Failing (critical): \`${FAILED_CRITICAL}\`"
+            if [ -n "${FAILED_WARN}" ]; then
+              echo "- Also failing (non-critical): \`${FAILED_WARN}\`"
+            fi
+            echo "- Runner public egress IP: \`${EGRESS_IP}\`"
+            echo "- Run: ${RUN_URL}"
+            echo
+            cat "${RUNNER_TEMP}/report.md"
+            echo
+            echo "### Reading the timings"
+            echo
+            echo "- \`connect\` = 0 while \`dns\` is non-zero → TCP never established: a network-path"
+            echo "  blackhole (routing/prefix/firewall), **not** an application fault."
+            echo "- \`connect\` fine but \`tls\` = 0 → TLS handshake failed (certificate/SNI/edge)."
+            echo "- All timings fine but a non-2xx code or a failed body assertion → the app itself."
+            echo
+            echo "This issue is updated in place; it is **not** reopened every run. It closes"
+            echo "automatically when the probe recovers."
+            echo
+            echo "<!-- uptime-fingerprint: ${FINGERPRINT} -->"
+          } > "$BODY"
+
+          NUM=$(gh issue list --repo "${GITHUB_REPOSITORY}" --label "${ALERT_LABEL}" \
+                  --state open --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)
+
+          if [ -z "${NUM}" ]; then
+            echo "No open alert issue — creating one."
+            gh issue create --repo "${GITHUB_REPOSITORY}" \
+              --title "🔴 External uptime alert: ${FAILED_CRITICAL} unreachable from outside the homelab" \
+              --label "${ALERT_LABEL}" \
+              --body-file "$BODY"
+          else
+            echo "Alert issue #${NUM} already open."
+            LAST=$(gh issue view "${NUM}" --repo "${GITHUB_REPOSITORY}" --json body,comments \
+                     --jq 'if (.comments | length) > 0 then .comments[-1].body else .body end' 2>/dev/null || true)
+            if printf '%s' "${LAST}" | grep -q "uptime-fingerprint: ${FINGERPRINT}"; then
+              echo "State unchanged (fingerprint ${FINGERPRINT}) — not commenting, to avoid issue spam."
+            else
+              echo "State changed — adding one comment."
+              gh issue comment "${NUM}" --repo "${GITHUB_REPOSITORY}" --body-file "$BODY"
+            fi
+          fi
+
+      - name: Comment and close on recovery
+        if: steps.mode.outputs.alerting == 'on' && steps.probe.outputs.failed_critical == ''
+        env:
+          FINGERPRINT: ${{ steps.probe.outputs.fingerprint }}
+          EGRESS_IP: ${{ steps.egress.outputs.ip }}
+        run: |
+          set -uo pipefail
+
+          NUM=$(gh issue list --repo "${GITHUB_REPOSITORY}" --label "${ALERT_LABEL}" \
+                  --state open --limit 1 --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -z "${NUM}" ]; then
+            echo "All critical endpoints healthy and no alert issue open — nothing to do."
+            exit 0
+          fi
+
+          BODY="${RUNNER_TEMP}/recovered.md"
+          {
+            echo "## ✅ Recovered"
+            echo
+            echo "All **critical** endpoints answered from the external GitHub-hosted vantage point"
+            echo "(egress IP \`${EGRESS_IP}\`)."
+            echo
+            cat "${RUNNER_TEMP}/report.md"
+            echo
+            echo "- Run: ${RUN_URL}"
+            echo
+            echo "Closing automatically. It will reopen as a new issue if this recurs."
+            echo
+            echo "<!-- uptime-fingerprint: recovered-${FINGERPRINT} -->"
+          } > "$BODY"
+
+          gh issue comment "${NUM}" --repo "${GITHUB_REPOSITORY}" --body-file "$BODY"
+          gh issue close "${NUM}" --repo "${GITHUB_REPOSITORY}" --reason completed
+
+      - name: Fail the run if a critical endpoint is down
+        if: steps.probe.outputs.failed_critical != ''
+        run: |
+          echo "::error::Critical endpoints unreachable from outside the homelab: ${FAILED_CRITICAL}"
+          exit 1
+        env:
+          FAILED_CRITICAL: ${{ steps.probe.outputs.failed_critical }}

--- a/.github/workflows/external-uptime-monitor.yml
+++ b/.github/workflows/external-uptime-monitor.yml
@@ -26,6 +26,10 @@ name: External Uptime Monitor
 #  unlimited. This costs $0. If the repo ever goes private, reduce the cron to hourly.
 # =====================================================================================
 
+# Domain vocabulary and curl `-w` field names used throughout this file. `.cspell.json` runs
+# with `strict: true` on every PR to develop, so without this the Cspell check goes red.
+# cspell:ignore homelab ttfb blackhole redirs namelookup appconnect starttransfer esac
+
 on:
   schedule:
     # Every 15 minutes. Free on public repos. GitHub's scheduler is best-effort and can
@@ -38,6 +42,16 @@ on:
         description: 'Probe the endpoints but never open, comment on, or close the alert issue'
         type: boolean
         default: false
+      test_target_url:
+        # Without this, every route into the alerting code is closed off in advance: pull_request
+        # forces alerting off, dry_run forces it off, and a manual run against a HEALTHY production
+        # takes the recovery branch and exits early. That leaves `gh issue create` / `comment` /
+        # `close` executing for the first time in their lives DURING a real incident — a monitor
+        # whose alert delivery has only ever been assumed. This input lets a human rehearse the
+        # full open → comment → close cycle on demand.
+        description: 'Rehearsal only: add an extra CRITICAL target that is expected to FAIL (e.g. https://httpstat.us/503) to exercise the real alert open/comment/close path. This WILL open a real issue.'
+        type: string
+        default: ''
 
   # Self-test: whenever THIS file changes, run it on the pull request so the YAML is proven
   # to parse and the probes are proven to work before it is merged. Alerting is force-disabled
@@ -106,7 +120,10 @@ jobs:
       - name: Record runner public egress IP
         id: egress
         run: |
-          set -uo pipefail
+          # GitHub invokes every `run:` step as `/usr/bin/bash -e {0}`, so -e is ALREADY on and a bare
+          # `set -uo pipefail` cannot turn it off. Spelled out so nobody assumes otherwise: anything
+          # here that is allowed to fail must carry its own `|| true` / `if !` guard.
+          set -euo pipefail
           # Knowing WHERE the probe observed from is what separates "production is down"
           # from "this particular network path is broken".
           IP=""
@@ -121,7 +138,10 @@ jobs:
       - name: Probe endpoints
         id: probe
         run: |
-          set -uo pipefail
+          # GitHub invokes every `run:` step as `/usr/bin/bash -e {0}`, so -e is ALREADY on and a bare
+          # `set -uo pipefail` cannot turn it off. Spelled out so nobody assumes otherwise: anything
+          # here that is allowed to fail must carry its own `|| true` / `if !` guard.
+          set -euo pipefail
 
           # id | severity | url | body-regex (empty = no body assertion)
           #
@@ -130,13 +150,28 @@ jobs:
           #                      stage is WIP by fleet policy and brief downtime is expected;
           #                      letting it flap would keep the alert issue permanently open
           #                      and mask a real production outage.
+          # `prod-web` is half the CRITICAL surface, so it must not pass on a bare 2xx: nginx will
+          # answer 200 for a wrong-image deploy, a different app on the hostname, or a default
+          # page. `<ga-app` is the Angular root selector, verified present in the live index.html.
+          # Be honest about what this buys: it closes "the content served is not the Gauzy app",
+          # NOT "the app boots in a browser" — the selector is in index.html whether or not the JS
+          # bundle loads. It also cannot detect a bad route: this is an SPA, so a bogus path
+          # correctly returns the same shell (measured: /bogus-xyz-9931 -> 200, identical bytes).
           TARGETS=(
-            'prod-web|critical|https://app.gauzy.co/|'
+            'prod-web|critical|https://app.gauzy.co/|<ga-app'
             'prod-api|critical|https://api.gauzy.co/api/health|"status"[[:space:]]*:[[:space:]]*"ok"'
             'marketing|warn|https://gauzy.co/|'
             'stage-web|warn|https://stage.gauzy.co/|'
             'stage-api|warn|https://apistage.gauzy.co/api/health|"status"[[:space:]]*:[[:space:]]*"ok"'
           )
+
+          # Rehearsal target from workflow_dispatch, so the alert path can be exercised on demand
+          # instead of debuting during a real incident. Appended last so it can never displace or
+          # reorder a real target.
+          if [ -n "${TEST_TARGET_URL}" ]; then
+            TARGETS+=("selftest|critical|${TEST_TARGET_URL}|")
+            echo "::warning::Rehearsal target added: ${TEST_TARGET_URL} — if it fails, this run WILL open a real ${ALERT_LABEL} issue."
+          fi
 
           REPORT="${RUNNER_TEMP}/report.md"
           : > "$REPORT"
@@ -253,11 +288,16 @@ jobs:
           echo "failed_critical='${FAILED_CRITICAL}' failed_warn='${FAILED_WARN}' fp=${FP}"
         env:
           EGRESS_IP: ${{ steps.egress.outputs.ip }}
+          # Empty on every trigger except a manual rehearsal run. Declared here so `set -u` sees it.
+          TEST_TARGET_URL: ${{ github.event.inputs.test_target_url }}
 
       - name: Ensure alert label exists
         if: steps.mode.outputs.alerting == 'on'
         run: |
-          set -uo pipefail
+          # GitHub invokes every `run:` step as `/usr/bin/bash -e {0}`, so -e is ALREADY on and a bare
+          # `set -uo pipefail` cannot turn it off. Spelled out so nobody assumes otherwise: anything
+          # here that is allowed to fail must carry its own `|| true` / `if !` guard.
+          set -euo pipefail
           gh label create "${ALERT_LABEL}" \
             --color B60205 \
             --description 'Automated external uptime probe alert' \
@@ -332,7 +372,10 @@ jobs:
               echo "::error::Could not read alert issue #${NUM}. The outage is already visible there, so skipping the comment rather than risking a duplicate."
               exit 1
             fi
-            if printf '%s' "${LAST}" | grep -q "uptime-fingerprint: ${FINGERPRINT}"; then
+            # No pipe in a decision. Under `pipefail` a SIGPIPE'd producer can make an already-
+            # MATCHED grep report failure, which would post a redundant comment on every run of a
+            # steady outage — defeating the de-duplication exactly when it matters most.
+            if grep -q "uptime-fingerprint: ${FINGERPRINT}" <<< "${LAST}"; then
               echo "State unchanged (fingerprint ${FINGERPRINT}) — not commenting, to avoid issue spam."
             else
               echo "State changed — adding one comment."
@@ -376,7 +419,13 @@ jobs:
             echo "<!-- uptime-fingerprint: recovered-${FINGERPRINT} -->"
           } > "$BODY"
 
-          gh issue comment "${NUM}" --repo "${GITHUB_REPOSITORY}" --body-file "$BODY"
+          # Never let a failed recovery comment block the close. Under `set -e` a transient
+          # secondary-rate-limit on the comment would abort this step BEFORE the close below,
+          # leaving a stale "production is down" issue open on a recovered service — exactly the
+          # outcome the comment above says this step exists to prevent. Warn, then close anyway.
+          gh issue comment "${NUM}" --repo "${GITHUB_REPOSITORY}" --body-file "$BODY" \
+            || echo "::warning::Recovery comment on #${NUM} failed; closing the issue regardless."
+          # The close itself stays fatal under -e — that one must never fail silently.
           gh issue close "${NUM}" --repo "${GITHUB_REPOSITORY}" --reason completed
 
       - name: Fail the run if a critical endpoint is down
@@ -386,3 +435,11 @@ jobs:
           exit 1
         env:
           FAILED_CRITICAL: ${{ steps.probe.outputs.failed_critical }}
+
+      - name: Report that the probe itself broke
+        # A custom `if:` is implicitly combined with success(), so if the probe step dies every step
+        # above is skipped: the run goes red with no alert issue and no explanation, and "the probe
+        # broke" becomes indistinguishable from "production is down". Say so explicitly.
+        if: failure() && steps.probe.outcome == 'failure'
+        run: |
+          echo "::error::The probe step itself failed — this run is NOT evidence about production. Investigate the runner/tooling, not the endpoints."


### PR DESCRIPTION
## Why

Today (2026-08-15) a routing fault at the owner's ISP (Orange, Spain) made Cloudflare's
`188.114.96.0/22` prefix unreachable **from the homelab**. Every `gauzy.co` hostname resolves into
that prefix, and **every existing probe of production runs inside the `ever-k8s` cluster** — so all
of them went red simultaneously and it looked exactly like "production is down".

It was not. Real users were served the entire time. Hours were lost on a false alarm.

This PR adds the missing capability: **a vantage point OUTSIDE the homelab network.**

The fault is still reproducible from the homelab as I write this — DNS resolves fine but TCP never
establishes, while a *different* Cloudflare prefix answers normally:

```
app.gauzy.co    -> 188.114.96.5   code=000  dns=0.028  connect=0.000   <- blackholed
api.gauzy.co    -> 188.114.97.5   code=000  dns=0.008  connect=0.000   <- blackholed
www.cloudflare.com -> 104.16.123.96  code=200  dns=0.092  connect=0.202   <- fine
api.github.com  -> 140.82.121.5   code=200  dns=0.016  connect=0.097   <- fine
```

That `connect=0.000` with a healthy `dns` is the exact signature that distinguishes a **network-path
blackhole** from an **application outage** — which is why this workflow records the full curl timing
breakdown rather than just a status code.

## 🛑 Why this one workflow uses `ubuntu-latest`

Every other workflow here targets the self-hosted ARC pool (`vars.RUNNER_LINUX_X64_4` / `_8`).
**This one is a deliberate, documented exception**, and the file carries a prominent header block
saying so.

Self-hosted / ARC runners live in the homelab and share the exact same uplink that broke today.
Moving this job onto them would silently destroy its only value while still appearing to work.
Please do not "fix" it back — if a CI policy check flags it, exempt this file.

## Cost: $0

`ever-co/ever-gauzy` is a **public** repository, so GitHub-hosted minutes are **free and unlimited**
— no consumption of the 2,000-min/month private-repo quota.

Cadence is `*/15 * * * *`. Each run does no `actions/checkout` and only a handful of curls, so a
healthy run finishes in well under a minute (~96 runs/day, ~2,900 min/month — all free at $0).
**If this repo is ever made private, drop the cron to hourly** (a note to that effect is in the file
header).

## What is monitored

| Target | Severity | URL | Assertion |
|---|---|---|---|
| `prod-web` | **critical** | `https://app.gauzy.co/` | HTTP 2xx (redirects followed) |
| `prod-api` | **critical** | `https://api.gauzy.co/api/health` | HTTP 2xx **and** body matches `"status": "ok"` |
| `marketing` | warn | `https://gauzy.co/` | HTTP 2xx |
| `stage-web` | warn | `https://stage.gauzy.co/` | HTTP 2xx |
| `stage-api` | warn | `https://apistage.gauzy.co/api/health` | HTTP 2xx **and** body matches `"status": "ok"` |

**Only `critical` failures open an alert issue.** Stage is WIP by fleet policy and brief downtime is
expected; letting it flap would keep the alert issue permanently open and mask a real production
outage. `warn` targets are still probed and always shown in the run summary and in the issue body.

The API health check asserts on the **body**, not just the status code — a 200 with a broken payload
is still an outage.

## Alerting behaviour (designed against issue spam)

Issue spam is the main way monitors like this get muted, so:

- **One rolling issue**, found by the `uptime-alert` label. If one is already open, the run
  **comments instead of opening a second**.
- **A failing state comments only when the state actually changes.** Each report embeds
  `<!-- uptime-fingerprint: … -->` derived from the exact set of failing targets; if the newest
  comment already carries that fingerprint, the run stays silent. A sustained outage therefore
  produces **one** comment, not 96 a day.
- **On recovery** the run comments with the healthy timings and **closes** the issue.
- The label is created idempotently, so no manual setup is required.

Every alert includes the failing URL, HTTP code, the full timing breakdown
(`time_namelookup` / `time_connect` / `time_appconnect` / `time_starttransfer` / `time_total`), the
resolved peer IP, and **the runner's public egress IP** — so the next time a network path breaks it
can be told apart from an application fault immediately, with a short "reading the timings" guide
in the issue body.

## No new secrets, least privilege

Uses only the automatically-provided `GITHUB_TOKEN` with `permissions: contents: read`,
`issues: write`. Nothing to configure.

## Evidence

- **YAML parses** and registers 1 job / 7 steps (validated with `js-yaml` before pushing).
- **No empty `${{ }}` expression anywhere**, including inside comments — that trap silently
  invalidates an entire workflow file, registering 0 jobs. Explicitly grepped for; the file is also
  LF-only.
- **The probe script was executed against known-good *and* deliberately known-bad controls** before
  being committed. Both failure modes were caught:
  - a target returning **HTTP 200 with a non-matching body** was correctly reported DOWN, proving
    the body assertion works;
  - a blackholed target produced `dns=0.0088`, `connect=0.000000`, proving the network-path
    signature is captured.
- This workflow **self-tests on its own pull request**: it has a `pull_request` trigger filtered to
  this one file path, with issue alerting **force-disabled** for `pull_request` events. That is also
  the only way to exercise it pre-merge, since `workflow_dispatch` is unavailable until the file
  exists on the default branch. See the `External Uptime Monitor` check on this PR for a live run
  against the real endpoints.

## Scope

Adds exactly **one** new file. No existing workflow, deploy pipeline, or release pipeline is
touched. Opened against `develop` per the `develop` → `stage` → `master` convention. **Not merged —
left for the owner.**

Two sibling PRs add the identical monitor to `ever-co/ever-teams` and `ever-works/ever-works`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a free external uptime monitor on GitHub-hosted runners to probe `app.gauzy.co` and `api.gauzy.co` from outside the homelab, preventing ISP routing faults from reading as production outages. Previously all probes ran inside the homelab; now CI only fails on sustained critical failures and raises a single rolling alert.

- Adds `.github/workflows/external-uptime-monitor.yml` on `ubuntu-latest`; schedule every 15m, `workflow_dispatch` with `dry_run` and `test_target_url` rehearsal, and PR self-test with alerting disabled.
- Critical assertions: `https://app.gauzy.co/` now requires 2xx and `<ga-app>` (was 2xx only); `https://api.gauzy.co/api/health` requires 2xx and `"status":"ok"`. Warn-only: marketing and stage endpoints.
- Probes retry 3×, capture full curl timings and runner egress IP to distinguish network-path faults from app failures.
- Alerting: single `uptime-alert` issue with fingerprint de-duplication; guards against GitHub API errors; recovery always comments and closes; run fails if any critical target remains down.
- Least privilege and concurrency: workflow default `contents: read`; `issues: write` scoped to alert job; separate concurrency groups for live runs vs PR self-tests. No new secrets.
- Tooling: CSpell ignores added (including `selftest` and `SIGPIPE`); SIGPIPE phrasing adjusted; new “probe itself broke” notice clarifies tooling failures.
- Rollout: keep GitHub-hosted runners; if the repo becomes private, reduce the cron to hourly.

<sup>Written for commit b38bd963cc8498adbdfd33fa42dc742c8c965613. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

