### PR TITLE
fix(time-tracking): React screenshot caption on its own line; Angular screenshot-card styles (danger border etc.) actually compile

### DIFF
--- a/packages/plugins/dashboard-time-track-react-ui/src/lib/components/styles.ts
+++ b/packages/plugins/dashboard-time-track-react-ui/src/lib/components/styles.ts
@@ -33,7 +33,14 @@ export const TIME_TRACKING_STYLES = `
 .gz-rtt .gz-rtt-custom-card-body-inner-list .gz-rtt-custom-card-button { display: flex; justify-content: flex-end; margin: 1rem 15px 0 15px; }
 .gz-rtt .gz-rtt-font-weight-bold { font-weight: 600; color: var(--gauzy-text-color-2); }
 .gz-rtt .gz-rtt-project-name { color: var(--gauzy-text-color-1); font-size: 14px; font-weight: 600; }
-.gz-rtt .gz-rtt-hour-label { display: flex; justify-content: space-between; }
+/* Angular has TWO different .hour-label rules that never meet because of view encapsulation:
+   the dashboard's own (time-tracking.component.scss) is a flex space-between ROW for the
+   avatar line above each carousel, while the screenshot card's (screenshots-item.component.scss)
+   is font-only and its time span + date caption STACK. In this single stylesheet the flex
+   version leaked into the card and squeezed the date ("Tuesday, August 18, 2026") into a
+   47px, 3-line column spilling past the card edge. The row layout lives on
+   .gz-rtt-avatar-row; inside the card the class carries only the type. */
+.gz-rtt .gz-rtt-shot .gz-rtt-hour-label { font-size: 14px; font-weight: 400; line-height: 11px; letter-spacing: 0em; text-align: left; }
 .gz-rtt .gz-rtt-button-container { display: flex; gap: 1rem; }
 .gz-rtt .gz-rtt-text-center { text-align: center; }
 .gz-rtt .gz-rtt-text-left { text-align: left; }

--- a/packages/ui-core/shared/src/lib/timesheet/screenshots/screenshots-item/screenshots-item.component.scss
+++ b/packages/ui-core/shared/src/lib/timesheet/screenshots/screenshots-item/screenshots-item.component.scss
@@ -1,4 +1,9 @@
-@forward 'report';
+// `@use`, not `@forward`: forwarding only re-exports the module to OUR importers, it does
+// not bring `nb-theme()` into this file — every nb-theme() below was emitted as invalid CSS and
+// dropped by the browser since the Angular 19 upgrade (no card radius/background, no danger
+// border for not-work-related slots, no progress-track colour). The React port of this card
+// (dashboard-time-track-react-ui) renders these values, so this restores parity.
+@use 'report' as *;
 
 :host {
   ::ng-deep {
@@ -9,7 +14,7 @@
   }
   .card {
     border-radius: nb-theme(border-radius);
-    background: var(gauzy-sidebar-background-4);
+    background: var(--gauzy-sidebar-background-4);
     box-shadow: var(--gauzy-shadow);
     min-width: 189px;
     max-width: 270px;


### PR DESCRIPTION
Follow-up to #9989 from comparing the React and Angular Time Tracking dashboards on demo.

## 1. React — the date caption spilled out of the screenshot card
"Tuesday, August 18, 2026" rendered as a 47 px, 3-line column beside the time range and past the card edge. Cause: Angular has **two** `.hour-label` rules kept apart by view encapsulation — the dashboard's (`time-tracking.component.scss`) is a flex `space-between` **row** for the avatar line above each carousel; the card's (`screenshots-item.component.scss`) is type-only, so time + caption **stack**. The single React stylesheet applied the flex row to the card. Fix: the row layout lives on `.gz-rtt-avatar-row`; inside `.gz-rtt-shot` the class carries only the type. Measured against the live stylesheet: time-span `display: block`, caption under the time, 157×11 px inside a 189 px card — Angular's exact numbers.

## 2. Angular — the screenshot card's `nb-theme()` styles were dead
`screenshots-item.component.scss` began with `@forward 'report'`, which re-exports the theme module to importers but does **not** bring `nb-theme()` into the file itself, so every `nb-theme()` there was emitted literally and dropped by the browser (verified on demo: the compiled `.card.danger-bordered` rule contained only `box-shadow: none`). Since the Angular 19 upgrade (2025-04) the card had no radius/background, no danger border for slots whose screenshots are all flagged not-work-related, no badge colour, no progress-track colour. `@use 'report' as *` restores them (+ `var(gauzy-sidebar-background-4)` → `var(--gauzy-sidebar-background-4)`). Standalone Sass compile: `border: 2px solid var(--color-danger-500) !important`, 0 literal `nb-theme(` left.

Net: both flavours now render the same card — including the red border you saw in React (it was always the intended Angular behaviour; only React actually painted it). If the border is unwanted the call is a product one and applies to both flavours.

Same bug family, **not** touched here (log as follow-up): `timesheet/gauzy-filters/filters.component.scss` (`@use 'themes'` without `as *` → 16 dead `select-outline-*` declarations on the activity-level filter) and `integrations/github/repository-selector/repository-selector.component.scss` (no theme import, 1 call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns React and Angular Time Tracking screenshot cards and restores Angular theme styles. Previously, React squeezed the date caption beside the time in the screenshot card; now it stacks under the time. Angular cards lost `nb-theme()` styles after the Angular 19 upgrade; now theme-driven radius, background, and the danger border render again.

- React: move the flex row layout to the avatar row; make `.gz-rtt-shot .gz-rtt-hour-label` type-only so the caption renders on its own line, matching Angular.
- Angular: replace `@forward 'report'` with `@use 'report' as *` and fix `var(--gauzy-sidebar-background-4)`. Compiled CSS now includes the 2px danger border and other theme values; no literal `nb-theme(` remains.
- Result: both frameworks render the same screenshot card, including the danger border for all-not-work-related slots. No migration required.

<sup>Written for commit 51f0227d0b86ac09ea16fcde169a9ee88a7a26af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

