### PR TITLE
fix(ci): give build-monorepo-root the same 180-minute timeout as its siblings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,12 @@ jobs:
   build-monorepo-root:
     name: build-monorepo-root
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-    timeout-minutes: 120
+    # 180 to match build-libs / build-api / build-web / build-desktop. This job had 120 while all
+    # four siblings had 180, despite being the ONLY one on the 4-core pool (RUNNER_LINUX_X64_4) —
+    # the smallest runner had the shortest budget. It consequently timed out at exactly 2h00m on
+    # both PR #9993 (run 31946461738) and PR #9995 (run 31961280325), which surfaces as a
+    # "cancelled" job rather than an obvious timeout.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

`build-monorepo-root` has `timeout-minutes: 120` while all four siblings have **180** — despite being the **only** one of the five on the 4-core pool:

| job | timeout | runs-on |
|---|---|---|
| **build-monorepo-root** | **120** | `RUNNER_LINUX_X64_4` |
| build-libs | 180 | `RUNNER_LINUX_X64_8` |
| build-api | 180 | `RUNNER_LINUX_X64_8` |
| build-web | 180 | `RUNNER_LINUX_X64_8` |
| build-desktop | 180 | `RUNNER_LINUX_X64_8` |

The smallest runner had the shortest budget.

## Effect

It times out on most PRs. Measured on the two most recent:

```
PR #9993  run 31946461738  12:17:54Z -> 14:18:07Z   2h00m13s
PR #9995  run 31961280325  17:20:49Z -> 19:21:15Z   2h00m26s
```

A timed-out job is reported as **"cancelled"**, so this reads as flakiness or someone cancelling the run — not as a budget that's simply too small. That's what made it easy to miss.

## Fix

`120` → `180`, matching the other four. One line plus a comment recording the evidence.

## Not addressed here

Putting the heaviest-sounding job on the *smallest* pool may itself be worth revisiting — but that's a capacity decision, not a config typo, so I've left it alone and flagged it in the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `build-monorepo-root` timeout from 120 to 180 minutes to match other build jobs and stop runs being marked “cancelled” at the 2-hour mark on the 4‑core pool.

- Old behavior: job timed out at ~2h and surfaced as “cancelled.” New behavior: 3h budget, matching peers, reducing false cancellations. Only change is `timeout-minutes: 180` in `.github/workflows/build.yml`; runner pool choice is unchanged.

<sup>Written for commit c6a50ee8a62334e32652b49be8390cf657146220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

