### PR TITLE
Release: develop → stage (CI supersede policy #10015 + NG5002 hotfix already in)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,14 @@ on:
 
 # Unique to this workflow and ref. Deliberately NOT a group shared with other workflows: a shared
 # group serializes unrelated builds and silently cancels them (see the image-build starvation
-# incident). Superseded PR runs are cancelled; pushes to the long-lived branches are not.
+# incident). Within this workflow+ref, only the newest commit is built.
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Was `github.event_name == 'pull_request'`, which left branch pushes uncancelled:
+  # four merges to develop in an hour meant four full 3-h compiles of commits that were
+  # already superseded. This job only compiles — nothing outside the run depends on a
+  # half-finished one — so the newest commit always wins.
+  cancel-in-progress: true
 
 env:
   # Mirrors the CircleCI `defaults` block. The `ng:*` scripts already set the heap themselves via

--- a/.github/workflows/deploy-civo-demo.yml
+++ b/.github/workflows/deploy-civo-demo.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-civo-prod.yml
+++ b/.github/workflows/deploy-civo-prod.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-civo-stage.yml
+++ b/.github/workflows/deploy-civo-stage.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-cw-demo.yml
+++ b/.github/workflows/deploy-cw-demo.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-cw-prod.yml
+++ b/.github/workflows/deploy-cw-prod.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-cw-stage.yml
+++ b/.github/workflows/deploy-cw-stage.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-app-platform-demo.yml
+++ b/.github/workflows/deploy-do-app-platform-demo.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-app-platform-prod.yml
+++ b/.github/workflows/deploy-do-app-platform-prod.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-app-platform-stage.yml
+++ b/.github/workflows/deploy-do-app-platform-stage.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-demo.yml
+++ b/.github/workflows/deploy-do-demo.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-droplet-demo.yml
+++ b/.github/workflows/deploy-do-droplet-demo.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-droplet-pre-demo.yml
+++ b/.github/workflows/deploy-do-droplet-pre-demo.yml
@@ -7,6 +7,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-droplet-pre-prod.yml
+++ b/.github/workflows/deploy-do-droplet-pre-prod.yml
@@ -7,6 +7,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-droplet-pre-stage.yml
+++ b/.github/workflows/deploy-do-droplet-pre-stage.yml
@@ -7,6 +7,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-droplet-prod.yml
+++ b/.github/workflows/deploy-do-droplet-prod.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-droplet-stage.yml
+++ b/.github/workflows/deploy-do-droplet-stage.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-fly-demo.yml
+++ b/.github/workflows/deploy-fly-demo.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-mcp-auth-demo.yml
+++ b/.github/workflows/deploy-mcp-auth-demo.yml
@@ -11,6 +11,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-mcp-auth-prod.yml
+++ b/.github/workflows/deploy-mcp-auth-prod.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-mcp-auth-stage.yml
+++ b/.github/workflows/deploy-mcp-auth-stage.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-mcp-demo.yml
+++ b/.github/workflows/deploy-mcp-demo.yml
@@ -11,6 +11,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-mcp-prod.yml
+++ b/.github/workflows/deploy-mcp-prod.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-mcp-stage.yml
+++ b/.github/workflows/deploy-mcp-stage.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-render-demo.yml
+++ b/.github/workflows/deploy-render-demo.yml
@@ -10,6 +10,14 @@ on:
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # This workflow only builds/tests/deploys from a checkout — read access is sufficient.
+concurrency:
+  # Collapse superseded runs WITHOUT interrupting one that is already applying: GitHub
+  # keeps a single pending run per group, so a newer commit replaces the one waiting
+  # while the in-flight deploy finishes. `cancel-in-progress: true` is deliberately NOT
+  # used here — killing a rollout mid-apply can leave the target half-updated.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker-build-publish-demo.yml
+++ b/.github/workflows/docker-build-publish-demo.yml
@@ -8,27 +8,19 @@ on:
     types: [completed]
 
 concurrency:
-  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  # One group PER WORKFLOW (never a group shared across the six non-prod image builds:
+  # that shared `gauzy-docker-build` group did not queue them, it STARVED them — GitHub
+  # keeps exactly one pending run per group, so an unrelated workflow's run cancelled
+  # whichever run was waiting, and environments silently kept serving their old image).
   #
-  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
-  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
-  # already waiting, whatever workflow it came from. A single push to develop fires three
-  # of these, a push to stage another three; five of every six were cancelled before they
-  # started. Environments then silently kept serving their previous image, which is how
-  # stage sat on an image five PRs old while its branch looked merged and green.
-  #
-  # Keyed by workflow so the useful part survives: a newer push still supersedes this
-  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
-  # build that is already running. What it no longer does is let an unrelated image build
-  # cancel this one.
-  #
-  # The cost is that these can once again overlap. That was the original worry — ~6-8
-  # parallel installs against one registry VIP — but an image that never builds is a worse
-  # failure than a slow one, and this is the only lever Actions offers: there is no way to
-  # ask for a queue deeper than one. The prod (master) workflows are still not in any
-  # shared group.
-  group: gauzy-docker-build-${{ github.workflow }}
-  cancel-in-progress: false
+  # Within this workflow the newest commit wins, matching the prod image builds. The
+  # trade-off is deliberate: an intermediate version tag can end up without an image,
+  # which is inert here because demo/stage deploy from `:latest` and only the release
+  # that actually ships needs its own tagged image. The alternative — letting a
+  # superseded build run for three hours on a fleet where one install takes 2-3 h —
+  # delays the image that IS wanted by exactly that long.
+  group: gauzy-docker-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # `packages: write` is required: these jobs log in to ghcr.io with GITHUB_TOKEN and push

--- a/.github/workflows/docker-build-publish-mcp-auth-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-demo.yml
@@ -11,28 +11,19 @@ permissions:
   packages: write
 
 concurrency:
-  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  # One group PER WORKFLOW (never a group shared across the six non-prod image builds:
+  # that shared `gauzy-docker-build` group did not queue them, it STARVED them — GitHub
+  # keeps exactly one pending run per group, so an unrelated workflow's run cancelled
+  # whichever run was waiting, and environments silently kept serving their old image).
   #
-  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
-  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
-  # already waiting, whatever workflow it came from. A single push to develop fires three
-  # of these, a push to stage another three; five of every six were cancelled before they
-  # started. Environments then silently kept serving their previous image, which is how
-  # stage sat on an image five PRs old while its branch looked merged and green.
-  #
-  # Keyed by workflow so the useful part survives: a newer push still supersedes this
-  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
-  # build that is already running. What it no longer does is let an unrelated image build
-  # cancel this one.
-  #
-  # The cost is that these can once again overlap. That was the original worry — ~6-8
-  # parallel installs against one registry VIP — but an image that never builds is a worse
-  # failure than a slow one, and this is the only lever Actions offers: there is no way to
-  # ask for a queue deeper than one. The prod (master) workflows are still not in any
-  # shared group.
-  group: gauzy-docker-build-${{ github.workflow }}
-  cancel-in-progress: false
-
+  # Within this workflow the newest commit wins, matching the prod image builds. The
+  # trade-off is deliberate: an intermediate version tag can end up without an image,
+  # which is inert here because demo/stage deploy from `:latest` and only the release
+  # that actually ships needs its own tagged image. The alternative — letting a
+  # superseded build run for three hours on a fleet where one install takes 2-3 h —
+  # delays the image that IS wanted by exactly that long.
+  group: gauzy-docker-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   gauzy-mcp-auth:
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}

