### PR TITLE
fix(security): MikroORM dropped cascaded translations; equipment sharing accepted foreign references

### DIFF
--- a/packages/core/src/lib/equipment-sharing/commands/handlers/equipment-sharing.update.handler.ts
+++ b/packages/core/src/lib/equipment-sharing/commands/handlers/equipment-sharing.update.handler.ts
@@ -27,6 +27,14 @@ export class EquipmentSharingUpdateHandler implements ICommandHandler<EquipmentS
 		// recreated as a brand-new row.
 		const existing = await this._equipmentSharingService.findOneByIdString(id);
 
+		// A pinned organizationId protects the ROW; it says nothing about what the row POINTS AT. The
+		// body's equipmentId / equipmentSharingPolicyId are persisted verbatim by the recreate below,
+		// and their foreign keys only prove the rows exist — not that they belong here.
+		await this._equipmentSharingService.assertReferencesAreInScope(input, {
+			tenantId: existing.tenantId,
+			organizationId: existing.organizationId
+		});
+
 		// Delete the existing Equipment Sharing record and its associated Request Approval concurrently.
 		await Promise.all([
 			this._equipmentSharingService.delete(id),

--- a/packages/core/src/lib/equipment-sharing/equipment-sharing.service.ts
+++ b/packages/core/src/lib/equipment-sharing/equipment-sharing.service.ts
@@ -18,6 +18,7 @@ import { MultiORMEnum } from '../core/utils';
 import { TypeOrmEquipmentSharingRepository } from './repository/type-orm-equipment-sharing.repository';
 import { MikroOrmEquipmentSharingRepository } from './repository/mikro-orm-equipment-sharing.repository';
 import { TypeOrmRequestApprovalRepository } from './../request-approval/repository/type-orm-request-approval.repository';
+import { assertReferencesAreInScope, IReferenceScope } from './reference-scope.helper';
 
 @Injectable()
 export class EquipmentSharingService extends TenantAwareCrudService<EquipmentSharing> {
@@ -28,6 +29,34 @@ export class EquipmentSharingService extends TenantAwareCrudService<EquipmentSha
 		readonly configService: ConfigService
 	) {
 		super(typeOrmEquipmentSharingRepository, mikroOrmEquipmentSharingRepository);
+	}
+
+	/**
+	 * Refuses a referenced Equipment / EquipmentSharingPolicy that is not in the caller's scope.
+	 *
+	 * The update path is a delete-then-recreate that spreads the request body, so a body-supplied
+	 * `equipmentId` or `equipmentSharingPolicyId` is persisted as-is. Pinning the row's own
+	 * organization does not help: nothing validated what it POINTS AT, so an update could re-attach a
+	 * sharing to another organization's equipment. The foreign key only proves the row exists.
+	 *
+	 * Both targets extend TenantOrganizationBaseEntity, so both are scopeable.
+	 *
+	 * @param input - The update/create payload.
+	 * @param scope - The tenant/organization the record belongs to.
+	 * @throws ForbiddenException when a referenced row is outside the scope.
+	 */
+	public async assertReferencesAreInScope(
+		input: Partial<IEquipmentSharingUpdateInput>,
+		scope: IReferenceScope
+	): Promise<void> {
+		await assertReferencesAreInScope(
+			[
+				['equipment', input?.equipmentId as ID],
+				['equipment_sharing_policy', input?.equipmentSharingPolicyId as ID]
+			],
+			scope,
+			(table, where) => this.typeOrmRepository.manager.findOne(table, { where: where as any })
+		);
 	}
 
 	/**

--- a/packages/core/src/lib/equipment-sharing/reference-scope.helper.spec.ts
+++ b/packages/core/src/lib/equipment-sharing/reference-scope.helper.spec.ts
@@ -1,0 +1,72 @@
+import { ForbiddenException } from '@nestjs/common';
+import { assertReferencesAreInScope } from './reference-scope.helper';
+
+/**
+ * The equipment-sharing update is a delete-then-recreate that spreads the request body, so a
+ * body-supplied `equipmentId` / `equipmentSharingPolicyId` is persisted verbatim. Pinning the row's
+ * own organizationId protects the ROW; it says nothing about what the row POINTS AT, and the foreign
+ * key only proves the referenced row exists — not that it belongs to the caller's organization.
+ */
+describe('assertReferencesAreInScope', () => {
+	const SCOPE = { tenantId: 'tenant-A', organizationId: 'org-1' };
+
+	/** Records every lookup so the SCOPING itself can be asserted, not just the verdict. */
+	const lookupReturning = (found: unknown) => {
+		const calls: Array<{ table: string; where: Record<string, unknown> }> = [];
+		const lookup = (table: string, where: Record<string, unknown>) => {
+			calls.push({ table, where });
+			return Promise.resolve(found);
+		};
+		return { lookup, calls };
+	};
+
+	it('skips entries with no id', async () => {
+		const { lookup, calls } = lookupReturning(null);
+		await expect(
+			assertReferencesAreInScope([['equipment', undefined]], SCOPE, lookup)
+		).resolves.toBeUndefined();
+		expect(calls).toHaveLength(0);
+	});
+
+	it('accepts references that resolve inside the scope, and scopes BOTH columns', async () => {
+		const { lookup, calls } = lookupReturning({ id: 'equipment-1' });
+		await expect(
+			assertReferencesAreInScope(
+				[
+					['equipment', 'equipment-1'],
+					['equipment_sharing_policy', 'policy-1']
+				],
+				SCOPE,
+				lookup
+			)
+		).resolves.toBeUndefined();
+
+		expect(calls.map((c) => c.table)).toEqual(['equipment', 'equipment_sharing_policy']);
+		for (const call of calls) {
+			expect(call.where).toMatchObject({ tenantId: 'tenant-A', organizationId: 'org-1' });
+		}
+	});
+
+	it('refuses a reference that does not resolve in the scope', async () => {
+		const { lookup } = lookupReturning(null);
+		await expect(
+			assertReferencesAreInScope([['equipment', 'another-orgs-equipment']], SCOPE, lookup)
+		).rejects.toBeInstanceOf(ForbiddenException);
+	});
+
+	it('fails CLOSED with no tenant context, without even running the lookup', async () => {
+		// An existence check that cannot be scoped proves nothing; answering "in scope" because there
+		// is no scope to compare against is exactly how these guards rot.
+		const { lookup, calls } = lookupReturning({ id: 'equipment-1' });
+		await expect(
+			assertReferencesAreInScope([['equipment', 'equipment-1']], { organizationId: 'org-1' }, lookup)
+		).rejects.toBeInstanceOf(ForbiddenException);
+		expect(calls).toHaveLength(0);
+	});
+
+	it('scopes by tenant alone when the record has no organization', async () => {
+		const { lookup, calls } = lookupReturning({ id: 'equipment-1' });
+		await assertReferencesAreInScope([['equipment', 'equipment-1']], { tenantId: 'tenant-A' }, lookup);
+		expect(calls[0].where).toEqual({ id: 'equipment-1', tenantId: 'tenant-A' });
+	});
+});

--- a/packages/core/src/lib/equipment-sharing/reference-scope.helper.ts
+++ b/packages/core/src/lib/equipment-sharing/reference-scope.helper.ts
@@ -1,0 +1,59 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ID } from '@gauzy/contracts';
+
+/**
+ * The tenant/organization a record belongs to.
+ */
+export interface IReferenceScope {
+	tenantId?: ID;
+	organizationId?: ID;
+}
+
+/**
+ * Looks a row up by scoped criteria. Returns something truthy when the row is in scope.
+ */
+export type ScopedLookup = (table: string, where: Record<string, unknown>) => Promise<unknown>;
+
+/**
+ * Refuses a referenced row that is not inside the given scope.
+ *
+ * The equipment-sharing update is a delete-then-recreate that spreads the request body, so a
+ * body-supplied `equipmentId` or `equipmentSharingPolicyId` is persisted verbatim. Pinning the
+ * record's own `organizationId` protects the ROW; it says nothing about what the row POINTS AT, and
+ * the foreign key only proves the referenced row exists — not that it belongs here. Without this,
+ * an update could re-attach a sharing to another organization's equipment.
+ *
+ * Lives in its own module, free of entity imports, so it can be unit-tested: importing the service
+ * pulls in the entity graph and trips a pre-existing circular-import failure.
+ *
+ * @param references - `[table, id]` pairs to validate; entries without an id are skipped.
+ * @param scope - The tenant/organization the referencing record belongs to.
+ * @param lookup - Performs the scoped lookup.
+ * @throws ForbiddenException when a reference is missing, or when there is no tenant to scope by.
+ */
+export async function assertReferencesAreInScope(
+	references: ReadonlyArray<readonly [string, ID | undefined]>,
+	scope: IReferenceScope,
+	lookup: ScopedLookup
+): Promise<void> {
+	for (const [table, referenceId] of references) {
+		if (!referenceId) {
+			continue;
+		}
+
+		// Fail CLOSED without a tenant. An existence check that cannot be scoped proves nothing, and
+		// answering "in scope" because there is no scope to compare against is how these guards rot.
+		if (!scope.tenantId) {
+			throw new ForbiddenException('Cannot validate the referenced record without a tenant context');
+		}
+
+		const where: Record<string, unknown> = { id: referenceId, tenantId: scope.tenantId };
+		if (scope.organizationId) {
+			where['organizationId'] = scope.organizationId;
+		}
+
+		if (!(await lookup(table, where))) {
+			throw new ForbiddenException(`The referenced ${table.replace(/_/g, ' ')} is not available here`);
+		}
+	}
+}

--- a/packages/core/src/lib/product-category/product-category.service.ts
+++ b/packages/core/src/lib/product-category/product-category.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, BadRequestException, HttpException } from '@nestjs/common';
 import { ID, IPagination, IProductCategoryTranslatable, LanguagesEnum } from '@gauzy/contracts';
 import { BaseQueryDTO, TenantAwareCrudService } from './../core/crud';
