### PR TITLE
fix(ci): stop installing npm dependencies through the public packages.ever.co route

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,11 @@
         "GHSA-[A-Za-z0-9-]+"
     ],
     "words": [
+        "ENOENT",
+        "gzipped",
+        "gzips",
+        "npmjs",
+        "rspack",
         "dlib",
         "codesign",
         "codesigning",

--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,8 @@
         "GHSA-[A-Za-z0-9-]+"
     ],
     "words": [
+        "esac",
+        "POSTCONDITION",
         "ENOENT",
         "gzipped",
         "gzips",

--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -112,7 +112,7 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -213,7 +213,7 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \

--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -118,6 +118,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
+    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -219,6 +220,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
+    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -118,7 +118,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
-    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+    echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -220,7 +220,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
-    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+    echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -70,7 +70,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -158,7 +158,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \

--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -76,6 +76,7 @@ RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_RE
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
+    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -164,6 +165,7 @@ RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_RE
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
+    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/mcp-auth/Dockerfile
+++ b/.deploy/mcp-auth/Dockerfile
@@ -76,7 +76,7 @@ RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_RE
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
-    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+    echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -165,7 +165,7 @@ RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_RE
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
-    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+    echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -121,6 +121,7 @@ RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_RE
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
+    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -203,6 +204,7 @@ RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_RE
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
+    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -121,7 +121,7 @@ RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_RE
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
-    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+    echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -204,7 +204,7 @@ RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_RE
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
-    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+    echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/mcp/Dockerfile
+++ b/.deploy/mcp/Dockerfile
@@ -115,7 +115,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -197,7 +197,7 @@ COPY --chown=node:node .scripts/postinstall.js ./.scripts/
 
 ARG VERDACCIO_TOKEN
 ARG VERDACCIO_REGISTRY=""
-RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+RUN if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -147,6 +147,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
 	sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
 	sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
 	elif [ -n "$VERDACCIO_TOKEN" ]; then \
+	echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
 	echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
 	echo "registry=https://packages.ever.co/" >> .npmrc && \
 	echo "always-auth=true" >> .npmrc && \

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -147,7 +147,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
 	sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
 	sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
 	elif [ -n "$VERDACCIO_TOKEN" ]; then \
-	echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+	echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
 	echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
 	echo "registry=https://packages.ever.co/" >> .npmrc && \
 	echo "always-auth=true" >> .npmrc && \

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -141,7 +141,7 @@ ENV REQUIRE_NATIVE_BINARIES=""
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
 	VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-	if [ -n "$VERDACCIO_REGISTRY" ]; then \
+	if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
 	echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
 	echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
 	sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \

--- a/.deploy/worker/Dockerfile
+++ b/.deploy/worker/Dockerfile
@@ -112,7 +112,7 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
@@ -213,7 +213,7 @@ COPY --chown=node:node patches ./patches
 ARG VERDACCIO_REGISTRY=""
 RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     VERDACCIO_TOKEN="$(cat /run/secrets/VERDACCIO_TOKEN 2>/dev/null || true)" && \
-    if [ -n "$VERDACCIO_REGISTRY" ]; then \
+    if [ -n "$VERDACCIO_REGISTRY" ] && wget -q -T 5 -O /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then \
     echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
     echo "registry \"${VERDACCIO_REGISTRY}\"" >> .yarnrc && \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \

--- a/.deploy/worker/Dockerfile
+++ b/.deploy/worker/Dockerfile
@@ -118,6 +118,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
+    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -219,6 +220,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
+    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.deploy/worker/Dockerfile
+++ b/.deploy/worker/Dockerfile
@@ -118,7 +118,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
-    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+    echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \
@@ -220,7 +220,7 @@ RUN --mount=type=secret,id=VERDACCIO_TOKEN,uid=1000 \
     sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" yarn.lock && \
     sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" yarn.lock; \
     elif [ -n "$VERDACCIO_TOKEN" ]; then \
-    echo "Verdaccio VIP unreachable - falling back to the public packages.ever.co route (known to truncate large tarballs mid-stream)." && \
+    echo "Internal Verdaccio VIP not in use (VERDACCIO_REGISTRY unset, or its probe failed) - installing through the public packages.ever.co route, which is known to truncate large tarballs mid-stream." && \
     echo "//packages.ever.co/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://packages.ever.co/" >> .npmrc && \
     echo "always-auth=true" >> .npmrc && \

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -174,31 +174,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -206,6 +210,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -396,22 +396,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -181,28 +181,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -210,19 +236,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -239,6 +252,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -184,7 +184,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -235,9 +235,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -379,7 +382,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -391,18 +391,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -215,11 +215,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -245,29 +247,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -357,3 +343,26 @@ jobs:
           AGENT_APP_DESCRIPTION: 'Gauzy Agent'
           AGENT_APP_ID: 'com.ever.gauzyagent'
           COMPANY_SITE_LINK: 'https://gauzy.co'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -364,5 +364,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -368,25 +368,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -244,9 +244,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -360,16 +365,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/agent-demo.yml
+++ b/.github/workflows/agent-demo.yml
@@ -151,15 +151,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -193,31 +193,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -225,6 +229,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -388,31 +405,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -420,6 +441,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -545,31 +579,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -577,6 +615,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -733,31 +784,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -765,6 +820,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -969,31 +1037,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1001,6 +1073,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -335,28 +335,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -611,28 +641,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -857,28 +917,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1155,28 +1245,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1466,25 +1586,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -200,28 +200,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -229,19 +255,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -258,6 +271,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump agent version
         uses: actions/github-script@v8
@@ -412,28 +441,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -441,19 +496,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -470,6 +512,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version agent app
         uses: actions/github-script@v8
@@ -586,28 +644,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -615,19 +699,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -644,6 +715,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -791,28 +878,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -820,19 +933,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -849,6 +949,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -1044,28 +1160,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1073,19 +1215,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1102,6 +1231,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version agent app
         uses: actions/github-script@v8

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -331,8 +331,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -583,8 +590,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -805,8 +819,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1079,8 +1100,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1366,5 +1394,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -263,9 +263,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -327,18 +332,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -520,9 +534,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -586,18 +605,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -739,9 +767,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -815,18 +848,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -989,9 +1031,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1096,18 +1143,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1287,9 +1343,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1390,16 +1451,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -363,22 +363,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -686,22 +689,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -979,22 +985,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1324,22 +1333,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1682,22 +1694,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -358,18 +358,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -664,18 +681,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -940,18 +974,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1268,18 +1319,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1609,18 +1677,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -234,11 +234,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -264,29 +266,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump agent version
         uses: actions/github-script@v8
@@ -324,6 +310,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -475,11 +484,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -505,29 +516,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version agent app
         uses: actions/github-script@v8
@@ -567,6 +562,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -678,11 +696,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -708,29 +728,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -780,6 +784,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -912,11 +939,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -942,29 +971,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -1045,6 +1058,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1194,11 +1230,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1224,29 +1262,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version agent app
         uses: actions/github-script@v8
@@ -1323,3 +1345,26 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -203,7 +203,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -254,9 +254,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -346,7 +349,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -474,7 +477,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -525,9 +528,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -619,7 +625,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -707,7 +713,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -758,9 +764,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -862,7 +871,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -971,7 +980,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1022,9 +1031,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1157,7 +1169,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1283,7 +1295,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1334,9 +1346,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1465,7 +1480,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/agent-prod.yml
+++ b/.github/workflows/agent-prod.yml
@@ -170,15 +170,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -309,15 +365,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -410,15 +522,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -542,15 +710,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -722,15 +946,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -251,9 +251,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -315,18 +320,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -492,9 +506,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -558,18 +577,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -711,9 +739,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -818,18 +851,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -992,9 +1034,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1126,18 +1173,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1337,9 +1393,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1467,16 +1528,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -188,28 +188,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -217,19 +243,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -246,6 +259,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -384,28 +413,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -413,19 +468,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -442,6 +484,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version agent app
         uses: actions/github-script@v8
@@ -558,28 +616,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -587,19 +671,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -616,6 +687,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -794,28 +881,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -823,19 +936,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -852,6 +952,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -1094,28 +1210,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1123,19 +1265,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1152,6 +1281,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version agent app
         uses: actions/github-script@v8

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -222,11 +222,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -252,29 +254,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -312,6 +298,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -447,11 +456,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -477,29 +488,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version agent app
         uses: actions/github-script@v8
@@ -539,6 +534,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -650,11 +668,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -680,29 +700,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -783,6 +787,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -915,11 +942,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -945,29 +974,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Agent version
         uses: actions/github-script@v8
@@ -1075,6 +1088,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1244,11 +1280,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1274,29 +1312,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version agent app
         uses: actions/github-script@v8
@@ -1400,3 +1422,26 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -181,31 +181,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -213,6 +217,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -360,31 +377,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -392,6 +413,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -517,31 +551,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -549,6 +587,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -736,31 +787,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -768,6 +823,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1019,31 +1087,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1051,6 +1123,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -319,8 +319,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -555,8 +562,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -808,8 +822,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1109,8 +1130,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1443,5 +1471,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -158,15 +158,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -281,15 +337,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -382,15 +494,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -545,15 +713,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -772,15 +996,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -346,18 +346,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -636,18 +653,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -943,18 +977,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1298,18 +1349,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1686,18 +1754,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -323,28 +323,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -583,28 +613,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -860,28 +920,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1185,28 +1275,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1543,25 +1663,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -191,7 +191,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -242,9 +242,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -334,7 +337,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -446,7 +449,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -497,9 +500,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -591,7 +597,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -679,7 +685,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -730,9 +736,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -865,7 +874,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -974,7 +983,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1025,9 +1034,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1187,7 +1199,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1333,7 +1345,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1384,9 +1396,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1542,7 +1557,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/agent-stage.yml
+++ b/.github/workflows/agent-stage.yml
@@ -351,22 +351,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -658,22 +661,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -982,22 +988,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1354,22 +1363,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1759,22 +1771,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -152,15 +152,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -245,9 +245,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -365,16 +370,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -373,25 +373,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -216,11 +216,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -246,29 +248,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -362,3 +348,26 @@ jobs:
           DESKTOP_APP_DESCRIPTION: 'Gauzy Desktop'
           DESKTOP_APP_ID: 'com.ever.gauzydesktop'
           COMPANY_SITE_LINK: 'https://gauzy.co'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -175,31 +175,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -207,6 +211,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -185,7 +185,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -236,9 +236,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -384,7 +387,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -182,28 +182,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -211,19 +237,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -240,6 +253,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -401,22 +401,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -396,18 +396,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/desktop-app-demo.yml
+++ b/.github/workflows/desktop-app-demo.yml
@@ -369,5 +369,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -200,28 +200,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -229,19 +255,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -258,6 +271,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -412,28 +441,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -441,19 +496,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -470,6 +512,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -586,28 +644,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -615,19 +699,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -644,6 +715,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -791,28 +878,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -820,19 +933,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -849,6 +949,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -1048,28 +1164,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1077,19 +1219,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1106,6 +1235,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -335,28 +335,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -611,28 +641,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -857,28 +917,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1159,28 +1249,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1474,25 +1594,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -363,22 +363,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -686,22 +689,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -979,22 +985,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1328,22 +1337,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1690,22 +1702,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -331,8 +331,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -583,8 +590,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -805,8 +819,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1083,8 +1104,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1374,5 +1402,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -358,18 +358,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -664,18 +681,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -940,18 +974,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1272,18 +1323,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1617,18 +1685,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -234,11 +234,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -264,29 +266,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -324,6 +310,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -475,11 +484,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -505,29 +516,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -567,6 +562,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -678,11 +696,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -708,29 +728,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -780,6 +784,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -912,11 +939,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -942,29 +971,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -1049,6 +1062,29 @@ jobs:
           # failures. Matches the e2e workflow's proven setting on the same box.
           NX_ISOLATE_PLUGINS: false
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1198,11 +1234,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1228,29 +1266,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -1331,3 +1353,26 @@ jobs:
           # failures. Matches the e2e workflow's proven setting on the same box.
           NX_ISOLATE_PLUGINS: false
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -170,15 +170,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -309,15 +365,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -410,15 +522,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -542,15 +710,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -726,15 +950,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -193,31 +193,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -225,6 +229,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -388,31 +405,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -420,6 +441,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -545,31 +579,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -577,6 +615,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -733,31 +784,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -765,6 +820,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -973,31 +1041,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1005,6 +1077,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -203,7 +203,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -254,9 +254,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -346,7 +349,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -474,7 +477,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -525,9 +528,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -619,7 +625,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -707,7 +713,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -758,9 +764,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -862,7 +871,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -971,7 +980,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1022,9 +1031,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1161,7 +1173,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1287,7 +1299,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1338,9 +1350,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1473,7 +1488,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/desktop-app-prod.yml
+++ b/.github/workflows/desktop-app-prod.yml
@@ -263,9 +263,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -327,18 +332,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -520,9 +534,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -586,18 +605,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -739,9 +767,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -815,18 +848,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -989,9 +1031,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1100,18 +1147,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1291,9 +1347,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1398,16 +1459,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -320,8 +320,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -556,8 +563,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -809,8 +823,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1114,8 +1135,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1452,5 +1480,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -159,15 +159,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -282,15 +338,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -383,15 +495,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -546,15 +714,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -777,15 +1001,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -189,28 +189,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -218,19 +244,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -247,6 +260,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -385,28 +414,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -414,19 +469,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -443,6 +485,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -559,28 +617,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -588,19 +672,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -617,6 +688,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -795,28 +882,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -824,19 +937,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -853,6 +953,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -1099,28 +1215,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1128,19 +1270,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1157,6 +1286,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -347,18 +347,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -637,18 +654,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -944,18 +978,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1303,18 +1354,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1695,18 +1763,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -252,9 +252,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -316,18 +321,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -493,9 +507,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -559,18 +578,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -712,9 +740,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -819,18 +852,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -993,9 +1035,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1131,18 +1178,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1342,9 +1398,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1476,16 +1537,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -182,31 +182,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -214,6 +218,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -361,31 +378,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -393,6 +414,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -518,31 +552,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -550,6 +588,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -737,31 +788,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -769,6 +824,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1024,31 +1092,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1056,6 +1128,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -192,7 +192,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -243,9 +243,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -335,7 +338,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -447,7 +450,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -498,9 +501,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -592,7 +598,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -680,7 +686,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -731,9 +737,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -866,7 +875,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -975,7 +984,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1026,9 +1035,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1192,7 +1204,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1338,7 +1350,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1389,9 +1401,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1551,7 +1566,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -223,11 +223,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -253,29 +255,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -313,6 +299,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -448,11 +457,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -478,29 +489,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -540,6 +535,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -651,11 +669,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -681,29 +701,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -784,6 +788,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -916,11 +943,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -946,29 +975,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -1080,6 +1093,29 @@ jobs:
           # failures. Matches the e2e workflow's proven setting on the same box.
           NX_ISOLATE_PLUGINS: false
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1249,11 +1285,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1279,29 +1317,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop app
         uses: actions/github-script@v8
@@ -1409,3 +1431,26 @@ jobs:
           # failures. Matches the e2e workflow's proven setting on the same box.
           NX_ISOLATE_PLUGINS: false
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -324,28 +324,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -584,28 +614,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -861,28 +921,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1190,28 +1280,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1552,25 +1672,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/desktop-app-stage.yml
+++ b/.github/workflows/desktop-app-stage.yml
@@ -352,22 +352,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -659,22 +662,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -983,22 +989,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1359,22 +1368,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1768,22 +1780,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -395,18 +395,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -400,22 +400,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -174,31 +174,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -206,6 +210,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -244,9 +244,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -364,16 +369,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -184,7 +184,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -235,9 +235,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -383,7 +386,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -181,28 +181,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -210,19 +236,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -239,6 +252,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -372,25 +372,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -215,11 +215,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -245,29 +247,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -361,3 +347,26 @@ jobs:
           DESKTOP_TIMER_APP_DESCRIPTION: 'Gauzy Desktop Timer'
           DESKTOP_TIMER_APP_ID: 'com.ever.gauzydesktoptimer'
           COMPANY_SITE_LINK: 'https://gauzy.co'          
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -368,5 +368,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-timer-app-demo.yml
+++ b/.github/workflows/desktop-timer-app-demo.yml
@@ -151,15 +151,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -335,28 +335,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -611,28 +641,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -857,28 +917,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1159,28 +1249,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1474,25 +1594,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -234,11 +234,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -264,29 +266,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -324,6 +310,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -475,11 +484,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -505,29 +516,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -567,6 +562,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -678,11 +696,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -708,29 +728,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -780,6 +784,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -912,11 +939,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -942,29 +971,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -1049,6 +1062,29 @@ jobs:
           # failures. Matches the e2e workflow's proven setting on the same box.
           NX_ISOLATE_PLUGINS: false
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1198,11 +1234,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1228,29 +1266,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -1331,3 +1353,26 @@ jobs:
           # failures. Matches the e2e workflow's proven setting on the same box.
           NX_ISOLATE_PLUGINS: false
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -363,22 +363,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -686,22 +689,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -979,22 +985,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1328,22 +1337,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1690,22 +1702,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -331,8 +331,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -583,8 +590,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -805,8 +819,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1083,8 +1104,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1374,5 +1402,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -358,18 +358,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -664,18 +681,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -940,18 +974,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1272,18 +1323,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1617,18 +1685,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -170,15 +170,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -309,15 +365,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -410,15 +522,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -542,15 +710,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -726,15 +950,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -200,28 +200,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -229,19 +255,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -258,6 +271,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -412,28 +441,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -441,19 +496,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -470,6 +512,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -586,28 +644,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -615,19 +699,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -644,6 +715,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -791,28 +878,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -820,19 +933,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -849,6 +949,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -1048,28 +1164,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1077,19 +1219,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1106,6 +1235,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -193,31 +193,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -225,6 +229,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -388,31 +405,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -420,6 +441,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -545,31 +579,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -577,6 +615,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -733,31 +784,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -765,6 +820,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -973,31 +1041,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1005,6 +1077,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -203,7 +203,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -254,9 +254,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -346,7 +349,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -474,7 +477,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -525,9 +528,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -619,7 +625,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -707,7 +713,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -758,9 +764,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -862,7 +871,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -971,7 +980,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1022,9 +1031,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1161,7 +1173,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1287,7 +1299,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1338,9 +1350,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1473,7 +1488,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/desktop-timer-app-prod.yml
+++ b/.github/workflows/desktop-timer-app-prod.yml
@@ -263,9 +263,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -327,18 +332,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -520,9 +534,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -586,18 +605,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -739,9 +767,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -815,18 +848,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -989,9 +1031,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1100,18 +1147,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1291,9 +1347,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1398,16 +1459,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -222,11 +222,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -252,29 +254,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -312,6 +298,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -447,11 +456,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -477,29 +488,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -539,6 +534,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -650,11 +668,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -680,29 +700,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -783,6 +787,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -915,11 +942,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -945,29 +974,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -1079,6 +1092,29 @@ jobs:
           # failures. Matches the e2e workflow's proven setting on the same box.
           NX_ISOLATE_PLUGINS: false
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1248,11 +1284,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1278,29 +1316,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -1408,3 +1430,26 @@ jobs:
           # failures. Matches the e2e workflow's proven setting on the same box.
           NX_ISOLATE_PLUGINS: false
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -188,28 +188,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -217,19 +243,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -246,6 +259,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -384,28 +413,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -413,19 +468,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -442,6 +484,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -558,28 +616,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -587,19 +671,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -616,6 +687,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -794,28 +881,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -823,19 +936,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -852,6 +952,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8
@@ -1098,28 +1214,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1127,19 +1269,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1156,6 +1285,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version desktop timer app
         uses: actions/github-script@v8

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -181,31 +181,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -213,6 +217,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -360,31 +377,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -392,6 +413,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -517,31 +551,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -549,6 +587,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -736,31 +787,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -768,6 +823,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1023,31 +1091,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1055,6 +1127,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -323,28 +323,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -583,28 +613,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -860,28 +920,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1189,28 +1279,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1551,25 +1671,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -351,22 +351,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -658,22 +661,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -982,22 +988,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1358,22 +1367,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1767,22 +1779,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -319,8 +319,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -555,8 +562,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -808,8 +822,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1113,8 +1134,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1451,5 +1479,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -251,9 +251,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -315,18 +320,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -492,9 +506,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -558,18 +577,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -711,9 +739,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -818,18 +851,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -992,9 +1034,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1130,18 +1177,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1341,9 +1397,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1475,16 +1536,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -346,18 +346,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -636,18 +653,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -943,18 +977,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1302,18 +1353,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1694,18 +1762,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -191,7 +191,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -242,9 +242,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -334,7 +337,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -446,7 +449,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -497,9 +500,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -591,7 +597,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -679,7 +685,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -730,9 +736,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -865,7 +874,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -974,7 +983,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1025,9 +1034,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1191,7 +1203,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1337,7 +1349,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1388,9 +1400,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1550,7 +1565,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/desktop-timer-app-stage.yml
+++ b/.github/workflows/desktop-timer-app-stage.yml
@@ -158,15 +158,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -281,15 +337,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -382,15 +494,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -545,15 +713,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -776,15 +1000,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/docker-build-publish-mcp-auth-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-prod.yml
@@ -44,6 +44,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NX_CLOUD_ACCESS_TOKEN=${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
             NX_BRANCH=${{ github.ref_name }}
             VERDACCIO_TOKEN=${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/docker-build-publish-mcp-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-prod.yml
@@ -44,6 +44,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NX_CLOUD_ACCESS_TOKEN=${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
             NX_BRANCH=${{ github.ref_name }}
             VERDACCIO_TOKEN=${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -52,6 +52,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
@@ -153,6 +154,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}
@@ -256,6 +258,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             DEMO=false
             NX_BRANCH=${{ github.ref_name }}
             GAUZY_APP_VERSION=${{ steps.relver.outputs.version }}

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -174,31 +174,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -206,6 +210,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -396,22 +396,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -181,28 +181,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -210,19 +236,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -239,6 +252,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -184,7 +184,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -235,9 +235,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -379,7 +382,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -391,18 +391,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -364,5 +364,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -368,25 +368,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -244,9 +244,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -360,16 +365,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -151,15 +151,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-api-demo.yml
+++ b/.github/workflows/server-api-demo.yml
@@ -215,11 +215,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -245,29 +247,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -357,3 +343,26 @@ jobs:
           DESKTOP_API_SERVER_APP_DESCRIPTION: 'Gauzy API Server'
           DESKTOP_API_SERVER_APP_ID: 'com.ever.gauzyapiserver'
           COMPANY_SITE_LINK: 'https://gauzy.co'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -200,28 +200,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -229,19 +255,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -258,6 +271,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -412,28 +441,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -441,19 +496,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -470,6 +512,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server api app
         uses: actions/github-script@v8
@@ -586,28 +644,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -615,19 +699,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -644,6 +715,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -791,28 +878,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -820,19 +933,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -849,6 +949,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1044,28 +1160,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1073,19 +1215,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1102,6 +1231,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server api app
         uses: actions/github-script@v8

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -193,31 +193,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -225,6 +229,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -388,31 +405,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -420,6 +441,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -545,31 +579,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -577,6 +615,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -733,31 +784,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -765,6 +820,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -969,31 +1037,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1001,6 +1073,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -335,28 +335,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -611,28 +641,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -857,28 +917,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1155,28 +1245,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1466,25 +1586,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -331,8 +331,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -583,8 +590,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -805,8 +819,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1079,8 +1100,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1366,5 +1394,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -263,9 +263,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -327,18 +332,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -520,9 +534,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -586,18 +605,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -739,9 +767,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -815,18 +848,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -989,9 +1031,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1096,18 +1143,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1287,9 +1343,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1390,16 +1451,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -363,22 +363,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -686,22 +689,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -979,22 +985,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1324,22 +1333,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1682,22 +1694,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -234,11 +234,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -264,29 +266,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -324,6 +310,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -475,11 +484,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -505,29 +516,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server api app
         uses: actions/github-script@v8
@@ -567,6 +562,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -678,11 +696,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -708,29 +728,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -780,6 +784,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -912,11 +939,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -942,29 +971,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1045,6 +1058,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1194,11 +1230,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1224,29 +1262,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server api app
         uses: actions/github-script@v8
@@ -1323,3 +1345,26 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -358,18 +358,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -664,18 +681,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -940,18 +974,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1268,18 +1319,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1609,18 +1677,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -203,7 +203,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -254,9 +254,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -346,7 +349,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -474,7 +477,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -525,9 +528,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -619,7 +625,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -707,7 +713,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -758,9 +764,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -862,7 +871,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -971,7 +980,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1022,9 +1031,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1157,7 +1169,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1283,7 +1295,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1334,9 +1346,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1465,7 +1480,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-api-prod.yml
+++ b/.github/workflows/server-api-prod.yml
@@ -170,15 +170,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -309,15 +365,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -410,15 +522,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -542,15 +710,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -722,15 +946,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -189,28 +189,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -218,19 +244,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -247,6 +260,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -385,28 +414,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -414,19 +469,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -443,6 +485,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server api app
         uses: actions/github-script@v8
@@ -559,28 +617,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -588,19 +672,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -617,6 +688,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -795,28 +882,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -824,19 +937,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -853,6 +953,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1095,28 +1211,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1124,19 +1266,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1153,6 +1282,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server api app
         uses: actions/github-script@v8

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -252,9 +252,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -316,18 +321,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -493,9 +507,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -559,18 +578,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -712,9 +740,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -819,18 +852,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -993,9 +1035,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1127,18 +1174,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1338,9 +1394,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1468,16 +1529,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -182,31 +182,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -214,6 +218,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -361,31 +378,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -393,6 +414,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -518,31 +552,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -550,6 +588,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -737,31 +788,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -769,6 +824,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1020,31 +1088,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1052,6 +1124,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -347,18 +347,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -637,18 +654,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -944,18 +978,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1299,18 +1350,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1687,18 +1755,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -320,8 +320,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -556,8 +563,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -809,8 +823,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1110,8 +1131,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1444,5 +1472,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -324,28 +324,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -584,28 +614,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -861,28 +921,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1186,28 +1276,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1544,25 +1664,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -192,7 +192,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -243,9 +243,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -335,7 +338,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -447,7 +450,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -498,9 +501,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -592,7 +598,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -680,7 +686,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -731,9 +737,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -866,7 +875,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -975,7 +984,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1026,9 +1035,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1188,7 +1200,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1334,7 +1346,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1385,9 +1397,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1543,7 +1558,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -352,22 +352,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -659,22 +662,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -983,22 +989,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1355,22 +1364,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1760,22 +1772,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -223,11 +223,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -253,29 +255,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -313,6 +299,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -448,11 +457,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -478,29 +489,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server api app
         uses: actions/github-script@v8
@@ -540,6 +535,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -651,11 +669,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -681,29 +701,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -784,6 +788,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -916,11 +943,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -946,29 +975,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1076,6 +1089,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1245,11 +1281,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1275,29 +1313,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server api app
         uses: actions/github-script@v8
@@ -1401,3 +1423,26 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-api-stage.yml
+++ b/.github/workflows/server-api-stage.yml
@@ -159,15 +159,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -282,15 +338,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -383,15 +495,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -546,15 +714,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -773,15 +997,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -174,31 +174,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -206,6 +210,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -396,22 +396,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -181,28 +181,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -210,19 +236,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -239,6 +252,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -184,7 +184,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -235,9 +235,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -379,7 +382,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -215,11 +215,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -245,29 +247,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -357,3 +343,26 @@ jobs:
           DESKTOP_SERVER_APP_DESCRIPTION: 'Gauzy Server'
           DESKTOP_SERVER_APP_ID: 'com.ever.gauzyserver'
           COMPANY_SITE_LINK: 'https://gauzy.co'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -391,18 +391,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -364,5 +364,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -368,25 +368,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -244,9 +244,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -360,16 +365,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-demo.yml
+++ b/.github/workflows/server-demo.yml
@@ -151,15 +151,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -215,11 +215,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -245,29 +247,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -357,3 +343,26 @@ jobs:
           DESKTOP_MCP_SERVER_APP_DESCRIPTION: 'Gauzy MCP Server'
           DESKTOP_MCP_SERVER_APP_ID: 'com.ever.gauzymcpserver'
           COMPANY_SITE_LINK: 'https://gauzy.co'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -174,31 +174,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -206,6 +210,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -396,22 +396,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -181,28 +181,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -210,19 +236,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -239,6 +252,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -184,7 +184,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -235,9 +235,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -379,7 +382,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -391,18 +391,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -364,5 +364,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -368,25 +368,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -244,9 +244,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -360,16 +365,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-mcp-demo.yml
+++ b/.github/workflows/server-mcp-demo.yml
@@ -151,15 +151,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -326,28 +326,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -593,28 +623,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -839,28 +899,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1137,28 +1227,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1448,25 +1568,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -194,7 +194,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -245,9 +245,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -337,7 +340,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -456,7 +459,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -507,9 +510,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -601,7 +607,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -689,7 +695,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -740,9 +746,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -844,7 +853,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -953,7 +962,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1004,9 +1013,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1139,7 +1151,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1265,7 +1277,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1316,9 +1328,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1447,7 +1462,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -254,9 +254,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -318,18 +323,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -502,9 +516,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -568,18 +587,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -721,9 +749,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -797,18 +830,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -971,9 +1013,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1078,18 +1125,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1269,9 +1325,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1372,16 +1433,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -191,28 +191,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -220,19 +246,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -249,6 +262,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -394,28 +423,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -423,19 +478,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -452,6 +494,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server mcp app
         uses: actions/github-script@v8
@@ -568,28 +626,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -597,19 +681,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -626,6 +697,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -773,28 +860,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -802,19 +915,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -831,6 +931,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1026,28 +1142,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1055,19 +1197,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1084,6 +1213,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server mcp app
         uses: actions/github-script@v8

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -161,15 +161,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -291,15 +347,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -392,15 +504,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -524,15 +692,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -704,15 +928,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -322,8 +322,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -565,8 +572,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -787,8 +801,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1061,8 +1082,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1348,5 +1376,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -225,11 +225,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -255,29 +257,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -315,6 +301,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -457,11 +466,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -487,29 +498,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server mcp app
         uses: actions/github-script@v8
@@ -549,6 +544,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -660,11 +678,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -690,29 +710,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -762,6 +766,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -894,11 +921,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -924,29 +953,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1027,6 +1040,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1176,11 +1212,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1206,29 +1244,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server mcp app
         uses: actions/github-script@v8
@@ -1305,3 +1327,26 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -349,18 +349,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -646,18 +663,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -922,18 +956,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1250,18 +1301,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1591,18 +1659,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -354,22 +354,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -668,22 +671,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -961,22 +967,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1306,22 +1315,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1664,22 +1676,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-mcp-prod.yml
+++ b/.github/workflows/server-mcp-prod.yml
@@ -184,31 +184,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -216,6 +220,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -370,31 +387,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -402,6 +423,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -527,31 +561,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -559,6 +597,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -715,31 +766,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -747,6 +802,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -951,31 +1019,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -983,6 +1055,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -183,7 +183,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -234,9 +234,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -326,7 +329,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -429,7 +432,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -480,9 +483,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -574,7 +580,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -662,7 +668,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -713,9 +719,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -848,7 +857,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -957,7 +966,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1008,9 +1017,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1170,7 +1182,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1316,7 +1328,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1367,9 +1379,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1525,7 +1540,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -311,8 +311,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -538,8 +545,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -791,8 +805,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1092,8 +1113,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1426,5 +1454,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -214,11 +214,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -244,29 +246,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -304,6 +290,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -430,11 +439,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -460,29 +471,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server mcp app
         uses: actions/github-script@v8
@@ -522,6 +517,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -633,11 +651,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -663,29 +683,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -766,6 +770,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -898,11 +925,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -928,29 +957,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1058,6 +1071,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1227,11 +1263,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1257,29 +1295,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server mcp app
         uses: actions/github-script@v8
@@ -1383,3 +1405,26 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -173,31 +173,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -205,6 +209,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -343,31 +360,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -375,6 +396,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -500,31 +534,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -532,6 +570,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -719,31 +770,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -751,6 +806,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1002,31 +1070,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1034,6 +1106,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -315,28 +315,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -566,28 +596,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -843,28 +903,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1168,28 +1258,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1526,25 +1646,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -150,15 +150,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -264,15 +320,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -365,15 +477,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -528,15 +696,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -755,15 +979,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -180,28 +180,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -209,19 +235,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -238,6 +251,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -367,28 +396,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -396,19 +451,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -425,6 +467,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server mcp app
         uses: actions/github-script@v8
@@ -541,28 +599,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -570,19 +654,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -599,6 +670,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -777,28 +864,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -806,19 +919,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -835,6 +935,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1077,28 +1193,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1106,19 +1248,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1135,6 +1264,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server mcp app
         uses: actions/github-script@v8

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -243,9 +243,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -307,18 +312,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -475,9 +489,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -541,18 +560,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -694,9 +722,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -801,18 +834,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -975,9 +1017,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1109,18 +1156,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1320,9 +1376,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1450,16 +1511,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -338,18 +338,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -619,18 +636,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -926,18 +960,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1281,18 +1332,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1669,18 +1737,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/server-mcp-stage.yml
+++ b/.github/workflows/server-mcp-stage.yml
@@ -343,22 +343,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -641,22 +644,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -965,22 +971,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1337,22 +1346,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1742,22 +1754,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -390,18 +390,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -730,18 +747,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1038,18 +1072,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1402,18 +1453,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1779,18 +1847,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -193,31 +193,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -225,6 +229,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -420,31 +437,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -452,6 +473,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -611,31 +645,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -643,6 +681,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -831,31 +882,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -863,6 +918,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1103,31 +1171,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1135,6 +1207,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -395,22 +395,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -752,22 +755,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1077,22 +1083,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1458,22 +1467,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1852,22 +1864,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -203,7 +203,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -254,9 +254,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -378,7 +381,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -506,7 +509,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -557,9 +560,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -685,7 +691,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -773,7 +779,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -824,9 +830,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -960,7 +969,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1069,7 +1078,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1120,9 +1129,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1291,7 +1303,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1417,7 +1429,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1468,9 +1480,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1635,7 +1650,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -367,28 +367,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -677,28 +707,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -955,28 +1015,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1289,28 +1379,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1636,25 +1756,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -200,28 +200,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -229,19 +255,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -258,6 +271,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -444,28 +473,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -473,19 +528,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -502,6 +544,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server app
         uses: actions/github-script@v8
@@ -652,28 +710,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -681,19 +765,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -710,6 +781,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -889,28 +976,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -918,19 +1031,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -947,6 +1047,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1178,28 +1294,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1207,19 +1349,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1236,6 +1365,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server app
         uses: actions/github-script@v8

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -170,15 +170,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -341,15 +397,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -476,15 +588,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -640,15 +808,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -856,15 +1080,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -363,8 +363,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -649,8 +656,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -903,8 +917,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1213,8 +1234,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1536,5 +1564,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -263,9 +263,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -359,18 +364,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -552,9 +566,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -652,18 +671,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -805,9 +833,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -913,18 +946,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -1087,9 +1129,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1230,18 +1277,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1421,9 +1477,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1560,16 +1621,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-prod.yml
+++ b/.github/workflows/server-prod.yml
@@ -234,11 +234,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -264,29 +266,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -356,6 +342,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -507,11 +516,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -537,29 +548,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server app
         uses: actions/github-script@v8
@@ -633,6 +628,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -744,11 +762,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -774,29 +794,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -878,6 +882,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -1010,11 +1037,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1040,29 +1069,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1179,6 +1192,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1328,11 +1364,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1358,29 +1396,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server app
         uses: actions/github-script@v8
@@ -1493,3 +1515,26 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -251,9 +251,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -347,18 +352,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
@@ -524,9 +538,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -624,18 +643,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
@@ -777,9 +805,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -916,18 +949,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
@@ -1090,9 +1132,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1260,18 +1307,27 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
@@ -1471,9 +1527,14 @@ jobs:
           VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
           VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
           VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
-          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
-          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
-          # as the discriminator here without firing false warnings on 24 external jobs.
+          # true for the IN-NETWORK runners: the 18 [self-hosted, Windows, X64] jobs, plus any
+          # ever-k8s-* ARC pool reached through a runner variable (release-linux takes its os from
+          # vars.RUNNER_LINUX_APPS_X64, which may point at one). The ever-k8s disjunct is a no-op in
+          # workflows whose matrix cannot yield that label - it is kept so all 66 copies stay
+          # byte-identical and a future ARC matrix entry gets the retry and warning automatically.
+          # ubicloud and cirruslabs runners also report RUNNER_ENVIRONMENT=self-hosted, so that
+          # variable cannot be used as the discriminator without firing false warnings on the
+          # external jobs.
           EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
@@ -1637,16 +1698,25 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          if [ -f .npmrc ]; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
-            mv -f .npmrc.scrubbed .npmrc
+          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
+          # this step before the token was removed - the exact outcome the step exists to prevent -
+          # so nothing is allowed to short-circuit it. The build is already finished and nothing
+          # downstream reads the result, so a cleanup failure must not redden a green release.
+          set +e
+          # Restoring from git removes the credential in one operation and also undoes the
+          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
+          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
+          # Configure Registry step to reset them.
+          git checkout -- .npmrc yarn.lock 2>/dev/null
+          # Belt and braces for a workspace where the restore could not run at all.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
-          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
-          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
-          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
-          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
-          # not redden a green release - unlike the reset in Configure Registry, where the
-          # registry decision depends on it and a failure therefore has to stop the step.
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          # Do not just assume it worked - a silent failure here leaves a live token on a reused
+          # runner, so say so loudly instead.
+          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
+            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+            exit 1
+          fi
           echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -181,31 +181,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -213,6 +217,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -392,31 +409,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -424,6 +445,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -583,31 +617,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -615,6 +653,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -834,31 +885,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -866,6 +921,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1153,31 +1221,35 @@ jobs:
           # the VIP rather than by hardcoding a runner list, because release-linux runs on
           # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
           #
-          # When nothing is written here the repo's committed .npmrc applies
-          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
-          # i.e. external runners resolve straight from the public npm registry.
-          #
           # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
           # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+
+          # Start from a known state. The self-hosted Windows jobs check out with clean: false and
+          # their cleanup step removes only dist/ and node_modules/, so registry edits from a
+          # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
+          # so nothing restores it: a stale "registry" line from an earlier run would silently
+          # win over this run's decision and point the install at a registry we just rejected.
+          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+
+          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
+          # flap) should not demote an in-network runner to the public registry for a whole build.
           REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-            REGISTRY="${VERDACCIO_REGISTRY%/}/"
-            echo "Verdaccio VIP is reachable - using the internal npm cache."
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+          if [ -n "$VERDACCIO_REGISTRY" ]; then
+            for attempt in 1 2; do
+              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                break
+              fi
+              [ "$attempt" = "1" ] && sleep 3
+            done
+          fi
+          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable
-            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
-            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
-            # blip must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1185,6 +1257,19 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+            # Asked for the public route but no token to authenticate with: say so, rather than
+            # blaming the VIP for a path we never even probed for.
+            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
+            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
+            # must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -222,11 +222,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -252,29 +254,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -344,6 +330,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -479,11 +488,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -509,29 +520,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server app
         uses: actions/github-script@v8
@@ -605,6 +600,29 @@ jobs:
           NX_DAEMON: false
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-mac:
     needs: check-release-tag
@@ -716,11 +734,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -746,29 +766,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -881,6 +885,29 @@ jobs:
           APPLE_API_KEY: /tmp/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows:
     needs: check-release-tag
@@ -1013,11 +1040,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1043,29 +1072,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1209,6 +1222,29 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1378,11 +1414,13 @@ jobs:
                   break
                 fi
                 attempt=$((attempt + 1))
-                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+                if [ "$attempt" -le "$ATTEMPTS" ]; then sleep 3; fi
               done
             fi
-            if [ -z "$REGISTRY" ]; then
-              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+            if [ -z "$REGISTRY" ] && [ -z "$VERDACCIO_REGISTRY" ]; then
+              echo "No internal Verdaccio registry is configured (VERDACCIO_REGISTRY is empty) - resolving from the public npm registry."
+            elif [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP did not answer - resolving from the public npm registry."
               # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
               # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
               # has a recurring MetalLB speaker flap that presents exactly this way), so surface
@@ -1408,29 +1446,13 @@ jobs:
           # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
           # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
           # as the discriminator here without firing false warnings on 24 external jobs.
-          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') || contains(matrix.os, 'ever-k8s') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
-
-      - name: Scrub registry credentials
-        if: always()
-        shell: bash
-        run: |
-          # The auth token must not outlive the job. These runners check out with clean: false and
-          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
-          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
-          # Registry step resets it - readable by anything scheduled on this runner in between.
-          # Only the credential lines go; the registry= line stays so any later step still
-          # resolves from the same place. Runs on failure too, which is when it would linger.
-          if [ -f .npmrc ]; then
-            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
-            rm -f .npmrc.bak
-          fi
-          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server app
         uses: actions/github-script@v8
@@ -1570,3 +1592,26 @@ jobs:
           NX_NO_CLOUD: true
           NX_PLUGIN_NO_TIMEOUTS: true
           NX_DAEMON: false
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk after the job ends - readable by
+          # anything scheduled on this runner before the next Configure Registry step resets it.
+          #
+          # This is deliberately the LAST step of the job: the build steps above run
+          # postinstall.electron / electron-builder install-app-deps, which resolve dependencies,
+          # so the credential has to survive until they are done. Only the credential lines go;
+          # the registry= line stays. Runs on failure too, which is when it would linger.
+          #
+          # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
+          # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
+            mv -f .npmrc.scrubbed .npmrc
+          fi
+          rm -f .npmrc.bak .npmrc.scrubbed
+          echo "Registry credentials scrubbed from .npmrc."

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -383,22 +383,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -724,22 +727,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1080,22 +1086,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1488,22 +1497,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"
@@ -1929,22 +1941,25 @@ jobs:
           # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
           # bare existence test cannot tell an absent file from an unreachable one.
           cred_state="undetermined"
-          if [ -e .npmrc ]; then
+          if [ -e .npmrc ] || [ -L .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
-          elif [ -r . ]; then
-            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+          elif [ -r . ] && [ -x . ]; then
+            # The directory is both readable AND searchable and neither a file nor a symlink named
+            # .npmrc exists, so the absence is proven rather than merely unobservable. Without the
+            # -x test a stat could fail in a directory that still answers -r, and without the -L
+            # test above a dangling symlink would read as "missing" while its target held a token.
             cred_state="absent"
           fi
           # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
           # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
           # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
           for stray in .npmrc.bak .npmrc.scrubbed; do
-            if [ -e "$stray" ]; then
+            if [ -e "$stray" ] || [ -L "$stray" ]; then
               grep -q '_authToken=' "$stray"
               if [ "$?" -ne 1 ]; then
                 cred_state="present in $stray"

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -351,8 +351,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-linux-arm64:
     needs: check-release-tag
@@ -621,8 +628,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-mac:
     needs: check-release-tag
@@ -906,8 +920,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows:
     needs: check-release-tag
@@ -1243,8 +1264,15 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1613,5 +1641,12 @@ jobs:
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed
             mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed
-          echo "Registry credentials scrubbed from .npmrc."
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          # Hand the workspace back the way git has it. The untracked .yarnrc and the yarn.lock
+          # rewritten to the internal VIP would otherwise survive on a clean: false runner and be
+          # inherited by a job from ANOTHER workflow that has no Configure Registry step to reset
+          # them. Best-effort on purpose: this is cleanup after the build, so a failure here must
+          # not redden a green release - unlike the reset in Configure Registry, where the
+          # registry decision depends on it and a failure therefore has to stop the step.
+          git checkout -- .npmrc yarn.lock 2>/dev/null || true
+          echo "Registry credentials scrubbed and workspace registry config restored."

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -355,28 +355,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-linux-arm64:
     needs: check-release-tag
@@ -649,28 +679,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-mac:
     needs: check-release-tag
@@ -958,28 +1018,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows:
     needs: check-release-tag
@@ -1319,28 +1409,58 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi
 
   release-windows-arm64:
     needs: check-release-tag
@@ -1713,25 +1833,55 @@ jobs:
           #
           # No 'sed -i.bak': the backup would itself hold the token if this step were interrupted.
           # The temp file only ever holds the SCRUBBED content, so a partial run leaks nothing.
-          # Failures here are non-fatal BY DESIGN. Under `set -e` a failing sed or mv would abort
-          # this step before the token was removed - the exact outcome the step exists to prevent -
-          # so nothing is allowed to short-circuit it. The build is already finished and nothing
-          # downstream reads the result, so a cleanup failure must not redden a green release.
+          # Cleanup policy, precisely:
+          #   * individual cleanup ATTEMPTS are best-effort. Under `set -e` a failing sed or mv
+          #     would abort this step before the token was removed - the exact outcome the step
+          #     exists to prevent - so nothing is allowed to short-circuit it.
+          #   * the POSTCONDITION is not best-effort. A surviving CREDENTIAL fails the step, because
+          #     handing a live token to the next job on a reused clean: false runner is worse than a
+          #     red build. Leftover registry STATE (a stale .yarnrc, a yarn.lock still rewritten to
+          #     the VIP) only warns: it is a correctness nuisance for an unrelated workflow, not a
+          #     secret, and the next Configure Registry step resets it anyway.
+          # Anything that cannot be DETERMINED counts as dirty, so an unreadable file is never
+          # mistaken for a clean one (grep exits 2 on a read error, which is not "no token").
           set +e
-          # Restoring from git removes the credential in one operation and also undoes the
-          # yarn.lock rewrite and the untracked .yarnrc, which would otherwise survive on a
-          # clean: false runner and be inherited by a job from ANOTHER workflow that has no
-          # Configure Registry step to reset them.
+
+          # Restoring the tracked files from git is the primary mechanism: it reverts the whole
+          # file, so the credential, the appended registry= line and the yarn.lock rewrite all go
+          # in one operation.
           git checkout -- .npmrc yarn.lock 2>/dev/null
-          # Belt and braces for a workspace where the restore could not run at all.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
+          # Fallback for a workspace where git cannot run at all.
+          if [ -f .npmrc ]; then
+            sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed 2>/dev/null && mv -f .npmrc.scrubbed .npmrc
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
-          # Do not just assume it worked - a silent failure here leaves a live token on a reused
-          # runner, so say so loudly instead.
-          if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
-            echo "::error title=Registry credential could not be removed::.npmrc still contains an auth token after cleanup on ${RUNNER_NAME:-this runner}."
+
+          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
+          cred_state="absent"
+          if [ -f .npmrc ]; then
+            grep -q '_authToken=' .npmrc
+            case "$?" in
+              0) cred_state="present" ;;
+              1) cred_state="absent" ;;
+              *) cred_state="undetermined" ;;
+            esac
+          fi
+          if [ "$cred_state" != "absent" ]; then
+            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
-          echo "Registry credentials scrubbed and workspace registry config restored."
+
+          # Report - but do not fail on - leftover registry state.
+          leftover=""
+          [ -e .yarnrc ] && leftover="$leftover .yarnrc"
+          git diff --quiet -- .npmrc yarn.lock 2>/dev/null
+          case "$?" in
+            0) ;;
+            1) leftover="$leftover .npmrc/yarn.lock(modified)" ;;
+            *) leftover="$leftover .npmrc/yarn.lock(unverifiable)" ;;
+          esac
+          if [ -n "$leftover" ]; then
+            echo "::warning title=Registry state left behind::Cleanup could not fully restore:$leftover on ${RUNNER_NAME:-this runner}. The next Configure Registry step resets it, but a job from another workflow could inherit it first."
+          else
+            echo "Registry credential removed; .npmrc, .yarnrc and yarn.lock restored to HEAD."
+          fi

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -158,15 +158,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -313,15 +369,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -448,15 +560,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -643,15 +811,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'
@@ -906,15 +1130,71 @@ jobs:
       - name: Configure Registry
         shell: bash
         run: |
