### PR TITLE
fix(ai-chat-settings): AI Providers page fits beside the expanded chat (header actions wrap, list scrolls in card)

### DIFF
--- a/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.scss
+++ b/packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.scss
@@ -5,6 +5,7 @@
 .ai-chat-settings {
 	.page-header {
 		display: flex;
+		flex-wrap: wrap; // beside an expanded chat the actions drop under the title instead of overflowing
 		align-items: flex-start;
 		justify-content: space-between;
 		gap: 1rem;
@@ -25,12 +26,15 @@
 		}
 
 		// "+ Add AI Provider" and "+ Add AI Voice Provider" side by side; wraps on narrow cards.
+		// No `flex-shrink: 0` here — it pinned the pair at its full width (≈360px), so on a
+		// canvas narrowed by the expanded chat the whole page scrolled horizontally instead
+		// of the buttons wrapping onto a second line.
 		.header-actions {
 			display: flex;
 			flex-wrap: wrap;
 			gap: 0.5rem;
 			justify-content: flex-end;
-			flex-shrink: 0;
+			min-width: 0;
 		}
 	}
 
@@ -379,6 +383,11 @@
 	.provider-rows {
 		display: flex;
 		flex-direction: column;
+		// The grid's column minimums (~30rem + gaps + actions) exceed a card that sits beside
+		// the expanded chat; scroll the LIST inside its card (like every data table) rather
+		// than letting it push the whole canvas into horizontal scroll.
+		min-width: 0;
+		overflow-x: auto;
 
 		.row-head,
 		.row {


### PR DESCRIPTION
Follow-up to #9989 (ask 5: *pages must fit next to the expanded chat, prefer fixing widths*). On demo.gauzy.co with the chat expanded (canvas 630 px at 1280) the **AI Providers** page forced the whole canvas into horizontal scroll (731 px):

- `.header-actions` had `flex-shrink: 0`, so the two "+ Add" buttons (≈360 px) could never wrap despite `flex-wrap`.
- The provider list grid's column minimums (~30 rem + gaps + actions) exceed the card.

Fix: `.page-header` wraps and `.header-actions` may shrink (`min-width: 0`) → the buttons drop onto a second line; `.provider-rows` gets `min-width: 0; overflow-x: auto` → the list scrolls inside its card like every data table.

Verified in dev mode at 1280×720 with the chat expanded (384 px): canvas `scrollWidth == clientWidth == 630` (was 731/630); buttons at y 220/260 inside the canvas; list scrolls internally. CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
AI Providers page now fits beside the expanded chat. Previously it pushed the canvas into horizontal scroll; now header actions wrap and the provider list scrolls within its card.

- Styles updated in `packages/plugins/ai-chat-react-ui/src/lib/settings/ai-chat-settings.component.scss`: `.page-header { flex-wrap: wrap }`, `.header-actions { min-width: 0 }` so the "+ Add" buttons can wrap to a second line.
- `.provider-rows` gains `min-width: 0; overflow-x: auto` so the list scrolls inside its card instead of widening the page.
- CSS-only; verified at 1280×720 with chat expanded: canvas scroll width equals client width (630 px).

<sup>Written for commit 2feff7b0de140d1ec24ddaf778ea5b3d7d3deddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

