### PR TITLE
release: cascade develop to stage — closes a residual driver-message leak

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
 	"$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
 	"ignoreRegExpList": ["GHSA-[A-Za-z0-9-]+"],
 	"words": [
+        "ELIFECYCLE",
         "PRIMARYKEY",
         "NOTNULL",
         "FOREIGNKEY",

--- a/packages/core/src/lib/core/errors/database-error.filter.ts
+++ b/packages/core/src/lib/core/errors/database-error.filter.ts
@@ -107,8 +107,14 @@ export class DatabaseErrorFilter extends BaseExceptionFilter {
 	 * @param depth - Current depth.
 	 */
 	private withoutNestedDatabaseFields(value: unknown, seen = new WeakSet<object>(), depth = 0): unknown {
-		if (!value || typeof value !== 'object' || depth > DatabaseErrorFilter.MAX_SANITIZE_DEPTH) {
+		if (!value || typeof value !== 'object') {
 			return value;
+		}
+		// Fail CLOSED at the limit. Returning the subtree unexamined would hand back exactly the
+		// `query`/`parameters` this walk exists to remove, for any payload that buries the driver
+		// error deeper than the bound.
+		if (depth > DatabaseErrorFilter.MAX_SANITIZE_DEPTH) {
+			return undefined;
 		}
 		if (seen.has(value as object)) {
 			return undefined;
@@ -165,8 +171,12 @@ export class DatabaseErrorFilter extends BaseExceptionFilter {
 			// Driver text arriving as a plain message still names constraints and, on MySQL, values.
 			return safeMessageForDatabaseText(value) ?? value;
 		}
-		if (!value || typeof value !== 'object' || depth > DatabaseErrorFilter.MAX_SANITIZE_DEPTH) {
+		if (!value || typeof value !== 'object') {
 			return value;
+		}
+		// Same reasoning as the response walk: past the bound, drop rather than copy.
+		if (depth > DatabaseErrorFilter.MAX_SANITIZE_DEPTH) {
+			return '[depth-limited]';
 		}
 		if (seen.has(value as object)) {
 			return '[circular]';

--- a/packages/core/src/lib/core/errors/database-error.spec.ts
+++ b/packages/core/src/lib/core/errors/database-error.spec.ts
@@ -518,3 +518,60 @@ describe('driver message signatures', () => {
 		expect(safeMessageForDatabaseText('Cannot add or update a child row: ER_NO_REFERENCED_ROW_2')).toBeDefined();
 	});
 });
+
+describe('review-pass regressions', () => {
+	it('recognizes letter-leading PostgreSQL SQLSTATEs', () => {
+		// P0001 is what every PL/pgSQL RAISE produces; XX000 is internal_error.
+		for (const code of ['P0001', 'XX000', 'F0000', 'HV000', '23505', '42P01']) {
+			expect(looksLikeDriverCode(code)).toBe(true);
+		}
+	});
+
+	it('does not mistake a five-letter word for a SQLSTATE', () => {
+		// The obvious widening to /^[0-9A-Z]{5}$/ matches these; every real SQLSTATE has a digit.
+		for (const code of ['ADMIN', 'LOGIN', 'TOKEN', 'EMPTY', 'VALID']) {
+			expect(looksLikeDriverCode(code)).toBe(false);
+		}
+	});
+
+	it('sanitizes an unmapped driver error rather than returning its message', () => {
+		// toSafeHttpException used to hand this to sanitizeErrorBody, which collapses an Error to its
+		// `.message` and drops the code — so `42P01` became the bare string `relation "user" does not
+		// exist`, which matches no message signature and reached the client naming a real table.
+		const { toSafeHttpException } = require('../interceptors/safe-http-exception');
+		const failure: any = new QueryFailedError('SELECT * FROM "user"', ['secret-value'], {
+			code: '42P01'
+		} as any);
+		failure.message = 'relation "user" does not exist';
+
+		const safe = toSafeHttpException(new BadRequestException(failure));
+		const serialized = JSON.stringify(safe.getResponse());
+
+		expect(safe.getStatus()).toBe(400);
+		expect(serialized).not.toContain('relation');
+		expect(serialized).not.toContain('secret-value');
+		expect(serialized).not.toContain('SELECT');
+	});
+});
+
+describe('log masking of value-bearing quotes', () => {
+	const withMessage = (message: string) =>
+		Object.assign(new QueryFailedError('SELECT 1', [], { code: '22P02' } as any), { message });
+
+	it('masks a postgres rejected value, which follows a colon', () => {
+		const out = JSON.stringify(redactDatabaseError(withMessage('invalid input syntax for type uuid: "not-a-uuid"')));
+		expect(out).not.toContain('not-a-uuid');
+	});
+
+	it('keeps a double-quoted constraint identifier, which is diagnostic', () => {
+		const out = JSON.stringify(
+			redactDatabaseError(withMessage('duplicate key value violates unique constraint "user_email_key"'))
+		);
+		expect(out).toContain('user_email_key');
+	});
+
+	it("handles SQL's doubled-quote escape without splitting the literal", () => {
+		const out = JSON.stringify(redactDatabaseError(withMessage("Duplicate entry 'O''Brien' for key 'user.name'")));
+		expect(out).not.toContain('Brien');
+	});
+});

--- a/packages/core/src/lib/core/errors/database-error.ts
+++ b/packages/core/src/lib/core/errors/database-error.ts
@@ -176,7 +176,14 @@ export function isDatabaseErrorPayload(value: unknown): boolean {
  * one without a mapped message simply gets the generic text.
  */
 const DRIVER_CODE_SHAPES: ReadonlyArray<RegExp> = [
-	/^[0-9][0-9A-Z]{4}$/, // postgres SQLSTATE — five chars, leading digit (23505, 42P01, 22P02, 08006)
+	// postgres SQLSTATE — five chars of [0-9A-Z] that contain AT LEAST ONE DIGIT.
+	//
+	// A leading digit is wrong: P0001 (raise_exception, what every PL/pgSQL RAISE produces), XX000
+	// (internal_error), F0000 and HV000 are all valid and all letter-led. But the obvious widening
+	// to /^[0-9A-Z]{5}$/ matches any five-letter upper-case word — ADMIN, LOGIN, TOKEN, EMPTY —
+	// which would classify an ordinary application error code as a database error and replace its
+	// message. Every real SQLSTATE carries a digit; those words do not.
+	/^(?=.*[0-9])[0-9A-Z]{5}$/,
 	/^SQLITE_[A-Z0-9_]+$/, // better-sqlite3 / sqlite3
 	/^ER_[A-Z0-9_]+$/ // mysql / mariadb
 ];
@@ -251,7 +258,16 @@ function maskQuotedLiterals(message: unknown): unknown {
 	if (typeof message !== 'string') {
 		return message;
 	}
-	return message.replace(/'[^']*'/g, "'<redacted>'");
+	return (
+		message
+			// MySQL: `Duplicate entry 'alice@example.com' for key 'user.email'`. `''` is SQL's escape
+			// for a literal quote, so it is consumed as part of the same literal rather than ending it.
+			.replace(/'(?:[^']|'')*'/g, "'<redacted>'")
+			// Postgres puts a REJECTED VALUE in double quotes after a colon
+			// (`invalid input syntax for type uuid: "not-a-uuid"`), while a double-quoted identifier
+			// elsewhere is a constraint/column name and is worth keeping for diagnosis.
+			.replace(/:\s*"[^"]*"/g, ': "<redacted>"')
+	);
 }
 
 /**

--- a/packages/core/src/lib/core/interceptors/safe-http-exception.ts
+++ b/packages/core/src/lib/core/interceptors/safe-http-exception.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import { describeDatabaseError, isDatabaseErrorPayload } from '../errors/database-error';
 
 /**
  * Body keys that never belong in an HTTP response: driver / transport internals that carry SQL
@@ -40,6 +41,14 @@ export function toSafeHttpException(error: unknown): HttpException {
 		if (typeof response !== 'object' || response === null) {
 			return error;
 		}
+		// Classify BEFORE sanitizing. `sanitizeErrorBody` collapses any `Error` to its `.message` and
+		// drops every other field — including the driver `code`. For a QueryFailedError that turns
+		// `{ code: '42P01', query, parameters }` into the bare string `relation "user" does not exist`:
+		// the SQL and parameters are gone, but the driver's own text (and the table it names) is now
+		// the response, and no message signature matches that phrasing. Describe it by code instead.
+		if (isDatabaseErrorPayload(response)) {
+			return new BadRequestException(describeDatabaseError(response));
+		}
 		// This branch used to return the body VERBATIM, to keep class-validator's `message: [...]`
 		// array intact. But `CrudService` throws `new BadRequestException(queryFailedError)` — also a
 		// BadRequestException — so every failed database write skipped the scrub below and answered
@@ -51,6 +60,10 @@ export function toSafeHttpException(error: unknown): HttpException {
 		const response = error.getResponse();
 		if (typeof response !== 'object' || response === null) {
 			return error;
+		}
+		// Same reasoning as the BadRequestException branch above.
+		if (isDatabaseErrorPayload(response)) {
+			return new HttpException(describeDatabaseError(response), error.getStatus());
 		}
 		const safe = sanitizeErrorBody(response) as Record<string, unknown>;
 		// Nothing to scrub (the common case) → the ORIGINAL instance, subclass and all.


### PR DESCRIPTION
Promotes `develop` → `stage`.

The bulk of the security work (#10003, #10007, #10008) already reached stage via #10016. This carries the two commits that landed after it — one of which closes a **residual leak in the #10008 fix itself**.

## What this adds

**#10017 — an unmapped driver code still reached the client**

`toSafeHttpException` handed the driver error to `sanitizeErrorBody`, which collapses any `Error` to its `.message` and drops every other field, including the code. `{ code: '42P01', query, parameters }` therefore became the bare string `relation "user" does not exist` — the SQL and bound values were gone, but the driver's own text, naming a real table, *was* the response, and no message signature matches that phrasing. Database errors are now classified before the collapse.

Also in it:

- the SQLSTATE shape required a leading digit, so `P0001` (what every PL/pgSQL `RAISE` produces), `XX000`, `F0000` and `HV000` were not recognised as database errors at all;
- both recursive walks returned the subtree **unexamined** past `MAX_SANITIZE_DEPTH`, handing back exactly the `query`/`parameters` they exist to remove;
- log masking now handles SQL's doubled-quote escape and postgres rejected values, while keeping double-quoted constraint identifiers.

**#10014 — Cspell** allows `ELIFECYCLE`, an npm error code named in the regression test that pins npm/network codes as *not* database codes.

## Verification, against a live API built from merged `develop`

Not from inspection — the API was booted from `dist` and probed over HTTP, with the serving PID confirmed to be the new process (an earlier run silently answered from a stale binary after an `EADDRINUSE`).

| Probe | Result |
|---|---|
| SQL / parameter disclosure | **0 of 6** failing writes leak (3 of 6 on the pre-fix control) |
| ai-chat attachments, LOCAL provider | **12 / 12** |
| SUPER_ADMIN registration boundary | **11 / 11** |
| Endpoints changed by the advisory work | 12 / 14 — see below |

The two non-passes are the probe's **detector**, not a regression: it identified a pre-existing sqlite-only bind failure (`shareRules` maps to `text` on SQLite while the DTO requires an object) by the presence of a `query` key in the response body — and the leak fix now sanitizes exactly that body. The server log still shows `Too few parameter values` twice, and `"query"` appears **zero** times in the log, so the underlying cause is unchanged and both the response and the log are now clean. All four SharedEntity guards fire with their exact messages, including the advisory's cross-tenant pivot (403).

Static: core **34 suites / 354 tests**, `tsc --noEmit` clean, and the message-rewriting detection re-measured against all **382** hand-written exception messages in the repo — **0 false positives**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes develop to stage and closes a residual database driver-message leak. Previously, unmapped driver errors were collapsed to their .message and returned to clients; now errors are classified by driver code before sanitization to prevent SQL/parameter exposure.

- Classifies database errors pre-sanitize in toSafeHttpException; returns a generic `BadRequestException` based on driver code instead of the raw driver `.message`.
- Recognizes letter-leading PostgreSQL SQLSTATEs (`P0001`, `XX000`, `F0000`, `HV000`) while requiring at least one digit to avoid matching plain words like ADMIN/LOGIN.
- Scrub walks now fail closed at max depth: drop subtrees instead of returning them; responses/logs use placeholders rather than nested `query`/`parameters`.
- Improves log masking: handles doubled-quote SQL escapes; redacts Postgres rejected values after a colon; keeps diagnostic double-quoted constraint identifiers.
- CI: allows `ELIFECYCLE` in `cspell` to unblock the dictionary check.

<sup>Written for commit e5c2317d6be686835848c7955f2210b68fddb00b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