-          if [ -n "${{ secrets.VERDACCIO_TOKEN }}" ]; then
-            echo "//packages.ever.co/:_authToken=${{ secrets.VERDACCIO_TOKEN }}" >> .npmrc
-            echo "registry=https://packages.ever.co/" >> .npmrc
+          # Registry selection is CONDITIONAL on where this job runs.
+          #
+          # The public Cloudflare-fronted route https://packages.ever.co intermittently TRUNCATES
+          # large tarballs mid-stream. Measured 2026-08-16 on
+          # @rspack/binding-win32-arm64-msvc@1.7.6: 9,525,323 bytes from packages.ever.co against
+          # 14,590,565 bytes (byte-exact) from BOTH the internal VIP and npmjs. The route sustains
+          # only ~280 KB/s, and a single release-windows-arm64 job logged 12 "unexpected end of
+          # file" errors against it.
+          #
+          # The truncation is UNDETECTABLE by the client: Cloudflare always sends
+          # "Accept-Encoding: gzip" to the origin, Verdaccio then re-gzips the already-gzipped
+          # .tgz, which drops Content-Length in favour of chunked encoding. A cut stream is
+          # therefore not a short read but a complete-looking HTTP 200 whose body fails gunzip,
+          # and Range requests are ignored so there is no resume and no length cross-check.
+          #
+          # Jobs in this repo run on a MIX of runners:
+          #   in-network - [self-hosted, Windows, X64] and the ever-k8s ARC pools
+          #   external   - windows-11-arm, ubicloud-*-arm, cirruslabs macOS, ubuntu-latest
+          # Only in-network runners can reach the VIP, and the internal cache buys an external
+          # runner nothing while adding a failure mode. The choice is therefore made by PROBING
+          # the VIP rather than by hardcoding a runner list, because release-linux runs on
+          # "vars.RUNNER_LINUX_APPS_X64 or ubuntu-latest" and so is not statically known.
+          #
+          # When nothing is written here the repo's committed .npmrc applies
+          # (registry=https://registry.yarnpkg.com/) and yarn.lock's own resolved URLs are used,
+          # i.e. external runners resolve straight from the public npm registry.
+          #
+          # NO-REMOVAL RULE: the packages.ever.co path below is GATED, not deleted. Set the
+          # repo/org variable VERDACCIO_FORCE_PUBLIC=true to bring it back.
+          REGISTRY=""
+          if [ -n "$VERDACCIO_REGISTRY" ] && curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+            REGISTRY="${VERDACCIO_REGISTRY%/}/"
+            echo "Verdaccio VIP is reachable - using the internal npm cache."
+          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            REGISTRY="https://packages.ever.co/"
+            echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
+            echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
-            echo 'registry "https://packages.ever.co/"' >> .yarnrc
-            sed -i.bak 's|https://registry.yarnpkg.com|https://packages.ever.co|g' yarn.lock
-            sed -i.bak 's|https://registry.npmjs.org|https://packages.ever.co|g' yarn.lock
+          else
+            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
+            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
+            # IN-NETWORK runner failing it means the internal cache is silently unavailable
+            # (this fleet has a recurring MetalLB speaker flap that presents exactly this way),
+            # so surface it on the run summary. Deliberately a warning, not a failure: a cache
+            # blip must never redden a release pipeline that npmjs can serve correctly.
+            if [ "$EXPECT_VIP" = "true" ]; then
+              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+            fi
+          fi
+          if [ -n "$REGISTRY" ]; then
+            echo "registry=$REGISTRY" >> .npmrc
+            echo "registry \"$REGISTRY\"" >> .yarnrc
+            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
+            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
           fi
