### PR TITLE
fix(ui): NG5002 — two HTML comments were written inside their tags (breaks build-web/build-libs)

### DIFF
--- a/packages/plugins/docs-ui/src/lib/components/filter-bar/saved-views.component.html
+++ b/packages/plugins/docs-ui/src/lib/components/filter-bar/saved-views.component.html
@@ -55,6 +55,8 @@
 				<!-- Inline rename -->
 				<ng-container *ngIf="renamingId === view.id; else viewRow">
 					<!-- Only one row can be in rename mode at a time, so the id stays unique. -->
+					<!-- Esc stops here: the component also closes the whole panel on a
+					     document-level Esc, so the rename would take the panel with it. -->
 					<input
 						nbInput
 						fieldSize="tiny"
@@ -64,7 +66,6 @@
 						[attr.aria-label]="'DOCS.SAVED_VIEWS.RENAME' | translate"
 						[(ngModel)]="renameDraft"
 						(keydown.enter)="commitRename(view)"
-						<!-- Stop here: the component also closes the whole panel on a document-level Esc. -->
 						(keydown.escape)="cancelRename(); $event.stopPropagation()"
 					/>
 					<button nbButton ghost size="tiny" type="button" (click)="commitRename(view)">

--- a/packages/ui-core/theme/src/lib/components/user/user.component.html
+++ b/packages/ui-core/theme/src/lib/components/user/user.component.html
@@ -1,4 +1,6 @@
 @if (user$ | async; as user) {
+	<!-- Space scrolls the page on a div; the role="button" contract is to activate instead,
+	     hence the preventDefault() on the Space handler below. -->
 	<div
 		class="user-container"
 		[class.with-identity]="showIdentity"
@@ -8,7 +10,6 @@
 		tabindex="0"
 		(click)="onClicked()"
 		(keydown.enter)="onClicked()"
-		<!-- Space scrolls the page on a div; the role="button" contract is to activate instead. -->
 		(keydown.space)="$event.preventDefault(); onClicked()"
 	>
 		<div class="img-container">


### PR DESCRIPTION
**Breakage on `develop` (and already cascaded to `stage`) — fixing now.**

My review-round commits on #10001 (`cabe745`) added explanatory comments between attributes:

```html
<div class="user-container" …
  <!-- Space scrolls the page on a div … -->
  (keydown.space)="$event.preventDefault(); onClicked()"
>
```

Angular's template parser stops there:

```
packages/ui-core/theme/src/lib/components/user/user.component.html:2:2 - error NG5002:
  Opening tag "div" not terminated.
```

`build-web` and `build-libs` failed on it (run 32350414087) — that run completed **after** #10001 was merged, so the breakage reached `develop` and the `develop → stage` cascade (#10011).

The same mistake was in the saved-views rename input; a scan of all 829 templates in the repo found no others.

## Fix
Both comments moved above their element. **Compiled this time, not just scanned:** `nx build ui-core` ✅ and `nx build plugin-docs-ui` ✅ (0 NG errors).

Cascading straight on to `stage` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Angular template parse error that broke builds on `develop` and `stage`. Moves two HTML comments out of element start tags to unblock `build-web`/`build-libs`.

- Old: comments inside opening tags triggered `NG5002: Opening tag "div" not terminated`, failing compilation. New: comments sit above their elements; templates compile with no behavior change.
- Affected files: `packages/ui-core/theme/src/lib/components/user/user.component.html`, `packages/plugins/docs-ui/src/lib/components/filter-bar/saved-views.component.html`.
- Validation: `nx build ui-core` and `nx build plugin-docs-ui` pass; a scan of 829 templates found no other instances.
- Rollout: Safe to cascade to `stage`. No migrations or config changes required.

<sup>Written for commit 31b5ed039aba1ae436a4f6cfb78fdc331a3de5a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

