### PR TITLE
fix(ui-core): pin the nav rail to the viewport so the sidebar footer (logout) stays reachable

### DIFF
--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -441,6 +441,19 @@ nb-sidebar[tag='menu-sidebar'] {
     overflow: visible;
   }
 
+  // `overflow: visible` above also strips `.scrollable` of its scroll-container
+  // status, which flips its flex automatic minimum size (`min-height: auto`)
+  // from 0 to CONTENT-based — Nebular's `.scrollable { flex: 1 }` then grows
+  // past its 100vh container whenever the nav list is long (an expanded
+  // submenu is enough at 720px), pushing `.sidebar-footer` — the user block
+  // and the app's ONLY logout entry point — below the fold with no scrollable
+  // ancestor left to bring it back. `min-height: 0` pins the rail to its
+  // container; `.custom-row.menu` owns the nav list's scrolling (see below).
+  nb-layout .layout .layout-container nb-sidebar[tag='menu-sidebar'] .main-container > .scrollable,
+  nb-layout .layout .layout-container nb-sidebar[tag='menu-sidebar'] .main-container-fixed > .scrollable {
+    min-height: 0;
+  }
+
   // While the AI chat is maximized the canvas SHRINKS to zero width instead
   // of being covered or display:none'd — the page stays alive and restoring
   // simply gives the space back. (All nb-sidebars are projected before the
@@ -552,7 +565,14 @@ nb-sidebar[tag='menu-sidebar'] {
 
 .custom-box .custom-row.menu {
   flex: 1 1 auto;
-  overflow-y: overlay;
+  // The flex automatic minimum (`min-height: auto`) would size this row to the
+  // FULL nav list and defeat the overflow below — 0 lets the row shrink so the
+  // list scrolls inside it and `.sidebar-footer` stays on-screen.
+  min-height: 0;
+  // `auto`, not the deprecated `overlay`: Chromium computes `overlay` as
+  // `auto` anyway, and Firefox drops the declaration entirely — leaving the
+  // row `overflow: visible` and the rail unscrollable.
+  overflow-y: auto;
   padding: 0 0.75rem;
 }
 


### PR DESCRIPTION
## What broke

Stage e2e run [32431521753](https://github.com/ever-co/ever-gauzy/actions/runs/32431521753) (shard 3) failed 3/3 attempts on `my-tasks-tracked-in-timesheets.feature` with:

```
locator.click: Element is outside of the viewport  →  div.user-container
```

at the scenario's first logout (`steps.ts:51` → `commands.ts logout` → `clickUserName`). The clicked element is the **sidebar-footer user block — the app's only logout entry point** (the header has no user widget). Playwright resolved it, scrolled, and it was still off-screen: the element was genuinely unreachable.

**This is an app regression, not a flaky test.** A real user in a ~720px-tall window on a page with an expanded submenu (e.g. Organization → Tags) cannot log out or reach below-fold menu items.

## Baseline verdict

NEW failure, introduced in the 2026-08-19/20 window. The spec passed on first attempt in 30 consecutive executed develop runs from 2026-07-31 through 2026-08-19 (last green: run 32202518805 / 32285142151-a2, head `948f901b`). No run executed the spec between that head and the failing stage head `71998862` (the Aug-20 develop run's shard 3 was cancelled pre-test), so CI history alone could not narrow further — code inspection did.

## Root cause

`247b8bdb74a` (PR #10001, `feat/topbar-selector-ui`, merged to develop 2026-08-20) forced `overflow: visible` on the menu sidebar's whole container chain — host, `.main-container(-fixed)`, **and `.scrollable`** — so the new rail-edge buttons could straddle the rail's edge. Its comment counts on `.custom-row.menu`'s own `overflow-y` to keep the nav list scrolling:

> Dropping the rail's own scroll costs nothing: `.custom-row.menu` owns the nav list's overflow

That bet loses to the **flex automatic minimum size**:

1. Once `.scrollable` stops being a scroll container, its `min-height: auto` becomes *content-based* — Nebular's `.scrollable { flex: 1 }` grows past its `100vh` container instead of being clamped to it.
2. `.custom-row.menu` (`flex: 1 1 auto`, no `min-height: 0`) has the same automatic minimum, so its `overflow-y` never engages either.
3. Net: with the Organization submenu expanded the rail grows to ~1000px in a 720px viewport, `.sidebar-footer` lands below the fold, and there is **no scrollable ancestor left** — `scrollIntoView` is a no-op, which is exactly Playwright's "done scrolling → Element is outside of the viewport".

Only this scenario calls `CustomCommands.logout` in the whole BDD suite, which is why the 17 sibling tests in the shard stayed green.

## Fix

`packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss`, keeping `overflow: visible` (the rail-edge buttons still need it):

- `.scrollable` (both `.main-container` variants, menu-sidebar-scoped): add `min-height: 0` — pins the rail back to its container instead of its content.
- `.custom-box .custom-row.menu`: add `min-height: 0` so the row can shrink and actually scroll, and switch `overflow-y: overlay` → `auto` (the deprecated `overlay` computes to `auto` in Chromium anyway, and Firefox drops the declaration entirely, leaving the row unscrollable there even before this regression).

## Validation

- Numeric repro of the exact flex/overflow chain (Nebular `.main-container` → `.scrollable` → `.custom-box` rows) at a 720px frame with 892px of menu content, driven in Chromium:
  - **before**: `.scrollable` 993px, menu cannot scroll, footer at y 952–985 → unreachable;
  - **after (this diff)**: `.scrollable` pinned at 720px, menu scrolls internally (619px viewport over 892px content), footer visible at y 679–712.
- `dart-sass` compile of the edited file succeeds; both new rules render in the output CSS.
- The Playwright e2e itself does not run per-PR (it runs on push to develop/stage); shard 3 on the next develop run is the end-to-end proof.

## Note for a follow-up (deliberately NOT in this PR)

`apps/gauzy-e2e/playwright.config.ts` declares a 1920×1080 viewport (line 68), but both projects spread `devices['Desktop Chrome']` into `use`, which silently overrides it to 1280×720 — the failure screenshots are all 1280×720. At the documented 1920×1080 this regression would have been missed. Left untouched here: the smaller viewport is what *caught* a real bug, and bumping it would have masked it. Owner call on whether the config comment or the viewport should change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the menu sidebar (nav rail) to the viewport so the footer (logout) remains reachable. Previously, forcing `overflow: visible` on the sidebar containers removed the scroll container, letting the rail grow past 100vh and hiding the footer; now the rail stays within the viewport and the menu scrolls internally.

- CSS-only fix in `packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss`: under `nb-sidebar[tag='menu-sidebar']`, set `min-height: 0` on `.main-container > .scrollable` and `.main-container-fixed > .scrollable`; on `.custom-row.menu`, set `min-height: 0` and switch `overflow-y` from `overlay` to `auto`. Keeps `overflow: visible` for rail-edge buttons.
- Verify visually at 1280×720 with a long submenu: the rail height is clamped to the viewport, the footer is visible or reachable by scrolling, and the rail-edge buttons still straddle the edge. Firefox now scrolls correctly. No migrations or JS changes; e2e will re-validate on the next develop run.

<sup>Written for commit d95cde975395801534f5b312d517fcfb0f1c242b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