+          echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
+        env:
+          VERDACCIO_REGISTRY: ${{ vars.VERDACCIO_REGISTRY }}
+          VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+          VERDACCIO_FORCE_PUBLIC: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # true only for the 18 [self-hosted, Windows, X64] jobs. ubicloud and cirruslabs
+          # runners also report RUNNER_ENVIRONMENT=self-hosted, so that variable cannot be used
+          # as the discriminator here without firing false warnings on 24 external jobs.
+          EXPECT_VIP: ${{ contains(matrix.os, 'self-hosted') }}
 
       - name: Install Yarn dependencies
         run: 'yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts'

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -188,28 +188,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -217,19 +243,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -246,6 +259,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump server version
         uses: actions/github-script@v8
@@ -416,28 +445,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -445,19 +500,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -474,6 +516,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server app
         uses: actions/github-script@v8
@@ -624,28 +682,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -653,19 +737,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -682,6 +753,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -892,28 +979,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -921,19 +1034,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -950,6 +1050,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump Server version
         uses: actions/github-script@v8
@@ -1228,28 +1344,54 @@ jobs:
           # their cleanup step removes only dist/ and node_modules/, so registry edits from a
           # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
           # so nothing restores it: a stale "registry" line from an earlier run would silently
-          # win over this run's decision and point the install at a registry we just rejected.
+          # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+          # a known starting state we must not go on to pick a registry, because the install would
+          # then quietly run against whatever the last job left behind.
           rm -f .yarnrc .npmrc.bak yarn.lock.bak
