### PR TITLE
ci: never cancel a release run — a cancelled release publishes no image

### DIFF
--- a/.github/workflows/release-demo.yml
+++ b/.github/workflows/release-demo.yml
@@ -7,12 +7,20 @@ on:
       - temp
 
 concurrency:
-  # One release per ref at a time, newest wins. Safe to cancel because the tag is no
-  # longer pushed by a separate earlier step: `dry_run` makes the version calculation
-  # side-effect free, and the release action then creates the tag AND the release in a
-  # single API call, so an interrupted run leaves nothing behind to clean up.
+  # Serialize releases on a ref, but NEVER cancel one: this job takes about a minute, so
+  # superseding it saves nothing — and cancelling it silently breaks the delivery chain.
+  # The image build is wired to this workflow with
+  #   workflow_run: types: [completed]   +   if: workflow_run.conclusion == 'success'
+  # so a CANCELLED release makes its image build SKIP. If that happens to the last release
+  # of a burst, no image is published for the new code at all and the environment keeps
+  # serving the previous image until somebody pushes again (demo sat a day behind exactly
+  # this way on 2026-08-20).
+  #
+  # Superseding still happens where the time actually goes: `build.yml` and the image
+  # builds cancel their own older runs, so a burst of merges still produces exactly ONE
+  # full compile and ONE published image — the newest.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # `contents: write` is required: the release action creates the version tag together with

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -6,12 +6,20 @@ on:
       - master
 
 concurrency:
-  # One release per ref at a time, newest wins. Safe to cancel because the tag is no
-  # longer pushed by a separate earlier step: `dry_run` makes the version calculation
-  # side-effect free, and the release action then creates the tag AND the release in a
-  # single API call, so an interrupted run leaves nothing behind to clean up.
+  # Serialize releases on a ref, but NEVER cancel one: this job takes about a minute, so
+  # superseding it saves nothing — and cancelling it silently breaks the delivery chain.
+  # The image build is wired to this workflow with
+  #   workflow_run: types: [completed]   +   if: workflow_run.conclusion == 'success'
+  # so a CANCELLED release makes its image build SKIP. If that happens to the last release
+  # of a burst, no image is published for the new code at all and the environment keeps
+  # serving the previous image until somebody pushes again (demo sat a day behind exactly
+  # this way on 2026-08-20).
+  #
+  # Superseding still happens where the time actually goes: `build.yml` and the image
+  # builds cancel their own older runs, so a burst of merges still produces exactly ONE
+  # full compile and ONE published image — the newest.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # `contents: write` is required: the release action creates the version tag together with

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -6,12 +6,20 @@ on:
       - stage
 
 concurrency:
-  # One release per ref at a time, newest wins. Safe to cancel because the tag is no
-  # longer pushed by a separate earlier step: `dry_run` makes the version calculation
-  # side-effect free, and the release action then creates the tag AND the release in a
-  # single API call, so an interrupted run leaves nothing behind to clean up.
+  # Serialize releases on a ref, but NEVER cancel one: this job takes about a minute, so
+  # superseding it saves nothing — and cancelling it silently breaks the delivery chain.
+  # The image build is wired to this workflow with
+  #   workflow_run: types: [completed]   +   if: workflow_run.conclusion == 'success'
+  # so a CANCELLED release makes its image build SKIP. If that happens to the last release
+  # of a burst, no image is published for the new code at all and the environment keeps
+  # serving the previous image until somebody pushes again (demo sat a day behind exactly
+  # this way on 2026-08-20).
+  #
+  # Superseding still happens where the time actually goes: `build.yml` and the image
+  # builds cancel their own older runs, so a burst of merges still produces exactly ONE
+  # full compile and ONE published image — the newest.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Least-privilege scope for the automatic GITHUB_TOKEN.
 # `contents: write` is required: the release action creates the version tag together with


### PR DESCRIPTION
Follow-up to #10015, fixing the one place where superseding backfires.

## The chain

```
push to develop → Release Demo (~1 min: version + tag + release)
                → Build and Publish Docker Images Demo (~3 h)   [workflow_run, types: completed]
                                                                 if: workflow_run.conclusion == 'success'
                → Argo Image Updater sees the new :latest digest → demo pods roll
```

## The hole #10015 opened

With `cancel-in-progress: true` on the release, a second merge cancels the first release. The `workflow_run` event still fires — with `conclusion: cancelled` — so that image build **skips**. Usually fine, because the newer release carries the older commit's code anyway.

But if the **last** release of a burst is the one cancelled (or its image build is cancelled/starved), **no image build completes for the burst at all**. The chain only re-fires on the next push, so the environment keeps serving the previous image while `develop` has moved on — with every check green. That is what left demo on the 03:22 image (`64f50117`) all day today while #10001 sat merged in `develop`.

## Fix

Releases are ~1 minute — superseding them saved nothing and created the skip path. They are now **serialized per ref but never cancelled**. Superseding stays where the hours actually are:

| | supersedes? |
|---|---|
| `build.yml` (~3 h) | yes |
| image builds (~3 h) | yes |
| `release-*` (~1 min) | **no** |
| `deploy-*` | pending-collapse only |

A burst of merges therefore still produces exactly **one** full compile and **one** published image — the newest — but the chain can no longer end with nothing published.

The atomic tag+release from #10015 stays: it is what makes an interrupted release harmless if one ever is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cancelling release workflows so every merge yields a publishable image. Previously, cancelling the last `release-*` run in a burst caused its downstream image build to skip, leaving no new image and environments stuck on the previous one.

- Changes: set `concurrency.cancel-in-progress: false` in `release-demo.yml`, `release-stage.yml`, and `release-prod.yml`; runs remain serialized per ref.
- Effect: release jobs (~1 min) never supersede; `build.yml` and image builds still supersede older runs, so bursts produce one compile and one published image (the newest).
- Rollout: no migration; expect short queues instead of cancelled release runs.

<sup>Written for commit baa3c0eaaa89b502304c7ecedf5a548511e68590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

