### PR TITLE
perf(ci): route the build gate's installs through Verdaccio — with the key trap handled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,23 @@ jobs:
           path: ${{ env.NODE_MODULES_ARCHIVE }}
           key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('yarn.lock', 'package.json', 'patches/**', '.scripts/postinstall.js') }}
 
+      # Route the install through the internal Verdaccio cache. Placed AFTER the cache restore on
+      # purpose: this action rewrites yarn.lock's resolved URLs, and hashFiles() in a cache key
+      # evaluates at step runtime - configuring the registry before the restore would move the key
+      # and bifurcate the cache namespace by VIP reachability (the reason #10025 skipped this file).
+      # Measured cost of NOT having it here: the bootstrap fallback pulled from the public registry
+      # and blew through the 180-minute job ceiling twice on stage run 32513912629.
+      - name: Configure Registry
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # Not contains(matrix.os, ...): these jobs define no matrix.os, so that expression is
+          # always false and would silently disable the in-network VIP retry and warning.
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
+
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --network-timeout 1000000 --frozen-lockfile --ignore-scripts
@@ -120,7 +137,10 @@ jobs:
         # a CROSS-run optimization — see the upload below for why it cannot be the handoff.
         with:
           path: ${{ env.NODE_MODULES_ARCHIVE }}
-          key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('yarn.lock', 'package.json', 'patches/**', '.scripts/postinstall.js') }}
+          # Pinned to the key the RESTORE computed, not re-derived: Configure Registry rewrites
+          # yarn.lock after the restore, and hashFiles() here evaluates at save time - re-deriving
+          # would write the archive under a different key than the next run looks up.
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
       - name: Upload node_modules archive
         uses: actions/upload-artifact@v7
@@ -185,6 +205,22 @@ jobs:
           path: ${{ env.NODE_MODULES_ARCHIVE }}
           key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('yarn.lock', 'package.json', 'patches/**', '.scripts/postinstall.js') }}
 
+      # Route the install through the internal Verdaccio cache. Placed AFTER the cache restore on
+      # purpose: this action rewrites yarn.lock's resolved URLs, and hashFiles() in a cache key
+      # evaluates at step runtime - configuring the registry before the restore would move the key
+      # and bifurcate the cache namespace by VIP reachability (the reason #10025 skipped this file).
+      # Measured cost of NOT having it here: the bootstrap fallback pulled from the public registry
+      # and blew through the 180-minute job ceiling twice on stage run 32513912629.
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # Not contains(matrix.os, ...): these jobs define no matrix.os, so that expression is
+          # always false and would silently disable the in-network VIP retry and warning.
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
+
       - name: Restore node_modules
         shell: bash
         # Unpacks the tree build-monorepo-root published, or installs from scratch if the cache is
@@ -234,6 +270,22 @@ jobs:
           path: ${{ env.NODE_MODULES_ARCHIVE }}
           key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('yarn.lock', 'package.json', 'patches/**', '.scripts/postinstall.js') }}
 
+      # Route the install through the internal Verdaccio cache. Placed AFTER the cache restore on
+      # purpose: this action rewrites yarn.lock's resolved URLs, and hashFiles() in a cache key
+      # evaluates at step runtime - configuring the registry before the restore would move the key
+      # and bifurcate the cache namespace by VIP reachability (the reason #10025 skipped this file).
+      # Measured cost of NOT having it here: the bootstrap fallback pulled from the public registry
+      # and blew through the 180-minute job ceiling twice on stage run 32513912629.
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # Not contains(matrix.os, ...): these jobs define no matrix.os, so that expression is
+          # always false and would silently disable the in-network VIP retry and warning.
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
+
       - name: Restore node_modules
         shell: bash
         # Unpacks the tree build-monorepo-root published, or installs from scratch if the cache is
@@ -282,6 +334,22 @@ jobs:
           # cache is best effort here, and the script below still has the install fallback.
           path: ${{ env.NODE_MODULES_ARCHIVE }}
           key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('yarn.lock', 'package.json', 'patches/**', '.scripts/postinstall.js') }}
+
+      # Route the install through the internal Verdaccio cache. Placed AFTER the cache restore on
+      # purpose: this action rewrites yarn.lock's resolved URLs, and hashFiles() in a cache key
+      # evaluates at step runtime - configuring the registry before the restore would move the key
+      # and bifurcate the cache namespace by VIP reachability (the reason #10025 skipped this file).
+      # Measured cost of NOT having it here: the bootstrap fallback pulled from the public registry
+      # and blew through the 180-minute job ceiling twice on stage run 32513912629.
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # Not contains(matrix.os, ...): these jobs define no matrix.os, so that expression is
+          # always false and would silently disable the in-network VIP retry and warning.
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Restore node_modules
         shell: bash
@@ -342,6 +410,22 @@ jobs:
           # cache is best effort here, and the script below still has the install fallback.
           path: ${{ env.NODE_MODULES_ARCHIVE }}
           key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('yarn.lock', 'package.json', 'patches/**', '.scripts/postinstall.js') }}
+
+      # Route the install through the internal Verdaccio cache. Placed AFTER the cache restore on
+      # purpose: this action rewrites yarn.lock's resolved URLs, and hashFiles() in a cache key
+      # evaluates at step runtime - configuring the registry before the restore would move the key
+      # and bifurcate the cache namespace by VIP reachability (the reason #10025 skipped this file).
+      # Measured cost of NOT having it here: the bootstrap fallback pulled from the public registry
+      # and blew through the 180-minute job ceiling twice on stage run 32513912629.
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # Not contains(matrix.os, ...): these jobs define no matrix.os, so that expression is
+          # always false and would silently disable the in-network VIP retry and warning.
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
 
       - name: Restore node_modules
         shell: bash


### PR DESCRIPTION
build.yml was the one workflow **deliberately skipped** by #10025, because the registry action rewrites `yarn.lock` and this file keys its cache on `hashFiles('yarn.lock', …)` — naive placement bifurcates 2.9 GB cache entries by VIP reachability.

**The deferral had a measured cost tonight** ([32513912629](https://github.com/ever-co/ever-gauzy/actions/runs/32513912629)): artifact deleted by cleanup + cache LRU-evicted + bootstrap from the **public** registry = two 180-minute ceiling kills on `build-api`.

Both traps handled explicitly:

| Trap | Handling |
|---|---|
| Key bifurcation | Step placed **after** every lockfile-keyed cache; producer save key **pinned to `steps.cache.outputs.cache-primary-key`** (computed pre-rewrite) |
| `expect-vip` mute switch | Derived from `vars.RUNNER_LINUX_X64_8` — these jobs define no `matrix.os` |

Producer step gated on cache-miss (warm runs stay pristine); consumer steps sit before the restore script so only the bootstrap fallback pays. Pinned to `aa4ee199`, the action revision that survives pnpm/npm repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes build.yml installs through the internal Verdaccio cache without splitting cache keys. Before: skipping registry config caused public-registry bootstraps and `yarn.lock` rewrites that bifurcated 2.9 GB cache entries; after: configure the registry only after cache restore and save under the restore’s primary key. Warm runs stay unchanged; bootstrap path uses Verdaccio and avoids 180‑minute timeouts.

- Adds `ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee199` after each lockfile-keyed cache restore; producer step runs only on cache miss.
- Saves the node_modules cache with `key: ${{ steps.cache.outputs.cache-primary-key }}` to avoid re-deriving a post-rewrite key.
- Sets `expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}` since these jobs have no `matrix.os`, preserving in-network VIP retry and warnings.

<sup>Written for commit a81dbc073a5ed6ac2b17c86605fcb8837470beab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

