### PR TITLE
fix(ci): the install-once producer breaks on every cache HIT

### DIFF
--- a/.github/scripts/archive-node-modules.sh
+++ b/.github/scripts/archive-node-modules.sh
@@ -5,6 +5,10 @@
 # Paired with restore-node-modules.sh. A single ~2.9 GB file beats handing actions/cache ~900k loose
 # files in both directions, and it is small enough to sit in the 10 GB per-repo cache budget — which
 # the exploded ~9 GB tree never was.
+# `set -e` matters here: without it a tar exit status of 2 (a REAL error, unlike the tolerated
+# exit 1 below) falls straight through to the size check, and a ~2.9 GB tree truncated early still
+# clears the 100 MB floor - so a corrupt archive gets published and four consumer jobs unpack it.
+set -e
 set -o pipefail
 
 ARCHIVE="${NODE_MODULES_ARCHIVE:?NODE_MODULES_ARCHIVE must be set}"
@@ -29,8 +33,15 @@ fi
 
 # `--warning=no-file-changed` because yarn's daemon can touch files while we read them; `|| [ $? -eq 1 ]`
 # accepts tar's "file changed as we read it" (exit 1) while still failing on a real error (exit 2).
+# Capture the status explicitly. `|| [ $? -eq 1 ]` cannot express this: under `set -e` it still
+# swallows every non-1 failure exactly as it did without it.
+tar_status=0
 tar --warning=no-file-changed --use-compress-program="$COMPRESS" \
-	-cf "$ARCHIVE" "${PATHS[@]}" || [ $? -eq 1 ]
+	-cf "$ARCHIVE" "${PATHS[@]}" || tar_status=$?
+if [ "$tar_status" -ne 0 ] && [ "$tar_status" -ne 1 ]; then
+	echo "::error::tar failed with status $tar_status - refusing to publish a partial archive"
+	exit "$tar_status"
+fi
 
 # Tolerating exit 1 means a TRUNCATED archive could be published, and every consumer would then fall
 # back to its own multi-hour install. A cheap size floor catches the gross case.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,10 +89,13 @@ jobs:
         id: cache
         uses: actions/cache/restore@v4
         with:
-          # lookup-only: on a HIT this job does nothing with the archive — every step below is gated
-          # on `cache-hit != 'true'` — so downloading ~2.9 GB would be pure serial latency in front of
-          # four jobs that are waiting on it. The output it sets is all this job needs.
-          lookup-only: true
+          # NOT lookup-only. It was, and that made every warm run fail: on a cache HIT the archive
+          # is never written to disk, so `Archive node_modules` is skipped along with the other
+          # producer steps, and the UNGUARDED `Upload node_modules archive` below then trips its
+          # `if-no-files-found: error`. The cold run that first writes the key passes; the NEXT run,
+          # the one the cache exists for, is the one that breaks - the worst place to put a failure.
+          # Downloading ~2.9 GB here costs a few minutes against the ~90-minute install it replaces,
+          # and it is what guarantees the run-scoped artifact handoff below actually has a file.
           path: ${{ env.NODE_MODULES_ARCHIVE }}
           key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('yarn.lock', 'package.json', 'patches/**', '.scripts/postinstall.js') }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,7 @@ jobs:
           node-version: 24
 
       - name: Download node_modules archive
+        id: artifact
         uses: actions/download-artifact@v8
         # Primary handoff — run-scoped, so no other workflow can evict it between jobs.
         continue-on-error: true
@@ -170,6 +171,12 @@ jobs:
           name: build-node-modules
 
       - name: Restore node_modules archive (cache fallback)
+        # Gated, because it was NOT before and the comment below claimed otherwise. With no `if:`
+        # this ran even on a successful artifact download, and since the producer saves the same
+        # key each cold run the lookup HITS - so every consumer pulled the same ~2.9 GB twice.
+        # Measured on run 32418672320: artifact download 1015s/1028s/1102s, then this step still
+        # running past 209s on top. ~17 min of pure waste per consumer, ~68 min per run.
+        if: steps.artifact.outcome != 'success'
         uses: actions/cache/restore@v4
         continue-on-error: true
         with:
@@ -205,6 +212,7 @@ jobs:
           node-version: 24
 
       - name: Download node_modules archive
+        id: artifact
         uses: actions/download-artifact@v8
         # Primary handoff — run-scoped, so no other workflow can evict it between jobs.
         continue-on-error: true
@@ -212,6 +220,12 @@ jobs:
           name: build-node-modules
 
       - name: Restore node_modules archive (cache fallback)
+        # Gated, because it was NOT before and the comment below claimed otherwise. With no `if:`
+        # this ran even on a successful artifact download, and since the producer saves the same
+        # key each cold run the lookup HITS - so every consumer pulled the same ~2.9 GB twice.
+        # Measured on run 32418672320: artifact download 1015s/1028s/1102s, then this step still
+        # running past 209s on top. ~17 min of pure waste per consumer, ~68 min per run.
+        if: steps.artifact.outcome != 'success'
         uses: actions/cache/restore@v4
         continue-on-error: true
         with:
@@ -247,6 +261,7 @@ jobs:
           node-version: 24
 
       - name: Download node_modules archive
+        id: artifact
         uses: actions/download-artifact@v8
         # Primary handoff — run-scoped, so no other workflow can evict it between jobs.
         continue-on-error: true
@@ -254,6 +269,12 @@ jobs:
           name: build-node-modules
 
       - name: Restore node_modules archive (cache fallback)