-          git checkout -- .npmrc yarn.lock 2>/dev/null || true
-
-          # Two attempts: a single transient miss (this fleet has a recurring MetalLB speaker
-          # flap) should not demote an in-network runner to the public registry for a whole build.
-          REGISTRY=""
-          if [ -n "$VERDACCIO_REGISTRY" ]; then
-            for attempt in 1 2; do
-              if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
-                REGISTRY="${VERDACCIO_REGISTRY%/}/"
-                echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
-                break
-              fi
-              [ "$attempt" = "1" ] && sleep 3
-            done
+          if ! git checkout -- .npmrc yarn.lock; then
+            echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+            exit 1
           fi
-          if [ -z "$REGISTRY" ] && [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+
+          REGISTRY=""
+          if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ] && [ -n "$VERDACCIO_TOKEN" ]; then
+            # Evaluated BEFORE the probe so the override actually overrides: an operator setting
+            # this wants the public route even when the VIP is up (e.g. the internal cache is
+            # serving bad data). Gating it on a failed probe would make the flag a no-op.
             REGISTRY="https://packages.ever.co/"
             echo "::warning title=Verdaccio public route in use::VERDACCIO_FORCE_PUBLIC=true - installing through packages.ever.co, which is known to truncate large tarballs mid-stream."
             echo "//packages.ever.co/:_authToken=$VERDACCIO_TOKEN" >> .npmrc
             echo "always-auth=true" >> .npmrc
