### PR TITLE
fix(time-tracking): Angular Recent Activities carousel — slides never narrower than the screenshot card (overlap beside the expanded chat)

### DIFF
--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/time-tracking.component.html
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/time-tracking.component.html
@@ -267,11 +267,22 @@
 									</div>
 								</div>
 								<div>
+									<!--
+										`slides-per-view="auto"` + a slide width in the stylesheet, NOT a
+										hard-coded three-up: the screenshot card has its own
+										`min-width: 189px`, so once the window is narrower than ~600px
+										(e.g. beside the expanded AI chat) three slices are narrower than
+										the card and every card overflows its slide — the thumbnails and
+										the time/date block below them visibly collide. The stylesheet
+										keeps three across while they fit and falls back to 189px slides
+										that scroll. `slides-per-group-auto` makes the arrows advance by
+										however many are actually visible.
+									-->
 									<swiper-container
 										#swiperRef
-										slides-per-view="3"
+										slides-per-view="auto"
 										space-between="16"
-										slides-per-group="3"
+										slides-per-group-auto="true"
 										loop="false"
 										navigation="true"
 										[pagination]="{ clickable: true }"

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/time-tracking.component.scss
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/time-tracking.component.scss
@@ -305,3 +305,20 @@ nb-card-body > .header-widget {
   // Was a `!important` viewport calc; see the `card_overrides` note above.
   height: auto !important;
 }
+
+// Recent Activities carousel: three across while they fit, never narrower than the
+// screenshot card's own `min-width` (189px, screenshots-item.component.scss). Swiper
+// reads these widths because the container runs with `slides-per-view="auto"`; below
+// ~600px it simply shows fewer slides and scrolls, instead of squeezing every card
+// past the edge of its slide (overlapping thumbnails + collided time/date text).
+.m-swiper {
+  display: block;
+  width: 100%;
+  min-width: 0;
+
+  swiper-slide {
+    display: block;
+    width: max(calc((100% - 2 * 16px) / 3), 189px);
+    height: auto;
+  }
+}


### PR DESCRIPTION
Reported on demo: with the AI chat expanded, the **Angular** Time Tracking dashboard's Recent Activities screenshots and the info block under them are mangled — thumbnails run into each other and the time/date text collides (`03:20:00 AM - 03:30:0|08:40:00 AM - 03:20:0…`).

## Cause

`time-tracking.component.html` hard-codes `slides-per-view="3"`, but `ngx-screenshots-item`'s card has its own `min-width: 189px`. Once the window is narrower than ~600px — which is exactly what the expanded 384px chat does — a third of the width is smaller than the card, so **every card overflows its slide** and paints over its neighbour.

Measured on demo (chat expanded, 1920 viewport):

| | before |
|---|---|
| swiper container | 550px |
| slide (`slidesSizesGrid`) | 173px |
| card | 189px (`min-width`) |
| **card overflow per slide** | **+16px** (≈ +47px at a 460px window → the visible collision) |

## Fix

`slides-per-view="auto"` + a slide width in the stylesheet — the same pattern the **widget** carousel in this plugin already uses, and what the React flavour does with `flex: 0 0 max(calc(…), 189px)`:

```scss
.m-swiper swiper-slide { width: max(calc((100% - 2 * 16px) / 3), 189px); }
```

Three across while they fit; below that, fewer slides show and the track scrolls. `slides-per-group-auto="true"` makes the arrows advance by the number actually visible (replacing the fixed `slides-per-group="3"`).

## Verification

Applied live against the deployed Angular flavour on demo (inject the rule, switch the container to `auto`, `swiper.update()`), at three window widths:

| container | slide | card | card overflow | neighbour overlap | visible |
|---|---|---|---|---|---|
| 550px | 189 | 189 | 0 | 0 | 2 + scroll |
| 460px | 189 | 189 | 0 | 0 | 2 + scroll |
| 380px | 189 | 189 | 0 | 0 | 1 + scroll |

Template/CSS only. (Note: Swiper does not lay out slides in a hidden browser pane — `slidesSizesGrid` stays empty — so these numbers come from forcing `swiper.update()`; the same applies to any automated check of this carousel.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Angular Time Tracking Recent Activities carousel so slides are never narrower than the screenshot card, preventing thumbnail and time text overlap beside the expanded chat. Previously it forced three slides per view, which made each card overflow at narrow widths; now it uses auto slides per view with a min slide width so fewer slides show and the track scrolls.

- HTML: switch to slides-per-view="auto" and slides-per-group-auto="true" (replaces slides-per-view="3" and slides-per-group="3").
- CSS: set swiper-slide width to max of one-third minus gaps or 189px, preserving three across when they fit and falling back to 189px slides.
- Scope: template/CSS only in the Angular dashboard time-tracking component; matches the existing widget carousel pattern.
- Review: resize with the chat open; expect 2 or 1 slides with scroll, no thumbnail/text collisions; navigation advances by the number of visible slides.

<sup>Written for commit f7e3e0248a498ac807c62d7ab510070825b05dcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