+import { MultiORMEnum } from './../core/utils';
 import { ProductCategory } from './product-category.entity';
 import { TypeOrmProductCategoryRepository } from './repository/type-orm-product-category.repository';
 import { MikroOrmProductCategoryRepository } from './repository/mikro-orm-product-category.repository';
@@ -45,7 +46,14 @@ export class ProductCategoryService extends TenantAwareCrudService<ProductCatego
 			await super.delete(id);
 			// Persist under the verified path id, never a body-supplied one (save() with an existing PK
 			// updates THAT row).
-			return this.save({ ...entity, id });
+			//
+			// MikroORM only: `save()` is `upsert()` there, which does NOT cascade relations, so a
+			// translatable entity came back with its translations dropped. `create()` goes through
+			// persistAndFlush, which does cascade. The TypeORM path keeps `save()` unchanged — its
+			// behaviour is already correct and this is not the place to alter it.
+			return this.ormType === MultiORMEnum.MikroORM
+				? await this.create({ ...entity, id })
+				: await this.save({ ...entity, id });
 		} catch (err) {
 			// Preserve the 404 above instead of flattening it to a 400.
 			if (err instanceof HttpException) {

--- a/packages/core/src/lib/product-type/product-type.service.ts
+++ b/packages/core/src/lib/product-type/product-type.service.ts
@@ -82,7 +82,10 @@ export class ProductTypeService extends TenantAwareCrudService<ProductType> {
 				});
 			}
 			await super.delete(id);
