### PR TITLE
fix(configure-registry): guard yarn.lock rewrite; rewrite package-lock.json for npm repos

### DIFF
--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -157,7 +157,7 @@ runs:
           # (pnpm and npm repos included): a pnpm repo has NO root yarn.lock, and under the
           # composite `bash -eo pipefail` shell an unguarded `sed missing-file` exits 2 and kills
           # the job the moment the VIP answers - config-only is all a pnpm repo needs, because
-          # pnpm-lock.yaml stores no registry host. yarn/npm lockfiles DO store the resolved
+          # pnpm-lock.yaml stores no registry host. yarn/npm lock files DO store the resolved
           # tarball host, so where those files exist the rewrite is load-bearing: without it the
           # install follows the lockfile's npmjs URLs and the registry config is a measured no-op.
           if [ -f yarn.lock ]; then

--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -78,13 +78,13 @@ runs:
         # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
         # a known starting state we must not go on to pick a registry, because the install would
         # then quietly run against whatever the last job left behind.
-        rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten
+        rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten package-lock.json.rewritten
         # Reset per-path, not as one pathspec list. `git checkout -- a b` exits 1 when EITHER path is
         # untracked, so the original form hard-failed on every pnpm repo (no .npmrc, no yarn.lock) and
         # turned 'this repo has no cache configured' into 'this repo's CI is red'. Tracked files are
         # restored; untracked leftovers from a previous run on a clean:false runner are removed.
         reset_failed=""
-        for f in .npmrc yarn.lock; do
+        for f in .npmrc yarn.lock package-lock.json; do
           # Exit status matters: 0 = tracked, 1 = genuinely absent, anything else (128 = git
           # metadata unavailable) means we CANNOT tell. Treating every nonzero as absent would
           # delete the files and continue, which is exactly the unknown-state hazard this reset
@@ -152,8 +152,24 @@ runs:
           # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
           # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
           # sed on the macOS runners. The temp file is only ever the finished rewrite.
-          sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
-              -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
-          mv -f yarn.lock.rewritten yarn.lock
+          #
+          # BOTH rewrites are gated on the lockfile existing. This action is consumed cross-repo
+          # (pnpm and npm repos included): a pnpm repo has NO root yarn.lock, and under the
+          # composite `bash -eo pipefail` shell an unguarded `sed missing-file` exits 2 and kills
+          # the job the moment the VIP answers - config-only is all a pnpm repo needs, because
+          # pnpm-lock.yaml stores no registry host. yarn/npm lockfiles DO store the resolved
+          # tarball host, so where those files exist the rewrite is load-bearing: without it the
+          # install follows the lockfile's npmjs URLs and the registry config is a measured no-op.
+          if [ -f yarn.lock ]; then
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
+          fi
+          # npm follows package-lock.json's `resolved` URLs the same way (integrity hashes are
+          # host-independent sha512 sums, so `npm ci` still verifies every tarball byte-for-byte).
+          if [ -f package-lock.json ]; then
+            sed -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" package-lock.json > package-lock.json.rewritten
+            mv -f package-lock.json.rewritten package-lock.json
+          fi
         fi
         echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"

--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -89,8 +89,15 @@ runs:
           # metadata unavailable) means we CANNOT tell. Treating every nonzero as absent would
           # delete the files and continue, which is exactly the unknown-state hazard this reset
           # exists to prevent - so only 1 is trusted, and everything else fails closed.
-          git ls-files --error-unmatch "$f" >/dev/null 2>&1
-          tracked=$?
+          # The probe MUST sit in an `if` guard: composite bash runs with -e, so the bare
+          # `git ls-files ...; tracked=$?` form never reaches the assignment on any repo
+          # where $f is untracked - the step dies with exit 1 and no output at all
+          # (measured on the first pnpm consumer repo of this action, 2026-08-21).
+          if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+            tracked=0
+          else
+            tracked=$?
+          fi
           if [ "$tracked" -eq 0 ]; then
             git checkout -- "$f" || reset_failed="$reset_failed $f"
           elif [ "$tracked" -eq 1 ]; then


### PR DESCRIPTION
## What

Two additive fixes to the shared `.github/actions/configure-registry` action so the Verdaccio rollout can proceed on non-yarn repos:

1. **Guard the `yarn.lock` rewrite on the file existing.** The composite step runs under `bash -eo pipefail`; on any repo without a root `yarn.lock` (all pnpm and npm repos — githands, ever-hust, cloc-co/platform, ever-jobs, …) the unguarded `sed yarn.lock` exits 2 and kills the job the moment the VIP answers. Reproduced locally: `sed missing-file > out` exits 2 under `-e`. This mirrors the guard the reviewed local copy in `ever-works/ever-works` already carries.
2. **Rewrite `package-lock.json` where present** (same pattern, same guard). npm follows the lockfile's `resolved` URLs, so for npm repos a config-only registry change is a measured no-op (`registry-config-is-a-noop-with-lockfiles`). Integrity hashes are host-independent sha512, so `npm ci` still verifies every tarball. `package-lock.json` also joins the per-path reset loop and the stale-temp-file cleanup.

## Why now

Fleet Verdaccio rollout (owner goal: traffic reduction). The next consumers are pnpm/npm repos referencing this action by pinned SHA; without these guards their first in-network run fails at Configure Registry.

## Risk

None to this repo: root `yarn.lock` exists, so the guard is always true here and no `package-lock.json` exists at the root. Behaviour on gauzy's own 66 call sites is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards lockfile rewrites and the tracked-file probe in `.github/actions/configure-registry` so non-yarn repos don’t fail and npm installs use the selected registry. Previously we always rewrote `yarn.lock` and probed tracked files under `bash -e`, which crashed on repos without those files; `npm` repos also kept using `registry.npmjs.org` from `package-lock.json`.

- Gate `yarn.lock` and `package-lock.json` rewrites on existence; rewrite `resolved` URLs to the chosen registry; integrity stays sha512-verified (`npm ci` unchanged).
- Add `package-lock.json` and its `.rewritten` temp to the per-path reset and cleanup.
- Guard the `git ls-files` probe to avoid `-e` errexit on untracked files; preserve fail-closed behavior on unknown states.
- No behavior change for this repo (root `yarn.lock` present; no root `package-lock.json`).

<sup>Written for commit aa4ee19926fabcf820aa1294385a76aec6bdb548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