--- a/.github/workflows/docker-build-publish-mcp-auth-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-auth-stage.yml
@@ -10,28 +10,19 @@ permissions:
   packages: write
 
 concurrency:
-  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  # One group PER WORKFLOW (never a group shared across the six non-prod image builds:
+  # that shared `gauzy-docker-build` group did not queue them, it STARVED them — GitHub
+  # keeps exactly one pending run per group, so an unrelated workflow's run cancelled
+  # whichever run was waiting, and environments silently kept serving their old image).
   #
-  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
-  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
-  # already waiting, whatever workflow it came from. A single push to develop fires three
-  # of these, a push to stage another three; five of every six were cancelled before they
-  # started. Environments then silently kept serving their previous image, which is how
-  # stage sat on an image five PRs old while its branch looked merged and green.
-  #
-  # Keyed by workflow so the useful part survives: a newer push still supersedes this
-  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
-  # build that is already running. What it no longer does is let an unrelated image build
-  # cancel this one.
-  #
-  # The cost is that these can once again overlap. That was the original worry — ~6-8
-  # parallel installs against one registry VIP — but an image that never builds is a worse
-  # failure than a slow one, and this is the only lever Actions offers: there is no way to
-  # ask for a queue deeper than one. The prod (master) workflows are still not in any
-  # shared group.
-  group: gauzy-docker-build-${{ github.workflow }}
-  cancel-in-progress: false
-
+  # Within this workflow the newest commit wins, matching the prod image builds. The
+  # trade-off is deliberate: an intermediate version tag can end up without an image,
+  # which is inert here because demo/stage deploy from `:latest` and only the release
+  # that actually ships needs its own tagged image. The alternative — letting a
+  # superseded build run for three hours on a fleet where one install takes 2-3 h —
+  # delays the image that IS wanted by exactly that long.
+  group: gauzy-docker-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   gauzy-mcp-auth:
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}

