### PR TITLE
fix(ui-core): route registry must not emit canActivate: [] — redirect route blanks the app (NG04014) [demo hotfix]

### DIFF
--- a/packages/ui-core/core/src/lib/services/page/page-route-registry.service.spec.ts
+++ b/packages/ui-core/core/src/lib/services/page/page-route-registry.service.spec.ts
@@ -50,6 +50,29 @@ describe('PageRouteRegistryService — navigation-target contract', () => {
 		expect(route.loadComponent).toBe(loadComponent);
 	});
 
+	it('emits NO guard keys on a redirect route (Angular rejects redirectTo + canActivate, even `[]`)', () => {
+		// demo.gauzy.co 2026-08-17: `canActivate: []` is truthy, and the dev-mode router
+		// validator throws NG04014 "redirectTo and canActivate cannot be used together" while the
+		// lazy parent config loads — a blank app for every user of a development-configuration
+		// bundle. Guards must be attached only when there is at least one.
+		register({ path: 'dashboard-time-track', redirectTo: '/pages/dashboard/time-tracking', route: { pathMatch: 'full' } });
+
+		const [route] = service.getPageLocationRoutes(PAGE_SECTIONS_LOCATION);
+		expect(route.redirectTo).toBe('/pages/dashboard/time-tracking');
+		expect(route.pathMatch).toBe('full');
+		expect('canActivate' in route).toBe(false);
+		expect('canMatch' in route).toBe(false);
+	});
+
+	it('still attaches canActivate / canMatch when the registration provides them', () => {
+		const guard = () => true;
+		register({ path: 'jobs', component: class {} as never, canActivate: [guard], canMatch: [guard] });
+
+		const [route] = service.getPageLocationRoutes(PAGE_SECTIONS_LOCATION);
+		expect(route.canActivate).toEqual([guard]);
+		expect(route.canMatch).toEqual([guard]);
+	});
+
 	it('lets a component-ish target take precedence over redirectTo in the else-chain', () => {
 		const component = class {};
 		register({ path: 'jobs', component: component as never, redirectTo: 'unused' });

--- a/packages/ui-core/core/src/lib/services/page/page-route-registry.service.ts
+++ b/packages/ui-core/core/src/lib/services/page/page-route-registry.service.ts
@@ -224,9 +224,17 @@ export class PageRouteRegistryService implements IPageRouteRegistry {
 			const route: Route = {
 				path: config.path, // Add path property
 				pathMatch: config.path ? 'prefix' : 'full', // Set pathMatch property
-				data: config.data || {}, // Add data property if it exists
-				canActivate: config.canActivate || [] // Add canActivate property if it exists
+				data: config.data || {} // Add data property if it exists
 			};
+
+			// Guards are attached ONLY when present. An empty `canActivate: []` is still a truthy
+			// value, and Angular's dev-mode `validateConfig` rejects ANY guard on a redirect route
+			// (`redirectTo and canActivate cannot be used together`, NG04014) — which is thrown
+			// while the lazy parent config loads and blanks the whole app in `nx serve` and in
+			// development-configuration bundles such as demo.gauzy.co.
+			if (config.canActivate?.length) {
+				route.canActivate = config.canActivate;
+			}
 
 			// `canMatch` decides whether this registration takes part in matching at all — it is
 			// what lets two flavours of one page share a path, so it must reach the router.


### PR DESCRIPTION
## What broke

After #9989 landed, **demo.gauzy.co boots to a blank page**: the browser console shows

```
NG04014: Invalid configuration of route 'dashboard…': redirectTo and canActivate cannot be used together. Redirects happen before guards are executed.
```

`PageRouteRegistryService.getPageLocationRoutes` always emitted `canActivate: config.canActivate || []` on every generated route. #9989 registered the first **top-level redirect** through the registry (`dashboard-time-track → /pages/dashboard/time-tracking`), and Angular's dev-mode `validateConfig` treats the empty array as a guard:

```js
if (route.redirectTo) { if (route.canMatch || route.canActivate) throw new RuntimeError(4014, …) }
```

The throw happens while the lazy parent config loads, so **every development-configuration bundle** (`nx serve`, and the demo webapp image, which is built in development mode) dies at boot. Production bundles skip `validateConfig`, so stage/prod would not have been affected — but demo is the one built that way.

## Fix

Attach `canActivate` (like `canMatch`) **only when the registration provides at least one guard**. Two spec cases added (redirect route emits no guard keys; guards still copied when present) — 8/8 green.

## Verification

- `jest packages/ui-core/core/src/lib/services/page/page-route-registry.service.spec.ts` ✅
- Local dev-mode boot (`nx serve gauzy`) with the fix: `/` → dashboard renders, no NG04014 (see follow-up comment)
- After merge: demo image → `demo.gauzy.co` boots and renders (this PR's purpose)

## Ops note

Written up in the workspace incident log (`knowledge/incidents/2026-08-17-demo-api-503.md` gets the follow-up); demo is not covered by `external-uptime-monitor.yml`, so nothing paged for either the API 503 (01:47–16:35 UTC, cluster-side, resolved by the 16:35 rollout) or this blank page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents NG04014 and a blank app in development by stopping `PageRouteRegistryService` from emitting `canActivate: []` on every route. Previously, redirects with a (truthy) empty `canActivate` triggered “redirectTo and canActivate cannot be used together”; now `canActivate` is attached only when guards are provided, and dev bundles (`nx serve`, demo) boot normally. Production behavior is unchanged.

**Review notes**
- Set `canActivate` only when `config.canActivate.length > 0`; `canMatch` remains conditional when present.
- Added two unit tests: no guard keys on redirect routes; guards are preserved when provided.
- No migration required. Existing registrations with guards continue to work; redirects should not include guards.

<sup>Written for commit 781713d736722a8ac3a8033eecba5c89016dfc10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/9999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