+        # Gated, because it was NOT before and the comment below claimed otherwise. With no `if:`
+        # this ran even on a successful artifact download, and since the producer saves the same
+        # key each cold run the lookup HITS - so every consumer pulled the same ~2.9 GB twice.
+        # Measured on run 32418672320: artifact download 1015s/1028s/1102s, then this step still
+        # running past 209s on top. ~17 min of pure waste per consumer, ~68 min per run.
+        if: steps.artifact.outcome != 'success'
         uses: actions/cache/restore@v4
         continue-on-error: true
         with:
@@ -300,6 +321,7 @@ jobs:
             build-essential icnsutils graphicsmagick binutils libappindicator3-1 || true
 
       - name: Download node_modules archive
+        id: artifact
         uses: actions/download-artifact@v8
         # Primary handoff — run-scoped, so no other workflow can evict it between jobs.
         continue-on-error: true
@@ -307,6 +329,12 @@ jobs:
           name: build-node-modules
 
       - name: Restore node_modules archive (cache fallback)
+        # Gated, because it was NOT before and the comment below claimed otherwise. With no `if:`
+        # this ran even on a successful artifact download, and since the producer saves the same
+        # key each cold run the lookup HITS - so every consumer pulled the same ~2.9 GB twice.
+        # Measured on run 32418672320: artifact download 1015s/1028s/1102s, then this step still
+        # running past 209s on top. ~17 min of pure waste per consumer, ~68 min per run.
+        if: steps.artifact.outcome != 'success'
         uses: actions/cache/restore@v4
         continue-on-error: true
         with:


### PR DESCRIPTION
## Why this exists

Triage of the AI review comments on #10010 (CodeRabbit, cubic, greptile) **after** it was merged. Two findings are real correctness bugs; I verified both against the merged code on `develop` rather than trusting the bot text.

> ⏸️ **Not for merging yet** — `develop` build [32418672320](https://github.com/ever-co/ever-gauzy/actions/runs/32418672320) is mid-flight and should finalise first. Bug 1 does **not** affect that run (it is a cold/cache-miss run); it bites the *next* one.

## 1 · `build.yml` — every warm run would fail 🔴

`Restore node_modules archive` used `lookup-only: true`, so on a cache **HIT** the archive is never written to disk.

`Install`, `Run postinstall`, `Archive` and `Save` are all gated on `cache-hit != 'true'` and correctly skip — but `Upload node_modules archive` carries **no `if:` guard** and sets `if-no-files-found: error`:

```yaml
- name: Upload node_modules archive     # ← no if:
  uses: actions/upload-artifact@v7
  with:
    if-no-files-found: error            # ← fails when Archive was skipped
```

On a hit it uploads nothing and fails the job. The other four jobs `needs:` this one, so it takes the whole gate down.

**The cold run that first writes the key passes** — so this is invisible until the second run, the one the cache exists for. That is the worst possible place to hide a failure, and it would have read tomorrow as "the install-once change made CI worse".

Fix: drop `lookup-only`. The producer always materialises the archive. ~2.9 GB of download costs a few minutes against the ~90-minute install it replaces, and it is what makes the run-scoped artifact handoff actually have a file.

## 2 · `archive-node-modules.sh` — a failed `tar` could publish a corrupt archive 🔴

The script set only `-o pipefail`, never `-e`, and tolerated tar exit 1 via `|| [ $? -eq 1 ]`. A tar exit status of **2** — a real error — leaves that compound false and execution simply continues to the size check. A ~2.9 GB tree truncated early still clears the 100 MB floor, so the partial archive gets published and four consumer jobs unpack it.

Now `set -e`, with the tar status captured explicitly so exit 1 stays tolerated and anything else aborts.

## Reviewed and deliberately deferred

| Finding | Assessment |
|---|---|
| `test_playwright.yml` cleanup breaks failed-job reruns (greptile P1, cubic P1) | **Real**, but it is the Playwright gate, not the build gate. Separate PR — it needs a design call on whether rerun-reuse or artifact quota wins. |
| Scope `actions: write` to the `cleanup` job (cubic P2) | **Real** least-privilege issue, worth doing, no correctness impact. Separate PR. |
| Cache key omits workspace `package.json` files (cubic P2) | **Real** — a workspace manifest change hits a stale archive. Wants a considered key, not a rushed one. |
| Pin `actions/cache@v4` to commit SHAs (CodeRabbit) | Valid, but repo-wide convention — should be done across all 66 workflows, not one file. |
| `const payload` mutated in `expenses.component.ts` (greptile P2) | Style only. |
| `fail-on-cache-miss` vs the documented bootstrap fallback (cubic P3) | Comment accuracy, no behaviour change. |

## Also flagged

SonarCloud's quality gate **failed on #10010** (C security rating) and I merged past it on your instruction — worth a look independently of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops warm CI runs from failing, prevents publishing a partial `node_modules` archive, and removes redundant 2.9 GB downloads by consumer jobs. Previously, a cache HIT produced no on-disk archive (upload then failed), the cache fallback ran unconditionally (double-download), and the archiver could continue after a real `tar` error.

- `.github/workflows/build.yml`: remove `lookup-only` from `actions/cache/restore@v4` so a HIT downloads the archive for the upload step; add `id: artifact` to `actions/download-artifact@v8` and gate the cache fallback with `if: steps.artifact.outcome != 'success'` so it runs only when the artifact download actually fails.
- `.github/scripts/archive-node-modules.sh`: add `set -e`, capture `tar` status, tolerate exit 1 only, and abort on any other status to avoid publishing a truncated archive.

<sup>Written for commit 7118ab32fa257083d2663e4e04dd6fac642cfeea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