--- a/.github/workflows/docker-build-publish-mcp-demo.yml
+++ b/.github/workflows/docker-build-publish-mcp-demo.yml
@@ -11,28 +11,19 @@ permissions:
   packages: write
 
 concurrency:
-  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  # One group PER WORKFLOW (never a group shared across the six non-prod image builds:
+  # that shared `gauzy-docker-build` group did not queue them, it STARVED them — GitHub
+  # keeps exactly one pending run per group, so an unrelated workflow's run cancelled
+  # whichever run was waiting, and environments silently kept serving their old image).
   #
-  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
-  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
-  # already waiting, whatever workflow it came from. A single push to develop fires three
-  # of these, a push to stage another three; five of every six were cancelled before they
-  # started. Environments then silently kept serving their previous image, which is how
-  # stage sat on an image five PRs old while its branch looked merged and green.
-  #
-  # Keyed by workflow so the useful part survives: a newer push still supersedes this
-  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
-  # build that is already running. What it no longer does is let an unrelated image build
-  # cancel this one.
-  #
-  # The cost is that these can once again overlap. That was the original worry — ~6-8
-  # parallel installs against one registry VIP — but an image that never builds is a worse
-  # failure than a slow one, and this is the only lever Actions offers: there is no way to
-  # ask for a queue deeper than one. The prod (master) workflows are still not in any
-  # shared group.
-  group: gauzy-docker-build-${{ github.workflow }}
-  cancel-in-progress: false
-
+  # Within this workflow the newest commit wins, matching the prod image builds. The
+  # trade-off is deliberate: an intermediate version tag can end up without an image,
+  # which is inert here because demo/stage deploy from `:latest` and only the release
+  # that actually ships needs its own tagged image. The alternative — letting a
+  # superseded build run for three hours on a fleet where one install takes 2-3 h —
+  # delays the image that IS wanted by exactly that long.
+  group: gauzy-docker-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   gauzy-mcp:
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -10,28 +10,19 @@ permissions:
   packages: write
 
 concurrency:
-  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  # One group PER WORKFLOW (never a group shared across the six non-prod image builds:
+  # that shared `gauzy-docker-build` group did not queue them, it STARVED them — GitHub
+  # keeps exactly one pending run per group, so an unrelated workflow's run cancelled
+  # whichever run was waiting, and environments silently kept serving their old image).
   #
-  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
-  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
-  # already waiting, whatever workflow it came from. A single push to develop fires three
-  # of these, a push to stage another three; five of every six were cancelled before they
-  # started. Environments then silently kept serving their previous image, which is how
-  # stage sat on an image five PRs old while its branch looked merged and green.
-  #
-  # Keyed by workflow so the useful part survives: a newer push still supersedes this
-  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
-  # build that is already running. What it no longer does is let an unrelated image build
-  # cancel this one.
-  #
-  # The cost is that these can once again overlap. That was the original worry — ~6-8
-  # parallel installs against one registry VIP — but an image that never builds is a worse
-  # failure than a slow one, and this is the only lever Actions offers: there is no way to
-  # ask for a queue deeper than one. The prod (master) workflows are still not in any
-  # shared group.
-  group: gauzy-docker-build-${{ github.workflow }}
-  cancel-in-progress: false
-
+  # Within this workflow the newest commit wins, matching the prod image builds. The
+  # trade-off is deliberate: an intermediate version tag can end up without an image,
+  # which is inert here because demo/stage deploy from `:latest` and only the release
+  # that actually ships needs its own tagged image. The alternative — letting a
+  # superseded build run for three hours on a fleet where one install takes 2-3 h —
+  # delays the image that IS wanted by exactly that long.
+  group: gauzy-docker-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   gauzy-mcp:
     runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -6,27 +6,19 @@ on:
       - stage
 
 concurrency:
