### PR TITLE
ci(verdaccio): route the Cypress and Currents e2e installs through the internal npm cache

### DIFF
--- a/.github/workflows/test_currents.yml
+++ b/.github/workflows/test_currents.yml
@@ -87,6 +87,33 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-yarn-
 
+      # Route the installs below through the internal Verdaccio cache. This job resolves to the
+      # self-hosted ARC pool (vars.RUNNER_LINUX_X64_8), which is the only place the VIP is
+      # reachable; the action PROBES it and falls back to the public npm registry otherwise, so the
+      # `|| 'ubuntu-latest'` fallback runner degrades to today's behaviour instead of hanging.
+      #
+      # Placed AFTER the yarn cache restore on purpose: the action rewrites yarn.lock's resolved
+      # URLs (that rewrite is the load-bearing half — yarn v1 fetches the URL recorded in the
+      # lockfile and ignores the registry setting), and hashFiles() in a cache key evaluates at step
+      # runtime. Configuring the registry before the restore would move the key and bifurcate the
+      # cache namespace by VIP reachability. Same ordering as build.yml.
+      #
+      # No save-key pinning is needed here, unlike build.yml: that file uses a split
+      # cache/restore + cache/save pair, whose save step re-derives hashFiles() at save time. This
+      # is the COMBINED actions/cache action — it captures its primary key during the restore, i.e.
+      # before the rewrite, and its post-job save reuses that captured key, so the entry is written
+      # under exactly the key the next run's restore computes.
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # NOT contains(matrix.os, ...) as the app workflows use: this job's only matrix key is
+          # `containers`, so that expression collapses to false and would silently disable the
+          # in-network VIP retry and its warning. Derive it from the runner variable this job uses.
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
+
       # - name: Increase file limit
       #  run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 

--- a/.github/workflows/test_cypress.yml
+++ b/.github/workflows/test_cypress.yml
@@ -83,6 +83,38 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-yarn-
 
+      # Route the installs below through the internal Verdaccio cache. This job resolves to the
+      # self-hosted ARC pool (vars.RUNNER_LINUX_X64_8), which is the only place the VIP is
+      # reachable; the action PROBES it and falls back to the public npm registry otherwise, so the
+      # `|| 'ubuntu-latest'` fallback runner degrades to today's behaviour instead of hanging.
+      #
+      # Placed AFTER the yarn cache restore on purpose: the action rewrites yarn.lock's resolved
+      # URLs (that rewrite is the load-bearing half — yarn v1 fetches the URL recorded in the
+      # lockfile and ignores the registry setting), and hashFiles() in a cache key evaluates at step
+      # runtime. Configuring the registry before the restore would move the key and bifurcate the
+      # cache namespace by VIP reachability. Same ordering as build.yml.
+      #
+      # No save-key pinning is needed here, unlike build.yml: that file uses a split
+      # cache/restore + cache/save pair, whose save step re-derives hashFiles() at save time. This
+      # is the COMBINED actions/cache action — it captures its primary key during the restore, i.e.
+      # before the rewrite, and its post-job save reuses that captured key, so the entry is written
+      # under exactly the key the next run's restore computes.
+      #
+      # Deliberately NOT added to the `e2e-tests-setup` job above: its cypress-io/github-action step
+      # overrides the install with `install-command: node -p 'os.cpus()'`, so that job resolves no
+      # packages from any npm registry. Adding the step there would buy nothing and would rewrite
+      # yarn.lock ahead of that action's own internal lockfile-keyed cache, splitting it in two.
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          # NOT contains(matrix.os, ...) as the app workflows use: this job's only matrix key is
+          # `containers`, so that expression collapses to false and would silently disable the
+          # in-network VIP retry and its warning. Derive it from the runner variable this job uses.
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
+
       # - name: Increase file limit
       #  run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

---

## What

Adds the shared `configure-registry` action to the two dependency-installing workflows that were still
missing it, so their installs resolve through the internal Verdaccio npm cache instead of going straight
to the public registry:

| File | Job | `runs-on` | Change |
|---|---|---|---|
| `.github/workflows/test_currents.yml` | `e2e-tests` | `${{ vars.RUNNER_LINUX_X64_8 \|\| 'ubuntu-latest' }}` | **step added** |
| `.github/workflows/test_currents.yml` | `prepare` | `${{ vars.RUNNER_LINUX_X64_4 \|\| 'ubuntu-latest' }}` | skipped — installs nothing |
| `.github/workflows/test_cypress.yml` | `e2e-tests` | `${{ vars.RUNNER_LINUX_X64_8 \|\| 'ubuntu-latest' }}` | **step added** |
| `.github/workflows/test_cypress.yml` | `e2e-tests-setup` | `${{ vars.RUNNER_LINUX_X64_4 \|\| 'ubuntu-latest' }}` | skipped — see below |

