### PR TITLE
perf(ci): serve the Playwright deps install from Verdaccio, not the internet

### DIFF
--- a/.github/workflows/test_playwright.yml
+++ b/.github/workflows/test_playwright.yml
@@ -73,6 +73,31 @@ jobs:
       # NO actions/cache here, deliberately — see the archive step below. The budget is full of
       # caches that other workflows genuinely need, and writing this one would evict them.
 
+      # Point yarn at the internal Verdaccio VIP before the heaviest install in the fleet. This
+      # job is self-documented at 88 min, 3h20m and 3h46m, and every byte of it currently crosses
+      # the WAN to the public registry: the repo .npmrc pins registry.yarnpkg.com and nothing here
+      # overrode it.
+      #
+      # The action appends to .npmrc/.yarnrc AND rewrites the resolved URLs in yarn.lock. The
+      # rewrite is the load-bearing half: yarn v1 fetches the URL recorded in the lockfile and
+      # ignores the registry setting, so a config-only change here would be a measurable no-op.
+      # Verified separately that this does NOT break --frozen-lockfile: yarn compares package.json
+      # patterns against lockfile entries, and the resolved host is not part of that comparison.
+      #
+      # The action probes the VIP and falls back to the public registry, so a MetalLB speaker flap
+      # costs a slow install rather than a red build. Safe to place here: unlike build.yml, this
+      # workflow deliberately has NO actions/cache, so rewriting yarn.lock cannot move a cache key.
+      - name: Configure Registry
+        uses: ./.github/actions/configure-registry
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # NOT contains(matrix.os, ...) as the app workflows use: this workflow defines no
+          # matrix.os (its only matrix key is shard), so that expression collapses to false and
+          # silently disables the in-network VIP retry and its warning. Derive it from the runner
+          # variable this job actually uses instead.
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
       - name: Install Packages & Bootstrap
         shell: bash
         # Retry once: run 30330950619 died here after 9 min. A transient registry/FS hiccup on


### PR DESCRIPTION
> ⏸️ **Open for review — not for merging yet.**

## The problem

`test_playwright.yml` never pointed at our internal npm cache. The heaviest install in the fleet pulls **~4.2 GB from `registry.yarnpkg.com` on every run**. The job documents itself at **88 min, 3h 20m and 3h 46m**.

An audit of all 11 GitHub orgs found **177 workflows across 56 repos** in the same state. This is the highest-traffic one (222 runs) and the cleanest to fix — so it goes first, alone, as a measurable proof point.

## Why this reuses the composite action instead of a one-line registry setting

This is the part worth reading, because the obvious fix is a no-op:

**yarn v1 fetches the URL recorded in `yarn.lock` and ignores the registry setting.** Measured with a negative control — a blackholed `resolved` URL with `.yarnrc` pointing at a *working* registry:

```
yarn 1.22.22 → error getaddrinfo ENOTFOUND registry.blackhole-does-not-exist.invalid
npm  11.11.0 → same, RC=1   (only with an isolated cache; a warm _cacache masks it)
```

If registry config won, both would have succeeded. A config-only patch here would merge, go green, and leave the 83 minutes exactly where it is. The action **rewrites the lockfile URLs** — that's the half that actually moves the bytes.

**`--frozen-lockfile` is safe.** Verified against the real VIP with npmjs-generated `integrity` unchanged: `RC=0`, lockfile unmodified. Yarn's frozen check compares `package.json` patterns to lockfile entries; the resolved *host* isn't part of that comparison.

**The probe-and-fallback is mandatory, not decorative.** The VIP is a single MetalLB L2 announcement with a recurring speaker flap (`metallb-frr-k8s` restarts visible now). Hardcoding the registry would turn a cache optimisation into a CI outage vector.

## Two deliberate deviations from how the app workflows call this action

| | Standard | Here | Why |
|---|---|---|---|
| `expect-vip` | `contains(matrix.os, …)` | `vars.RUNNER_LINUX_X64_8 != ''` | This workflow defines **no `matrix.os`** (only `shard`), so the standard expression evaluates **false** and silently disables the VIP retry and warning — a mute switch, not an error |
| Placement | after checkout | after checkout | Safe **here** because this workflow deliberately has no `actions/cache`. The same placement in `build.yml` would move the `hashFiles('yarn.lock')` cache key — which is why `build.yml` is **not** touched by this PR |

The `cleanup` job stays on `ubuntu-latest` and deliberately does **not** get this step — a GitHub-hosted runner cannot reach `192.168.1.183` and would hang.

## Acceptance criteria — do not trust a green build

A green build proves nothing here; the no-op case is also green. The only trustworthy proof is **wall-clock install duration dropping toward the ~411s Verdaccio figure**, or a log line showing tarballs fetched from `192.168.1.183:4873`. Please check one of those before merging.

## Context

Follows #10010 (install once per run) and #10023 (three correctness fixes). Those took `build-api` from 151m → 31m. This targets the remaining dominant cost: the install itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve Playwright dependency installs in `test_playwright.yml` from the internal Verdaccio VIP instead of the public registry. Previously the job pulled ~4.2 GB from `registry.yarnpkg.com` on each run; now we rewrite `yarn.lock` resolved URLs and set `.npmrc`/`.yarnrc` via `./.github/actions/configure-registry`, with automatic fallback to the public registry. `--frozen-lockfile` behavior and package integrity remain unchanged.

**Review and rollout**
- Verify impact before merge: either see tarball fetches from `192.168.1.183:4873` in logs or see install time drop toward the ~411s Verdaccio baseline.
- Enable VIP probing by deriving `expect-vip` from `vars.RUNNER_LINUX_X64_8 != ''` (this workflow has no `matrix.os`).
- Place the step after checkout only in this workflow; it is safe here because there is no `actions/cache`. Do not copy this placement into workflows where `hashFiles('yarn.lock')` contributes to cache keys (for example `build.yml`).
- Leave the `cleanup` job unchanged on `ubuntu-latest`; GitHub-hosted runners cannot reach the VIP.

<sup>Written for commit fb6673c79771011c3d3eb6035fcf338c1569c0db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

