### PR TITLE
fix(security): review pass — an unmapped driver code still reached the client

### DIFF
--- a/packages/core/src/lib/core/errors/database-error.filter.ts
+++ b/packages/core/src/lib/core/errors/database-error.filter.ts
@@ -107,8 +107,14 @@ export class DatabaseErrorFilter extends BaseExceptionFilter {
 	 * @param depth - Current depth.
 	 */
 	private withoutNestedDatabaseFields(value: unknown, seen = new WeakSet<object>(), depth = 0): unknown {
-		if (!value || typeof value !== 'object' || depth > DatabaseErrorFilter.MAX_SANITIZE_DEPTH) {
+		if (!value || typeof value !== 'object') {
 			return value;
+		}
+		// Fail CLOSED at the limit. Returning the subtree unexamined would hand back exactly the
+		// `query`/`parameters` this walk exists to remove, for any payload that buries the driver
+		// error deeper than the bound.
+		if (depth > DatabaseErrorFilter.MAX_SANITIZE_DEPTH) {
+			return undefined;
 		}
 		if (seen.has(value as object)) {
 			return undefined;
@@ -165,8 +171,12 @@ export class DatabaseErrorFilter extends BaseExceptionFilter {
 			// Driver text arriving as a plain message still names constraints and, on MySQL, values.
 			return safeMessageForDatabaseText(value) ?? value;
 		}
-		if (!value || typeof value !== 'object' || depth > DatabaseErrorFilter.MAX_SANITIZE_DEPTH) {
+		if (!value || typeof value !== 'object') {
 			return value;
+		}
+		// Same reasoning as the response walk: past the bound, drop rather than copy.
+		if (depth > DatabaseErrorFilter.MAX_SANITIZE_DEPTH) {
+			return '[depth-limited]';
 		}
 		if (seen.has(value as object)) {
 			return '[circular]';

--- a/packages/core/src/lib/core/errors/database-error.spec.ts
+++ b/packages/core/src/lib/core/errors/database-error.spec.ts
@@ -518,3 +518,60 @@ describe('driver message signatures', () => {
 		expect(safeMessageForDatabaseText('Cannot add or update a child row: ER_NO_REFERENCED_ROW_2')).toBeDefined();
 	});
 });
+
+describe('review-pass regressions', () => {
+	it('recognizes letter-leading PostgreSQL SQLSTATEs', () => {
+		// P0001 is what every PL/pgSQL RAISE produces; XX000 is internal_error.
+		for (const code of ['P0001', 'XX000', 'F0000', 'HV000', '23505', '42P01']) {
+			expect(looksLikeDriverCode(code)).toBe(true);
+		}
+	});
+
+	it('does not mistake a five-letter word for a SQLSTATE', () => {
+		// The obvious widening to /^[0-9A-Z]{5}$/ matches these; every real SQLSTATE has a digit.
+		for (const code of ['ADMIN', 'LOGIN', 'TOKEN', 'EMPTY', 'VALID']) {
+			expect(looksLikeDriverCode(code)).toBe(false);
+		}
+	});
+
+	it('sanitizes an unmapped driver error rather than returning its message', () => {
+		// toSafeHttpException used to hand this to sanitizeErrorBody, which collapses an Error to its
+		// `.message` and drops the code — so `42P01` became the bare string `relation "user" does not
+		// exist`, which matches no message signature and reached the client naming a real table.
+		const { toSafeHttpException } = require('../interceptors/safe-http-exception');
+		const failure: any = new QueryFailedError('SELECT * FROM "user"', ['secret-value'], {
+			code: '42P01'
+		} as any);
+		failure.message = 'relation "user" does not exist';
+
+		const safe = toSafeHttpException(new BadRequestException(failure));
+		const serialized = JSON.stringify(safe.getResponse());
+
+		expect(safe.getStatus()).toBe(400);
+		expect(serialized).not.toContain('relation');
+		expect(serialized).not.toContain('secret-value');
+		expect(serialized).not.toContain('SELECT');
+	});
+});
+
+describe('log masking of value-bearing quotes', () => {
+	const withMessage = (message: string) =>
+		Object.assign(new QueryFailedError('SELECT 1', [], { code: '22P02' } as any), { message });
+
+	it('masks a postgres rejected value, which follows a colon', () => {
+		const out = JSON.stringify(redactDatabaseError(withMessage('invalid input syntax for type uuid: "not-a-uuid"')));
+		expect(out).not.toContain('not-a-uuid');
+	});
+
+	it('keeps a double-quoted constraint identifier, which is diagnostic', () => {
+		const out = JSON.stringify(
+			redactDatabaseError(withMessage('duplicate key value violates unique constraint "user_email_key"'))
+		);
+		expect(out).toContain('user_email_key');
+	});
+
+	it("handles SQL's doubled-quote escape without splitting the literal", () => {
+		const out = JSON.stringify(redactDatabaseError(withMessage("Duplicate entry 'O''Brien' for key 'user.name'")));
+		expect(out).not.toContain('Brien');
+	});
+});

--- a/packages/core/src/lib/core/errors/database-error.ts
+++ b/packages/core/src/lib/core/errors/database-error.ts
@@ -176,7 +176,14 @@ export function isDatabaseErrorPayload(value: unknown): boolean {
  * one without a mapped message simply gets the generic text.
  */
 const DRIVER_CODE_SHAPES: ReadonlyArray<RegExp> = [
-	/^[0-9][0-9A-Z]{4}$/, // postgres SQLSTATE — five chars, leading digit (23505, 42P01, 22P02, 08006)
+	// postgres SQLSTATE — five chars of [0-9A-Z] that contain AT LEAST ONE DIGIT.
+	//
+	// A leading digit is wrong: P0001 (raise_exception, what every PL/pgSQL RAISE produces), XX000
+	// (internal_error), F0000 and HV000 are all valid and all letter-led. But the obvious widening
+	// to /^[0-9A-Z]{5}$/ matches any five-letter upper-case word — ADMIN, LOGIN, TOKEN, EMPTY —
+	// which would classify an ordinary application error code as a database error and replace its
+	// message. Every real SQLSTATE carries a digit; those words do not.
+	/^(?=.*[0-9])[0-9A-Z]{5}$/,
 	/^SQLITE_[A-Z0-9_]+$/, // better-sqlite3 / sqlite3
 	/^ER_[A-Z0-9_]+$/ // mysql / mariadb
 ];
@@ -251,7 +258,16 @@ function maskQuotedLiterals(message: unknown): unknown {
 	if (typeof message !== 'string') {
 		return message;
 	}
-	return message.replace(/'[^']*'/g, "'<redacted>'");
+	return (
+		message
+			// MySQL: `Duplicate entry 'alice@example.com' for key 'user.email'`. `''` is SQL's escape
+			// for a literal quote, so it is consumed as part of the same literal rather than ending it.
+			.replace(/'(?:[^']|'')*'/g, "'<redacted>'")
+			// Postgres puts a REJECTED VALUE in double quotes after a colon
+			// (`invalid input syntax for type uuid: "not-a-uuid"`), while a double-quoted identifier
+			// elsewhere is a constraint/column name and is worth keeping for diagnosis.
+			.replace(/:\s*"[^"]*"/g, ': "<redacted>"')
+	);
 }
 
 /**

--- a/packages/core/src/lib/core/interceptors/safe-http-exception.ts
+++ b/packages/core/src/lib/core/interceptors/safe-http-exception.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import { describeDatabaseError, isDatabaseErrorPayload } from '../errors/database-error';
 
 /**
  * Body keys that never belong in an HTTP response: driver / transport internals that carry SQL
@@ -40,6 +41,14 @@ export function toSafeHttpException(error: unknown): HttpException {
 		if (typeof response !== 'object' || response === null) {
 			return error;
 		}
+		// Classify BEFORE sanitizing. `sanitizeErrorBody` collapses any `Error` to its `.message` and
+		// drops every other field — including the driver `code`. For a QueryFailedError that turns
+		// `{ code: '42P01', query, parameters }` into the bare string `relation "user" does not exist`:
+		// the SQL and parameters are gone, but the driver's own text (and the table it names) is now
+		// the response, and no message signature matches that phrasing. Describe it by code instead.
+		if (isDatabaseErrorPayload(response)) {
+			return new BadRequestException(describeDatabaseError(response));
+		}
 		// This branch used to return the body VERBATIM, to keep class-validator's `message: [...]`
 		// array intact. But `CrudService` throws `new BadRequestException(queryFailedError)` — also a
 		// BadRequestException — so every failed database write skipped the scrub below and answered
@@ -51,6 +60,10 @@ export function toSafeHttpException(error: unknown): HttpException {
 		const response = error.getResponse();
 		if (typeof response !== 'object' || response === null) {
 			return error;
+		}
+		// Same reasoning as the BadRequestException branch above.
+		if (isDatabaseErrorPayload(response)) {
+			return new HttpException(describeDatabaseError(response), error.getStatus());
 		}
 		const safe = sanitizeErrorBody(response) as Record<string, unknown>;
 		// Nothing to scrub (the common case) → the ORIGINAL instance, subclass and all.


### PR DESCRIPTION
Review pass over what actually landed on `develop`, reading every bot (CodeRabbit, cubic, Greptile, SonarQube). It found a residual leak in my own root-cause fix from #10008, plus two fail-open paths.

**The residual leak.** `toSafeHttpException` handed the driver error to `sanitizeErrorBody`, which collapses any `Error` to its `.message` and drops every other field — including the code. So `{ code: '42P01', query, parameters }` became the bare string `relation \\user\\ does not exist`: the SQL and bound values were gone, but the driver's own text, naming a real table, was now the response — and no message signature matches that phrasing. Flagged independently by cubic and CodeRabbit; verified against a real `QueryFailedError` before fixing. Database errors are classified **before** the collapse now.

**Two fail-open paths.** The SQLSTATE shape required a leading digit, so `P0001` (what every PL/pgSQL `RAISE` produces), `XX000`, `F0000` and `HV000` were not recognised as database errors at all. And both recursive walks returned the subtree *unexamined* past `MAX_SANITIZE_DEPTH`, handing back exactly the `query`/`parameters` they exist to remove.

**Where I did not follow the suggestion.** Both bots proposed widening the SQLSTATE pattern to `/^[0-9A-Z]{5}\$/`. That matches `ADMIN`, `LOGIN`, `TOKEN`, `EMPTY` — it would classify ordinary application error codes as database errors and replace their messages. Every real SQLSTATE contains a digit; those words do not, so that is the discriminator used.

Also: log masking now handles SQL's doubled-quote escape and postgres rejected values (which follow a colon) while keeping double-quoted constraint identifiers; and a test of mine that passed for the wrong reason is replaced — the `ER_` digit case used a message that also matched the *cannot add or update a child row* signature, so it never exercised the `ER_` pattern.

**Verification:** core 34 suites / 354 tests, tsc clean, detection re-measured against all 382 hand-written exception messages in the repo (0 false positives).

**Deliberately not in scope** (pre-existing, not regressions from this work): product-type's MikroORM path uses `save`/upsert so omitted translations are still dropped there, and equipment-sharing's update does not validate a body-supplied `equipmentId`/`equipmentSharingPolicyId` against the caller's organization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents database driver messages from reaching clients and makes sanitization fail-closed at depth limits. Previously, unmapped `QueryFailedError`s were collapsed to their `.message` and returned; now we classify by driver code before sanitizing and respond with mapped or generic safe text.

- Detects database errors in `toSafeHttpException` before sanitization; preserves original HTTP status.
- Recognizes letter-leading PostgreSQL SQLSTATEs by requiring “at least one digit” in a 5‑char code; avoids five-letter words like `ADMIN` or `LOGIN`.
- Changes both recursive walkers to drop payloads past `MAX_SANITIZE_DEPTH`, preventing `query`/`parameters` leakage.
- Improves log masking: handles doubled single quotes in SQL literals, masks rejected values after a colon in PostgreSQL, and keeps double‑quoted constraint identifiers for diagnostics.
- Adds regression tests and replaces a false-positive test to cover these cases.

<sup>Written for commit 4a2f4807f4092e434046f0ff30ffad633f1fd7aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

