### PR TITLE
fix(ci): keep the node_modules artifact when the run is red so reruns can restore it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,9 +358,16 @@ jobs:
   cleanup:
     name: Delete node_modules artifact
     needs: [build-monorepo-root, build-libs, build-api, build-web, build-desktop]
-    # `always()`: the archive is just as useless after a failed build, and leaving ~2.9 GB behind on
-    # red runs is exactly how the org's Actions storage quota filled and stopped artifact uploads.
-    if: always()
+    # Delete only when nothing failed. This used to be a bare `always()` (rationale then: red-run
+    # leftovers once filled the org's Actions storage quota and stopped uploads) - but the artifact
+    # is this run's ONLY dependency handoff, so deleting it on a red run breaks "Re-run failed
+    # jobs": every rerun consumer falls into the 1-3h bootstrap fallback. Measured on stage run
+    # 32513912629 (2026-08-21): a seconds-long DNS blip failed one restore, cleanup deleted the
+    # artifact, and the rerun cost build-libs 178m and pushed build-api into the 180m ceiling.
+    # The quota concern is now bounded instead of ignored: red Build runs are rare since the gate
+    # rework, and retention-days: 1 ages a kept artifact out within a day regardless.
+    # `skipped` (build-desktop on PR runs) still allows deletion - only failure/cancelled block it.
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
The cleanup job deleted the run's **only** dependency handoff unconditionally. That was deliberate at the time — red-run leftovers once filled the org's Actions quota — but it breaks **"Re-run failed jobs"**: with the artifact gone, every rerun consumer falls into the 1–3h bootstrap fallback.

**Measured tonight** on stage run [32513912629](https://github.com/ever-co/ever-gauzy/actions/runs/32513912629): a seconds-long DNS blip failed one restore → cleanup deleted the artifact → the rerun cost `build-libs` **178m** and pushed `build-api` into the **180m ceiling**.

Deletion now happens only when no needed job failed or was cancelled. The quota concern is **bounded, not ignored**: red Build runs are rare since the gate rework, and `retention-days: 1` ages a kept artifact out within a day. `skipped` (build-desktop on PR runs) still allows deletion.

This is the greptile/cubic **P1** from #10010 that was catalogued as "deferred — needs a design call". Production made the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the run’s node_modules artifact on red runs so reruns can restore dependencies. Previously cleanup always deleted it; now it deletes only when no needed job failed or was canceled, avoiding the 1–3h bootstrap fallback on reruns.

**Review notes**
- Deletion condition: only when none of the `needs` results are failure or cancelled; `skipped` still permits deletion (e.g., build-desktop on PRs).
- No developer action required; storage impact is bounded by retention-days: 1.

<sup>Written for commit 2a58ca4609869c27b9232c0f01722c10d783af5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

