### PR TITLE
fix(ci): make configure-registry actually reusable from other repos

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -20,6 +20,8 @@
 		"gzipped",
 		"gzips",
 		"npmjs",
+		"unmatch",
+		"pathspec",
 		"yarnpkg",
 		"rspack",
 		"dlib",

--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -13,7 +13,10 @@ description: >-
 
 inputs:
   verdaccio-registry:
-    description: Internal Verdaccio VIP, normally ${{ vars.VERDACCIO_REGISTRY }}. Empty disables the probe.
+    # NOTE: no GitHub expression syntax in this field. GitHub evaluates action metadata, and `vars` is
+    # not a valid context there - an expression here makes every CROSS-REPO use fail at 'Set up job' with
+    # TemplateValidationException: Unrecognized named-value: 'vars'. Name the variable in prose instead.
+    description: Internal Verdaccio VIP, normally the org variable VERDACCIO_REGISTRY. Empty disables the probe.
     required: false
     default: ''
   verdaccio-token:
@@ -76,8 +79,20 @@ runs:
         # a known starting state we must not go on to pick a registry, because the install would
         # then quietly run against whatever the last job left behind.
         rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
-        if ! git checkout -- .npmrc yarn.lock; then
-          echo "::error title=Could not reset registry configuration::git checkout -- .npmrc yarn.lock failed on this workspace, so the previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+        # Reset per-path, not as one pathspec list. `git checkout -- a b` exits 1 when EITHER path is
+        # untracked, so the original form hard-failed on every pnpm repo (no .npmrc, no yarn.lock) and
+        # turned 'this repo has no cache configured' into 'this repo's CI is red'. Tracked files are
+        # restored; untracked leftovers from a previous run on a clean:false runner are removed.
+        reset_failed=""
+        for f in .npmrc yarn.lock; do
+          if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+            git checkout -- "$f" || reset_failed="$reset_failed $f"
+          else
+            rm -f "$f"
+          fi
+        done
+        if [ -n "$reset_failed" ]; then
+          echo "::error title=Could not reset registry configuration::git checkout -- failed for:$reset_failed. The previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
           exit 1
         fi
 

--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -85,10 +85,18 @@ runs:
         # restored; untracked leftovers from a previous run on a clean:false runner are removed.
         reset_failed=""
         for f in .npmrc yarn.lock; do
-          if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+          # Exit status matters: 0 = tracked, 1 = genuinely absent, anything else (128 = git
+          # metadata unavailable) means we CANNOT tell. Treating every nonzero as absent would
+          # delete the files and continue, which is exactly the unknown-state hazard this reset
+          # exists to prevent - so only 1 is trusted, and everything else fails closed.
+          git ls-files --error-unmatch "$f" >/dev/null 2>&1
+          tracked=$?
+          if [ "$tracked" -eq 0 ]; then
             git checkout -- "$f" || reset_failed="$reset_failed $f"
-          else
+          elif [ "$tracked" -eq 1 ]; then
             rm -f "$f"
+          else
+            reset_failed="$reset_failed $f(git-exit-$tracked)"
           fi
         done
         if [ -n "$reset_failed" ]; then


### PR DESCRIPTION
Two defects that only appear when the action is used from **another repo** — which is why gauzy never hit them.

## 1. An expression in action metadata killed every cross-repo use 🔴

`inputs.verdaccio-registry.description` contained a GitHub expression naming `vars.VERDACCIO_REGISTRY`. GitHub evaluates action metadata, and `vars` is **not a valid context** there:

```
.github/actions/configure-registry/action.yml (Line: 16, Col: 18):
Unrecognized named-value: 'vars'  ->  TemplateValidationException
```

Reproduced on `ever-digital/ever-digital` run `32475781533`: the job that previously installed dependencies successfully afterwards executed **nothing** — it died at `Set up job`.

## 2. The reset hard-failed on every pnpm repo 🔴

```bash
git checkout -- .npmrc yarn.lock   # exits 1 if EITHER path is untracked
```

A pnpm repo tracks neither file, so the action `exit 1`s before selecting a registry — turning *"this repo has no cache configured"* into *"this repo's CI is red"*. Proven with a negative control against a simulated pnpm checkout.

Now reset **per-path**: tracked files restored, untracked leftovers from a `clean: false` runner removed, and only a genuine checkout failure aborts.

## Gauzy is unaffected

Both files are tracked in this repo, so each takes the same `git checkout` branch as before. Verified: zero expressions remain in the metadata block, and the extracted `run:` script passes `bash -n`.

## Why it matters now

This action is the mechanism for routing the fleet through Verdaccio. Until it is fixed, **every pnpm repo and every cross-repo reference fails** — and pnpm is 33 of our 106 repos with a lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `configure-registry` action reusable across repos and hardens its reset logic. Previously, cross-repo runs died at “Set up job” due to an invalid metadata expression and `pnpm` repos failed because `git checkout -- .npmrc yarn.lock` aborted; now metadata is plain text, the reset runs per-path (restore tracked, remove untracked), and it fails closed when Git cannot determine tracking state. Behavior in `yarn` workspaces is unchanged.

- Review/QA: run from another repo with and without org variable `VERDACCIO_REGISTRY` set; verify a `pnpm` repo without `.npmrc`/`yarn.lock` no longer fails; confirm no change in a `yarn` workspace; check that an unknown Git state aborts with a clear error (no silent file deletes).
- Rollout: no workflow changes required. To route through Verdaccio, ensure the org variable `VERDACCIO_REGISTRY` is set.

<sup>Written for commit 911b50bd2bdd8b3e36f3dc4de2202f34d7c84aba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