+          else
+            if [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
+              echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; probing the internal VIP instead."
+            fi
+            # Retry only where the VIP is expected to answer. An external runner can never reach
+            # it, so a second attempt would just add dead time to every release job.
+            if [ "$EXPECT_VIP" = "true" ]; then ATTEMPTS=2; else ATTEMPTS=1; fi
+            if [ -n "$VERDACCIO_REGISTRY" ]; then
+              attempt=1
+              while [ "$attempt" -le "$ATTEMPTS" ]; do
+                if curl -fsS --connect-timeout 5 --max-time 15 -o /dev/null "${VERDACCIO_REGISTRY%/}/-/ping"; then
+                  REGISTRY="${VERDACCIO_REGISTRY%/}/"
+                  echo "Verdaccio VIP is reachable (attempt $attempt) - using the internal npm cache."
+                  break
+                fi
+                attempt=$((attempt + 1))
+                [ "$attempt" -le "$ATTEMPTS" ] && sleep 3
+              done
+            fi
+            if [ -z "$REGISTRY" ]; then
+              echo "Verdaccio VIP is not in use - resolving from the public npm registry."
+              # An EXTERNAL runner not reaching the VIP is the designed outcome and stays quiet.
+              # An IN-NETWORK runner means the internal cache is silently unavailable (this fleet
+              # has a recurring MetalLB speaker flap that presents exactly this way), so surface
+              # it. Deliberately a warning, not a failure: a cache blip must never redden a
+              # release pipeline that npmjs can serve correctly.
+              if [ "$EXPECT_VIP" = "true" ]; then
+                echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
+              fi
+            fi
           fi
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
@@ -1257,19 +1399,6 @@ jobs:
             sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
             sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
             rm -f yarn.lock.bak
-          elif [ "$VERDACCIO_FORCE_PUBLIC" = "true" ]; then
-            # Asked for the public route but no token to authenticate with: say so, rather than
-            # blaming the VIP for a path we never even probed for.
-            echo "::warning title=VERDACCIO_FORCE_PUBLIC set without a token::VERDACCIO_TOKEN is empty, so packages.ever.co cannot be used; resolving from the public npm registry instead."
-          else
-            echo "Verdaccio VIP is not reachable from this runner - resolving from the public npm registry."
-            # An EXTERNAL runner failing the probe is the designed outcome and stays quiet. An
-            # IN-NETWORK runner failing it means the internal cache is silently unavailable, so
-            # surface it on the run summary. Deliberately a warning, not a failure: a cache blip
-            # must never redden a release pipeline that npmjs can serve correctly.
-            if [ "$EXPECT_VIP" = "true" ]; then
-              echo "::warning title=Verdaccio VIP unreachable from an in-network runner::${RUNNER_NAME:-unknown} fell back to the public npm registry; the internal cache was expected to be reachable here."
-            fi
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1286,6 +1415,22 @@ jobs:
 
       - name: Run Postinstall Manually
         run: 'yarn postinstall.manual'
+
+      - name: Scrub registry credentials
+        if: always()
+        shell: bash
+        run: |
+          # The auth token must not outlive the job. These runners check out with clean: false and
+          # clean only dist/ and node_modules/, so a workspace .npmrc carrying
+          # //packages.ever.co/:_authToken=... would sit on disk until the NEXT job's Configure
+          # Registry step resets it - readable by anything scheduled on this runner in between.
+          # Only the credential lines go; the registry= line stays so any later step still
+          # resolves from the same place. Runs on failure too, which is when it would linger.
+          if [ -f .npmrc ]; then
+            sed -i.bak -e '/_authToken=/d' -e '/always-auth=/d' .npmrc
+            rm -f .npmrc.bak
+          fi
+          echo "Registry credentials scrubbed from .npmrc."
 
       - name: Bump version server app
         uses: actions/github-script@v8

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -191,7 +191,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -242,9 +242,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -366,7 +369,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -478,7 +481,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -529,9 +532,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -657,7 +663,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -745,7 +751,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -796,9 +802,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -963,7 +972,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1072,7 +1081,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1123,9 +1132,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1321,7 +1333,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
@@ -1467,7 +1479,7 @@ jobs:
           # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
           # a known starting state we must not go on to pick a registry, because the install would
           # then quietly run against whatever the last job left behind.
-          rm -f .yarnrc .npmrc.bak yarn.lock.bak
+          rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
           if ! git checkout -- .npmrc yarn.lock; then
             echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
             exit 1
@@ -1518,9 +1530,12 @@ jobs:
           if [ -n "$REGISTRY" ]; then
             echo "registry=$REGISTRY" >> .npmrc
             echo "registry \"$REGISTRY\"" >> .yarnrc
-            sed -i.bak "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" yarn.lock
-            sed -i.bak "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock
-            rm -f yarn.lock.bak
+            # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
+            # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
+            # sed on the macOS runners. The temp file is only ever the finished rewrite.
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
           fi
           echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"
         env:
@@ -1712,7 +1727,7 @@ jobs:
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then
             sed -e '/_authToken=/d' -e '/always-auth=/d' .npmrc > .npmrc.scrubbed && mv -f .npmrc.scrubbed .npmrc
           fi
-          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc
+          rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
           # Do not just assume it worked - a silent failure here leaves a live token on a reused
           # runner, so say so loudly instead.
           if [ -f .npmrc ] && grep -q '_authToken=' .npmrc; then

--- a/.github/workflows/server-stage.yml
+++ b/.github/workflows/server-stage.yml
@@ -378,18 +378,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -702,18 +719,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1041,18 +1075,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1432,18 +1483,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 
@@ -1856,18 +1924,35 @@ jobs:
           fi
           rm -f .npmrc.bak .npmrc.scrubbed .yarnrc yarn.lock.bak yarn.lock.rewritten
 
-          # Prove the credential is gone. Fail closed: statuses other than 1 mean "could not tell".
-          cred_state="absent"
-          if [ -f .npmrc ]; then
+          # Prove the credential is gone, starting from "undetermined" rather than "absent" so no
+          # inconclusive result can pass. Two ways to be inconclusive: grep exits 2 when a file
+          # cannot be READ, and [ -f ] answers false for both "missing" and "cannot stat", so a
+          # bare existence test cannot tell an absent file from an unreachable one.
+          cred_state="undetermined"
+          if [ -e .npmrc ]; then
             grep -q '_authToken=' .npmrc
             case "$?" in
               0) cred_state="present" ;;
               1) cred_state="absent" ;;
               *) cred_state="undetermined" ;;
             esac