-  # One group PER WORKFLOW, not one shared across all six non-prod image builds.
+  # One group PER WORKFLOW (never a group shared across the six non-prod image builds:
+  # that shared `gauzy-docker-build` group did not queue them, it STARVED them — GitHub
+  # keeps exactly one pending run per group, so an unrelated workflow's run cancelled
+  # whichever run was waiting, and environments silently kept serving their old image).
   #
-  # The shared `gauzy-docker-build` group did not queue them — it starved them. GitHub
-  # keeps exactly ONE pending run per group, so every newly queued run cancels the run
-  # already waiting, whatever workflow it came from. A single push to develop fires three
-  # of these, a push to stage another three; five of every six were cancelled before they
-  # started. Environments then silently kept serving their previous image, which is how
-  # stage sat on an image five PRs old while its branch looked merged and green.
-  #
-  # Keyed by workflow so the useful part survives: a newer push still supersedes this
-  # workflow's own older pending run, and `cancel-in-progress: false` still never kills a
-  # build that is already running. What it no longer does is let an unrelated image build
-  # cancel this one.
-  #
-  # The cost is that these can once again overlap. That was the original worry — ~6-8
-  # parallel installs against one registry VIP — but an image that never builds is a worse
-  # failure than a slow one, and this is the only lever Actions offers: there is no way to
-  # ask for a queue deeper than one. The prod (master) workflows are still not in any
-  # shared group.
-  group: gauzy-docker-build-${{ github.workflow }}
-  cancel-in-progress: false
+  # Within this workflow the newest commit wins, matching the prod image builds. The
+  # trade-off is deliberate: an intermediate version tag can end up without an image,
+  # which is inert here because demo/stage deploy from `:latest` and only the release
+  # that actually ships needs its own tagged image. The alternative — letting a
+  # superseded build run for three hours on a fleet where one install takes 2-3 h —
+  # delays the image that IS wanted by exactly that long.
+  group: gauzy-docker-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # `packages: write` is required: these jobs log in to ghcr.io with GITHUB_TOKEN and push

--- a/.github/workflows/release-demo.yml
+++ b/.github/workflows/release-demo.yml
@@ -6,9 +6,17 @@ on:
       - develop
       - temp
 
+concurrency:
+  # One release per ref at a time, newest wins. Safe to cancel because the tag is no
+  # longer pushed by a separate earlier step: `dry_run` makes the version calculation
+  # side-effect free, and the release action then creates the tag AND the release in a
+  # single API call, so an interrupted run leaves nothing behind to clean up.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege scope for the automatic GITHUB_TOKEN.
-# `contents: write` is required: this workflow pushes a version tag and creates the
-# GitHub release that the downstream image/desktop builds key off.
+# `contents: write` is required: the release action creates the version tag together with
+# the GitHub release that the downstream image/desktop builds key off.
 permissions:
   contents: write
 
@@ -25,15 +33,20 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v5
 
-      - name: Bump version and push tag
+      # Calculate ONLY — `dry_run` means no tag is pushed here. The release step below
+      # creates the tag together with the release, so there is never a window in which a
+      # tag exists without its release (a cancelled run used to strand one forever: the
+      # next run computes the NEXT version and never backfills the orphan).
+      - name: Calculate the next version (no tag pushed)
         uses: mathieudutour/github-tag-action@v6.1
         id: tag_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
           release_branches: master,main,develop,stage
           pre_release_branches: something_to_possible_use_later
 
-      - name: Create a GitHub release
+      - name: Create the tag and the GitHub release (one call)
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -41,5 +54,7 @@ jobs:
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.tag_version.outputs.new_tag }}
+          # Create the tag as part of this call, pinned to the commit that was built.
+          commit: ${{ github.sha }}
           name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -5,9 +5,17 @@ on:
     branches:
       - master
 
+concurrency:
+  # One release per ref at a time, newest wins. Safe to cancel because the tag is no
+  # longer pushed by a separate earlier step: `dry_run` makes the version calculation
+  # side-effect free, and the release action then creates the tag AND the release in a
+  # single API call, so an interrupted run leaves nothing behind to clean up.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege scope for the automatic GITHUB_TOKEN.
-# `contents: write` is required: this workflow pushes a version tag and creates the
-# GitHub release that the downstream image/desktop builds key off.
+# `contents: write` is required: the release action creates the version tag together with
+# the GitHub release that the downstream image/desktop builds key off.
 permissions:
   contents: write
 
