### PR TITLE
fix(tasks): includeRootEpic breaks on SQLite — dialect-aware placeholder in findParentUntilEpic

### DIFF
--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -34,7 +34,7 @@ import {
 	NotificationActionTypeEnum
 } from '@gauzy/contracts';
 import { isEmpty, isNotEmpty } from '@gauzy/utils';
-import { isSqlite } from '@gauzy/config';
+import { isPostgres, isSqlite } from '@gauzy/config';
 import { TenantAwareCrudService, BaseQueryDTO } from './../core/crud';
 import { IPartialEntity } from './../core/crud/icrud.service';
 import { sanitizeRichHtml } from './../core/html-sanitizer';
@@ -411,12 +411,19 @@ export class TaskService extends TenantAwareCrudService<Task> {
 			}
 			case MultiORMEnum.TypeORM:
 			default: {
+				// TypeORM's `query()` hands the parameters straight to the driver, so the placeholder
+				// syntax is dialect-specific: PostgreSQL uses `$1`, while SQLite/better-sqlite3 and
+				// MySQL use `?`. `$1` on better-sqlite3 is parsed as a *named* parameter, so binding
+				// a positional array throws "RangeError: Too many parameter values were provided"
+				// and every `GET /tasks/:id?includeRootEpic=true` fails on SQLite (demo) instances.
+				const idPlaceholder = isPostgres() ? '$1' : '?';
+
 				// Define the recursive SQL query to find the parent epic
 				const query = p(`
 					WITH RECURSIVE IssueHierarchy AS (
 						SELECT *
 						FROM task
-						WHERE id = $1
+						WHERE id = ${idPlaceholder}
 					UNION ALL
 						SELECT i.*
 						FROM task i


### PR DESCRIPTION
## Problem

`GET /api/tasks/:id?includeRootEpic=true` fails on every SQLite / better-sqlite3 instance (e.g. the demo API behind demo.ever.team) with

```
RangeError: Too many parameter values were provided
```

`TaskService.findParentUntilEpic` (TypeORM branch) hard-codes the PostgreSQL positional placeholder `$1` in its recursive CTE. TypeORM's `query()` hands parameters straight to the driver: better-sqlite3 parses `$1` as a **named** parameter, so binding the positional `[issueId]` array throws. Ever Teams' task detail page always sends `includeRootEpic=true`, so the task page was broken on demo.ever.team (the web app logs `[TaskService] Task by ID validation failed` because the body it gets back is `{"message":"RangeError: …"}`).

Reproduced live on `apidev.ever.team` (gauzy-api-demo): the same request without `includeRootEpic` returns the task; with it, the error above. `includeRootEpic=true` alone (no relations/joins) is enough to trigger it.

## Fix

Pick the placeholder per dialect — `$1` on PostgreSQL, `?` otherwise (SQLite / better-sqlite3 / MySQL) — using `isPostgres()` from `@gauzy/config`, the same helper `priority.service.ts` / `size.service.ts` / `related-issue-type.service.ts` already use for their TypeORM dialect branches. The MikroORM/knex branch already used `?` and is untouched. **No behaviour change on PostgreSQL.**

## Test plan

- [x] Diagnosed against the live demo API (8 query-shape variants: only the ones with `includeRootEpic=true` fail).
- [ ] After merge, `gauzy-api-demo` rebuilds → verify `GET /api/tasks/:id?includeRootEpic=true` returns the task on demo (Ever Teams task page loads without the console error).
- Postgres path is byte-identical (`$1`) — stage/prod unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GET /api/tasks/:id?includeRootEpic=true` on SQLite by making the TypeORM recursive query use dialect-aware parameter placeholders. Previously it hard-coded `$1`, which better-sqlite3 treated as a named parameter and threw “Too many parameter values were provided”; now it uses `$1` on Postgres and `?` otherwise, with no behavior change on Postgres.

**Review notes**
- Change is scoped to the TypeORM path in `TaskService.findParentUntilEpic`; MikroORM/knex path is unchanged.
- Chooses the placeholder via `isPostgres()` from `@gauzy/config`.
- Validate on SQLite: the endpoint with `includeRootEpic=true` should now return the task; Postgres instances should behave identically as before.

<sup>Written for commit da939b9f2d6952e9de52c9235b7df8d711261942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