+          elif [ -r . ]; then
+            # The directory is readable and there is genuinely no .npmrc, so there is no token.
+            cred_state="absent"
           fi
+          # Artifacts that can also carry the token: .npmrc.bak is written by older revisions of
+          # this workflow, and a surviving .npmrc.scrubbed means the mv above did not complete.
+          # Present-but-clean is only clutter; present-and-carrying-a-token (or unreadable) is not.
+          for stray in .npmrc.bak .npmrc.scrubbed; do
+            if [ -e "$stray" ]; then
+              grep -q '_authToken=' "$stray"
+              if [ "$?" -ne 1 ]; then
+                cred_state="present in $stray"
+              fi
+            fi
+          done
           if [ "$cred_state" != "absent" ]; then
-            echo "::error title=Registry credential may still be present::.npmrc auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
+            echo "::error title=Registry credential may still be present::Auth token is $cred_state after cleanup on ${RUNNER_NAME:-this runner}."
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

`https://packages.ever.co` (the Cloudflare-fronted public Verdaccio route) intermittently **truncates large tarballs mid-stream**, breaking CI.

Measured 2026-08-16 on `@rspack/binding-win32-arm64-msvc@1.7.6`:

| source | bytes | result |
|---|---:|---|
| `packages.ever.co` | 9,525,323 | truncated, invalid gzip |
| internal VIP `:4873` | 14,590,565 | OK |
| `registry.npmjs.org` | 14,590,565 | OK |

