### PR TITLE
fix(configure-registry): restore a TRACKED .yarnrc instead of deleting it

### DIFF
--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -73,18 +73,25 @@ runs:
 
         # Start from a known state. The self-hosted Windows jobs check out with clean: false and
         # their cleanup step removes only dist/ and node_modules/, so registry edits from a
-        # PREVIOUS run can still be on disk. .yarnrc in particular is untracked and un-ignored,
-        # so nothing restores it: a stale "registry" line from an earlier run would silently
-        # win over this run's decision. This reset is NOT best-effort -- if we cannot establish
+        # PREVIOUS run can still be on disk: a stale "registry" line from an earlier run would
+        # silently win over this run's decision.
+        #
+        # .yarnrc goes through the per-path loop below rather than the rm -f list. It is untracked
+        # in ever-gauzy, but ever-co/ever-teams TRACKS it and pins the yarn binary there
+        # (yarn-path ".yarn/releases/yarn-1.22.22.cjs"). Deleting it outright dropped that pin, so
+        # `yarn install --frozen-lockfile` ran against whatever yarn the runner resolved. The loop
+        # restores it when tracked and still removes it when it is a stale untracked leftover.
+        #
+        # This reset is NOT best-effort -- if we cannot establish
         # a known starting state we must not go on to pick a registry, because the install would
         # then quietly run against whatever the last job left behind.
-        rm -f .yarnrc .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten package-lock.json.rewritten
+        rm -f .npmrc.bak .npmrc.scrubbed yarn.lock.bak yarn.lock.rewritten package-lock.json.rewritten
         # Reset per-path, not as one pathspec list. `git checkout -- a b` exits 1 when EITHER path is
         # untracked, so the original form hard-failed on every pnpm repo (no .npmrc, no yarn.lock) and
         # turned 'this repo has no cache configured' into 'this repo's CI is red'. Tracked files are
         # restored; untracked leftovers from a previous run on a clean:false runner are removed.
         reset_failed=""
-        for f in .npmrc yarn.lock package-lock.json; do
+        for f in .npmrc .yarnrc yarn.lock package-lock.json; do
           # Exit status matters: 0 = tracked, 1 = genuinely absent, anything else (128 = git
           # metadata unavailable) means we CANNOT tell. Treating every nonzero as absent would
           # delete the files and continue, which is exactly the unknown-state hazard this reset


### PR DESCRIPTION
## The bug

The reset block asserts, in a comment, that **".yarnrc in particular is untracked and un-ignored"**.

That is true in `ever-gauzy`. It is **false** in `ever-co/ever-teams`, where `.yarnrc` is a tracked file containing:

```
nodeLinker: node-modules
yarn-path ".yarn/releases/yarn-1.22.22.cjs"
```

So `rm -f .yarnrc` **destroys the repo's pinned yarn binary** before `yarn install --frozen-lockfile` runs, and nothing puts it back — the per-path reset loop immediately below covers only `.npmrc yarn.lock package-lock.json`. The install then resolves whatever `yarn` the runner happens to have, and `--frozen-lockfile` is a yarn-1-only flag.

Any consumer repo that tracks `.yarnrc` has this exposure. Today that is ever-teams; the action is consumed by 29+ workflows across the fleet.

## The fix

No new mechanism — `.yarnrc` simply moves out of the unconditional `rm -f` list and into the per-path loop that is already right there. That loop:

- tracked → `git checkout -- "$f"` (restores it)
- genuinely untracked (git exit 1) → `rm -f "$f"` (**unchanged** behaviour for ever-gauzy and every other repo where it is a stale leftover)
- git exit 128 → fail closed

So behaviour is identical everywhere `.yarnrc` is untracked, and the data loss stops where it is tracked. The stale comment is corrected in the same commit.

## How it was found

Adversarial review of [ever-co/ever-teams#4433](https://github.com/ever-co/ever-teams/pull/4433), which migrates 20 jobs onto this action. That review also surfaced two ever-teams-side issues (EAS/Vercel upload archives shipping the rewritten `yarn.lock`/`.yarnrc`) which are being fixed in that PR, not here.

## Risk

Low and strictly reductive: one file moves between two branches of the same existing reset, no input surface change, so consumers pinned at `aa4ee199` keep working and can adopt the new sha when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore a tracked `.yarnrc` during the registry reset instead of deleting it, preserving pinned Yarn and ensuring `yarn install --frozen-lockfile` runs under the intended Yarn 1 when repos pin it. Previously the action unconditionally removed `.yarnrc`, which dropped the pin and let installs run with whatever Yarn the runner provided; now it restores tracked files and only removes untracked leftovers.

- Move `.yarnrc` from the `rm -f` list into the per-path reset loop with `.npmrc`, `yarn.lock`, and `package-lock.json`.
- Behavior: tracked → `git checkout --`, untracked → `rm -f`, unknown Git state (128) → fail closed. Behavior is unchanged where `.yarnrc` is untracked.

<sup>Written for commit 51b69031fae2f7e71ea58d4a656d3b07228f5912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

