### PR TITLE
fix(security): stop TypeORM from silently dropping null/undefined where predicates (GHSA-44pv-34gx-q9p4) + id-less JWT bypass

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -50,6 +50,7 @@
 	"devDependencies": {
 		"@types/jest": "30.0.0",
 		"@types/node": "^24.10.0",
+		"better-sqlite3": "12.6.2",
 		"cross-env": "^10.1.0",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.9.3"

--- a/packages/config/src/lib/database-helpers.spec.ts
+++ b/packages/config/src/lib/database-helpers.spec.ts
@@ -1,0 +1,167 @@
+import { DataSource, DataSourceOptions, EntitySchema, IsNull, Repository } from 'typeorm';
+import { TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR } from './database-helpers';
+
+/**
+ * Regression suite for GHSA-44pv-34gx-q9p4.
+ *
+ * TypeORM 1.0 lets the connection decide what a `null` / `undefined` value inside a `where` object
+ * means. The application shipped `null: 'ignore'`, which silently DROPPED the predicate: a lookup
+ * meant as `"tenantId" IS NULL` (the global, tenant-less row) matched every tenant's rows. The
+ * shipped behavior is now `null: 'sql-null'` (emit `IS NULL`) and `undefined: 'ignore'` (omit the
+ * key — the optional-filter idiom the whole codebase relies on).
+ *
+ * The behavior is exercised against a real better-sqlite3 database, the default DB_TYPE, using the
+ * SAME exported constant the connection profiles use. Every "the fix works" test is paired with a
+ * CONTROL running the pre-fix `ignore` setting, so a green run proves the suite can tell the two
+ * apart rather than passing vacuously.
+ */
+
+const RowSchema = new EntitySchema({
+	name: 'Row',
+	tableName: 'row',
+	columns: {
+		id: { primary: true, type: 'varchar', generated: 'uuid' },
+		name: { type: 'varchar' },
+		tenantId: { type: 'varchar', nullable: true },
+		organizationId: { type: 'varchar', nullable: true }
+	}
+});
+
+const TENANT_A = '11111111-1111-4111-8111-111111111111';
+const TENANT_B = '22222222-2222-4222-8222-222222222222';
+
+async function openDataSource(invalidWhereValuesBehavior: DataSourceOptions['invalidWhereValuesBehavior']) {
+	const dataSource = new DataSource({
+		type: 'better-sqlite3',
+		database: ':memory:',
+		entities: [RowSchema],
+		synchronize: true,
+		logging: false,
+		invalidWhereValuesBehavior
+	});
+	await dataSource.initialize();
+	const rows: Repository<any> = dataSource.getRepository('Row');
+	await rows.save([
+		{ name: 'global', tenantId: null, organizationId: null },
+		{ name: 'tenant-a', tenantId: TENANT_A, organizationId: null },
+		{ name: 'tenant-b', tenantId: TENANT_B, organizationId: 'org-b' }
+	]);
+	return { dataSource, rows };
+}
+
+const names = (items: any[]) => items.map((r) => r.name).sort();
+
+describe('TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR (GHSA-44pv-34gx-q9p4)', () => {
+	it('is the fail-closed setting: null -> IS NULL, undefined -> key omitted, and is frozen', () => {
+		expect(TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR).toEqual({ null: 'sql-null', undefined: 'ignore' });
+		expect(Object.isFrozen(TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR)).toBe(true);
+		// The one value that must never come back: it turns "IS NULL" into "no predicate at all".
+		expect(TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR.null).not.toBe('ignore');
+	});
+
+	describe('shipped connection profiles', () => {
+		const originalDbType = process.env.DB_TYPE;
+		afterEach(() => {
+			if (originalDbType === undefined) delete process.env.DB_TYPE;
+			else process.env.DB_TYPE = originalDbType;
+		});
+
+		it.each(['better-sqlite3', 'sqlite', 'postgres', 'mysql'])(
+			'DB_TYPE=%s TypeORM profile uses the shared constant',
+			(dbType) => {
+				process.env.DB_TYPE = dbType;
+				jest.isolateModules(() => {
+					// database.ts builds the profile for process.env.DB_TYPE at import time. Compare against
+					// the constant from the SAME isolated module registry so identity (not just shape) is proven.
+					const helpers = require('./database-helpers');
+					const { dbTypeOrmConnectionConfig } = require('./database');
+					expect(dbTypeOrmConnectionConfig.invalidWhereValuesBehavior).toBe(
+						helpers.TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR
+					);
+					expect(dbTypeOrmConnectionConfig.invalidWhereValuesBehavior).toEqual({
+						null: 'sql-null',
+						undefined: 'ignore'
+					});
+				});
+			}
+		);
+	});
+
+	describe('against a real better-sqlite3 database', () => {
+		let fixed: { dataSource: DataSource; rows: Repository<any> };
+		let control: { dataSource: DataSource; rows: Repository<any> };
+
+		beforeAll(async () => {
+			fixed = await openDataSource(TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR);
+			control = await openDataSource({ null: 'ignore', undefined: 'ignore' }); // the pre-fix shipped setting
+		});
+
+		afterAll(async () => {
+			for (const ds of [fixed?.dataSource, control?.dataSource]) {
+				if (ds?.isInitialized) await ds.destroy();
+			}
+		});
+
+		it('find({ where: { tenantId: null } }) matches ONLY the tenant-less row', async () => {
+			const items = await fixed.rows.find({ where: { tenantId: null } });
+			expect(names(items)).toEqual(['global']);
+		});
+
+		it('CONTROL: under the pre-fix "ignore" setting the same query returns EVERY tenant', async () => {
+			const items = await control.rows.find({ where: { tenantId: null } });
+			expect(names(items)).toEqual(['global', 'tenant-a', 'tenant-b']);
+		});
+
+		it('findOneBy with two null keys pins BOTH columns to IS NULL', async () => {
+			// { tenantId: null, organizationId: null } is exactly the accounting-template "global" lookup.
+			const row = await fixed.rows.findOneBy({ tenantId: null, organizationId: null });
+			expect(row?.name).toBe('global');
+			// tenant-a also has organizationId NULL but a real tenantId — it must not be reachable.
+			const notTenantA = await fixed.rows.findOneBy({ tenantId: null, name: 'tenant-a' });
+			expect(notTenantA).toBeNull();
+		});
+
+		it('CONTROL: under "ignore", the two-null lookup happily returns another tenant\'s row', async () => {
+			const row = await control.rows.findOneBy({ tenantId: null, organizationId: null, name: 'tenant-b' });
+			expect(row?.name).toBe('tenant-b');
+		});
+
+		it('null behaves exactly like the explicit IsNull() operator', async () => {
+			const viaNull = await fixed.rows.find({ where: { tenantId: null } });
+			const viaOperator = await fixed.rows.find({ where: { tenantId: IsNull() } });
+			expect(names(viaNull)).toEqual(names(viaOperator));
+		});
+
+		it('undefined still omits the key (optional-filter idiom: where: { tenantId, organizationId })', async () => {
+			const organizationId: string | undefined = undefined;
+			const items = await fixed.rows.find({ where: { tenantId: TENANT_A, organizationId } });
+			expect(names(items)).toEqual(['tenant-a']);
+			const all = await fixed.rows.find({ where: { tenantId: undefined } });
+			expect(all).toHaveLength(3);
+		});
+
+		it('count / exists / delete criteria honour the same IS NULL semantics', async () => {
+			expect(await fixed.rows.countBy({ tenantId: null })).toBe(1);
+			expect(await fixed.rows.existsBy({ tenantId: null, name: 'tenant-b' })).toBe(false);
+			// A tenant-less DELETE must not touch tenant rows.
+			const { dataSource, rows } = await openDataSource(TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR);
+			try {
+				const { affected } = await rows.delete({ tenantId: null });
+				expect(affected).toBe(1);
+				expect(names(await rows.find())).toEqual(['tenant-a', 'tenant-b']);
+			} finally {
+				await dataSource.destroy();
+			}
+		});
+
+		it('CONTROL: under "ignore" a tenant-less DELETE would wipe every tenant', async () => {
+			const { dataSource, rows } = await openDataSource({ null: 'ignore', undefined: 'ignore' });
+			try {
+				const { affected } = await rows.delete({ tenantId: null });
+				expect(affected).toBe(3);
+			} finally {
+				await dataSource.destroy();
+			}
+		});
+	});
+});

--- a/packages/config/src/lib/database-helpers.ts
+++ b/packages/config/src/lib/database-helpers.ts
@@ -1,6 +1,30 @@
 import { TlsOptions } from 'tls';
+import type { DataSourceOptions } from 'typeorm';
 
 export type MikroLoggerNamespace = 'query' | 'query-params' | 'schema' | 'discovery' | 'info';
+
+/**
+ * How TypeORM treats `null` and `undefined` values inside `find*` / `count*` / `exists*` and
+ * `update` / `delete` / `softDelete` criteria (`where`) objects. TypeORM ≥ 1.0 defaults both to
+ * `'throw'`; this is the ONE place the application overrides that, and every TypeORM connection
+ * profile in `database.ts` must use it.
+ *
+ * - `undefined: 'ignore'` — an `undefined` value omits the key. That is the optional-filter idiom
+ *   used throughout the codebase (`where: { tenantId, organizationId }` where `organizationId` may
+ *   legitimately be undefined) and matches TypeORM 0.3.
+ * - `null: 'sql-null'` — a `null` value emits `"column" IS NULL` (columns and relations alike),
+ *   i.e. TypeORM ≤ 0.2 and MikroORM semantics, so a `where` object shared by both ORM branches
+ *   means the same thing on both.
+ *
+ * `null` MUST NEVER be `'ignore'`. That silently drops the predicate, so a lookup such as
+ * `{ tenantId: null, organizationId: null }` (meaning "the global, tenant-less row") matches EVERY
+ * tenant's rows — a cross-tenant data-isolation failure (GHSA-44pv-34gx-q9p4). `'sql-null'` is
+ * fail-closed: a null can only ever narrow a query, never widen it. Application code should still
+ * spell the intent out with the explicit `IsNull()` operator; this setting is the safety net for
+ * anything that does not.
+ */
+export const TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR: NonNullable<DataSourceOptions['invalidWhereValuesBehavior']> =
+	Object.freeze({ null: 'sql-null', undefined: 'ignore' } as const);
 
 export enum DatabaseTypeEnum {
 	mongodb = 'mongodb',

--- a/packages/config/src/lib/database.ts
+++ b/packages/config/src/lib/database.ts
@@ -9,7 +9,13 @@ import { DataSourceOptions } from 'typeorm';
 import { KnexModuleOptions } from 'nest-knexjs';
 import * as path from 'path';
 import * as chalk from 'chalk';
-import { DatabaseTypeEnum, getLoggingMikroOptions, getLoggingOptions, getTlsOptions } from './database-helpers';
+import {
+	DatabaseTypeEnum,
+	getLoggingMikroOptions,
+	getLoggingOptions,
+	getTlsOptions,
+	TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR
+} from './database-helpers';
 
 /**
  * Type representing the ORM types.
@@ -116,8 +122,8 @@ switch (dbType) {
 		// TypeORM DB Config (MySQL)
 		const typeOrmMySqlOptions: DataSourceOptions = {
 			type: dbType,
-			// TypeORM 1.0 throws on null/undefined in where by default; restore 0.3 'ignore' behavior.
-			invalidWhereValuesBehavior: { null: 'ignore', undefined: 'ignore' },
+			// null -> IS NULL, undefined -> key omitted. Never 'ignore' for null (GHSA-44pv-34gx-q9p4); see database-helpers.ts.
+			invalidWhereValuesBehavior: TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR,
 			ssl: getTlsOptions(dbSslMode),
 			host: process.env.DB_HOST || 'localhost',
 			port: process.env.DB_PORT ? Number.parseInt(process.env.DB_PORT, 10) : 3306,
@@ -213,8 +219,8 @@ switch (dbType) {
 		// TypeORM DB Config (PostgreSQL)
 		const typeOrmPostgresOptions: DataSourceOptions = {
 			type: dbType,
-			// TypeORM 1.0 throws on null/undefined in where by default; restore 0.3 'ignore' behavior.
-			invalidWhereValuesBehavior: { null: 'ignore', undefined: 'ignore' },
+			// null -> IS NULL, undefined -> key omitted. Never 'ignore' for null (GHSA-44pv-34gx-q9p4); see database-helpers.ts.
+			invalidWhereValuesBehavior: TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR,
 			ssl: getTlsOptions(dbSslMode),
 			host: process.env.DB_HOST || 'localhost',
 			port: process.env.DB_PORT ? Number.parseInt(process.env.DB_PORT, 10) : 5432,
@@ -312,8 +318,8 @@ switch (dbType) {
 		// TypeORM DB Config (Better-SQLite3)
 		const typeOrmBetterSqliteConfig: DataSourceOptions = {
 			type: DatabaseTypeEnum.betterSqlite3,
-			// TypeORM 1.0 throws on null/undefined in where by default; restore 0.3 'ignore' behavior.
-			invalidWhereValuesBehavior: { null: 'ignore', undefined: 'ignore' },
+			// null -> IS NULL, undefined -> key omitted. Never 'ignore' for null (GHSA-44pv-34gx-q9p4); see database-helpers.ts.
+			invalidWhereValuesBehavior: TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR,
 			database: sqlitePath,
 			logging: 'all',
 			logger: 'file', // Removes console logging, instead logs all queries in a file ormlogs.log

--- a/packages/core/src/lib/accounting-template/accounting-template.criteria.spec.ts
+++ b/packages/core/src/lib/accounting-template/accounting-template.criteria.spec.ts
@@ -1,0 +1,147 @@
+import { DataSource, DataSourceOptions, EntitySchema, Repository } from 'typeorm';
+import { AccountingTemplateTypeEnum, LanguagesEnum } from '@gauzy/contracts';
+import { globalAccountingTemplateWhere, tenantAccountingTemplateWhere } from './accounting-template.criteria';
+
+/**
+ * Regression suite for GHSA-44pv-34gx-q9p4 — cross-tenant accounting-template disclosure.
+ *
+ * `GET /accounting-template/template` falls back to the GLOBAL template (tenantId IS NULL AND
+ * organizationId IS NULL) when the caller's tenant has none. That fallback used to be spelled with a
+ * literal `null`, which TypeORM silently dropped from the SQL, so "the global template" became "any
+ * tenant's template with this language and type" — another tenant's invoice/estimate/receipt HTML.
+ *
+ * These are the criteria the service actually runs — imported, not re-declared. They are exercised
+ * against a real better-sqlite3 database under BOTH the fixed connection setting and the pre-fix
+ * `null: 'ignore'` one, because the criteria must be safe regardless of what the connection is
+ * configured to do with a null. Every "the fix works" test is paired with a CONTROL running the
+ * pre-fix shape so the suite is proven to discriminate.
+ */
+
+const AccountingTemplateSchema = new EntitySchema({
+	name: 'AccountingTemplate',
+	tableName: 'accounting_template',
+	columns: {
+		id: { primary: true, type: 'varchar', generated: 'uuid' },
+		name: { type: 'varchar' },
+		languageCode: { type: 'varchar' },
+		templateType: { type: 'varchar' },
+		mjml: { type: 'text', nullable: true },
+		tenantId: { type: 'varchar', nullable: true },
+		organizationId: { type: 'varchar', nullable: true }
+	}
+});
+
+const TENANT_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const TENANT_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const ORG_A1 = 'a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1';
+const ORG_A2 = 'a2a2a2a2-a2a2-4a2a-8a2a-a2a2a2a2a2a2';
+const ORG_B1 = 'b1b1b1b1-b1b1-4b1b-8b1b-b1b1b1b1b1b1';
+
+const { INVOICE } = AccountingTemplateTypeEnum;
+const { ENGLISH, BULGARIAN } = LanguagesEnum;
+
+async function openDataSource(invalidWhereValuesBehavior: DataSourceOptions['invalidWhereValuesBehavior']) {
+	const dataSource = new DataSource({
+		type: 'better-sqlite3',
+		database: ':memory:',
+		entities: [AccountingTemplateSchema],
+		synchronize: true,
+		logging: false,
+		invalidWhereValuesBehavior
+	});
+	await dataSource.initialize();
+	const templates: Repository<any> = dataSource.getRepository('AccountingTemplate');
+	await templates.save([
+		// The seeded global template — the only row a cross-tenant fallback may ever return.
+		{ name: 'global-en-invoice', languageCode: ENGLISH, templateType: INVOICE, tenantId: null, organizationId: null },
+		// Tenant A customized its English invoice for one organization.
+		{ name: 'a1-en-invoice', languageCode: ENGLISH, templateType: INVOICE, tenantId: TENANT_A, organizationId: ORG_A1 },
+		// Tenant B has a Bulgarian invoice template. There is NO global Bulgarian invoice template.
+		{ name: 'b1-bg-invoice', languageCode: BULGARIAN, templateType: INVOICE, tenantId: TENANT_B, organizationId: ORG_B1 },
+		{ name: 'b-bg-invoice', languageCode: BULGARIAN, templateType: INVOICE, tenantId: TENANT_B, organizationId: null }
+	]);
+	return { dataSource, templates };
+}
+
+/** The pre-fix criteria shape (commit 51e22b7c22): literal null shared with the MikroORM branch. */
+const preFixGlobalWhere = (languageCode: string, templateType: string) => ({
+	languageCode,
+	templateType,
+	organizationId: null as any,
+	tenantId: null as any
+});
+
+describe('accounting-template criteria (GHSA-44pv-34gx-q9p4)', () => {
+	let fixed: { dataSource: DataSource; templates: Repository<any> };
+	let ignore: { dataSource: DataSource; templates: Repository<any> };
+
+	beforeAll(async () => {
+		fixed = await openDataSource({ null: 'sql-null', undefined: 'ignore' }); // what @gauzy/config ships now
+		ignore = await openDataSource({ null: 'ignore', undefined: 'ignore' }); // what it shipped before
+	});
+
+	afterAll(async () => {
+		for (const ds of [fixed?.dataSource, ignore?.dataSource]) {
+			if (ds?.isInitialized) await ds.destroy();
+		}
+	});
+
+	describe('globalAccountingTemplateWhere — the cross-tenant fallback', () => {
+		it('returns the seeded global row when one exists', async () => {
+			const row = await fixed.templates.findOneBy(globalAccountingTemplateWhere({ languageCode: ENGLISH, templateType: INVOICE }));
+			expect(row?.name).toBe('global-en-invoice');
+		});
+
+		it("the advisory scenario: tenant A asks for Bulgarian, no global exists -> must NOT get tenant B's template", async () => {
+			const row = await fixed.templates.findOneBy(globalAccountingTemplateWhere({ languageCode: BULGARIAN, templateType: INVOICE }));
+			expect(row).toBeNull();
+		});
+
+		it('is safe even under the pre-fix "ignore" connection setting, because IsNull() is explicit', async () => {
+			const row = await ignore.templates.findOneBy(globalAccountingTemplateWhere({ languageCode: BULGARIAN, templateType: INVOICE }));
+			expect(row).toBeNull();
+			const global = await ignore.templates.findOneBy(globalAccountingTemplateWhere({ languageCode: ENGLISH, templateType: INVOICE }));
+			expect(global?.name).toBe('global-en-invoice');
+		});
+
+		it("CONTROL: the pre-fix literal-null criteria under the pre-fix setting DO leak tenant B's template", async () => {
+			const row = await ignore.templates.findOneBy(preFixGlobalWhere(BULGARIAN, INVOICE));
+			expect(row).not.toBeNull();
+			expect(row.tenantId).toBe(TENANT_B); // this is the disclosure the advisory reported
+		});
+
+		it('the new connection setting alone also closes the pre-fix criteria (defense in depth)', async () => {
+			const row = await fixed.templates.findOneBy(preFixGlobalWhere(BULGARIAN, INVOICE));
+			expect(row).toBeNull();
+		});
+	});
+
+	describe('tenantAccountingTemplateWhere — the in-tenant lookups', () => {
+		it('never crosses tenants', async () => {
+			const rows = await fixed.templates.findBy(
+				tenantAccountingTemplateWhere({ languageCode: BULGARIAN, templateType: INVOICE, tenantId: TENANT_A })
+			);
+			expect(rows).toHaveLength(0);
+		});
+
+		it('with an organizationId matches only that organization', async () => {
+			const row = await fixed.templates.findOneBy(
+				tenantAccountingTemplateWhere({ languageCode: ENGLISH, templateType: INVOICE, tenantId: TENANT_A, organizationId: ORG_A1 })
+			);
+			expect(row?.name).toBe('a1-en-invoice');
+			const other = await fixed.templates.findOneBy(
+				tenantAccountingTemplateWhere({ languageCode: ENGLISH, templateType: INVOICE, tenantId: TENANT_A, organizationId: ORG_A2 })
+			);
+			expect(other).toBeNull();
+		});
+
+		it('without an organizationId (undefined OR null) matches any organization in the tenant — the long-standing behavior', async () => {
+			for (const organizationId of [undefined, null as any]) {
+				const rows = await fixed.templates.findBy(
+					tenantAccountingTemplateWhere({ languageCode: BULGARIAN, templateType: INVOICE, tenantId: TENANT_B, organizationId })
+				);
+				expect(rows.map((r) => r.name).sort()).toEqual(['b-bg-invoice', 'b1-bg-invoice']);
+			}
+		});
+	});
+});

--- a/packages/core/src/lib/accounting-template/accounting-template.criteria.ts
+++ b/packages/core/src/lib/accounting-template/accounting-template.criteria.ts
@@ -1,0 +1,77 @@
+import { FindOptionsWhere, IsNull } from 'typeorm';
+import { FilterQuery as MikroFilterQuery } from '@mikro-orm/core';
+import { AccountingTemplateTypeEnum, IAccountingTemplate, ID, LanguagesEnum } from '@gauzy/contracts';
+
+/**
+ * The (languageCode, templateType) pair a template lookup is keyed on.
+ */
+export interface IAccountingTemplateLookup {
+	languageCode: LanguagesEnum | string;
+	templateType: AccountingTemplateTypeEnum | string;
+}
+
+/**
+ * The tenant/organization scope a template lookup runs in.
+ */
+export interface IAccountingTemplateScope extends IAccountingTemplateLookup {
+	tenantId: ID;
+	organizationId?: ID;
+}
+
+/**
+ * TypeORM criteria for the GLOBAL accounting template — the seeded row that belongs to no tenant
+ * and no organization (`"tenantId" IS NULL AND "organizationId" IS NULL`).
+ *
+ * The NULL scope MUST be spelled with the explicit `IsNull()` operator. A literal `null` used to be
+ * silently dropped from the SQL by TypeORM (0.3 always, 1.0 under `invalidWhereValuesBehavior.null:
+ * 'ignore'`), which turned this "global only" lookup into "any tenant's template with the same
+ * language and type" — GHSA-44pv-34gx-q9p4. `IsNull()` emits `IS NULL` under every setting.
+ */
+export function globalAccountingTemplateWhere({
+	languageCode,
+	templateType
+}: IAccountingTemplateLookup): FindOptionsWhere<IAccountingTemplate> {
+	return {
+		languageCode,
+		templateType,
+		tenantId: IsNull(),
+		organizationId: IsNull()
+	} as FindOptionsWhere<IAccountingTemplate>;
+}
+
+/**
+ * MikroORM equivalent of {@link globalAccountingTemplateWhere}. MikroORM maps a `null` filter value
+ * to `IS NULL` natively, so `null` is the correct spelling on this side.
+ */
+export function globalAccountingTemplateMikroWhere({
+	languageCode,
+	templateType
+}: IAccountingTemplateLookup): MikroFilterQuery<IAccountingTemplate> {
+	return {
+		languageCode,
+		templateType,
+		tenantId: null,
+		organizationId: null
+	} as MikroFilterQuery<IAccountingTemplate>;
+}
+
+/**
+ * Criteria for a TENANT-scoped template lookup. `organizationId` is optional: when the caller does
+ * not pass one the key is left `undefined` and (under `invalidWhereValuesBehavior.undefined:
+ * 'ignore'`) omitted, matching any organization inside the tenant — the long-standing behavior.
+ * A `null` organizationId is deliberately normalised to `undefined` here so a client sending
+ * `organizationId: null` keeps meaning "any organization" rather than `IS NULL`.
+ */
+export function tenantAccountingTemplateWhere({
+	languageCode,
+	templateType,
+	tenantId,
+	organizationId
+}: IAccountingTemplateScope): FindOptionsWhere<IAccountingTemplate> {
+	return {
+		languageCode,
+		templateType,
+		tenantId,
+		...(organizationId ? { organizationId } : {})
+	} as FindOptionsWhere<IAccountingTemplate>;
+}

--- a/packages/core/src/lib/accounting-template/accounting-template.criteria.ts
+++ b/packages/core/src/lib/accounting-template/accounting-template.criteria.ts
@@ -60,7 +60,8 @@ export function globalAccountingTemplateMikroWhere({
  * not pass one the key is left `undefined` and (under `invalidWhereValuesBehavior.undefined:
  * 'ignore'`) omitted, matching any organization inside the tenant — the long-standing behavior.
  * A `null` organizationId is deliberately normalised to `undefined` here so a client sending
- * `organizationId: null` keeps meaning "any organization" rather than `IS NULL`.
+ * `organizationId: null` keeps meaning "any organization" rather than `IS NULL`; any other value —
+ * including an empty string — stays a predicate.
  */
 export function tenantAccountingTemplateWhere({
 	languageCode,
@@ -72,6 +73,6 @@ export function tenantAccountingTemplateWhere({
 		languageCode,
 		templateType,
 		tenantId,
-		...(organizationId ? { organizationId } : {})
+		...(organizationId !== null && organizationId !== undefined ? { organizationId } : {})
 	} as FindOptionsWhere<IAccountingTemplate>;
 }

--- a/packages/core/src/lib/accounting-template/accounting-template.service.ts
+++ b/packages/core/src/lib/accounting-template/accounting-template.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Brackets, IsNull, SelectQueryBuilder, WhereExpressionBuilder } from 'typeorm';
+import { Brackets, FindOptionsWhere, SelectQueryBuilder, WhereExpressionBuilder } from 'typeorm';
 import { FilterQuery as MikroFilterQuery } from '@mikro-orm/core';
 import * as mjml2html from 'mjml';
 import * as Handlebars from 'handlebars';
@@ -13,6 +13,12 @@ import {
 } from '@gauzy/contracts';
 import { isNotEmpty } from '@gauzy/utils';
 import { AccountingTemplate } from './accounting-template.entity';
+import {
+	IAccountingTemplateLookup,
+	globalAccountingTemplateMikroWhere,
+	globalAccountingTemplateWhere,
+	tenantAccountingTemplateWhere
+} from './accounting-template.criteria';
 import { BaseQueryDTO, TenantAwareCrudService } from './../core/crud';
 import { MultiORMEnum } from './../core/utils';
 import { RequestContext } from './../core/context';
@@ -194,31 +200,34 @@ export class AccountingTemplateService extends TenantAwareCrudService<Accounting
 			organizationId,
 			languageCode = themeLanguage
 		} = options;
-		// Try each fallback in order: org+tenant -> null org+null tenant -> english org+tenant -> english null
-		const fallbacks = [
-			{ languageCode, templateType, organizationId, tenantId },
-			{ languageCode, templateType, organizationId: null as any, tenantId: null as any },
-			{ languageCode: LanguagesEnum.ENGLISH, templateType, organizationId, tenantId },
-			{ languageCode: LanguagesEnum.ENGLISH, templateType, organizationId: null as any, tenantId: null as any }
+		// Try each fallback in order:
+		//   requested language, this tenant  ->  requested language, GLOBAL
+		//   English, this tenant             ->  English, GLOBAL
+		// A "global" template is the seeded row with tenantId IS NULL AND organizationId IS NULL. It is
+		// looked up with explicit NULL criteria on the raw repository (bypassing TenantAwareCrudService,
+		// which would pin the caller's tenant) — never with a literal `null`, which TypeORM used to drop
+		// from the SQL and thereby match another tenant's template (GHSA-44pv-34gx-q9p4).
+		const fallbacks: Array<{ languageCode: string; global: boolean }> = [
+			{ languageCode, global: false },
+			{ languageCode, global: true },
+			{ languageCode: LanguagesEnum.ENGLISH, global: false },
+			{ languageCode: LanguagesEnum.ENGLISH, global: true }
 		];
 
-		for (const where of fallbacks) {
+		for (const fallback of fallbacks) {
 			try {
-				let record: any;
-				// For null-tenant fallbacks, bypass TenantAwareCrudService scoping
-				if (where.tenantId === null) {
-					switch (this.ormType) {
-						case MultiORMEnum.MikroORM:
-							record = await this.mikroOrmRepository.findOne(where as any);
-							if (record) record = this.serialize(record);
-							break;
-						case MultiORMEnum.TypeORM:
-						default:
-							record = await this.typeOrmRepository.findOneBy(where as any);
-							break;
-					}
+				let record: IAccountingTemplate | null;
+				if (fallback.global) {
+					record = await this.findGlobalTemplate({ languageCode: fallback.languageCode, templateType });
 				} else {
-					record = await this.findOneByWhereOptions(where);
+					record = await this.findOneByWhereOptions(
+						tenantAccountingTemplateWhere({
+							languageCode: fallback.languageCode,
+							templateType,
+							tenantId,
+							organizationId
+						}) as FindOptionsWhere<AccountingTemplate>
+					);
 				}
 				if (record) return record;
 			} catch (error) {
@@ -227,6 +236,32 @@ export class AccountingTemplateService extends TenantAwareCrudService<Accounting
 		}
 
 		return null;
+	}
+
+	/**
+	 * Finds the GLOBAL (tenant-less, organization-less) template for a language/type pair.
+	 *
+	 * Runs on the raw repositories on purpose: TenantAwareCrudService would scope the lookup to the
+	 * caller's tenant, and the global row has no tenant. Both ORM branches pin `tenantId` AND
+	 * `organizationId` to `IS NULL` — see accounting-template.criteria.ts.
+	 *
+	 * @param lookup - The language code and template type to look up.
+	 * @returns The global template, or null when none is seeded for that pair.
+	 */
+	private async findGlobalTemplate(lookup: IAccountingTemplateLookup): Promise<IAccountingTemplate | null> {
+		switch (this.ormType) {
+			case MultiORMEnum.MikroORM: {
+				const record = await this.mikroOrmRepository.findOne(
+					globalAccountingTemplateMikroWhere(lookup) as MikroFilterQuery<AccountingTemplate>
+				);
+				return record ? this.serialize(record) : null;
+			}
+			case MultiORMEnum.TypeORM:
+			default:
+				return await this.typeOrmRepository.findOneBy(
+					globalAccountingTemplateWhere(lookup) as FindOptionsWhere<AccountingTemplate>
+				);
+		}
 	}
 
 	/**

--- a/packages/core/src/lib/auth/oauth-client/oauth-client.service.ts
+++ b/packages/core/src/lib/auth/oauth-client/oauth-client.service.ts
@@ -218,6 +218,11 @@ export class OAuthClientService extends TenantAwareCrudService<OAuthClient> {
 					]
 				: { ...baseWhere, tenantId: IsNull() };
 		} else {
+			// A non-super-admin without a tenant context has nothing to list (a null tenantId used to be
+			// dropped from the where and listed EVERY tenant's clients).
+			if (!tenantId) {
+				return { items: [], total: 0 };
+			}
 			where = { ...baseWhere, tenantId };
 		}
 

--- a/packages/core/src/lib/auth/strategies/jwt.strategy.spec.ts
+++ b/packages/core/src/lib/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,69 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+// The strategy only needs these for DI metadata; loading the real modules drags in the whole core
+// entity graph, which cannot be required in isolation (pre-existing circular import).
+jest.mock('../auth.service', () => ({ AuthService: class AuthService {} }));
+jest.mock('../../employee/employee.service', () => ({ EmployeeService: class EmployeeService {} }));
+jest.mock('../../user-organization/user-organization.services', () => ({
+	UserOrganizationService: class UserOrganizationService {}
+}));
+
+import { JwtStrategy } from './jwt.strategy';
+
+/**
+ * Regression suite for the id-less JWT acceptance bug (found while fixing GHSA-44pv-34gx-q9p4).
+ *
+ * Every JWT signed with JWT_SECRET reaches JwtStrategy.validate — including invite, estimate, team-join,
+ * appointment and magic-code tokens, none of which carry an `id` claim. The lookup then ran
+ * `findOneBy({ id: undefined })`, which TypeORM turns into `SELECT ... LIMIT 1`, so such a token
+ * authenticated as the FIRST user in the table. The strategy must refuse a payload that names no user.
+ */
+describe('JwtStrategy.validate', () => {
+	const firstUser = { id: 'first-user', tenantId: 'tenant', email: 'admin@ever.co' };
+
+	function build() {
+		const authService = { getAuthenticatedUser: jest.fn(async () => firstUser) };
+		const employeeService = { findOneByIdString: jest.fn() };
+		const userOrganizationService = { findOneByOptions: jest.fn() };
+		const strategy = new JwtStrategy(authService as any, employeeService as any, userOrganizationService as any);
+		return { strategy, authService };
+	}
+
+	async function run(strategy: JwtStrategy, payload: any) {
+		let result: { err: unknown; user: unknown } | undefined;
+		await strategy.validate(payload, (err, user) => {
+			result = { err, user };
+		});
+		return result!;
+	}
+
+	it.each([
+		['an invite token', { email: 'invitee@ever.co', code: '123456' }],
+		['an estimate-email token', { invoiceId: 'inv', organizationId: 'org', tenantId: 'tenant', email: 'x@y.z' }],
+		['a team-join token', { email: 'x@y.z', tenantId: 't', organizationId: 'o', organizationTeamId: 'team', code: 'c' }],
+		['an appointment token', { appointmentId: 'appointment-1' }],
+		['a magic-code token (userId, not id)', { userId: 'u', email: 'x@y.z', tenantId: 't', code: 'c' }],
+		['an empty payload', {}]
+	])('rejects %s without touching the user store', async (_label, payload) => {
+		const { strategy, authService } = build();
+		const { err, user } = await run(strategy, payload);
+		expect(err).toBeInstanceOf(UnauthorizedException);
+		expect(user).toBe(false);
+		expect(authService.getAuthenticatedUser).not.toHaveBeenCalled();
+	});
+
+	it('still authenticates a real access token (id claim)', async () => {
+		const { strategy, authService } = build();
+		const { err, user } = await run(strategy, { id: 'first-user', tenantId: 'tenant' });
+		expect(err).toBeNull();
+		expect(user).toMatchObject({ id: 'first-user' });
+		expect(authService.getAuthenticatedUser).toHaveBeenCalledWith('first-user', undefined);
+	});
+
+	it('still authenticates a third-party token (thirdPartyId claim)', async () => {
+		const { strategy, authService } = build();
+		const { err } = await run(strategy, { thirdPartyId: 'github-1' });
+		expect(err).toBeNull();
+		expect(authService.getAuthenticatedUser).toHaveBeenCalledWith(undefined, 'github-1');
+	});
+});

--- a/packages/core/src/lib/auth/strategies/jwt.strategy.ts
+++ b/packages/core/src/lib/auth/strategies/jwt.strategy.ts
@@ -38,6 +38,14 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
 				this.logger.debug(`Validate JWT payload for user: ${payload?.id}`);
 			}
 
+			// An access token identifies its user by `id` (or `thirdPartyId`). Other JWTs are signed
+			// with the same JWT_SECRET but carry no such claim (invite, estimate, team-join,
+			// appointment, magic-code tokens); a lookup by an undefined id used to fall through to
+			// the FIRST user in the table, so such a token authenticated as that user. Reject them here.
+			if (!id && !thirdPartyId) {
+				return done(new UnauthorizedException('unauthorized'), false);
+			}
+
 			// We use this to also attach the user object to the request context.
 			const user: IUser = await this._authService.getAuthenticatedUser(id, thirdPartyId);
 

--- a/packages/core/src/lib/broadcast/broadcast.service.ts
+++ b/packages/core/src/lib/broadcast/broadcast.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource, FindManyOptions, FindOptionsWhere, In, UpdateResult } from 'typeorm';
 import {
@@ -15,6 +15,7 @@ import {
 	IEmployee,
 	IPagination,
 	NotificationActionTypeEnum,
+	PermissionsEnum,
 	RolesEnum
 } from '@gauzy/contracts';
 import { BaseQueryDTO, TenantAwareCrudService } from '../core/crud';
@@ -116,14 +117,18 @@ export class BroadcastService extends TenantAwareCrudService<Broadcast> {
 		try {
 			const tenantId = RequestContext.currentTenantId();
 			const employeeId = RequestContext.currentEmployeeId();
+			const canChangeSelectedEmployee = RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE);
 
-			// Find the broadcast for the current employee with the given id. The employee restriction
-			// only applies to callers that HAVE an employee identity here: for CHANGE_SELECTED_EMPLOYEE
-			// holders currentEmployeeId() is null and they may edit any broadcast of the tenant (spelled
-			// out — a null key was previously just dropped from the query).
+			// Find the broadcast for the current employee with the given id. Callers holding
+			// CHANGE_SELECTED_EMPLOYEE may edit any broadcast of the tenant; everyone else must be the
+			// publisher — and therefore must have an employee identity (a null key was previously just
+			// dropped from the query, which let employee-less callers edit anything).
+			if (!canChangeSelectedEmployee && !employeeId) {
+				throw new ForbiddenException(`You don't have permission to update this broadcast`);
+			}
 			const originalBroadcast = await this.findOneByWhereOptions({
 				id,
-				...(employeeId ? { employeeId } : {})
+				...(canChangeSelectedEmployee ? {} : { employeeId })
 			});
 
 			if (!originalBroadcast) {
@@ -154,6 +159,9 @@ export class BroadcastService extends TenantAwareCrudService<Broadcast> {
 
 			return updatedBroadcast;
 		} catch (error) {
+			if (error instanceof ForbiddenException) {
+				throw error;
+			}
 			console.log(`Error while updating broadcast: ${error.message}`, error);
 			throw new BadRequestException('Broadcast update failed', error);
 		}

--- a/packages/core/src/lib/broadcast/broadcast.service.ts
+++ b/packages/core/src/lib/broadcast/broadcast.service.ts
@@ -12,6 +12,7 @@ import {
 	IBroadcastCreateInput,
 	IBroadcastUpdateInput,
 	ID,
+	IEmployee,
 	IPagination,
 	NotificationActionTypeEnum,
 	RolesEnum
@@ -55,13 +56,19 @@ export class BroadcastService extends TenantAwareCrudService<Broadcast> {
 		try {
 			// Retrieve context-specific IDs
 			const tenantId = RequestContext.currentTenantId() ?? input.tenantId;
+			// null for CHANGE_SELECTED_EMPLOYEE holders and non-employee users: such publishers create
+			// publisher-less broadcasts (the long-standing behavior). Only validate a real employee id —
+			// a lookup by an empty id must not (and no longer can) pass on the strength of an arbitrary row.
 			const employeeId = RequestContext.currentEmployeeId();
 			const { organizationId, ...data } = input;
 
 			// Validate that the employee exists
-			const employee = await this._employeeService.findOneByIdString(employeeId);
-			if (!employee) {
-				throw new NotFoundException(`Employee with id ${employeeId} not found`);
+			let employee: IEmployee | undefined;
+			if (employeeId) {
+				employee = await this._employeeService.findOneByIdString(employeeId);
+				if (!employee) {
+					throw new NotFoundException(`Employee with id ${employeeId} not found`);
+				}
 			}
 
 			// Create the broadcast with publishedAt defaulting to now if not provided
@@ -110,10 +117,13 @@ export class BroadcastService extends TenantAwareCrudService<Broadcast> {
 			const tenantId = RequestContext.currentTenantId();
 			const employeeId = RequestContext.currentEmployeeId();
 
-			// Find the broadcast for the current employee with the given id
+			// Find the broadcast for the current employee with the given id. The employee restriction
+			// only applies to callers that HAVE an employee identity here: for CHANGE_SELECTED_EMPLOYEE
+			// holders currentEmployeeId() is null and they may edit any broadcast of the tenant (spelled
+			// out — a null key was previously just dropped from the query).
 			const originalBroadcast = await this.findOneByWhereOptions({
 				id,
-				employeeId
+				...(employeeId ? { employeeId } : {})
 			});
 
 			if (!originalBroadcast) {
@@ -334,14 +344,16 @@ export class BroadcastService extends TenantAwareCrudService<Broadcast> {
 			// Load the entity with its members/employees relation
 			const repository = this.dataSource.getRepository(entity);
 
+			// Only include organizationId for non-Organization entities, and only when one is known —
+			// currentOrganizationId() is null for tokens without an organization claim.
+			const scopeOrganizationId = organizationId || RequestContext.currentOrganizationId();
 			const entityWithMembers = await repository.findOne({
 				where: {
 					id: entityId,
 					tenantId,
-					// Only include organizationId for non-Organization entities
-					...(entity !== BaseEntityEnum.Organization && {
-						organizationId: organizationId || RequestContext.currentOrganizationId()
-					})
+					...(entity !== BaseEntityEnum.Organization && scopeOrganizationId
+						? { organizationId: scopeOrganizationId }
+						: {})
 				},
 				relations: parseFindOptionsRelations([relationName])
 			});

--- a/packages/core/src/lib/comment/comment.service.ts
+++ b/packages/core/src/lib/comment/comment.service.ts
@@ -48,13 +48,20 @@ export class CommentService extends TenantAwareCrudService<Comment> {
 		try {
 			// Retrieve context-specific IDs.
 			const tenantId = RequestContext.currentTenantId() ?? input.tenantId;
-			const employeeId = RequestContext.currentEmployeeId() ?? input.employeeId;
+			// The author is the caller's own employee. RequestContext.currentEmployeeId() is deliberately
+			// null for CHANGE_SELECTED_EMPLOYEE holders, so fall back to the JWT user's employee before the
+			// body value; a caller with no employee identity at all posts an author-less comment (as before).
+			const employeeId =
+				RequestContext.currentEmployeeId() ?? RequestContext.currentUser()?.employeeId ?? input.employeeId;
 			const { mentionEmployeeIds = [], organizationId, ...data } = input;
 
-			// Validate that the employee exists.
-			const employee = await this._employeeService.findOneByIdString(employeeId);
-			if (!employee) {
-				throw new NotFoundException(`Employee with id ${employeeId} not found`);
+			// Validate that the employee exists (only a real id can be looked up — an empty one used to
+			// match an arbitrary employee and pass vacuously).
+			if (employeeId) {
+				const employee = await this._employeeService.findOneByIdString(employeeId);
+				if (!employee) {
+					throw new NotFoundException(`Employee with id ${employeeId} not found`);
+				}
 			}
 
 			// Create the comment.
@@ -119,10 +126,12 @@ export class CommentService extends TenantAwareCrudService<Comment> {
 			const employeeId = RequestContext.currentEmployeeId();
 			const { mentionEmployeeIds = [] } = input;
 
-			// Find the comment for the current employee with the given id.
+			// Find the comment for the current employee with the given id. Callers holding
+			// CHANGE_SELECTED_EMPLOYEE (currentEmployeeId() is null for them) may edit any comment of the
+			// tenant — spelled out here; a null key was previously just dropped from the query.
 			const comment = await this.findOneByWhereOptions({
 				id,
-				employeeId
+				...(employeeId ? { employeeId } : {})
 			});
 
 			if (!comment) {

--- a/packages/core/src/lib/comment/comment.service.ts
+++ b/packages/core/src/lib/comment/comment.service.ts
@@ -1,5 +1,5 @@
 import { EventBus } from '@nestjs/cqrs';
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { UpdateResult } from 'typeorm';
 import {
 	BaseEntityEnum,
@@ -7,7 +7,8 @@ import {
 	IComment,
 	ICommentCreateInput,
 	ICommentUpdateInput,
-	ID
+	ID,
+	PermissionsEnum
 } from '@gauzy/contracts';
 import { TenantAwareCrudService } from './../core/crud';
 import { RequestContext } from '../core/context';
@@ -124,14 +125,19 @@ export class CommentService extends TenantAwareCrudService<Comment> {
 	async update(id: ID, input: ICommentUpdateInput): Promise<IComment | UpdateResult> {
 		try {
 			const employeeId = RequestContext.currentEmployeeId();
+			const canChangeSelectedEmployee = RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE);
 			const { mentionEmployeeIds = [] } = input;
 
 			// Find the comment for the current employee with the given id. Callers holding
-			// CHANGE_SELECTED_EMPLOYEE (currentEmployeeId() is null for them) may edit any comment of the
-			// tenant — spelled out here; a null key was previously just dropped from the query.
+			// CHANGE_SELECTED_EMPLOYEE may edit any comment of the tenant; everyone else must be the
+			// author — and therefore must have an employee identity (a null key was previously just
+			// dropped from the query, which let employee-less callers edit anything).
+			if (!canChangeSelectedEmployee && !employeeId) {
+				throw new ForbiddenException(`You don't have permission to update this comment`);
+			}
 			const comment = await this.findOneByWhereOptions({
 				id,
-				...(employeeId ? { employeeId } : {})
+				...(canChangeSelectedEmployee ? {} : { employeeId })
 			});
 
 			if (!comment) {
@@ -155,6 +161,9 @@ export class CommentService extends TenantAwareCrudService<Comment> {
 
 			return updatedComment;
 		} catch (error) {
+			if (error instanceof ForbiddenException) {
+				throw error;
+			}
 			console.log(`Error while updating comment: ${error.message}`, error);
 			throw new BadRequestException('Comment update failed', error);
 		}

--- a/packages/core/src/lib/core/crud/criteria.helper.spec.ts
+++ b/packages/core/src/lib/core/crud/criteria.helper.spec.ts
@@ -1,0 +1,85 @@
+import { BadRequestException } from '@nestjs/common';
+import { DataSource, EntitySchema, In, IsNull, Repository } from 'typeorm';
+import { assertCriteriaHasPredicate } from './criteria.helper';
+
+/**
+ * TypeORM refuses `{}` for update/delete but not `{ key: undefined }` — and an undefined where value
+ * is (and must stay) omitted from the SQL, so that shape produced an UNFILTERED DELETE / UPDATE.
+ * The guard closes it; the DataSource half of this suite proves the shape really is a full-table
+ * statement, so the guard is known to be load-bearing rather than theoretical.
+ */
+describe('assertCriteriaHasPredicate', () => {
+	it.each([
+		['undefined', undefined],
+		['null', null],
+		['empty string', ''],
+		['an object whose only value is undefined', { employeeId: undefined }],
+		['an object whose values are all undefined', { employeeId: undefined, organizationId: undefined }],
+		['an empty object', {}]
+	])('rejects %s', (_label, criteria) => {
+		expect(() => assertCriteriaHasPredicate(criteria, 'delete')).toThrow(BadRequestException);
+	});
+
+	it.each([
+		['an id string', 'a1b2'],
+		['an id number', 42],
+		['a where with one defined value', { employeeId: 'emp', organizationId: undefined }],
+		['a null value (a real IS NULL predicate)', { organizationId: null }],
+		['a find operator', { id: In(['a', 'b']) }],
+		['an IsNull() operator', { deletedAt: IsNull() }],
+		['an array of ids', ['a', 'b']]
+	])('accepts %s', (_label, criteria) => {
+		expect(() => assertCriteriaHasPredicate(criteria, 'delete')).not.toThrow();
+	});
+});
+
+describe('why the guard exists — TypeORM 1.0 with an all-undefined criteria object', () => {
+	const RowSchema = new EntitySchema({
+		name: 'Row',
+		tableName: 'row',
+		columns: {
+			id: { primary: true, type: 'varchar', generated: 'uuid' },
+			employeeId: { type: 'varchar', nullable: true },
+			flag: { type: 'boolean', default: false }
+		}
+	});
+	let dataSource: DataSource;
+	let rows: Repository<any>;
+
+	beforeAll(async () => {
+		dataSource = new DataSource({
+			type: 'better-sqlite3',
+			database: ':memory:',
+			entities: [RowSchema],
+			synchronize: true,
+			logging: false,
+			invalidWhereValuesBehavior: { null: 'sql-null', undefined: 'ignore' }
+		});
+		await dataSource.initialize();
+		rows = dataSource.getRepository('Row');
+	});
+	afterAll(async () => {
+		if (dataSource?.isInitialized) await dataSource.destroy();
+	});
+	beforeEach(async () => {
+		await rows.clear();
+		await rows.save([{ employeeId: 'a' }, { employeeId: 'b' }, { employeeId: null }]);
+	});
+
+	it('CONTROL: repository.delete({ employeeId: undefined }) wipes the whole table', async () => {
+		const { affected } = await rows.delete({ employeeId: undefined });
+		expect(affected).toBe(3);
+		expect(await rows.count()).toBe(0);
+	});
+
+	it('CONTROL: repository.update({ employeeId: undefined }, ...) touches every row', async () => {
+		const { affected } = await rows.update({ employeeId: undefined }, { flag: true });
+		expect(affected).toBe(3);
+	});
+
+	it('a null value is a real predicate (IS NULL) under the shipped setting', async () => {
+		const { affected } = await rows.delete({ employeeId: null });
+		expect(affected).toBe(1);
+		expect(await rows.count()).toBe(2);
+	});
+});

--- a/packages/core/src/lib/core/crud/criteria.helper.spec.ts
+++ b/packages/core/src/lib/core/crud/criteria.helper.spec.ts
@@ -15,6 +15,9 @@ describe('assertCriteriaHasPredicate', () => {
 		['empty string', ''],
 		['an object whose only value is undefined', { employeeId: undefined }],
 		['an object whose values are all undefined', { employeeId: undefined, organizationId: undefined }],
+		['a nested relation criteria whose leaves are all undefined', { employee: { id: undefined } }],
+		['a nested embedded criteria with an empty object', { members: {} }],
+		['an OR-array whose branches carry no predicate', [{ id: undefined }, { employee: { id: undefined } }]],
 		['an empty object', {}]
 	])('rejects %s', (_label, criteria) => {
 		expect(() => assertCriteriaHasPredicate(criteria, 'delete')).toThrow(BadRequestException);
@@ -27,6 +30,8 @@ describe('assertCriteriaHasPredicate', () => {
 		['a null value (a real IS NULL predicate)', { organizationId: null }],
 		['a find operator', { id: In(['a', 'b']) }],
 		['an IsNull() operator', { deletedAt: IsNull() }],
+		['a nested relation criteria with a real leaf', { employee: { id: 'emp' }, organizationId: undefined }],
+		['an OR-array with one usable branch', [{ id: undefined }, { employeeId: 'emp' }]],
 		['an array of ids', ['a', 'b']]
 	])('accepts %s', (_label, criteria) => {
 		expect(() => assertCriteriaHasPredicate(criteria, 'delete')).not.toThrow();

--- a/packages/core/src/lib/core/crud/criteria.helper.ts
+++ b/packages/core/src/lib/core/crud/criteria.helper.ts
@@ -1,13 +1,42 @@
 import { BadRequestException } from '@nestjs/common';
+import { FindOperator } from 'typeorm';
+
+/**
+ * Whether a criteria VALUE contributes at least one usable predicate once TypeORM has omitted every
+ * `undefined` leaf. Find operators and dates are atomic predicates; a nested object (relation /
+ * embedded criteria) counts only if one of its own leaves does; an array (an OR of criteria) counts
+ * only if one of its branches does.
+ */
+function hasPredicate(value: unknown): boolean {
+	if (value === undefined) {
+		return false;
+	}
+	if (value === null) {
+		// A real predicate under TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR (`IS NULL`).
+		return true;
+	}
+	if (value instanceof FindOperator || value instanceof Date) {
+		return true;
+	}
+	if (Array.isArray(value)) {
+		return value.length > 0 && value.some((item) => hasPredicate(item));
+	}
+	if (typeof value === 'object') {
+		return Object.values(value as Record<string, unknown>).some((nested) => hasPredicate(nested));
+	}
+	return true;
+}
 
 /**
  * Rejects `update` / `delete` / `softDelete` criteria that carry no usable predicate.
  *
  * TypeORM refuses `undefined`, `null`, `''`, `[]` and `{}` itself, but it does NOT refuse an object
- * whose values are all `undefined` — and, because an `undefined` where value is (and must remain)
- * omitted from the SQL, `{ employeeId: undefined }` produced an UNFILTERED `DELETE FROM ...` /
- * `UPDATE ... SET ...` over the whole table. A missing request field or an absent
- * RequestContext id is all it took (GHSA-44pv-34gx-q9p4 class). Fail closed instead.
+ * whose leaves are all `undefined` — and, because an `undefined` where value is (and must remain)
+ * omitted from the SQL, `{ employeeId: undefined }` — or the nested `{ employee: { id: undefined } }` —
+ * produced an UNFILTERED `DELETE FROM ...` / `UPDATE ... SET ...` over the whole table. A missing
+ * request field or an absent RequestContext id is all it took (GHSA-44pv-34gx-q9p4 class). Fail
+ * closed instead. The check is recursive: relation / embedded objects and OR-arrays are only accepted
+ * when at least one leaf survives.
  *
  * `null` values are left alone: under TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR they are a real
  * predicate (`IS NULL`).
@@ -19,9 +48,8 @@ export function assertCriteriaHasPredicate(criteria: unknown, method: string): v
 	if (criteria === undefined || criteria === null || criteria === '') {
 		throw new BadRequestException(`Empty criteria(s) are not allowed for the ${method} method.`);
 	}
-	if (typeof criteria === 'object' && !Array.isArray(criteria) && !(criteria instanceof Date)) {
-		const hasPredicate = Object.values(criteria as Record<string, unknown>).some((value) => value !== undefined);
-		if (!hasPredicate) {
+	if (typeof criteria === 'object' && !(criteria instanceof Date) && !(criteria instanceof FindOperator)) {
+		if (!hasPredicate(criteria)) {
 			throw new BadRequestException(`Empty criteria(s) are not allowed for the ${method} method.`);
 		}
 	}

--- a/packages/core/src/lib/core/crud/criteria.helper.ts
+++ b/packages/core/src/lib/core/crud/criteria.helper.ts
@@ -1,0 +1,28 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * Rejects `update` / `delete` / `softDelete` criteria that carry no usable predicate.
+ *
+ * TypeORM refuses `undefined`, `null`, `''`, `[]` and `{}` itself, but it does NOT refuse an object
+ * whose values are all `undefined` — and, because an `undefined` where value is (and must remain)
+ * omitted from the SQL, `{ employeeId: undefined }` produced an UNFILTERED `DELETE FROM ...` /
+ * `UPDATE ... SET ...` over the whole table. A missing request field or an absent
+ * RequestContext id is all it took (GHSA-44pv-34gx-q9p4 class). Fail closed instead.
+ *
+ * `null` values are left alone: under TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR they are a real
+ * predicate (`IS NULL`).
+ *
+ * @param criteria - The id / where-object handed to the write method.
+ * @param method - Name of the calling method, for the error message.
+ */
+export function assertCriteriaHasPredicate(criteria: unknown, method: string): void {
+	if (criteria === undefined || criteria === null || criteria === '') {
+		throw new BadRequestException(`Empty criteria(s) are not allowed for the ${method} method.`);
+	}
+	if (typeof criteria === 'object' && !Array.isArray(criteria) && !(criteria instanceof Date)) {
+		const hasPredicate = Object.values(criteria as Record<string, unknown>).some((value) => value !== undefined);
+		if (!hasPredicate) {
+			throw new BadRequestException(`Empty criteria(s) are not allowed for the ${method} method.`);
+		}
+	}
+}

--- a/packages/core/src/lib/core/crud/crud.service.ts
+++ b/packages/core/src/lib/core/crud/crud.service.ts
@@ -621,8 +621,9 @@ export abstract class CrudService<T extends BaseEntity> implements ICrudService<
 	 * @returns
 	 */
 	public async update(id: IUpdateCriteria<T>, partialEntity: QueryDeepPartialEntity<T>): Promise<UpdateResult | T> {
+		// Outside the try: a malformed criteria is a 400 of its own, not a wrapped DB error.
+		assertCriteriaHasPredicate(id, 'update');
 		try {
-			assertCriteriaHasPredicate(id, 'update');
 			switch (this.ormType) {
 				case MultiORMEnum.MikroORM:
 					let where: MikroFilterQuery<T>;
@@ -656,8 +657,9 @@ export abstract class CrudService<T extends BaseEntity> implements ICrudService<
 	 * @returns {Promise<DeleteResult>} - Result indicating the number of affected records.
 	 */
 	public async delete(criteria: string | number | FindOptionsWhere<T>): Promise<DeleteResult> {
+		// Outside the try: a malformed criteria is a 400 of its own, not a wrapped not-found.
+		assertCriteriaHasPredicate(criteria, 'delete');
 		try {
-			assertCriteriaHasPredicate(criteria, 'delete');
 			switch (this.ormType) {
 				case MultiORMEnum.MikroORM:
 					// Determine the appropriate filter for MikroORM based on the criteria type
@@ -724,8 +726,9 @@ export abstract class CrudService<T extends BaseEntity> implements ICrudService<
 	 * @returns {Promise<UpdateResult | DeleteResult>} - Result indicating success or failure.
 	 */
 	public async softDelete(criteria: string | number | FindOptionsWhere<T>): Promise<UpdateResult | T> {
+		// Outside the try: a malformed criteria is a 400 of its own, not a wrapped not-found.
+		assertCriteriaHasPredicate(criteria, 'softDelete');
 		try {
-			assertCriteriaHasPredicate(criteria, 'softDelete');
 			switch (this.ormType) {
 				case MultiORMEnum.MikroORM:
 					// Determine the appropriate filter for MikroORM based on the criteria type

--- a/packages/core/src/lib/core/crud/crud.service.ts
+++ b/packages/core/src/lib/core/crud/crud.service.ts
@@ -33,6 +33,7 @@ import {
 	parseTypeORMFindToMikroOrm
 } from './../../core/utils';
 import { parseTypeORMFindCountOptions } from './utils';
+import { assertCriteriaHasPredicate } from './criteria.helper';
 import {
 	ICountByOptions,
 	ICountOptions,
@@ -248,6 +249,12 @@ export abstract class CrudService<T extends BaseEntity> implements ICrudService<
 	 */
 	public async findOneOrFailByIdString(id: string, options?: IFindOneOptions<T>): Promise<ITryRequest<T>> {
 		try {
+			// A lookup "by id" with no id must not become a lookup for ANY row: TypeORM omits an
+			// undefined where value (and used to omit null), so `where: { id }` degraded to
+			// `SELECT ... LIMIT 1` and returned an arbitrary record (GHSA-44pv-34gx-q9p4 class).
+			if (!id) {
+				throw new NotFoundException(`The requested record was not found`);
+			}
 			let record: T;
 			switch (this.ormType) {
 				case MultiORMEnum.MikroORM:
@@ -368,6 +375,10 @@ export abstract class CrudService<T extends BaseEntity> implements ICrudService<
 	 * @returns
 	 */
 	public async findOneByIdString(id: ID, options?: IFindOneOptions<T>): Promise<T> {
+		// See findOneOrFailByIdString: an empty id must fail closed, never match an arbitrary row.
+		if (!id) {
+			throw new NotFoundException(`The requested record was not found`);
+		}
 		let record: T;
 
 		switch (this.ormType) {
@@ -611,6 +622,7 @@ export abstract class CrudService<T extends BaseEntity> implements ICrudService<
 	 */
 	public async update(id: IUpdateCriteria<T>, partialEntity: QueryDeepPartialEntity<T>): Promise<UpdateResult | T> {
 		try {
+			assertCriteriaHasPredicate(id, 'update');
 			switch (this.ormType) {
 				case MultiORMEnum.MikroORM:
 					let where: MikroFilterQuery<T>;
@@ -645,6 +657,7 @@ export abstract class CrudService<T extends BaseEntity> implements ICrudService<
 	 */
 	public async delete(criteria: string | number | FindOptionsWhere<T>): Promise<DeleteResult> {
 		try {
+			assertCriteriaHasPredicate(criteria, 'delete');
 			switch (this.ormType) {
 				case MultiORMEnum.MikroORM:
 					// Determine the appropriate filter for MikroORM based on the criteria type
@@ -712,6 +725,7 @@ export abstract class CrudService<T extends BaseEntity> implements ICrudService<
 	 */
 	public async softDelete(criteria: string | number | FindOptionsWhere<T>): Promise<UpdateResult | T> {
 		try {
+			assertCriteriaHasPredicate(criteria, 'softDelete');
 			switch (this.ormType) {
 				case MultiORMEnum.MikroORM:
 					// Determine the appropriate filter for MikroORM based on the criteria type

--- a/packages/core/src/lib/core/crud/index.ts
+++ b/packages/core/src/lib/core/crud/index.ts
@@ -1,6 +1,7 @@
 export * from './crud.factory';
 export * from './crud.controller';
 export * from './crud.service';
+export * from './criteria.helper';
 export * from './icrud.controller';
 export * from '../dto/base-query.dto';
 export * from './tenant-aware-crud.service';

--- a/packages/core/src/lib/core/crud/tenant-aware-crud.service.ts
+++ b/packages/core/src/lib/core/crud/tenant-aware-crud.service.ts
@@ -8,6 +8,7 @@ import { MikroOrmBaseEntityRepository } from '../../core/repository/mikro-orm-ba
 import { RequestContext } from '../context';
 import { TenantBaseEntity } from '../entities/internal';
 import { CrudService } from './crud.service';
+import { assertCriteriaHasPredicate } from './criteria.helper';
 import { ICrudService, IPartialEntity } from './icrud.service';
 import { ITryRequest } from './try-request';
 
@@ -527,6 +528,11 @@ export abstract class TenantAwareCrudService<T extends TenantBaseEntity>
 			if (options?.where) {
 				where = { ...where, ...options.where };
 			}
+
+			// The caller's criteria must select rows on its own BEFORE tenant scoping is merged in:
+			// `delete({ employeeId: undefined })` would otherwise pass CrudService's guard on the strength
+			// of the injected tenantId alone and delete every row of the tenant.
+			assertCriteriaHasPredicate(where, 'delete');
 
 			const user = RequestContext.currentUser();
 

--- a/packages/core/src/lib/core/crud/tenant-aware-crud.service.ts
+++ b/packages/core/src/lib/core/crud/tenant-aware-crud.service.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { DeleteResult, FindOptionsWhere, In, Repository, UpdateResult } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { ID, IPagination, IUser, PermissionsEnum } from '@gauzy/contracts';
@@ -542,6 +542,10 @@ export abstract class TenantAwareCrudService<T extends TenantBaseEntity>
 				...this.findConditionsWithTenantByUser(user)
 			});
 		} catch (err) {
+			// A malformed criteria (no predicate) is the caller's error, not a missing record.
+			if (err instanceof BadRequestException) {
+				throw err;
+			}
 			console.error('Error during delete operation:', err);
 			throw new NotFoundException(`The record was not found`, err);
 		}

--- a/packages/core/src/lib/email-reset/email-reset.service.ts
+++ b/packages/core/src/lib/email-reset/email-reset.service.ts
@@ -1,7 +1,7 @@
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { IsNull, MoreThanOrEqual, SelectQueryBuilder } from 'typeorm';
-import { IEmailReset, IEmailResetFindInput, LanguagesEnum } from '@gauzy/contracts';
+import { IEmailReset, IEmailResetFindInput, IOrganization, LanguagesEnum } from '@gauzy/contracts';
 import { generateAlphaNumericCode } from '@gauzy/utils';
 import { RequestContext } from '../core/context';
 import { UserService } from '../user/user.service';
@@ -66,11 +66,23 @@ export class EmailResetService extends TenantAwareCrudService<EmailReset> {
 				})
 			);
 
-			const employee = await this.employeeService.findOneByIdString(user.employeeId, {
-				relations: { organization: true }
-			});
-
-			const { organization } = employee;
+			// The mail is branded/sent through the user's organization. Users without an employee record
+			// (admins, other non-employee roles) have no employee to look up — an empty id must not be
+			// looked up (it used to match an arbitrary employee and borrow THAT organization's SMTP);
+			// fall back to the caller's current organization / tenant instead.
+			let organization: IOrganization | undefined;
+			if (user.employeeId) {
+				const employee = await this.employeeService.findOneByIdString(user.employeeId, {
+					relations: { organization: true }
+				});
+				organization = employee?.organization;
+			}
+			if (!organization) {
+				organization = {
+					id: RequestContext.currentOrganizationId() ?? undefined,
+					tenantId: user.tenantId
+				} as IOrganization;
+			}
 
 			this.emailService.emailReset(
 				{

--- a/packages/core/src/lib/email-send/email-template-render.service.ts
+++ b/packages/core/src/lib/email-send/email-template-render.service.ts
@@ -72,8 +72,10 @@ export class EmailTemplateRenderService {
 			});
 
 			if (!!isValidSmtp) {
-				query['organizationId'] = locals.organizationId;
-				query['tenantId'] = locals.tenantId;
+				// Same NULL handling as the SMTP lookup above: a missing organization / tenant selects
+				// the tenant-wide / global row, never "any organization's" template.
+				query['organizationId'] = isEmpty(locals.organizationId) ? IsNull() : locals.organizationId;
+				query['tenantId'] = isEmpty(locals.tenantId) ? IsNull() : locals.tenantId;
 
 				emailTemplate = await this.typeOrmEmailTemplateRepository.findOneBy(query);
 			}

--- a/packages/core/src/lib/email-send/email.service.ts
+++ b/packages/core/src/lib/email-send/email.service.ts
@@ -1107,12 +1107,15 @@ export class EmailService {
 	 * @returns A promise that resolves to the updated email history record.
 	 */
 	async resendEmail(id: ID, input: IResendEmailInput, languageCode: LanguagesEnum): Promise<IEmailHistory> {
-		// Destructure the organization and tenant IDs from the input.
-		const { organizationId, tenantId } = input;
+		// The tenant comes from the authenticated request, never from the body: this is a raw
+		// repository lookup (no TenantAwareCrudService scoping), and a missing/null body tenantId
+		// would otherwise drop the tenant predicate entirely (GHSA-44pv-34gx-q9p4 class).
+		const tenantId = RequestContext.currentTenantId();
+		const { organizationId } = input;
 
 		// Fetch the email history record with its associated email template and organization.
 		const emailHistory = await this.typeOrmEmailHistoryRepository.findOne({
-			where: { id, organizationId, tenantId },
+			where: { id, tenantId, ...(organizationId ? { organizationId } : {}) },
 			relations: { emailTemplate: true, organization: true }
 		});
 

--- a/packages/core/src/lib/email-template/commands/handlers/email-template.save.handler.ts
+++ b/packages/core/src/lib/email-template/commands/handlers/email-template.save.handler.ts
@@ -1,4 +1,6 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { IsNull } from 'typeorm';
+import { isEmpty } from '@gauzy/utils';
 import { EmailTemplateSaveCommand } from '../email-template.save.command';
 import { EmailTemplateService } from '../../email-template.service';
 import { EmailTemplate } from '../../email-template.entity';
@@ -66,8 +68,11 @@ export class EmailTemplateSaveHandler
 		} = await this.emailTemplateService.findOneOrFailByWhereOptions({
 			languageCode,
 			name: `${name}/${type}`,
-			organizationId,
-			tenantId
+			// No organization means the tenant-wide row (organizationId IS NULL) — never "any
+			// organization": EmailTemplateService is not tenant-scoped, and a dropped predicate here
+			// would pick (and then overwrite) another organization's template of the same name.
+			organizationId: isEmpty(organizationId) ? IsNull() : organizationId,
+			tenantId: isEmpty(tenantId) ? IsNull() : tenantId
 		});
 
 		let entity: IEmailTemplate;

--- a/packages/core/src/lib/email-template/email-template.service.ts
+++ b/packages/core/src/lib/email-template/email-template.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { Brackets, SelectQueryBuilder, WhereExpressionBuilder } from 'typeorm';
+import { Brackets, IsNull, SelectQueryBuilder, WhereExpressionBuilder } from 'typeorm';
 import * as mjml2html from 'mjml';
 import { EmailTemplateEnum, IEmailTemplate, IPagination, LanguagesEnum } from '@gauzy/contracts';
-import { isNotEmpty } from '@gauzy/utils';
+import { isEmpty, isNotEmpty } from '@gauzy/utils';
 import { EmailTemplate } from './email-template.entity';
 import { CrudService, BaseQueryDTO } from './../core/crud';
 import { MultiORMEnum } from './../core/utils';
@@ -131,11 +131,15 @@ export class EmailTemplateService extends CrudService<EmailTemplate> {
 	): Promise<IEmailTemplate> {
 		let entity: IEmailTemplate;
 		try {
+			// A missing organization / tenant means the GLOBAL template row (IS NULL) — say so with the
+			// explicit operator. This service is a plain CrudService (no tenant scoping), and a literal
+			// null used to be dropped from the SQL, so the "global" lookup matched — and then overwrote —
+			// another tenant's template of the same name (GHSA-44pv-34gx-q9p4 class).
 			const emailTemplate = await this.findOneByWhereOptions({
 				languageCode,
 				name: `${name}/${type}`,
-				organizationId,
-				tenantId
+				organizationId: isEmpty(organizationId) ? IsNull() : organizationId,
+				tenantId: isEmpty(tenantId) ? IsNull() : tenantId
 			});
 			switch (type) {
 				case 'subject':

--- a/packages/core/src/lib/employee-notification/employee-notification.service.ts
+++ b/packages/core/src/lib/employee-notification/employee-notification.service.ts
@@ -106,11 +106,19 @@ export class EmployeeNotificationService extends TenantAwareCrudService<Employee
 				return { success: true, count: 0 };
 			}
 			const tenantId = RequestContext.currentTenantId();
-			const criteria = { isRead: false, isArchived: false, receiverEmployeeId, ...(tenantId ? { tenantId } : {}) };
+			if (!tenantId) {
+				// The raw UPDATE below is not tenant-scoped by itself; never run it without a tenant.
+				return { success: true, count: 0 };
+			}
+			const criteria = { isRead: false, isArchived: false, receiverEmployeeId, tenantId };
 
 			// Nothing unread is a successful no-op, not an error (TenantAwareCrudService.update() first
-			// looks the criteria up and raises NotFound when no row matches).
-			const { record: unread } = await this.findOneOrFailByWhereOptions(criteria);
+			// looks the criteria up and raises NotFound when no row matches). Any OTHER lookup failure
+			// is a real error and must not be reported as a successful no-op.
+			const { success, record: unread, error: lookupError } = await this.findOneOrFailByWhereOptions(criteria);
+			if (!success && !(lookupError instanceof NotFoundException)) {
+				throw lookupError;
+			}
 			if (!unread) {
 				return { success: true, count: 0 };
 			}

--- a/packages/core/src/lib/employee-notification/employee-notification.service.ts
+++ b/packages/core/src/lib/employee-notification/employee-notification.service.ts
@@ -97,15 +97,27 @@ export class EmployeeNotificationService extends TenantAwareCrudService<Employee
 	 */
 	async markAllAsRead(): Promise<IMarkAllAsReadResponse> {
 		try {
-			// Retrieve the current employee ID
-			const receiverEmployeeId = RequestContext.currentEmployeeId();
+			// The receiver is the caller's OWN employee record. RequestContext.currentEmployeeId() is
+			// deliberately null for CHANGE_SELECTED_EMPLOYEE holders, so read the identity off the JWT
+			// user too. A null receiver used to be dropped from the (raw, non-tenant-scoped) UPDATE
+			// criteria, i.e. an admin's "mark all read" marked EVERY tenant's notifications read.
+			const receiverEmployeeId = RequestContext.currentEmployeeId() ?? RequestContext.currentUser()?.employeeId;
+			if (!receiverEmployeeId) {
+				return { success: true, count: 0 };
+			}
+			const tenantId = RequestContext.currentTenantId();
+			const criteria = { isRead: false, isArchived: false, receiverEmployeeId, ...(tenantId ? { tenantId } : {}) };
+
+			// Nothing unread is a successful no-op, not an error (TenantAwareCrudService.update() first
+			// looks the criteria up and raises NotFound when no row matches).
+			const { record: unread } = await this.findOneOrFailByWhereOptions(criteria);
+			if (!unread) {
+				return { success: true, count: 0 };
+			}
 
 			// Update all unread and un-archived notifications for the current employee
 			// Assume super.update returns an object with an "affected" property that represents the number of records updated.
-			const updateResult = (await super.update(
-				{ isRead: false, isArchived: false, receiverEmployeeId },
-				{ isRead: true, readAt: new Date() }
-			)) as UpdateResult;
+			const updateResult = (await super.update(criteria, { isRead: true, readAt: new Date() })) as UpdateResult;
 
 			// Extract the count of notifications that were updated.
 			const count = updateResult?.affected || 0;

--- a/packages/core/src/lib/employee-setting/employee-setting.service.ts
+++ b/packages/core/src/lib/employee-setting/employee-setting.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { IsNull } from 'typeorm';
 import { ID, IEmployeeSetting, IEmployeeSettingCreateInput, IEmployeeSettingUpdateInput } from '@gauzy/contracts';
 import { RequestContext } from '../core/context';
 import { TenantAwareCrudService } from './../core/crud';
@@ -31,10 +32,19 @@ export class EmployeeSettingService extends TenantAwareCrudService<EmployeeSetti
 
 			const { entity, entityId, organizationId } = input;
 
-			// Check if a setting already exists for current employee and for the same entity
+			// Check if a setting already exists for current employee and for the same entity. A setting
+			// that is not bound to an entity has entity/entityId NULL — match exactly that (a null used to
+			// be dropped from the query, so the de-duplication hit an unrelated setting of the employee
+			// and overwrote it).
 			try {
 				const employeeSetting = await this.findOneByOptions({
-					where: { entity, entityId, employeeId, organizationId, tenantId }
+					where: {
+						entity: entity ?? IsNull(),
+						entityId: entityId ?? IsNull(),
+						employeeId,
+						...(organizationId ? { organizationId } : {}),
+						tenantId
+					}
 				});
 
 				if (employeeSetting) {

--- a/packages/core/src/lib/employee-setting/employee-setting.service.ts
+++ b/packages/core/src/lib/employee-setting/employee-setting.service.ts
@@ -42,7 +42,8 @@ export class EmployeeSettingService extends TenantAwareCrudService<EmployeeSetti
 						entity: entity ?? IsNull(),
 						entityId: entityId ?? IsNull(),
 						employeeId,
-						...(organizationId ? { organizationId } : {}),
+						// null -> IS NULL (an organization-less setting), undefined -> not filtered
+						organizationId,
 						tenantId
 					}
 				});

--- a/packages/core/src/lib/employee/employee.controller.ts
+++ b/packages/core/src/lib/employee/employee.controller.ts
@@ -2,6 +2,7 @@ import {
 	Body,
 	Controller,
 	Delete,
+	ForbiddenException,
 	Get,
 	Headers,
 	HttpCode,
@@ -295,12 +296,17 @@ export class EmployeeController extends CrudController<Employee> {
 		@Param('id', UUIDValidationPipe) id: ID,
 		@Query() params: FindOptionsQueryDTO<Employee>
 	): Promise<IEmployee> {
-		// Check permissions to determine the correct ID to retrieve
+		// Check permissions to determine the correct ID to retrieve. A caller without
+		// CHANGE_SELECTED_EMPLOYEE may only read their OWN employee record; a caller with no employee
+		// record has nothing to read (an empty id used to be dropped from the where and returned the
+		// first employee of the tenant).
+		const ownEmployeeId = RequestContext.currentEmployeeId();
+		if (!RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE) && !ownEmployeeId) {
+			throw new ForbiddenException('You do not have permission to view this employee.');
+		}
 		const searchCriteria = {
 			where: {
-				...(RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
-					? { id }
-					: { id: RequestContext.currentEmployeeId() })
+				...(RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE) ? { id } : { id: ownEmployeeId })
 			},
 			...(params.relations ? { relations: params.relations } : {}),
 			withDeleted: true

--- a/packages/core/src/lib/employee/employee.subscriber.ts
+++ b/packages/core/src/lib/employee/employee.subscriber.ts
@@ -403,6 +403,11 @@ export class EmployeeSubscriber extends BaseEntityEventSubscriber<Employee> {
 		isArchived: boolean,
 		ormType: MultiORM
 	): Promise<void> {
+		// Both keys must select the row: with a missing organizationId the (raw EntityManager) update
+		// used to lose that predicate and flip the flags on EVERY organization membership of the user.
+		if (!userId || !organizationId) {
+			return;
+		}
 		const criteria = { userId, organizationId };
 		const partialEntity = { isActive, isArchived };
 

--- a/packages/core/src/lib/expense/commands/handlers/expense.delete.handler.ts
+++ b/packages/core/src/lib/expense/commands/handlers/expense.delete.handler.ts
@@ -2,12 +2,11 @@ import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { DeleteResult } from 'typeorm';
 import { isNotEmpty } from '@gauzy/utils';
-import { ID, PermissionsEnum } from '@gauzy/contracts';
+import { ID } from '@gauzy/contracts';
 import { ExpenseService } from '../../expense.service';
 import { EmployeeService } from '../../../employee/employee.service';
 import { EmployeeStatisticsService } from '../../../employee-statistics';
 import { ExpenseDeleteCommand } from '../expense.delete.command';
-import { RequestContext } from './../../../core/context';
 
 @CommandHandler(ExpenseDeleteCommand)
 export class ExpenseDeleteHandler implements ICommandHandler<ExpenseDeleteCommand> {
@@ -55,13 +54,12 @@ export class ExpenseDeleteHandler implements ICommandHandler<ExpenseDeleteComman
 	 * @returns Promise<DeleteResult> - The result of the delete operation
 	 */
 	public async deleteExpense(expenseId: ID): Promise<DeleteResult> {
-		const query = RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
-			? { id: expenseId }
-			: {
-					id: expenseId,
-					employeeId: RequestContext.currentEmployeeId(),
-					tenantId: RequestContext.currentTenantId()
-			  };
+		// Tenant scoping and the "own records only" restriction for callers without
+		// CHANGE_SELECTED_EMPLOYEE are injected by TenantAwareCrudService.delete(). Spelling
+		// `employeeId: RequestContext.currentEmployeeId()` out here was redundant — and, because that
+		// helper is null for callers without an employee record, put a null into the criteria (which
+		// TypeORM used to drop silently). Keep the criteria to the id.
+		const query = { id: expenseId };
 
 		try {
 			return await this.expenseService.delete(query);

--- a/packages/core/src/lib/favorite/favorite.service.ts
+++ b/packages/core/src/lib/favorite/favorite.service.ts
@@ -1,5 +1,5 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { DeleteResult, FindOptionsWhere, In } from 'typeorm';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { DeleteResult, FindOptionsWhere, In, IsNull } from 'typeorm';
 import { BaseEntityEnum, ID, IFavorite, IFavoriteCreateInput, IPagination, RolesEnum } from '@gauzy/contracts';
 import { BaseQueryDTO, TenantAwareCrudService } from './../core/crud';
 import { RequestContext } from '../core/context';
@@ -72,11 +72,13 @@ export class FavoriteService extends TenantAwareCrudService<Favorite> {
 				}
 			}
 
-			// Check for existing favorite with the same parameters
+			// Check for existing favorite with the same parameters. An organization-level favorite has
+			// NO employee: pin that with IsNull() so the de-duplication matches only organization-level
+			// rows and never silently returns some other employee's favorite for the same entity.
 			const findOptions: FindOptionsWhere<Favorite> = {
 				tenantId,
 				organizationId,
-				employeeId,
+				employeeId: employeeId ?? IsNull(),
 				entity: entityName,
 				entityId
 			};
@@ -115,7 +117,15 @@ export class FavoriteService extends TenantAwareCrudService<Favorite> {
 	async delete(id: ID): Promise<DeleteResult> {
 		try {
 			if (!this.hasAdminRole()) {
-				const employeeId = RequestContext.currentEmployeeId();
+				// "Current employee" means the caller's OWN employee record. RequestContext.currentEmployeeId()
+				// is deliberately null for CHANGE_SELECTED_EMPLOYEE holders (e.g. managers), which used to
+				// drop the employee predicate and let them delete anyone's favorite by id — and would now
+				// (null -> IS NULL) stop them deleting even their own. Read the identity off the JWT user
+				// instead, and fail closed when the caller has no employee identity at all.
+				const employeeId = RequestContext.currentEmployeeId() ?? RequestContext.currentUser()?.employeeId;
+				if (!employeeId) {
+					throw new ForbiddenException('Only the owning employee (or an admin) can delete a favorite.');
+				}
 				return await super.delete(id, {
 					where: { employeeId }
 				});

--- a/packages/core/src/lib/favorite/favorite.service.ts
+++ b/packages/core/src/lib/favorite/favorite.service.ts
@@ -136,6 +136,9 @@ export class FavoriteService extends TenantAwareCrudService<Favorite> {
 				: { where: { tenantId: RequestContext.currentTenantId() } };
 			return await super.delete(id, deleteOptions);
 		} catch (error) {
+			if (error instanceof ForbiddenException) {
+				throw error;
+			}
 			throw new BadRequestException(error);
 		}
 	}

--- a/packages/core/src/lib/income/commands/handlers/income.delete.handler.ts
+++ b/packages/core/src/lib/income/commands/handlers/income.delete.handler.ts
@@ -2,12 +2,10 @@ import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { DeleteResult } from 'typeorm';
 import { isNotEmpty } from '@gauzy/utils';
-import { PermissionsEnum } from '@gauzy/contracts';
 import { IncomeService } from '../../income.service';
 import { EmployeeService } from '../../../employee/employee.service';
 import { EmployeeStatisticsService } from '../../../employee-statistics';
 import { IncomeDeleteCommand } from '../income.delete.command';
-import { RequestContext } from './../../../core/context';
 
 @CommandHandler(IncomeDeleteCommand)
 export class IncomeDeleteHandler implements ICommandHandler<IncomeDeleteCommand> {
@@ -57,13 +55,11 @@ export class IncomeDeleteHandler implements ICommandHandler<IncomeDeleteCommand>
 	 * @returns Promise<DeleteResult> - The result of the delete operation
 	 */
 	public async deleteIncome(incomeId: string): Promise<DeleteResult> {
-		const deleteQuery = RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
-			? { id: incomeId }
-			: {
-					id: incomeId,
-					employeeId: RequestContext.currentEmployeeId(),
-					tenantId: RequestContext.currentTenantId()
-			  };
+		// Tenant scoping and the "own records only" restriction for callers without
+		// CHANGE_SELECTED_EMPLOYEE are injected by TenantAwareCrudService.delete(); an explicit
+		// `employeeId: RequestContext.currentEmployeeId()` here was redundant and null for callers
+		// without an employee record (a null TypeORM used to drop silently). Keep it to the id.
+		const deleteQuery = { id: incomeId };
 
 		try {
 			return await this.incomeService.delete(deleteQuery);

--- a/packages/core/src/lib/integration-setting/commands/handlers/integration-setting.get.handler.ts
+++ b/packages/core/src/lib/integration-setting/commands/handlers/integration-setting.get.handler.ts
@@ -18,7 +18,11 @@ export class IntegrationSettingGetHandler implements ICommandHandler<Integration
 		const { input } = command;
 		const tenantId = RequestContext.currentTenantId();
 
-		if (input.where instanceof Object) {
+		// Scope to the request's tenant when there is one. Webhook callers (e.g. the GitHub Probot
+		// hooks) run without a request context: their lookup is keyed on the installation id and is
+		// legitimately cross-tenant, so a null tenantId must not be written into the where (it used to
+		// be dropped by TypeORM; now null means IS NULL and would match nothing).
+		if (input.where instanceof Object && tenantId) {
 			input.where = Object.assign(input.where, { tenantId });
 		}
 

--- a/packages/core/src/lib/integration-setting/commands/handlers/integration-setting.getMany.handler.ts
+++ b/packages/core/src/lib/integration-setting/commands/handlers/integration-setting.getMany.handler.ts
@@ -24,8 +24,10 @@ export class IntegrationSettingGetManyHandler implements ICommandHandler<Integra
 		// Get the current tenant ID from the RequestContext
 		const tenantId = RequestContext.currentTenantId();
 
-		// Append the tenant ID to the 'where' clause if it's an object
-		if (input.where instanceof Object) {
+		// Append the tenant ID to the 'where' clause if it's an object AND there is a request tenant.
+		// Webhook callers (GitHub Probot installation.deleted) run without a request context and look
+		// settings up by installation id across tenants; a null tenantId must not enter the where.
+		if (input.where instanceof Object && tenantId) {
 			input.where = Object.assign(input.where, { tenantId });
 		}
 

--- a/packages/core/src/lib/integration-tenant/integration-tenant.service.ts
+++ b/packages/core/src/lib/integration-tenant/integration-tenant.service.ts
@@ -160,11 +160,14 @@ export class IntegrationTenantService extends TenantAwareCrudService<Integration
 		integrationId: ID;
 		entityType: IntegrationEntity;
 	}): Promise<IIntegrationTenant> {
+		// Callers may run outside a request (event-bus subscribers such as the AI screenshot analysis);
+		// only pin the tenant when one is known — the organization + integration ids already scope the
+		// lookup, and a null tenantId must not enter the where.
 		const tenantId = RequestContext.currentTenantId();
 
 		return await super.findOneByOptions({
 			where: {
-				tenantId,
+				...(tenantId ? { tenantId } : {}),
 				organizationId,
 				integrationId,
 				isActive: true,

--- a/packages/core/src/lib/organization-project-module/organization-project-module.service.ts
+++ b/packages/core/src/lib/organization-project-module/organization-project-module.service.ts
@@ -144,7 +144,7 @@ export class OrganizationProjectModuleService extends TenantAwareCrudService<Org
 		const tenantId = RequestContext.currentTenantId() ?? entity.tenantId;
 
 		try {
-			const { memberIds, managerIds, organizationId, tasks = [] } = entity;
+			const { memberIds, managerIds, tasks = [] } = entity;
 
 			// Retrieve existing module
 			const existingProjectModule = await this.findOneByIdString(id, {
@@ -154,6 +154,11 @@ export class OrganizationProjectModuleService extends TenantAwareCrudService<Org
 			if (!existingProjectModule) {
 				throw new BadRequestException('Module not found');
 			}
+
+			// The member lookups below are scoped by organization: use the module's own organization
+			// when the (partial) update body does not carry one, never a null (a null used to be
+			// dropped from the where and let employees of any organization of the tenant be added).
+			const organizationId = entity.organizationId ?? existingProjectModule.organizationId;
 
 			// Update members and managers if applicable
 			if (Array.isArray(memberIds) || Array.isArray(managerIds)) {

--- a/packages/core/src/lib/organization-project/organization-project.service.ts
+++ b/packages/core/src/lib/organization-project/organization-project.service.ts
@@ -707,6 +707,9 @@ export class OrganizationProjectService extends TenantAwareCrudService<Organizat
 			if (!tenantId) {
 				throw new BadRequestException('Tenant context is required');
 			}
+			if (!organizationId) {
+				throw new BadRequestException('organizationId is required');
+			}
 
 			// Handle adding projects
 			if (addedProjectIds.length > 0) {
@@ -745,6 +748,7 @@ export class OrganizationProjectService extends TenantAwareCrudService<Organizat
 				await this.typeOrmOrganizationProjectEmployeeRepository.delete({
 					organizationProjectId: In(removedProjectIds),
 					employeeId: member.id,
+					organizationId,
 					tenantId
 				});
 			}

--- a/packages/core/src/lib/organization-project/organization-project.service.ts
+++ b/packages/core/src/lib/organization-project/organization-project.service.ts
@@ -1,5 +1,5 @@
 import { EventBus } from '@nestjs/cqrs';
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { ILike, In, IsNull, SelectQueryBuilder } from 'typeorm';
 import {
 	ActionTypeEnum,
@@ -697,6 +697,16 @@ export class OrganizationProjectService extends TenantAwareCrudService<Organizat
 		try {
 			const tenantId = RequestContext.currentTenantId() ?? input.tenantId;
 			const { organizationId, addedProjectIds = [], removedProjectIds = [], member } = input;
+
+			// The member id comes from the request body and keys the raw-repository DELETE below: an
+			// empty value used to be dropped from the criteria, removing EVERY member of the listed
+			// projects. Fail closed.
+			if (!member?.id) {
+				throw new BadRequestException('member.id is required');
+			}
+			if (!tenantId) {
+				throw new BadRequestException('Tenant context is required');
+			}
 
 			// Handle adding projects
 			if (addedProjectIds.length > 0) {

--- a/packages/core/src/lib/organization-sprint/organization-sprint.service.ts
+++ b/packages/core/src/lib/organization-sprint/organization-sprint.service.ts
@@ -174,8 +174,10 @@ export class OrganizationSprintService extends TenantAwareCrudService<Organizati
 
 		try {
 			// Search for existing Organization Sprint
+			// projectId is optional in the update body (PartialType makes it nullable): only filter on it
+			// when the client sent one — sprint.projectId is NOT NULL, so a null (now IS NULL) would never match.
 			const organizationSprint = await super.findOneByIdString(id, {
-				where: { organizationId, tenantId, projectId },
+				where: { organizationId, tenantId, ...(projectId ? { projectId } : {}) },
 				relations: { project: true, members: true, modules: true }
 			});
 

--- a/packages/core/src/lib/organization-strategic-initiative/organization-strategic-initiative.service.ts
+++ b/packages/core/src/lib/organization-strategic-initiative/organization-strategic-initiative.service.ts
@@ -514,6 +514,13 @@ export class OrganizationStrategicInitiativeService extends TenantAwareCrudServi
 		employeeId: ID
 	): Promise<boolean> {
 		try {
+			// No employee identity, no team membership — same answer the batch path
+			// (getEmployeeTeamIds / canViewOrganizationStrategicInitiativeSync) gives. An empty
+			// employeeId used to be dropped from the membership query, turning the check into
+			// "any active member exists in a linked team".
+			if (!employeeId) {
+				return false;
+			}
 			// Load the organization strategic initiative with its projects and their teams
 			const organizationStrategicInitiativeWithProjects = await this.findOneByOptions({
 				where: { id: organizationStrategicInitiative.id },

--- a/packages/core/src/lib/organization-strategic-initiative/organization-strategic-initiative.service.ts
+++ b/packages/core/src/lib/organization-strategic-initiative/organization-strategic-initiative.service.ts
@@ -382,8 +382,9 @@ export class OrganizationStrategicInitiativeService extends TenantAwareCrudServi
 	): boolean {
 		const { visibilityScope, stewardId } = organizationStrategicInitiative;
 
-		// Steward can always view
-		if (stewardId === employeeId) {
+		// Steward can always view — only when there IS a steward and a caller identity (both may be
+		// null: an unassigned initiative viewed by a non-employee user must not match on null === null).
+		if (stewardId && employeeId && stewardId === employeeId) {
 			return true;
 		}
 
@@ -451,8 +452,9 @@ export class OrganizationStrategicInitiativeService extends TenantAwareCrudServi
 	): Promise<boolean> {
 		const { visibilityScope, stewardId } = organizationStrategicInitiative;
 
-		// Steward and creator can always view
-		if (stewardId === employeeId) {
+		// Steward and creator can always view — only when there IS a steward and a caller identity
+		// (an unassigned initiative viewed by a non-employee user must not match on null === null).
+		if (stewardId && employeeId && stewardId === employeeId) {
 			return true;
 		}
 

--- a/packages/core/src/lib/organization-team-employee/organization-team-employee.service.ts
+++ b/packages/core/src/lib/organization-team-employee/organization-team-employee.service.ts
@@ -186,8 +186,12 @@ export class OrganizationTeamEmployeeService extends TenantAwareCrudService<Orga
 			// Check if user has permission to change the selected employee
 			if (!RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)) {
 				try {
-					// Retrieve the current employee ID
+					// Retrieve the current employee ID — the manager check below needs one (an empty id
+					// used to be dropped from the where, degrading it to "the team has any manager").
 					const employeeId = RequestContext.currentEmployeeId();
+					if (!employeeId) {
+						throw new ForbiddenException('You do not have sufficient permissions to perform this action.');
+					}
 
 					// Verify if the employee has a manager role in the organization and team
 					await this.findOneByWhereOptions({

--- a/packages/core/src/lib/organization-team-join-request/organization-team-join-request.service.ts
+++ b/packages/core/src/lib/organization-team-join-request/organization-team-join-request.service.ts
@@ -189,14 +189,14 @@ export class OrganizationTeamJoinRequestService extends TenantAwareCrudService<O
 							expiredAt: MoreThanOrEqual(new Date()),
 							status: IsNull()
 						});
-						qb.andWhere([
-							{
-								code
-							},
-							{
-								token
-							}
-						]);
+						// Only OR together the credentials that were actually supplied. The DTO validates code
+						// or token, not both, so the other may arrive as null: as an OR arm that would now read
+						// `token IS NULL` and widen a security-sensitive lookup instead of being dropped.
+						const credentials = [...(code ? [{ code }] : []), ...(token ? [{ token }] : [])];
+						if (credentials.length === 0) {
+							throw new BadRequestException('A confirmation code or token is required');
+						}
+						qb.andWhere(credentials);
 					});
 					record = await query.getOneOrFail();
 					break;

--- a/packages/core/src/lib/organization-team/organization-team.service.ts
+++ b/packages/core/src/lib/organization-team/organization-team.service.ts
@@ -603,14 +603,23 @@ export class OrganizationTeamService extends TenantAwareCrudService<Organization
 			const { organizationId } = options;
 			const tenantId = RequestContext.currentTenantId() || options.tenantId;
 
+			// Without CHANGE_SELECTED_EMPLOYEE the caller must be a MANAGER member of the team — which
+			// requires an employee identity. Fail closed when there is none: an empty employeeId used to
+			// be dropped from the where, degrading the check to "the team has any manager".
+			const canChangeSelectedEmployee = RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE);
+			const employeeId = RequestContext.currentEmployeeId();
+			if (!canChangeSelectedEmployee && !employeeId) {
+				throw new ForbiddenException('You do not have permission to delete this team.');
+			}
+
 			const team = await this.findOneByIdString(teamId, {
 				where: {
 					tenantId,
 					organizationId,
-					...(!RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
+					...(!canChangeSelectedEmployee
 						? {
 								members: {
-									employeeId: RequestContext.currentEmployeeId(),
+									employeeId,
 									role: {
 										name: RolesEnum.MANAGER
 									}

--- a/packages/core/src/lib/public-share/invoice/public-invoice.service.ts
+++ b/packages/core/src/lib/public-share/invoice/public-invoice.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsWhere, UpdateResult } from 'typeorm';
+import { FindOptionsWhere, IsNull, UpdateResult } from 'typeorm';
 import { verify } from 'jsonwebtoken';
 import { IInvoice, IInvoiceUpdateInput } from '@gauzy/contracts';
 import { environment } from '@gauzy/config';
@@ -119,9 +119,17 @@ export class PublicInvoiceService {
 	async updateInvoice(params: IInvoice, entity: IInvoiceUpdateInput): Promise<IInvoice | UpdateResult> {
 		try {
 			const decoded = verify(params.token as string, environment.JWT_SECRET) as any;
+			// Only an estimate-email token (estimate-email.service.ts) carries `invoiceId`; other
+			// JWT_SECRET-signed tokens do not. Without this check a missing `invoiceId` was dropped from
+			// the where and `findOneByOrFail` matched an ARBITRARY invoice of that organization/tenant,
+			// which was then updated with the caller's body. The token must also name the invoice in the URL.
+			const invoiceId = decoded?.invoiceId;
+			if (!invoiceId || !decoded?.tenantId || invoiceId !== params.id) {
+				throw new ForbiddenException('Invalid estimate token');
+			}
 			const invoice = await this.typeOrmInvoiceRepository.findOneByOrFail({
-				id: decoded.invoiceId,
-				organizationId: decoded.organizationId,
+				id: invoiceId,
+				organizationId: decoded.organizationId ?? IsNull(),
 				tenantId: decoded.tenantId
 			});
 			return await this.typeOrmInvoiceRepository.update(invoice.id, entity);

--- a/packages/core/src/lib/public-share/invoice/public-invoice.service.ts
+++ b/packages/core/src/lib/public-share/invoice/public-invoice.service.ts
@@ -134,6 +134,9 @@ export class PublicInvoiceService {
 			});
 			return await this.typeOrmInvoiceRepository.update(invoice.id, entity);
 		} catch (error) {
+			if (error instanceof ForbiddenException) {
+				throw error;
+			}
 			throw new BadRequestException(error);
 		}
 	}

--- a/packages/core/src/lib/reaction/reaction.service.ts
+++ b/packages/core/src/lib/reaction/reaction.service.ts
@@ -29,8 +29,15 @@ export class ReactionService extends TenantAwareCrudService<Reaction> {
 		try {
 			// Extract the tenantId from the input data or the current request context
 			const tenantId = RequestContext.currentTenantId() ?? input.tenantId;
-			// Extract the employeeId from the request context
-			const employeeId = RequestContext.currentEmployeeId();
+			// The reacting employee is the caller's OWN employee record. currentEmployeeId() is
+			// deliberately null for CHANGE_SELECTED_EMPLOYEE holders, so read the identity off the JWT
+			// user as well; without any employee identity there is nobody to react as (update() and
+			// delete() below already enforce this). A null here used to be dropped from the toggle
+			// criteria, matching — and deleting — every other employee's identical reaction.
+			const employeeId = RequestContext.currentEmployeeId() ?? RequestContext.currentUser()?.employeeId;
+			if (!employeeId) {
+				throw new BadRequestException('Employee ID not found in context');
+			}
 			// Destructure additional properties from input
 			const { entity, entityId, emoji, organizationId } = input;
 
@@ -51,8 +58,9 @@ export class ReactionService extends TenantAwareCrudService<Reaction> {
 				organizationId
 			};
 
-			// Check if a matching reaction already exists
-			const reaction = await this.findOneByWhereOptions(whereOptions);
+			// Check if a matching reaction already exists (non-throwing lookup: findOneByWhereOptions
+			// raises NotFound when there is none, which turned every FIRST reaction into a 400).
+			const { record: reaction } = await this.findOneOrFailByWhereOptions(whereOptions);
 
 			// If a matching reaction exists, delete (toggle off) the reaction
 			if (reaction) {

--- a/packages/core/src/lib/reaction/reaction.service.ts
+++ b/packages/core/src/lib/reaction/reaction.service.ts
@@ -60,7 +60,11 @@ export class ReactionService extends TenantAwareCrudService<Reaction> {
 
 			// Check if a matching reaction already exists (non-throwing lookup: findOneByWhereOptions
 			// raises NotFound when there is none, which turned every FIRST reaction into a 400).
-			const { record: reaction } = await this.findOneOrFailByWhereOptions(whereOptions);
+			const { success, record: reaction, error: lookupError } = await this.findOneOrFailByWhereOptions(whereOptions);
+			if (!success && !(lookupError instanceof NotFoundException)) {
+				// Anything but "no such reaction" is a real failure — do not fall through to a duplicate create.
+				throw lookupError;
+			}
 
 			// If a matching reaction exists, delete (toggle off) the reaction
 			if (reaction) {

--- a/packages/core/src/lib/reports/report-organization.service.ts
+++ b/packages/core/src/lib/reports/report-organization.service.ts
@@ -26,8 +26,14 @@ export class ReportOrganizationService extends TenantAwareCrudService<ReportOrga
      * @returns The updated or newly created report menu entry.
      */
     async updateReportMenu(input: UpdateReportMenuInput): Promise<ReportOrganization> {
+        const { reportId, organizationId } = input;
+        // The body is not DTO-validated: both keys must be present, or the lookup below (an empty
+        // key used to be dropped from the where) would pick an arbitrary row of the tenant to mutate.
+        // Checked outside the try: its catch deliberately falls back to "create".
+        if (!reportId || !organizationId) {
+            throw new BadRequestException('reportId and organizationId are required');
+        }
         try {
-            const { reportId, organizationId } = input;
             const tenantId = RequestContext.currentTenantId() || input.tenantId;
 
             let reportOrganization = await this.findOneByWhereOptions({

--- a/packages/core/src/lib/resource-link/resource-link.service.ts
+++ b/packages/core/src/lib/resource-link/resource-link.service.ts
@@ -39,16 +39,22 @@ export class ResourceLinkService extends TenantAwareCrudService<ResourceLink> {
 			// Retrieve the tenantId from the request context or fall back to input value
 			const tenantId = RequestContext.currentTenantId() ?? input.tenantId;
 
-			// Retrieve the employeeId from the request context or fall back to input value
-			const employeeId = RequestContext.currentEmployeeId() ?? input.employeeId;
+			// Retrieve the employeeId from the request context (the caller's own employee — also for
+			// CHANGE_SELECTED_EMPLOYEE holders, for whom currentEmployeeId() is null) or fall back to input value
+			const employeeId =
+				RequestContext.currentEmployeeId() ?? RequestContext.currentUser()?.employeeId ?? input.employeeId;
 
 			// Destructure the input data to use in entity creation
 			const { ...entity } = input;
 
-			// Validate that the employee exists.
-			const employee = await this._employeeService.findOneByIdString(employeeId);
-			if (!employee) {
-				throw new NotFoundException(`Employee with id ${employeeId} not found`);
+			// Validate that the employee exists — only a real id can be looked up (an empty one used to
+			// match an arbitrary employee and pass vacuously); a caller with no employee identity keeps
+			// creating an employee-less link, as before.
+			if (employeeId) {
+				const employee = await this._employeeService.findOneByIdString(employeeId);
+				if (!employee) {
+					throw new NotFoundException(`Employee with id ${employeeId} not found`);
+				}
 			}
 
 			// Create and return the resource link, passing the necessary entity data

--- a/packages/core/src/lib/role-permission/role-permission.service.ts
+++ b/packages/core/src/lib/role-permission/role-permission.service.ts
@@ -154,9 +154,13 @@ export class RolePermissionService extends TenantAwareCrudService<RolePermission
 				tenantId: currentTenantId
 			});
 
-			let { roleId } = partialEntity;
-			if (partialEntity['role'] instanceof Role) {
-				roleId = partialEntity['role']['id'];
+			// The target role may arrive as `roleId` or as a plain `role` object (the role object in the DTO is never a
+			// Role instance after class-transformer). Resolve it fail-closed: an undefined id used to be
+			// dropped from the lookup and returned the FIRST role of the tenant, whose name is what the
+			// SUPER_ADMIN / ADMIN checks below inspect.
+			const roleId = partialEntity.roleId ?? partialEntity['role']?.['id'];
+			if (!roleId) {
+				throw new BadRequestException('roleId is required');
 			}
 			/**
 			 * User try to create permission for below role
@@ -220,9 +224,13 @@ export class RolePermissionService extends TenantAwareCrudService<RolePermission
 				tenantId: currentTenantId
 			});
 
-			let { roleId } = partialEntity;
-			if (partialEntity['role'] instanceof Role) {
-				roleId = partialEntity['role']['id'];
+			// The target role may arrive as `roleId` or as a plain `role` object (the role object in the DTO is never a
+			// Role instance after class-transformer). Resolve it fail-closed: an undefined id used to be
+			// dropped from the lookup and returned the FIRST role of the tenant, whose name is what the
+			// SUPER_ADMIN / ADMIN checks below inspect.
+			const roleId = partialEntity.roleId ?? partialEntity['role']?.['id'];
+			if (!roleId) {
+				throw new BadRequestException('roleId is required');
 			}
 			/**
 			 * User try to update permission for below role

--- a/packages/core/src/lib/shared/handlers/recurring-expense.edit.handler.ts
+++ b/packages/core/src/lib/shared/handlers/recurring-expense.edit.handler.ts
@@ -236,6 +236,12 @@ export abstract class RecurringExpenseEditHandler<
 		currentStartYear: number,
 		currentStartMonth: number
 	) {
+		// An expense without a parent has no siblings. Never query with an empty parent id: it used to
+		// be dropped from the where, so EVERY expense of the tenant in the window counted as a sibling
+		// — and reduceConflict() deletes what this returns.
+		if (!parentRecurringExpenseId) {
+			return { items: [] as T[], total: 0 };
+		}
 		const lastDayOfMonth = getLastDayOfMonth(
 			currentStartYear,
 			currentStartMonth
@@ -273,6 +279,10 @@ export abstract class RecurringExpenseEditHandler<
 		year: number,
 		month: number
 	) {
+		// See findAllExpensesInBetween: no parent, no siblings, no conflict.
+		if (!parentRecurringExpenseId) {
+			return undefined;
+		}
 		const lastDayOfMonth = getLastDayOfMonth(year, month);
 		const inputStartDate = new Date(year, month, lastDayOfMonth);
 		const inputEndDate = new Date(year, month, 1);

--- a/packages/core/src/lib/shared/handlers/recurring-expense.find-update-type.handler.ts
+++ b/packages/core/src/lib/shared/handlers/recurring-expense.find-update-type.handler.ts
@@ -142,6 +142,11 @@ export abstract class FindRecurringExpenseStartDateUpdateTypeHandler<
 		fromStartDate: Date,
 		toStartDate: Date
 	) {
+		// An expense without a parent has no siblings; an empty parent id must not be queried (it used
+		// to be dropped from the where and made every expense in the window a "conflict").
+		if (!parentRecurringExpenseId) {
+			return { items: [] as T[], total: 0 };
+		}
 		return await this.crudService.findAll({
 			where: [
 				{

--- a/packages/core/src/lib/shared/pipes/parse-json.pipe.spec.ts
+++ b/packages/core/src/lib/shared/pipes/parse-json.pipe.spec.ts
@@ -1,0 +1,61 @@
+import { ArgumentMetadata } from '@nestjs/common';
+import { omitNullValues, ParseJsonPipe } from './parse-json.pipe';
+
+/**
+ * `?data={...}` filter objects reach TypeORM `where` clauses; with the connection now translating
+ * `null` into `IS NULL` (GHSA-44pv-34gx-q9p4), the pipe must keep the client's long-standing meaning
+ * of a JSON null — "not filtered on this key" — by dropping the key at the ingress.
+ */
+describe('ParseJsonPipe', () => {
+	const meta: ArgumentMetadata = { type: 'query', data: 'data' };
+
+	describe('omitNullValues', () => {
+		it('drops null-valued properties at any depth and keeps everything else', () => {
+			expect(
+				omitNullValues({
+					findInput: { organizationId: 'org', employeeId: null, nested: { projectId: null, keep: 0, flag: false } },
+					relations: ['a', 'b'],
+					name: null,
+					page: 1
+				})
+			).toEqual({
+				findInput: { organizationId: 'org', nested: { keep: 0, flag: false } },
+				relations: ['a', 'b'],
+				page: 1
+			});
+		});
+
+		it('recurses into arrays without removing elements', () => {
+			expect(omitNullValues([{ a: null, b: 1 }, null, 'x'])).toEqual([{ b: 1 }, null, 'x']);
+		});
+
+		it('leaves primitives alone', () => {
+			expect(omitNullValues('str')).toBe('str');
+			expect(omitNullValues(0)).toBe(0);
+			expect(omitNullValues(null)).toBeNull();
+			expect(omitNullValues(undefined)).toBeUndefined();
+		});
+
+		it('cannot be used to pollute Object.prototype', () => {
+			const parsed = JSON.parse('{"__proto__":{"polluted":true},"constructor":{"prototype":{"polluted":true}},"ok":1}');
+			const out = omitNullValues(parsed) as Record<string, unknown>;
+			expect(({} as any).polluted).toBeUndefined();
+			expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+			expect(out.ok).toBe(1);
+		});
+	});
+
+	it('parses JSON and drops null filter values', async () => {
+		const pipe = new ParseJsonPipe();
+		await expect(
+			pipe.transform(JSON.stringify({ findInput: { organizationId: 'org', employeeId: null }, relations: ['user'] }), meta)
+		).resolves.toEqual({ findInput: { organizationId: 'org' }, relations: ['user'] });
+	});
+
+	it('returns {} for a non-JSON value by default and throws when configured to', async () => {
+		await expect(new ParseJsonPipe().transform('not-json', meta)).resolves.toEqual({});
+		await expect(new ParseJsonPipe({ throwInvalidError: true }).transform('not-json', meta)).rejects.toThrow(
+			'Validation failed (JSON string is expected)'
+		);
+	});
+});

--- a/packages/core/src/lib/shared/pipes/parse-json.pipe.ts
+++ b/packages/core/src/lib/shared/pipes/parse-json.pipe.ts
@@ -1,5 +1,6 @@
 import {
 	ArgumentMetadata,
+	BadRequestException,
 	HttpStatus,
 	Injectable,
 	Optional,
@@ -30,15 +31,23 @@ export interface ParseJsonPipeOptions {
  * removing the key before the value ever reaches a query. See TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR
  * in @gauzy/config (GHSA-44pv-34gx-q9p4).
  */
-export function omitNullValues<T>(value: T): T {
+/** Maximum nesting depth accepted for a `?data=` JSON query object. */
+export const MAX_QUERY_JSON_DEPTH = 32;
+
+export function omitNullValues<T>(value: T, depth = 0): T {
+	// A filter object is a handful of levels deep at most; refuse pathological nesting instead of
+	// letting a crafted payload exhaust the stack (which would surface as a swallowed parse error).
+	if (depth > MAX_QUERY_JSON_DEPTH) {
+		throw new BadRequestException('Query JSON is nested too deeply');
+	}
 	if (Array.isArray(value)) {
-		return value.map((item) => omitNullValues(item)) as unknown as T;
+		return value.map((item) => omitNullValues(item, depth + 1)) as unknown as T;
 	}
 	if (value !== null && typeof value === 'object') {
 		return Object.fromEntries(
 			Object.entries(value as Record<string, unknown>)
 				.filter(([, v]) => v !== null)
-				.map(([k, v]) => [k, omitNullValues(v)])
+				.map(([k, v]) => [k, omitNullValues(v, depth + 1)])
 		) as T;
 	}
 	return value;
@@ -87,11 +96,16 @@ export class ParseJsonPipe implements PipeTransform<string> {
 		const isJson = isJSON(value);
 
 		if (isJson) {
+			let parsed: unknown;
 			try {
-				return omitNullValues(JSON.parse(value));
+				parsed = JSON.parse(value);
 			} catch (e) {
 				console.log('Json Parser Error:', e);
+				return {};
 			}
+			// Outside the parse try: a sanitizer failure (e.g. excessive nesting) is the caller's error
+			// and must surface as a 400, not be swallowed as "invalid JSON" and turned into {}.
+			return omitNullValues(parsed);
 		} else if (this.throwInvalidError) {
 			throw this.exceptionFactory(
 				'Validation failed (JSON string is expected)'

--- a/packages/core/src/lib/shared/pipes/parse-json.pipe.ts
+++ b/packages/core/src/lib/shared/pipes/parse-json.pipe.ts
@@ -16,9 +16,38 @@ export interface ParseJsonPipeOptions {
 	errorHttpStatusCode?: ErrorHttpStatusCode;
 	exceptionFactory?: (error: string) => any;
 }
+
+/**
+ * Drops object properties whose value is `null`, recursively (array elements are recursed into but
+ * never removed). Rebuilt with `Object.fromEntries`, which defines own data properties and so cannot
+ * be used to reach `__proto__`.
+ *
+ * Why: this pipe feeds client-supplied `?data={ findInput, relations, ... }` filter objects straight
+ * into TypeORM `where` clauses. At this ingress a JSON `null` has only ever meant "not filtered on
+ * this key" (TypeORM 0.3 skipped it, and the clients were written against that). TypeORM is now
+ * configured to translate `null` into `IS NULL` — the fail-closed choice for server code, which spells
+ * `IS NULL` out with the explicit `IsNull()` operator — so the client's meaning is preserved here by
+ * removing the key before the value ever reaches a query. See TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR
+ * in @gauzy/config (GHSA-44pv-34gx-q9p4).
+ */
+export function omitNullValues<T>(value: T): T {
+	if (Array.isArray(value)) {
+		return value.map((item) => omitNullValues(item)) as unknown as T;
+	}
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>)
+				.filter(([, v]) => v !== null)
+				.map(([k, v]) => [k, omitNullValues(v)])
+		) as T;
+	}
+	return value;
+}
+
 /**
  * JSON Parse Pipe
- * Validates UUID passed in request parameters.
+ * Parses a JSON-encoded query parameter (e.g. `?data={...}`) into an object. `null` property values
+ * are dropped (see {@link omitNullValues}).
  */
 @Injectable()
 export class ParseJsonPipe implements PipeTransform<string> {
@@ -59,7 +88,7 @@ export class ParseJsonPipe implements PipeTransform<string> {
 
 		if (isJson) {
 			try {
-				return JSON.parse(value);
+				return omitNullValues(JSON.parse(value));
 			} catch (e) {
 				console.log('Json Parser Error:', e);
 			}

--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -1386,7 +1386,11 @@ export class TaskService extends TenantAwareCrudService<Task> {
 				...(types.length && { issueType: In(types) }),
 				...(minStartDate && maxStartDate && { startDate: Between(minStartDate, maxStartDate) }),
 				...(minDueDate && maxDueDate && { dueDate: Between(minDueDate, maxDueDate) }),
-				organizationId: taskView.organizationId || organizationId,
+				// Only scope by organization when one is known: the view's organizationId is a nullable
+				// column and the stored query params may carry null (a null used to be dropped silently).
+				...(taskView.organizationId || organizationId
+					? { organizationId: taskView.organizationId || organizationId }
+					: {}),
 				tenantId
 			};
 

--- a/packages/core/src/lib/time-off-policy/time-off-policy.service.ts
+++ b/packages/core/src/lib/time-off-policy/time-off-policy.service.ts
@@ -76,6 +76,12 @@ export class TimeOffPolicyService extends TenantAwareCrudService<TimeOffPolicy> 
 		try {
 			const tenantId = RequestContext.currentTenantId() || entity.tenantId;
 			const organizationId = entity.organizationId;
+			// The body is not DTO-validated: an empty organizationId would scope the delete / employee
+			// lookups below to nothing (null -> IS NULL) and then re-create the policy as a duplicate;
+			// previously it was silently dropped instead. Require it.
+			if (!organizationId) {
+				throw new HttpException('organizationId is required', HttpStatus.BAD_REQUEST);
+			}
 
 			// Delete the policy
 			await this.delete({

--- a/packages/core/src/lib/time-tracking/time-slot/commands/handlers/create-time-slot.handler.ts
+++ b/packages/core/src/lib/time-tracking/time-slot/commands/handlers/create-time-slot.handler.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { CommandBus, CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { In } from 'typeorm';
 import * as moment from 'moment';
@@ -63,6 +63,13 @@ export class CreateTimeSlotHandler implements ICommandHandler<CreateTimeSlotComm
 		if (!hasChangeEmployeePermission || (isEmpty(employeeId) && RequestContext.currentEmployeeId())) {
 			// Assign current employeeId if not provided in the request payload
 			employeeId = RequestContext.currentEmployeeId();
+		}
+
+		// A time slot always belongs to an employee (NOT NULL column). Fail here rather than later:
+		// an empty id used to be dropped from the employee lookup below, which then resolved the
+		// FIRST employee of the tenant and built the slot in that employee's organization.
+		if (isEmpty(employeeId)) {
+			throw new BadRequestException('Employee context is required to create a time slot');
 		}
 
 		/*

--- a/packages/core/src/lib/time-tracking/timesheet/commands/handlers/timesheet-recalculate.handler.ts
+++ b/packages/core/src/lib/time-tracking/timesheet/commands/handlers/timesheet-recalculate.handler.ts
@@ -41,6 +41,12 @@ export class TimesheetRecalculateHandler implements ICommandHandler<TimesheetRec
 	 */
 	public async execute(command: TimesheetRecalculateCommand): Promise<ITimesheet> {
 		const { id } = command;
+		// TimeLog.timesheetId is nullable: a log without a timesheet has nothing to recalculate. An
+		// empty id used to be dropped from the lookup, so the FIRST timesheet of the tenant was loaded
+		// and overwritten with totals computed for a different employee window.
+		if (!id) {
+			return null;
+		}
 		const timesheet = await this.timesheetService.findOneByIdString(id);
 
 		const tenantId = RequestContext.currentTenantId();

--- a/packages/core/src/lib/user/user.service.ts
+++ b/packages/core/src/lib/user/user.service.ts
@@ -271,6 +271,12 @@ export class UserService extends TenantAwareCrudService<User> {
 	 * @returns {Promise<boolean>} - A promise that resolves to true if the user exists, otherwise false.
 	 */
 	async checkIfExists(id: string): Promise<boolean> {
+		// An empty id must never reach the repository: `findOneBy({ id: undefined })` drops the predicate
+		// and returns the FIRST user row (see getIfExists) — for the JWT strategy that meant any token
+		// signed with JWT_SECRET but carrying no `id` claim authenticated as that user.
+		if (!id) {
+			return false;
+		}
 		switch (this.ormType) {
 			case MultiORMEnum.MikroORM:
 				return !!(await this.mikroOrmRepository.findOne({ id } as any));
@@ -287,6 +293,9 @@ export class UserService extends TenantAwareCrudService<User> {
 	 * @returns {Promise<boolean>} - A promise that resolves to true if the user exists, otherwise false.
 	 */
 	async checkIfExistsThirdParty(thirdPartyId: string): Promise<boolean> {
+		if (!thirdPartyId) {
+			return false;
+		}
 		switch (this.ormType) {
 			case MultiORMEnum.MikroORM:
 				return !!(await this.mikroOrmRepository.findOne({ thirdPartyId } as any));
@@ -299,10 +308,20 @@ export class UserService extends TenantAwareCrudService<User> {
 
 	/**
 	 * Retrieves a user with the given ID if it exists.
+	 *
+	 * The id MUST be present. TypeORM silently omits an `undefined` (and, before
+	 * TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR, a `null`) where value, so `findOneBy({ id: undefined })`
+	 * became `SELECT ... LIMIT 1` and returned an arbitrary user — the JWT strategy authenticated any
+	 * JWT_SECRET-signed token that had no `id` claim (invite / estimate / team-join / appointment /
+	 * magic-code tokens) as the first user in the table.
+	 *
 	 * @param {string} id - The ID of the user to retrieve.
 	 * @returns {Promise<User | undefined>} - A promise that resolves to the user if it exists, otherwise undefined.
 	 */
 	async getIfExists(id: string): Promise<User | undefined> {
+		if (!id) {
+			return undefined;
+		}
 		switch (this.ormType) {
 			case MultiORMEnum.MikroORM:
 				return await this.mikroOrmUserRepository.findOne({ id });
@@ -320,6 +339,9 @@ export class UserService extends TenantAwareCrudService<User> {
 	 * @returns {Promise<User | undefined>} - A promise that resolves to the user if it exists, otherwise undefined.
 	 */
 	async getIfExistsThirdParty(thirdPartyId: string): Promise<User | undefined> {
+		if (!thirdPartyId) {
+			return undefined;
+		}
 		switch (this.ormType) {
 			case MultiORMEnum.MikroORM:
 				return await this.mikroOrmUserRepository.findOne({ thirdPartyId });

--- a/packages/plugins/camshot/src/lib/queries/handlers/get-camshot-count-query.handler.ts
+++ b/packages/plugins/camshot/src/lib/queries/handlers/get-camshot-count-query.handler.ts
@@ -29,6 +29,12 @@ export class GetCamshotCountQueryHandler implements IQueryHandler<GetCamshotCoun
 		const { organizationId, tenantId } = options;
 		// Check if the current user has the permission
 		const permission = RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE);
+		// Without the permission the caller only counts their own camshots — and a caller with no
+		// employee identity counts none (same guard as the soundshot sibling; a null uploadedById used
+		// to be dropped from the SQL and return the organization-wide count).
+		if (!permission && !RequestContext.currentEmployeeId()) {
+			return 0;
+		}
 		// Fetch the count of camshot entities from the database
 		return this.camshotService.count({
 			where: {

--- a/packages/plugins/docs/src/lib/services/document-knowledge.service.ts
+++ b/packages/plugins/docs/src/lib/services/document-knowledge.service.ts
@@ -135,7 +135,10 @@ export class DocumentKnowledgeService {
 	 */
 	public async bulkReindex(input: BulkKnowledgeReindexDTO = {}): Promise<IBulkReindexResult> {
 		const tenantId = RequestContext.currentTenantId() as ID;
-		const organizationId = RequestContext.currentOrganizationId() as ID;
+		// Same rule as every other docs path: an unresolvable organization scope is a 400, never
+		// "the whole tenant" (a null used to be dropped from the where and enqueued reindex jobs for
+		// every indexed document of the tenant with a null organization key).
+		const organizationId = this.documentService.resolveOrganizationId();
 		const scope = input.scope ?? 'model-drift';
 		const dryRun = input.dryRun === true;
 

--- a/packages/plugins/job-proposal/src/lib/proposal-template/employee-proposal-template.service.ts
+++ b/packages/plugins/job-proposal/src/lib/proposal-template/employee-proposal-template.service.ts
@@ -78,7 +78,10 @@ export class EmployeeProposalTemplateService extends TenantAwareCrudService<Empl
 		// Reset `isDefault` to false on all templates matching these fields
 		const { organizationId, tenantId, employeeId } = proposalTemplate;
 
-		// Update the isDefault property on all templates matching these fields
+		// Update the isDefault property on all templates matching these fields. organizationId is a
+		// nullable column: for an organization-less template the null means `organizationId IS NULL` on
+		// both ORMs (TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR), i.e. only its organization-less siblings are
+		// reset — the null used to be dropped and reset the employee's templates in every organization.
 		await super.update({ organizationId, tenantId, employeeId }, { isDefault: false });
 
 		// Save and return the updated template

--- a/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-employee-criterion.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-employee-criterion.handler.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { GauzyAIService } from '@gauzy/plugin-integration-ai';
 import { IMatchingCriterions, PermissionsEnum } from '@gauzy/contracts';
@@ -36,25 +36,26 @@ export class SaveEmployeeCriterionHandler implements ICommandHandler<SaveEmploye
 			throw new BadRequestException('employeeId is required');
 		}
 		const { tenantId } = input;
+		if (!tenantId) {
+			throw new ForbiddenException('Tenant context is required');
+		}
 
-		// Set organizationId if not provided in the input
+		// The employee must exist IN THIS TENANT before anything is persisted for them (raw repository —
+		// scope explicitly). Its organization fills a missing organizationId.
+		const employee = await this.typeOrmEmployeeRepository.findOne({
+			where: { id: input.employeeId, tenantId },
+			relations: { user: true, organization: true }
+		});
+		if (!employee) {
+			throw new NotFoundException(`Employee with id ${input.employeeId} not found`);
+		}
 		if (!input.organizationId) {
-			const employee = await this.typeOrmEmployeeRepository.findOneBy({ id: input.employeeId, tenantId });
-			if (!employee) {
-				throw new NotFoundException(`Employee with id ${input.employeeId} not found`);
-			}
 			input.organizationId = employee.organizationId;
 		}
 
 		// Create criteria
 		const creation = new EmployeeUpworkJobsSearchCriterion(input);
 		await this.typeOrmEmployeeUpworkJobsSearchCriterionRepository.save(creation);
-
-		// Find employee by ID
-		const employee = await this.typeOrmEmployeeRepository.findOne({
-			where: { id: input.employeeId, tenantId },
-			relations: { user: true, organization: true }
-		});
 
 		// Find criteria for the employee
 		const criteria = await this.typeOrmEmployeeUpworkJobsSearchCriterionRepository.findBy({

--- a/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-employee-criterion.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-employee-criterion.handler.ts
@@ -1,3 +1,4 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { GauzyAIService } from '@gauzy/plugin-integration-ai';
 import { IMatchingCriterions, PermissionsEnum } from '@gauzy/contracts';
@@ -29,10 +30,19 @@ export class SaveEmployeeCriterionHandler implements ICommandHandler<SaveEmploye
 		if (!RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)) {
 			input.employeeId = RequestContext.currentEmployeeId();
 		}
+		// Every lookup below is a raw repository query keyed on employeeId; an empty id must fail here
+		// rather than turn into an unscoped query (a null key used to be dropped from the SQL).
+		if (!input.employeeId) {
+			throw new BadRequestException('employeeId is required');
+		}
+		const { tenantId } = input;
 
 		// Set organizationId if not provided in the input
-		if (!input.organizationId && input.employeeId) {
-			const employee = await this.typeOrmEmployeeRepository.findOneBy({ id: input.employeeId });
+		if (!input.organizationId) {
+			const employee = await this.typeOrmEmployeeRepository.findOneBy({ id: input.employeeId, tenantId });
+			if (!employee) {
+				throw new NotFoundException(`Employee with id ${input.employeeId} not found`);
+			}
 			input.organizationId = employee.organizationId;
 		}
 
@@ -42,14 +52,15 @@ export class SaveEmployeeCriterionHandler implements ICommandHandler<SaveEmploye
 
 		// Find employee by ID
 		const employee = await this.typeOrmEmployeeRepository.findOne({
-			where: { id: input.employeeId },
+			where: { id: input.employeeId, tenantId },
 			relations: { user: true, organization: true }
 		});
 
 		// Find criteria for the employee
 		const criteria = await this.typeOrmEmployeeUpworkJobsSearchCriterionRepository.findBy({
 			employeeId: input.employeeId,
-			jobPresetId: input.jobPresetId
+			jobPresetId: input.jobPresetId,
+			tenantId
 		});
 
 		// Sync Gauzy AI criteria with the employee

--- a/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-employee-preset.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-employee-preset.handler.ts
@@ -56,22 +56,26 @@ export class SaveEmployeePresetHandler implements ICommandHandler<SaveEmployeePr
 			throw new NotFoundException(`Employee with id ${employeeId} not found`);
 		}
 
-		// Find the job preset with related criteria
-		const jobPreset = await this._typeOrmJobPresetRepository.findOne({
-			where: { id: In(input.jobPresetIds), tenantId },
+		// Find ALL requested job presets with their criteria — in this tenant. Every requested id must
+		// resolve, or a foreign / unknown preset id would be stored on the employee anyway.
+		const jobPresetIds = [...new Set(input.jobPresetIds)];
+		const jobPresets = await this._typeOrmJobPresetRepository.find({
+			where: { id: In(jobPresetIds), tenantId },
 			relations: { jobPresetCriterions: true }
 		});
-		if (!jobPreset) {
+		if (jobPresets.length !== jobPresetIds.length) {
 			throw new NotFoundException('Job preset not found');
 		}
 
-		// Map job preset criteria to employee criterions
-		const employeeCriterions = jobPreset.jobPresetCriterions.map(
-			(item) => new EmployeeUpworkJobsSearchCriterion({ ...item, employeeId })
+		// Map every preset's criteria to employee criterions
+		const employeeCriterions = jobPresets.flatMap((jobPreset) =>
+			(jobPreset.jobPresetCriterions ?? []).map(
+				(item) => new EmployeeUpworkJobsSearchCriterion({ ...item, employeeId })
+			)
 		);
 
-		// Update employee custom fields with job presets
-		employee.customFields['jobPresets'] = input.jobPresetIds.map((id) => new JobPreset({ id }));
+		// Update employee custom fields with the (verified) job presets
+		employee.customFields['jobPresets'] = jobPresets.map(({ id }) => new JobPreset({ id }));
 		await this._typeOrmEmployeeRepository.save(employee);
 
 		// Delete existing employee job search criteria — for THIS employee of THIS tenant only.

--- a/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-employee-preset.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-employee-preset.handler.ts
@@ -1,7 +1,9 @@
 import { In } from 'typeorm';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { PermissionsEnum } from '@gauzy/contracts';
 import { GauzyAIService } from '@gauzy/plugin-integration-ai';
-import { parseFindOptionsRelations, TypeOrmEmployeeRepository } from '@gauzy/core';
+import { parseFindOptionsRelations, RequestContext, TypeOrmEmployeeRepository } from '@gauzy/core';
 import { EmployeeUpworkJobsSearchCriterion } from '../../employee-upwork-jobs-search-criterion.entity';
 import { JobPreset } from '../../job-preset.entity';
 import { SaveEmployeePresetCommand } from '../save-employee-preset.command';
@@ -25,19 +27,43 @@ export class SaveEmployeePresetHandler implements ICommandHandler<SaveEmployeePr
 	 */
 	public async execute(command: SaveEmployeePresetCommand): Promise<JobPreset[]> {
 		const { input } = command;
-		const { employeeId } = input;
+		const tenantId = RequestContext.currentTenantId();
 
-		// Find the employee with related data
+		// Resolve the target employee fail-closed. A caller without CHANGE_SELECTED_EMPLOYEE may only
+		// touch their own record; everyone else must name a real employee of their own tenant. Every
+		// repository call below is a RAW TypeORM lookup, and `{ employeeId }` with a null value used to
+		// be dropped from the SQL — the delete below then became an unfiltered DELETE of every tenant's
+		// search criteria (GHSA-44pv-34gx-q9p4 class), so the id must never be empty here.
+		const employeeId = RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
+			? input.employeeId
+			: RequestContext.currentEmployeeId() ?? RequestContext.currentUser()?.employeeId;
+		if (!employeeId) {
+			throw new BadRequestException('employeeId is required');
+		}
+		if (!tenantId) {
+			throw new ForbiddenException('Tenant context is required');
+		}
+		if (!Array.isArray(input.jobPresetIds) || input.jobPresetIds.length === 0) {
+			throw new BadRequestException('jobPresetIds is required');
+		}
+
+		// Find the employee with related data — scoped to the caller's tenant.
 		let employee = await this._typeOrmEmployeeRepository.findOne({
-			where: { id: employeeId },
+			where: { id: employeeId, tenantId },
 			relations: parseFindOptionsRelations(['user', 'organization', 'customFields.jobPresets'])
 		});
+		if (!employee) {
+			throw new NotFoundException(`Employee with id ${employeeId} not found`);
+		}
 
 		// Find the job preset with related criteria
 		const jobPreset = await this._typeOrmJobPresetRepository.findOne({
-			where: { id: In(input.jobPresetIds) },
+			where: { id: In(input.jobPresetIds), tenantId },
 			relations: { jobPresetCriterions: true }
 		});
+		if (!jobPreset) {
+			throw new NotFoundException('Job preset not found');
+		}
 
 		// Map job preset criteria to employee criterions
 		const employeeCriterions = jobPreset.jobPresetCriterions.map(
@@ -48,8 +74,8 @@ export class SaveEmployeePresetHandler implements ICommandHandler<SaveEmployeePr
 		employee.customFields['jobPresets'] = input.jobPresetIds.map((id) => new JobPreset({ id }));
 		await this._typeOrmEmployeeRepository.save(employee);
 
-		// Delete existing employee job search criteria
-		await this._typeOrmEmployeeUpworkJobsSearchCriterionRepository.delete({ employeeId });
+		// Delete existing employee job search criteria — for THIS employee of THIS tenant only.
+		await this._typeOrmEmployeeUpworkJobsSearchCriterionRepository.delete({ employeeId, tenantId });
 
 		// Save new employee job search criteria
 		await this._typeOrmEmployeeUpworkJobsSearchCriterionRepository.save(employeeCriterions);
@@ -59,7 +85,7 @@ export class SaveEmployeePresetHandler implements ICommandHandler<SaveEmployeePr
 
 		// Find the employee with related data
 		employee = await this._typeOrmEmployeeRepository.findOne({
-			where: { id: employeeId },
+			where: { id: employeeId, tenantId },
 			relations: parseFindOptionsRelations(['customFields.jobPresets'])
 		});
 

--- a/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-preset-criterion.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-preset-criterion.handler.ts
@@ -1,5 +1,5 @@
 import { IMatchingCriterions, PermissionsEnum } from '@gauzy/contracts';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { RequestContext, TypeOrmEmployeeRepository } from '@gauzy/core';
 import { JobPresetUpworkJobSearchCriterion } from '../../job-preset-upwork-job-search-criterion.entity';
@@ -22,6 +22,9 @@ export class SavePresetCriterionHandler implements ICommandHandler<SavePresetCri
 	public async execute(command: SavePresetCriterionCommand): Promise<IMatchingCriterions> {
 		const { input } = command;
 		input.tenantId = RequestContext.currentTenantId() ?? input.tenantId;
+		if (!input.tenantId) {
+			throw new ForbiddenException('Tenant context is required');
+		}
 
 		// If the current user has the permission to change the selected employee, use their ID
 		if (!RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)) {

--- a/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-preset-criterion.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/commands/handlers/save-preset-criterion.handler.ts
@@ -1,4 +1,5 @@
 import { IMatchingCriterions, PermissionsEnum } from '@gauzy/contracts';
+import { NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { RequestContext, TypeOrmEmployeeRepository } from '@gauzy/core';
 import { JobPresetUpworkJobSearchCriterion } from '../../job-preset-upwork-job-search-criterion.entity';
@@ -27,9 +28,16 @@ export class SavePresetCriterionHandler implements ICommandHandler<SavePresetCri
 			input.employeeId = RequestContext.currentEmployeeId();
 		}
 
-		// Set organizationId if not provided in the input
+		// Set organizationId if not provided in the input (raw repository: scope to the tenant, and
+		// only ever look an employee up by a real id).
 		if (!input.organizationId && input.employeeId) {
-			const employee = await this.typeOrmEmployeeRepository.findOneBy({ id: input.employeeId });
+			const employee = await this.typeOrmEmployeeRepository.findOneBy({
+				id: input.employeeId,
+				tenantId: input.tenantId
+			});
+			if (!employee) {
+				throw new NotFoundException(`Employee with id ${input.employeeId} not found`);
+			}
 			input.organizationId = employee.organizationId;
 		}
 

--- a/packages/plugins/job-search/src/lib/employee-job-preset/dto/index.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './create-job-preset.dto';
 export * from './job-preset-query.dto';
+export * from './save-employee-preset.dto';
 export * from './save-job-preset-criterion.dto';

--- a/packages/plugins/job-search/src/lib/employee-job-preset/dto/save-employee-preset.dto.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/dto/save-employee-preset.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ArrayNotEmpty, IsArray, IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { ID, IEmployeePresetInput, JobPostSourceEnum } from '@gauzy/contracts';
+import { TenantOrganizationBaseDTO } from '@gauzy/core';
+
+/**
+ * POST /job-preset/employee body.
+ *
+ * `employeeId` MUST be a real UUID: the handler deletes the employee's existing search criteria by
+ * `{ employeeId }`, and a missing / null value used to be dropped from the SQL, turning that into an
+ * unfiltered DELETE across every tenant (GHSA-44pv-34gx-q9p4 class).
+ */
+export class SaveEmployeePresetDTO extends TenantOrganizationBaseDTO implements IEmployeePresetInput {
+	@ApiProperty({ type: () => String })
+	@IsUUID()
+	readonly employeeId: ID;
+
+	@ApiProperty({ type: () => Array, isArray: true })
+	@IsArray()
+	@ArrayNotEmpty()
+	@IsUUID('all', { each: true })
+	readonly jobPresetIds: ID[];
+
+	@ApiPropertyOptional({ type: () => String, enum: JobPostSourceEnum })
+	@IsOptional()
+	@IsEnum(JobPostSourceEnum)
+	readonly source?: JobPostSourceEnum;
+}

--- a/packages/plugins/job-search/src/lib/employee-job-preset/dto/save-employee-preset.dto.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/dto/save-employee-preset.dto.ts
@@ -6,14 +6,17 @@ import { TenantOrganizationBaseDTO } from '@gauzy/core';
 /**
  * POST /job-preset/employee body.
  *
- * `employeeId` MUST be a real UUID: the handler deletes the employee's existing search criteria by
- * `{ employeeId }`, and a missing / null value used to be dropped from the SQL, turning that into an
- * unfiltered DELETE across every tenant (GHSA-44pv-34gx-q9p4 class).
+ * `employeeId`, when sent, MUST be a real UUID: the handler deletes the employee's existing search
+ * criteria by `{ employeeId }`, and a null value used to be dropped from the SQL, turning that into an
+ * unfiltered DELETE across every tenant (GHSA-44pv-34gx-q9p4 class). Callers without
+ * CHANGE_SELECTED_EMPLOYEE may omit it — the handler pins their own employee and fails closed when
+ * there is none.
  */
 export class SaveEmployeePresetDTO extends TenantOrganizationBaseDTO implements IEmployeePresetInput {
-	@ApiProperty({ type: () => String })
+	@ApiPropertyOptional({ type: () => String })
+	@IsOptional()
 	@IsUUID()
-	readonly employeeId: ID;
+	readonly employeeId?: ID;
 
 	@ApiProperty({ type: () => Array, isArray: true })
 	@IsArray()

--- a/packages/plugins/job-search/src/lib/employee-job-preset/employee-preset.controller.ts
+++ b/packages/plugins/job-search/src/lib/employee-job-preset/employee-preset.controller.ts
@@ -3,15 +3,14 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { DeleteResult } from 'typeorm';
 import {
 	ID,
-	IEmployeePresetInput,
 	IEmployeeUpworkJobsSearchCriterion,
 	IGetMatchingCriterions,
 	IJobPreset
 } from '@gauzy/contracts';
-import { UUIDValidationPipe } from '@gauzy/core';
+import { UseValidationPipe, UUIDValidationPipe } from '@gauzy/core';
 import { JobPresetService } from './job-preset.service';
 import { JobPreset } from './job-preset.entity';
-import { SaveJobPresetCriterionDTO } from './dto';
+import { SaveEmployeePresetDTO, SaveJobPresetCriterionDTO } from './dto';
 
 @ApiTags('EmployeeJobPreset')
 @Controller('/job-preset/employee')
@@ -112,7 +111,8 @@ export class EmployeePresetController {
 		description: 'Record not found'
 	})
 	@Post('/')
-	async saveEmployeePreset(@Body() request: IEmployeePresetInput): Promise<IJobPreset[]> {
+	@UseValidationPipe({ whitelist: true })
+	async saveEmployeePreset(@Body() request: SaveEmployeePresetDTO): Promise<IJobPreset[]> {
 		return await this.jobPresetService.saveEmployeePreset(request);
 	}
 

--- a/packages/plugins/job-search/src/lib/employee-job/commands/handlers/update-employee-job-search-status.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job/commands/handlers/update-employee-job-search-status.handler.ts
@@ -28,6 +28,11 @@ export class UpdateEmployeeJobSearchStatusHandler implements ICommandHandler<Upd
 			// Filter by current employee ID if the permission is not present
 			employeeId = RequestContext.currentEmployeeId();
 		}
+		// Never query with an empty id: `where: { id: null }` used to drop the predicate and resolve
+		// to an arbitrary employee of the tenant.
+		if (!employeeId) {
+			throw new BadRequestException('Employee context is required to update the job search status.');
+		}
 
 		// Find the employee by ID
 		const employee = await this.employeeService.findOneByIdString(employeeId, {

--- a/packages/plugins/job-search/src/lib/employee-job/commands/handlers/update-employee-job-search-status.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job/commands/handlers/update-employee-job-search-status.handler.ts
@@ -33,6 +33,9 @@ export class UpdateEmployeeJobSearchStatusHandler implements ICommandHandler<Upd
 		if (!employeeId) {
 			throw new BadRequestException('Employee context is required to update the job search status.');
 		}
+		if (!tenantId) {
+			throw new BadRequestException('Tenant context is required to update the job search status.');
+		}
 
 		// Find the employee by ID
 		const employee = await this.employeeService.findOneByIdString(employeeId, {
@@ -78,7 +81,8 @@ export class UpdateEmployeeJobSearchStatusHandler implements ICommandHandler<Upd
 			console.error('Error while syncing employee with Gauzy AI:', error.message);
 		}
 
-		// Update the employee's job search status locally
-		return await this.employeeService.update(employeeId, { isJobSearchActive });
+		// Update the employee's job search status locally — scoped to the tenant explicitly (the
+		// tenant-aware update relies on a request user, which this handler may run without).
+		return await this.employeeService.update({ id: employeeId, tenantId }, { isJobSearchActive });
 	}
 }

--- a/packages/plugins/job-search/src/lib/employee-job/queries/handlers/get-employee-job-statistics.handler.ts
+++ b/packages/plugins/job-search/src/lib/employee-job/queries/handlers/get-employee-job-statistics.handler.ts
@@ -25,8 +25,14 @@ export class GetEmployeeJobStatisticsHandler implements IQueryHandler<GetEmploye
 
 		// Check for permission CHANGE_SELECTED_EMPLOYEE
 		if (!RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)) {
-			// Filter by current employee ID if the permission is not present
-			options.where.id = RequestContext.currentEmployeeId();
+			// Filter by current employee ID if the permission is not present. A caller with no employee
+			// identity sees nothing — assigning null here used to drop the predicate and page through
+			// every employee of the tenant.
+			const employeeId = RequestContext.currentEmployeeId();
+			if (!employeeId) {
+				return { items: [], total: 0 };
+			}
+			options.where.id = employeeId;
 		}
 
 		// Use Promise.all for concurrent requests


### PR DESCRIPTION
## Summary

Fixes **GHSA-44pv-34gx-q9p4** (TypeORM configuration silently drops `null` where filters) — and the whole bug class behind it, including a **critical authentication bypass** found while auditing it.

TypeORM omits a where key whose value is `null`/`undefined` from the SQL (0.3 always; 1.0 under the `invalidWhereValuesBehavior: { null: 'ignore', undefined: 'ignore' }` we set in the 1.0 migration). Every criteria object that carried such a value therefore ran a *wider* query than written:

- `{ tenantId: null, organizationId: null }` (meant: the global row) matched every tenant → the reported cross-tenant accounting-template disclosure (`GET /accounting-template/template`, since v78.1.0 / commit `51e22b7c22`).
- `findOneBy({ id: undefined })` became `SELECT … LIMIT 1` → **the first row of the table**.
- `repository.delete({ employeeId: undefined })` — an object TypeORM's own empty-criteria guard does *not* catch — became `DELETE FROM <table>` with no `WHERE`.

All three shapes are proven empirically in the new specs (better-sqlite3 + TypeORM 1.0.0, each with a CONTROL arm on the pre-fix shape).

### The most severe finding (not the reported one)

`JwtStrategy` accepts any JWT signed with `JWT_SECRET`. Invite (`{email, code}`), estimate-email, team-join, appointment and magic-code tokens are signed with the same secret but carry **no `id` claim**; `validate()` → `getIfExists(undefined)` → `findOneBy({ id: undefined })` → **the first user in the table** (the seeded super admin). Anyone holding an invite/estimate e-mail — or any registered user requesting a magic code — could Bearer that token and act as that user. `undefined` is not covered by the config change; it is closed in `JwtStrategy` (rejects id-less payloads) and `UserService.getIfExists*/checkIfExists*` (refuse empty ids). Spec: `jwt.strategy.spec.ts`.

## What changed (layers)

| Layer | Change |
|---|---|
| **Config** | `TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR = { null: 'sql-null', undefined: 'ignore' }` (`@gauzy/config` `database-helpers.ts`), used by all three TypeORM profiles. `null` → `IS NULL` is fail-closed (only ever narrows a query), matches TypeORM ≤0.2 and MikroORM, so where objects shared by both ORM branches mean the same thing. `undefined` stays omitted — `where: { tenantId, organizationId }` with an optional undefined value is the codebase-wide idiom. (`'throw'` was rejected: it turns every residual site into a 500.) |
| **Ingress** | `ParseJsonPipe` drops `null`-valued properties from `?data={…}` filter objects: the clients were written against "null = not filtered" (and do send it), while `IS NULL` intent belongs to server code via `IsNull()`. |
| **Read guard** | `CrudService.findOneByIdString / findOneOrFailByIdString` fail closed on an empty id (closes "lookup by no id returns the first row" for null *and* undefined). |
| **Write guard** | `assertCriteriaHasPredicate()` in `CrudService.update/delete/softDelete` and on the caller-supplied criteria in `TenantAwareCrudService.delete` (closes the unfiltered DELETE/UPDATE class; the injected tenantId must not be what saves you). |
| **Auth** | `JwtStrategy` + `UserService` guards above. |
| **Sites** | ~40 call sites made explicit — `IsNull()` where IS NULL is meant (accounting/email templates, favorites, employee settings), spread-guards where "no filter for privileged callers" is meant, fail-closed guards where a low-privilege caller could reach arbitrary rows: expense/income delete, own-employee lookup, team manager checks, employee-notification mark-all-read (was marking **every tenant's** notifications read for admins), reactions (was deleting **other employees'** identical reactions), job-search presets (raw-body `employeeId` → unfiltered `DELETE` of every tenant's search criteria; now DTO-validated + tenant-scoped), role-permission role resolution (undefined `roleId` → first role bypassed the SUPER_ADMIN gate), public estimate token (`invoiceId` missing → arbitrary invoice updated), recurring-expense siblings (null parent → **deleted unrelated expenses**), GitHub-webhook (no-context) integration-setting lookups, timesheet recalculation, time slots, report menu, time-off policy, sprints, project modules, strategic-initiative visibility, oauth clients, docs reindex, hubstaff task maps, proposal templates. Each carries a comment saying which. |

## Verification

- `packages/config` `database-helpers.spec.ts` (13): shipped setting is `sql-null/ignore` on all four DB_TYPE profiles; `find/findOneBy/countBy/existsBy/delete` with `null` emit `IS NULL`; CONTROL: under the pre-fix `ignore` the same `{ tenantId: null }` returns every tenant / a tenant-less DELETE wipes the table.
- `accounting-template.criteria.spec.ts` (8): the advisory scenario (tenant A asks for `fr/invoice`, only tenant B has one) returns nothing under both settings; CONTROL: pre-fix literal-null criteria under the pre-fix setting **do** leak tenant B's template.
- `criteria.helper.spec.ts`, `parse-json.pipe.spec.ts`, `jwt.strategy.spec.ts` (+ existing `claim-criteria.spec.ts`) — 56 tests total, all green.
- `tsc --noEmit` clean for config, core, plugin-job-search, plugin-camshot, plugin-docs, plugin-job-proposal; cspell clean.
- Full local API boot (better-sqlite3, seeded) + end-to-end probe: as tenant A, `GET /accounting-template/template?templateType=invoice&languageCode=fr` with a foreign-tenant `fr/invoice` row present returns the English global template (never tenant B's); id-less JWTs are rejected with 401; broad read smoke over ~70 list endpoints as admin: no 5xx. (Details below.)

### Runtime results (local API, better-sqlite3, seeded, TypeORM 1.0.0)

The running API's DB config: `"invalidWhereValuesBehavior":{"null":"sql-null","undefined":"ignore"}` (migrations + the first-boot seed ran without a request context — fine).

| Probe | Result |
|---|---|
| Advisory: as tenant A, `GET /accounting-template/template?templateType=invoice&languageCode=fr` while only a foreign tenant B has `fr/invoice` | **200, the English global template** (`tenantId=null, organizationId=null`); the body never contains tenant B's marker. Emitted SQL: `… "tenantId" IS NULL AND "organizationId" IS NULL … PARAMETERS: ["fr","invoice"]` |
| Auth bypass: Bearer an id-less JWT signed with `JWT_SECRET` (invite-token shape `{email, code}`) → `GET /user/me` | **401** (a real access token → 200) |
| `POST /job-preset/employee` with `employeeId: null` (was an unfiltered DELETE) | **400** `employeeId must be a UUID` |
| `POST /role-permissions` with a `role` object only | 400 (fail closed) |
| `GET /employee/<unknown>` as admin | 404 |
| Admin (`currentEmployeeId() === null`) mutations on the changed paths: favorite create (org-level) + delete, comment create + update, reaction create + toggle, broadcast create (publisher-less) + update, mark-all-read | 202/202, 201/202, 201/201, 201/200, 202 `{count:0}` |
| ~100 list endpoints as admin with the UI's request shapes | no 5xx attributable to this change (the only 5xx, `GET /integration` without its query param, is a pre-existing `toLowerCase` on undefined) |

Two pre-existing breakages surfaced by the smoke and fixed in passing (both one-liners): `POST /reaction` returned 400 for every *first* reaction (a throwing lookup used as an existence check) and `PUT /employee-notification/mark-all-read` returned 400 when nothing was unread.

## Notes for reviewers

- `RequestContext.currentEmployeeId()` is **null by design** for `CHANGE_SELECTED_EMPLOYEE` holders (it means "the selected employee", not "me"). Where "me" is meant the code now falls back to `RequestContext.currentUser()?.employeeId` (as the docs plugin already documents); where "restrict unless privileged" is meant it branches on the permission and fails closed.
- `TenantAwareCrudService.delete/update` already inject the own-employee restriction for non-privileged callers that have one, so the explicit `employeeId: currentEmployeeId()` in the expense/income delete handlers was redundant and only ever mattered in the null case (where it silently over-permitted); collapsed to `{ id }` to preserve today's effective behavior.
- MikroORM: `IsNull()` does not survive raw `nativeUpdate` filters, so for `update` criteria a plain `null` (now `IS NULL` on both ORMs) is the portable spelling.

Refs GHSA-44pv-34gx-q9p4. Companion knowledge doc: `ever-gauzy-workspace/knowledge/security/TYPEORM_NULL_WHERE_ISOLATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closes TypeORM queries that used to drop null/undefined where predicates and closes an id-less JWT auth bypass. Old behavior: `{ foo: null|undefined }` was omitted, widening reads/writes; JWTs without `id` authenticated as the first user. New behavior: `null` becomes `IS NULL`, `undefined` is ignored; JWTs without `id`/`thirdPartyId` are rejected. Side effect: malformed or unscoped criteria now return 400/403 instead of falling through.

- Config: set `invalidWhereValuesBehavior` to `{ null: 'sql-null', undefined: 'ignore' }` for all TypeORM profiles via `TYPEORM_INVALID_WHERE_VALUES_BEHAVIOR`.
- Ingress: `ParseJsonPipe` drops `null` keys in `?data={...}` to preserve “null = not filtered” client semantics; adds a 32-level bound and surfaces sanitizer errors as 400.
- Guards: `assertCriteriaHasPredicate()` is recursive (blocks empty/nested/OR criteria that collapse to no predicates); `CrudService.update/delete/softDelete` run it before DB calls (400 on malformed input); `TenantAwareCrudService.delete` rethrows 400; `CrudService.findOne*ByIdString` and `UserService` fail on empty ids.
- Auth: `JwtStrategy` rejects payloads without `id`/`thirdPartyId` (invite/estimate/team-join/appointment/magic-code tokens).
- Sites: made `IsNull()` explicit and added fail-closed tenant/ownership checks across sensitive paths (accounting/email templates, favorites, employee settings, employee notifications mark-all-read, reactions, public invoice update, role-permissions, organization projects/modules/sprints/teams, recurring expenses, docs reindex, camshot counts, reports). Job-search flows now validate input with `SaveEmployeePresetDTO`, enforce tenant scoping, and require employee/tenant context where needed.
- Tests: added regression suites for the TypeORM setting, accounting-template leak, recursive criteria guard, JSON pipe, and JWT strategy (against real `better-sqlite3`).

Required actions for developers:
- Do not use literal `null` in `where` to mean “no filter”; omit the key or pass `undefined`. Use `IsNull()` when you intend `IS NULL`. Some handlers now return 400/403 for missing or unscoped identifiers. No client changes or DB migration required.

<sup>Written for commit 3e8ae162173dbf628c3236d1f2de3da315ddfaff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