Both touched jobs resolve to the self-hosted ARC pool (`vars.RUNNER_LINUX_X64_8` = `ever-k8s-linux-x64-8`),
which is the only place the Verdaccio VIP answers. The action *probes* the VIP and falls back to the public
npm registry when it does not, so the `|| 'ubuntu-latest'` fallback runner degrades to today's behaviour
rather than hanging on a LAN address.

## Placement — same discipline as `build.yml`

The step goes **after the yarn cache restore** and **before `yarn bootstrap`**. The action rewrites
`yarn.lock`'s resolved URLs (that rewrite is the load-bearing half — yarn v1 fetches the URL recorded in the
lockfile and ignores the `registry` setting), and `hashFiles()` in a cache key evaluates at *step* runtime.
Configuring the registry ahead of the restore would move the key and bifurcate the cache namespace by VIP
reachability — the trap documented at length in `build.yml`.

## Why no save-key pinning was needed

`build.yml` has to pin its save key to `steps.cache.outputs.cache-primary-key` because it uses the **split**
`actions/cache/restore` + `actions/cache/save` pair, whose save step re-derives `hashFiles()` at save time.

Both files here use the **combined** `actions/cache`, which is a different code path:
`restoreImpl.ts` does `stateProvider.setState(State.CachePrimaryKey, primaryKey)` with the real
`StateProvider` (`setState = core.saveState`) during the *restore*, i.e. before the rewrite, and `saveImpl.ts`
reads that recorded key back (`stateProvider.getState(State.CachePrimaryKey) || core.getInput(Inputs.Key)`).
So the post-job save writes under exactly the key the next run's restore computes — there is no separate save
step to pin, and re-derivation never happens. (The split sub-actions use `NullStateProvider`, whose
`getState` returns `""`, which is precisely why `build.yml` needs the explicit pin.)

## What was deliberately left alone

- **`test_currents.yml` → `prepare`** emits a build UUID and nothing else. No install, nothing to route.
- **`test_cypress.yml` → `e2e-tests-setup`** runs `cypress-io/github-action@v5` with
  `install-command: node -p 'os.cpus()'`, which *replaces* the install entirely — that job resolves no
  packages from any npm registry (only the Cypress binary, which comes from `download.cypress.io`). Adding
  the step there would buy nothing, and it would rewrite `yarn.lock` ahead of that action's own
  lockfile-keyed internal cache, splitting it in two. Left as-is on purpose, with a comment saying so.

`expect-vip` is derived from the runner variable rather than the `contains(matrix.os, ...)` idiom the app
workflows use: these jobs' only matrix key is `containers`, so that expression would collapse to `false` and
silently disable the in-network VIP retry and its warning.

## Notes for the reviewer

- **Additive only.** No workflow, job, or step was removed, reordered, or otherwise changed — the diff is
  59 added lines and 0 deletions across the two files.
- Both workflows are currently **dormant** (`on: push: branches: [nope]`), so this cannot change any run
  today; it closes the gap for whenever they are re-enabled, and keeps the fleet's registry policy uniform.
- The action is pinned to the canonical SHA
  `ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548`, the same
  pin `build.yml` uses.
- Verified locally: both files parse as YAML, and the resulting step order is
  `actions/cache` → `Configure Registry` → `yarn bootstrap` in each touched job, matching `build.yml`
  (checked against `build.yml` as a known-good control in the same pass).

Targets `develop`. Not for `master`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Cypress and Currents E2E dependency installs through the internal Verdaccio npm cache. Previously these jobs fetched from the public registry; now they prefer the cache and fall back to the public registry when the VIP is unreachable.

- Adds shared `configure-registry` to `test_currents.yml:e2e-tests` and `test_cypress.yml:e2e-tests`, placed after `actions/cache` and before `yarn bootstrap`.
- Leaves `test_currents.yml:prepare` and `test_cypress.yml:e2e-tests-setup` unchanged; `prepare` does not install deps, and `e2e-tests-setup` uses `cypress-io/github-action` with a custom install command.
- Targets self-hosted ARC runners where the Verdaccio VIP is reachable; derives `expect-vip` from the runner variable.
- Keeps cache keys stable; the combined `actions/cache` path captures the primary key during restore, so no save-key pinning is required.
- Workflows are currently disabled; this has no immediate runtime effect and aligns them with the registry policy when re-enabled.

<sup>Written for commit a6ab2fc9e3c6bfce930f92464da4dfe16542fa8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

