### PR TITLE
fix(ci): configure-registry died under bash -e when .npmrc is untracked

### DIFF
--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -156,8 +156,14 @@ runs:
           # One pass, no -i: an -i.bak backup survives on a clean: false runner if the step
           # fails between the rewrite and its cleanup, and bare -i is not portable to the BSD
           # sed on the macOS runners. The temp file is only ever the finished rewrite.
-          sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
-              -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
-          mv -f yarn.lock.rewritten yarn.lock
+          # Guarded on the file existing: pnpm repos have no yarn.lock (pnpm-lock.yaml stores
+          # no registry host, so the .npmrc line above is the whole redirect there) and the
+          # unguarded sed died under bash -e with "sed: can't read yarn.lock" (measured:
+          # ever-works/ever-works-website run 32503441946, 2026-08-21).
+          if [ -f yarn.lock ]; then
+            sed -e "s|https://registry.yarnpkg.com|${REGISTRY%/}|g" \
+                -e "s|https://registry.npmjs.org|${REGISTRY%/}|g" yarn.lock > yarn.lock.rewritten
+            mv -f yarn.lock.rewritten yarn.lock
+          fi
         fi
         echo "Using npm registry: ${REGISTRY:-https://registry.yarnpkg.com/ (repo default)}"

--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -89,8 +89,12 @@ runs:
           # metadata unavailable) means we CANNOT tell. Treating every nonzero as absent would
           # delete the files and continue, which is exactly the unknown-state hazard this reset
           # exists to prevent - so only 1 is trusted, and everything else fails closed.
-          git ls-files --error-unmatch "$f" >/dev/null 2>&1
-          tracked=$?
+          # The capture is guarded with || because this composite step runs under `bash -e`:
+          # a bare failing `git ls-files` exits the whole script before tracked=$? runs, which
+          # killed the step at ~95ms with no output on every repo whose .npmrc is untracked
+          # (measured: ever-co/ever-apps-website run 32502549575, 2026-08-21).
+          tracked=0
+          git ls-files --error-unmatch "$f" >/dev/null 2>&1 || tracked=$?
           if [ "$tracked" -eq 0 ]; then
             git checkout -- "$f" || reset_failed="$reset_failed $f"
           elif [ "$tracked" -eq 1 ]; then


### PR DESCRIPTION
## What

`configure-registry` (the shared Verdaccio action) dies instantly — exit 1 at ~95ms, zero output — on any repo where `.npmrc` (or `yarn.lock`) is not a tracked file.

## Why

Composite-action `shell: bash` steps run `bash -e -o pipefail`. The reset loop captured the tracked-status as:

```bash
git ls-files --error-unmatch "$f" >/dev/null 2>&1
tracked=$?
```

Under `-e`, the bare `git ls-files` exiting 1 (file merely untracked — the *expected* case on most repos) terminates the whole script before `tracked=$?` ever runs. Repos with both files tracked (ever-digital/ever-digital) pass; repos without a tracked `.npmrc` die.

**Measured**: ever-co/ever-apps-website run [32502549575](https://github.com/ever-co/ever-apps-website/actions/runs/32502549575) — `Configure Registry` failed in 95ms with no output; ever-digital run 32502108087 with the identical pin succeeded past this step.

## Fix

```bash
tracked=0
git ls-files --error-unmatch "$f" >/dev/null 2>&1 || tracked=$?
```

The `||` guard makes the status capture `-e`-safe while preserving the designed 0 / 1 / other (fail-closed) distinction. One-line change + comment; no behavior change on repos that worked.

Verified: `bash --noprofile --norc -e -o pipefail` repro of both forms — the old form exits 1 before any output, the guarded form proceeds with `tracked=1`.

Part of the fleet-wide Verdaccio rollout. develop only — no cascade to master from this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the `configure-registry` composite action from exiting under `bash -e` when `.npmrc` is untracked or `yarn.lock` is absent. Previously, a bare `git ls-files` exit 1 and an unconditional `sed` killed the step; now both paths are guarded while preserving 0/1/other handling.

- Limited to `.github/actions/configure-registry/action.yml`: guard the tracked-status capture (`tracked=0; git ls-files ... || tracked=$?`) and run the lockfile rewrite only if `yarn.lock` exists; comments added.
- Behavior: unchanged for repos with a tracked `.npmrc` and a `yarn.lock`; pnpm repos without `yarn.lock` and repos with untracked `.npmrc` now proceed. Unexpected errors still fail closed.
- No migration or rollout actions required.

<sup>Written for commit c3318892694072ed850bb2615c0445dc81295ae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

