### PR TITLE
fix(time-tracking): carousel slide width must live in _swiper.scss (#10006 rule lost the cascade)

### DIFF
--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/_swiper.scss
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/_swiper.scss
@@ -44,7 +44,14 @@
     }
 
     swiper-slide {
-      width: 100%;
+      // Three across while they fit, but NEVER narrower than the screenshot card's
+      // own `min-width` (189px, screenshots-item.component.scss): beside the expanded
+      // AI chat the window is ~550px, so a third of it is 173px and every card
+      // overflowed its slide — smeared thumbnails and collided time/date text.
+      // `slides-per-view="auto"` on the container makes Swiper read this width, so
+      // below ~600px it simply shows fewer slides and scrolls. `16px` is the
+      // `space-between` Swiper writes as each slide's margin.
+      width: max(calc((100% - 2 * 16px) / 3), 189px);
       height: 100%;
       padding-bottom: 1rem;
       display: block;

--- a/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/time-tracking.component.scss
+++ b/packages/plugins/dashboard-time-track-angular-ui/src/lib/components/time-tracking/time-tracking.component.scss
@@ -306,19 +306,11 @@ nb-card-body > .header-widget {
   height: auto !important;
 }
 
-// Recent Activities carousel: three across while they fit, never narrower than the
-// screenshot card's own `min-width` (189px, screenshots-item.component.scss). Swiper
-// reads these widths because the container runs with `slides-per-view="auto"`; below
-// ~600px it simply shows fewer slides and scrolls, instead of squeezing every card
-// past the edge of its slide (overlapping thumbnails + collided time/date text).
+// Recent Activities carousel: the slide width itself lives in `_swiper.scss` (that
+// mixin is included under `:host`, so a rule here could never outrank it). This only
+// keeps the container able to shrink inside a narrow window.
 .m-swiper {
   display: block;
   width: 100%;
   min-width: 0;
-
-  swiper-slide {
-    display: block;
-    width: max(calc((100% - 2 * 16px) / 3), 189px);
-    height: auto;
-  }
 }


### PR DESCRIPTION
Follow-up to #10006 — that PR's template change is correct, but its CSS never took effect.

## What #10006 missed

`_swiper.scss` already contained:

```scss
swiper-container { swiper-slide { width: 100%; … } }
```

and that mixin is `@include`d **inside `:host`**, so it compiles to `[_nghost-x] swiper-container[_ngcontent-x] swiper-slide[_ngcontent-x]` — higher specificity than the `.m-swiper[_ngcontent-x] swiper-slide[_ngcontent-x]` rule #10006 added in the component stylesheet. Confirmed on the deployed page: both rules matched the element, the `width: 100%` one won, and slides still computed to the full container width (`slidesSizesGrid: [550, 550, 550]`).

## Fix

Move the width into `_swiper.scss` itself; the component stylesheet keeps only `.m-swiper { display: block; width: 100%; min-width: 0 }`.

## Verification (live, on demo, with the exact compiled selector injected)

| container | slide | card | card overflow | overlap | visible |
|---|---|---|---|---|---|
| 550px (chat expanded) | 189 | 189 | 0 | 0 | 2 + scroll |
| 460px | 189 | 189 | 0 | 0 | 2 + scroll |
| 380px | 189 | 189 | 0 | 0 | 1 + scroll |
| 900px (chat collapsed) | 289 | 270 | — | 0 | **3** (unchanged 3-up) |

CSS only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the carousel slide width into `_swiper.scss` so it wins the cascade and takes effect. Previously `swiper-slide { width: 100% }` inside `:host` overrode the component rule, keeping slides full-width; now slides size to three across when space allows and never below 189px.

- Sets `swiper-slide` width to `max(calc((100% - 2 * 16px) / 3), 189px)` in `_swiper.scss`; `slides-per-view="auto"` uses this to render fewer slides on narrow windows instead of squeezing.
- Leaves `.m-swiper` only with container sizing (`display: block; width: 100%; min-width: 0`) and removes slide rules from the component stylesheet.
- Verified behavior: ~900px shows 3 slides (unchanged); ~550/460/380px show 2/2/1 with scroll; no overflow or text overlap.

<sup>Written for commit 4779023b50cc744f7cfbd7cd32bf456126bf7872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