Verdaccio's storage is fine — this is a transport problem on the public route only.

### Why it presents as a random failure

**It is undetectable by the client.** Verdaccio sends `Content-Length` when no `Accept-Encoding` is present. Cloudflare *always* sends `Accept-Encoding: gzip` to origins, so Verdaccio re-gzips the already-gzipped `.tgz` (14,590,565 → 14,566,469, a 0.17% "saving"), which **drops `Content-Length` in favour of chunked encoding**. A cut stream is therefore not a short read — it is a complete-looking `HTTP 200` whose body fails gunzip. `Range` requests are ignored (a byte-range request returns `200` and the full body), so there is no resume and no length cross-check.

**And transfers are long enough to get cut.** The public path sustains 0.26–0.35 MB/s single-stream and a hard ~4.3 Mbit/s aggregate, so a 14.6 MB tarball holds the wire for 40–238s. This is *not* the homelab uplink — the VIP serves the same Verdaccio at 1.36–1.62 MB/s in the same minute, and connect (0.02–0.22s) and TTFB (0.30–0.58s) are healthy on every path. Origin logs put the real rate at **4 / 1,194 large-tarball fetches (0.335%)** in 24h, all from yarn on GitHub-hosted runners.

## Why ARM64 specifically

`windows-11-arm` jobs run on **GitHub-hosted** runners, outside the homelab. They cannot reach the internal VIP, so they were forced through the truncating public route — to reach a cache that buys an external runner nothing. One `release-windows-arm64` job logged 12 `unexpected end of file` errors.