@@ -24,15 +32,20 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v5
 
-      - name: Bump version and push tag
+      # Calculate ONLY — `dry_run` means no tag is pushed here. The release step below
+      # creates the tag together with the release, so there is never a window in which a
+      # tag exists without its release (a cancelled run used to strand one forever: the
+      # next run computes the NEXT version and never backfills the orphan).
+      - name: Calculate the next version (no tag pushed)
         uses: mathieudutour/github-tag-action@v6.1
         id: tag_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
           release_branches: master,main,develop,stage
           pre_release_branches: something_to_possible_use_later
 
-      - name: Create a GitHub release
+      - name: Create the tag and the GitHub release (one call)
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -40,5 +53,7 @@ jobs:
           prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.tag_version.outputs.new_tag }}
+          # Create the tag as part of this call, pinned to the commit that was built.
+          commit: ${{ github.sha }}
           name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -5,9 +5,17 @@ on:
     branches:
       - stage
 
+concurrency:
+  # One release per ref at a time, newest wins. Safe to cancel because the tag is no
+  # longer pushed by a separate earlier step: `dry_run` makes the version calculation
+  # side-effect free, and the release action then creates the tag AND the release in a
+  # single API call, so an interrupted run leaves nothing behind to clean up.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege scope for the automatic GITHUB_TOKEN.
-# `contents: write` is required: this workflow pushes a version tag and creates the
-# GitHub release that the downstream image/desktop builds key off.
+# `contents: write` is required: the release action creates the version tag together with
+# the GitHub release that the downstream image/desktop builds key off.
 permissions:
   contents: write
 
@@ -24,15 +32,20 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v5
 
-      - name: Bump version and push tag
+      # Calculate ONLY — `dry_run` means no tag is pushed here. The release step below
+      # creates the tag together with the release, so there is never a window in which a
+      # tag exists without its release (a cancelled run used to strand one forever: the
+      # next run computes the NEXT version and never backfills the orphan).
+      - name: Calculate the next version (no tag pushed)
         uses: mathieudutour/github-tag-action@v6.1
         id: tag_version
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
           release_branches: master,main,develop,stage
           pre_release_branches: something_to_possible_use_later
 
-      - name: Create a GitHub release
+      - name: Create the tag and the GitHub release (one call)
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -40,5 +53,7 @@ jobs:
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.tag_version.outputs.new_tag }}
+          # Create the tag as part of this call, pinned to the commit that was built.
+          commit: ${{ github.sha }}
           name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
Cascade so `stage` gets the same build-supersede policy as `develop`.

Carries [#10015](https://github.com/ever-co/ever-gauzy/pull/10015): only the newest commit on a ref builds — `build.yml` now cancels superseded branch pushes (it was PR-only), `release-*` became atomic (tag + release in one API call via `dry_run` + `commit:`) and therefore safe to supersede, the six non-prod image builds supersede within their own workflow+ref like prod already did, and the 26 `deploy-*` workflows — which had **no** `concurrency:` key at all — now collapse duplicate pending runs while never interrupting a rollout in flight.

Stage benefits directly: its own image builds were piling up the same way (the run for `3b367dbf` was still building the commit that had the NG5002 break when it was cancelled by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply “newest-commit wins” concurrency to `stage` and all non‑prod CI, and make releases atomic. Previously, branch pushes and deploys ran for superseded commits; now each workflow+ref cancels older pending/running work where safe and collapses duplicate deploys without interrupting rollouts.

- Build: `build.yml` sets `concurrency.group` to `build-${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true` for all events.
- Releases: `release-{demo,stage,prod}.yml` calculate version with `mathieudutour/github-tag-action` using `dry_run`; `ncipollo/release-action` creates the tag and release in one call with `commit: ${{ github.sha }}`. Adds per‑ref concurrency with `cancel-in-progress: true`.
- Images (non‑prod): `docker-build-publish-*` use per‑workflow+ref groups and `cancel-in-progress: true`. Removes the previously shared group that starved builds; intermediate tags may have no image, which is fine because demo/stage deploy from `:latest`. Prod image workflows remain unchanged.
- Deploys: All `deploy-*` workflows add per‑workflow+ref groups with `cancel-in-progress: false` to collapse superseded pending runs while never stopping an in‑flight rollout.

<sup>Written for commit 3490d5f5fab62d37bfedffc1b03fec74807f889a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