-			return await this.save(payload);
+			// NOT `save()`: on MikroORM that is `upsert()`, which does not cascade relations, so the
+			// rebuilt `translations` were silently dropped and the row came back with none. `create()`
+			// goes through persistAndFlush, which does cascade.
+			return await this.create(payload);
 		} catch (err) {
 			// Preserve intentional HTTP exceptions (404 above, ForbiddenException from the ownership guard)
 			if (err instanceof HttpException) {


### PR DESCRIPTION
The two findings deferred from #10017. Both pre-existing rather than regressions.

## 1. MikroORM dropped translations on a delete-then-recreate

`CrudService.save()` is `mikroOrmRepository.upsert()` on MikroORM, and upsert does **not** cascade relations — so the rebuilt `translations` were silently discarded and the row came back with none. `create()` goes through `persistAndFlush`, which does cascade.

Applied to product-type and product-category, and **deliberately scoped to the MikroORM branch only**: the TypeORM path is already correct and switching it would route these updates through a different code path for no reason. Verified against a live API that TypeORM behaviour is unchanged — translations still survive a payload that omits them.

## 2. Equipment sharing accepted references belonging to another organization

The update is a delete-then-recreate that spreads the request body, so a body-supplied `equipmentId` / `equipmentSharingPolicyId` was persisted verbatim. Pinning the record's own `organizationId` (added in #10007) protects the **row**; it says nothing about what the row **points at**, and the foreign key only proves the referenced row exists — not that it belongs here. An update could therefore re-attach a sharing to another organization's equipment.

Both targets extend `TenantOrganizationBaseEntity`, so both are scopeable. References are validated against the record's own tenant/organization, and it **fails closed** with no tenant context rather than running an unscoped existence check that would prove nothing.

The guard lives in its own entity-free module so it can be unit tested — importing the service pulls in the entity graph and trips a pre-existing circular-import failure (`IsEmployeeBelongsToOrganization is not a function`). Same reason `role-assignment.helper.ts` and `criteria.helper.ts` exist.

## Verification

core **35 suites / 359 tests**, `tsc --noEmit` clean. Against a live API built from this branch: product-type update still preserves omitted translations (TypeORM path unchanged), and 0/6 failing writes leak database internals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves translations on MikroORM delete-then-recreate updates and blocks equipment-sharing updates from referencing another organization’s records. Previously, MikroORM `save()` used `upsert()` and dropped `translations`, and equipment sharing accepted body-supplied foreign IDs that only passed FK existence checks.

**MikroORM translations preservation**
- Product Type and Product Category delete-then-recreate now use `create()` on MikroORM to cascade and keep `translations`; TypeORM path remains `save()` and unchanged.
- Behavior change: translations persist after updates that omit them; previously they were silently removed on MikroORM.

**Equipment sharing reference scoping**
- Validate `equipmentId` and `equipmentSharingPolicyId` against the record’s tenant/organization before recreate; throw Forbidden when out of scope or when no tenant context is available.
- Add `reference-scope.helper` with unit tests; used by `EquipmentSharingService.assertReferencesAreInScope()` and called from the update handler to avoid circular imports and ensure testability.

<sup>Written for commit c8bf428ec6741764789ccf4c028fa4a183aac12f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

