### PR TITLE
fix(cspell): allow ELIFECYCLE, an npm error code named in a regression test

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"ignoreRegExpList": ["GHSA-[A-Za-z0-9-]+"],
 	"words": [
+        "ELIFECYCLE",
         "PRIMARYKEY",
         "NOTNULL",
         "FOREIGNKEY",


### PR DESCRIPTION
Cspell went red on `develop` after #10008. One of the flagged words is mine.

`database-error.spec.ts` pins that npm/network error codes are **not** treated as database driver codes — `ECONNREFUSED`/`ETIMEDOUT`/`ENOTFOUND` are emitted by any HTTP client, and classifying them would replace a failed integration's message with generic database text. Naming `ELIFECYCLE` in that list is the point of the test, so the word belongs in the dictionary rather than out of the test.

It passed on the PR because the Cspell action runs with `incremental_files_only`; on `develop` it checks every file.

**The other six flagged words are not from this work** and are still outstanding on `develop`: `AKDT`, `Yakutat`, `ellipsize`, `sparkline` (dashboard-time-track-angular-ui), `ellipsises` (docs-ui), `KPI's` (ui-react-components). I have deliberately not added those — `ellipsises` and `KPI's` look like genuine typos rather than dictionary gaps, and silently allow-listing someone else's typo is the wrong fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows the word ELIFECYCLE in `cspell` to stop false-positive failures from a regression test that names npm error codes. Previously `cspell` flagged ELIFECYCLE on `develop`; now it passes with no runtime behavior changes.

- `database-error.spec.ts` intentionally lists npm/network error codes to assert they aren’t treated as DB driver codes; allowing ELIFECYCLE preserves that test.
- Fixes failures unique to `develop` where `cspell` scans all files; the PR branch passed due to `incremental_files_only`.
- Only `.cspell.json` changed; no migrations or code changes.
- Other unrelated flagged words on `develop` remain out of scope for this PR.

<sup>Written for commit 11063721286fe6326db98b21b115890c295e41ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