## What changed

**Runner-side installs** — all 66 `Configure Registry` steps across 18 workflows hardcoded the public route for *every* runner. Registry selection is now conditional:

- **in-network** runners (`[self-hosted, Windows, X64]`, `ever-k8s` ARC pools) probe `vars.VERDACCIO_REGISTRY` and use the internal cache;
- **external** runners (`windows-11-arm`, `ubicloud-*-arm`, cirruslabs macOS, `ubuntu-latest`) fail the probe, write nothing, and fall through to the committed `.npmrc` (`registry.yarnpkg.com`) and `yarn.lock`'s own resolved URLs.

It is a **runtime probe rather than a static runner list** because `release-linux` runs on `vars.RUNNER_LINUX_APPS_X64 || 'ubuntu-latest'`, and that variable is unset at org *and* repo level (run `31909638627` confirms it landed on `ubuntu-latest`).

**Silent-fallback guard** — because the fallback is silent by design on external runners, an in-network runner that loses the VIP would fail over unnoticed (this fleet has a recurring MetalLB speaker flap that presents exactly that way). The 18 self-hosted jobs now emit a `::warning::` when they fall back, keyed on `contains(matrix.os, 'self-hosted')`. `RUNNER_ENVIRONMENT` is unusable as the discriminator — ubicloud and cirruslabs runners also report `self-hosted`, which would fire false warnings on 24 jobs.

**Production image builds were the larger hole.** `docker-build-publish-prod.yml` (gauzy-api / gauzy-webapp / gauzy-worker), `-mcp-prod.yml` and `-mcp-auth-prod.yml` passed `VERDACCIO_TOKEN` but **no `VERDACCIO_REGISTRY` build-arg**, while stage and demo passed both. With the ARG empty the Dockerfiles took the `elif` and pulled all ~5,944 locked tarballs for `api.gauzy.co` / `app.gauzy.co` / worker / mcp through the truncating route — so **stage was validating a different dependency-resolution path than prod**. The five prod `build-args` blocks now match stage byte for byte.

To avoid trading one failure mode for another, the nine Dockerfile registry blocks gain the same reachability guard, so a VIP outage during a prod build falls through to the existing gated path instead of failing the build outright.

## No-removal rule

The `packages.ever.co` configuration is **gated everywhere, never deleted**:

- on runners, set `VERDACCIO_FORCE_PUBLIC=true` to restore it (that path emits a `::warning::`, since it re-enables the exact configuration that caused this incident);
- in the Dockerfiles it remains the fallback when the VIP is unreachable.

## Verification

- all four runner branches exercised in a sandbox (VIP up / var unset / VIP unroutable / force-public) plus both warning paths; an unroutable VIP costs **5s** and falls back cleanly
- all three Dockerfile branches exercised under POSIX `sh` in `node:22-alpine`, incl. `sh -n`; busybox `wget -T 5` confirmed to exit 0 against the live VIP **from inside a container** and to fail in exactly 5s otherwise
- `.npmrc` append-override confirmed with `npm config get registry`
- 65 workflow files parse under js-yaml; all 66 steps carry exactly the four expected `env` keys; **zero** `${{ }}` expressions leak into any run body
- `grep -rn '\${{ *}}' .github/workflows/` returns nothing
- 9/9 Dockerfile blocks guarded, 0 unguarded remaining
- `@ever-co/legal` — the repo's only private-scoped dependency — is published on public npmjs and already resolves there in `yarn.lock`, so the npmjs fallback cannot strand a Verdaccio-only package

## Follow-ups (not in this PR)

- **Fix the route itself.** Disabling Verdaccio's compression for `.tgz` would restore `Content-Length` and make truncation *detectable*; a CF cache rule for `packages.ever.co` would stop pulling 8.33 GiB/24h from origin (`cf-cache-status: DYNAMIC` on 100% of responses today, because `Authorization` suppresses CF caching by default).
- `release-linux-arm64` targets `ubicloud-standard-8-arm`, which has not answered since at least 2026-08-15 — six stage-apps runs are pinned open on it with every other job finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops installing npm dependencies via the public `packages.ever.co` route. CI now prefers the internal Verdaccio VIP when reachable and falls back to public npm, eliminating large‑tarball truncation and tightening token hygiene on reused runners.

- Conditional registry selection: probe `vars.VERDACCIO_REGISTRY`; evaluate `VERDACCIO_FORCE_PUBLIC` before probing; retry only for in‑network runners (including ARC `ever-k8s` pools); emit `::warning::` only on a real probe fallback; distinguish “not configured” vs “unreachable”.
- Strict reset before selection: restore committed `.npmrc` and `yarn.lock`, delete stale `.yarnrc`; fail fast if the restore fails; clean `.npmrc.bak`, `.npmrc.scrubbed`, `yarn.lock.bak`, `yarn.lock.rewritten`.
- Backup‑free lockfile rewrite: rewrite `yarn.lock` via a temp file and `mv` to avoid `sed -i` backups and BSD/GNU differences.
- Hardened end‑of‑job credential scrub: start with `set +e`, restore from git first, sed fallback without `.bak`, delete `.yarnrc`, and verify fail‑closed. Verification is now lstat‑aware, requires a readable and searchable workspace, and checks `.npmrc`, `.npmrc.bak`, and `.npmrc.scrubbed` for tokens; warn on surviving `yarn.lock` or `.yarnrc`.
- Docker builds: pass `VERDACCIO_REGISTRY` to all prod jobs; gate VIP usage with `wget -T 5 ... /-/ping`; log a neutral fallback when unset or the probe fails; keep `packages.ever.co` as a gated fallback.
- Tooling: unblock `cspell` with added terms (`esac`, `POSTCONDITION`, `ENOENT`, `gzipped`, `gzips`, `npmjs`, `rspack`).

**Required operator actions**
- To force the public route on runners, set `VERDACCIO_FORCE_PUBLIC=true` and provide `VERDACCIO_TOKEN`.

<sup>Written for commit 561f5c40460f7cf270c4bae6a780e41408cb98b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

