### PR TITLE
fix(billing): break the require cycle that stops the API booting

### DIFF
--- a/packages/core/src/lib/auth/auth.module.ts
+++ b/packages/core/src/lib/auth/auth.module.ts
@@ -13,7 +13,14 @@ import { PasswordResetModule } from '../password-reset/password-reset.module';
 import { RefreshTokenModule } from '../refresh-token/refresh-token.module';
 import { RolePermissionModule } from '../role-permission/role-permission.module';
 import { RoleModule } from '../role/role.module';
-import { StripeSubscriptionService } from '../shared/billing';
+// Deep path, not the '../shared/billing' barrel. The barrel re-exports BillingModule, which
+// imports TenantModule, which imports this module — so importing the barrel here closes a
+// require cycle (billing.module -> tenant.module -> auth.module -> billing/index ->
+// billing.module). TenantModule is then still mid-evaluation when BillingModule's @Module()
+// decorator runs, and its imports array gets `undefined` where TenantModule should be, which
+// Nest rejects at boot on every deployment — including self-hosted installs that never
+// configure Stripe. tenant.module.ts imports this service by the deep path for the same reason.
+import { StripeSubscriptionService } from '../shared/billing/stripe-subscription.service';
 import { UserOrganizationModule } from '../user-organization/user-organization.module';
 import { UserOrganizationService } from '../user-organization/user-organization.services';
 import { UserModule } from '../user/user.module';


### PR DESCRIPTION
**The API does not boot on develop.** This affects every deployment, including self-hosted installs that never configure Stripe.

`auth.module.ts` imported `StripeSubscriptionService` from the `'../shared/billing'` barrel. That barrel re-exports `BillingModule`, which imports `TenantModule`, which imports `AuthModule`:

```
billing.module -> tenant.module -> auth.module -> billing/index -> billing.module
```

`TenantModule` is still mid-evaluation when `BillingModule`'s `@Module()` decorator runs, so its imports array gets `undefined` where `TenantModule` belongs, and Nest rejects it. `BillingModule` is registered unconditionally in `app.module.ts`, so this is independent of whether a Stripe key is set — it breaks the plainest self-hosted install, which is the invariant the rest of this work guarded most carefully.

## The fix

Use the deep path, which is what `tenant.module.ts` already does for the same service and the same reason. Only `auth.module.ts` reached for the barrel; `app.module.ts` also imports from it, but nothing imports `app.module`, so it sits outside the cycle.

Verified: `billing.module` goes from sharing a cycle with **28 files** to **zero**. `tsc` clean on `@gauzy/core`.

## How this was missed

I checked for cycles when this was first raised, concluded there were none, and said so confidently. **The check was wrong.** It matched only `import … from`, and this barrel contains nothing but `export * from './billing.module'`. Re-exports compile to a runtime require, so the single edge that closes the cycle was the one edge the tool could not see — and barrels are exactly how this class of cycle forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a require cycle that prevented the API from booting by replacing the `../shared/billing` barrel import in `auth.module.ts` with a deep import of `StripeSubscriptionService`. The cycle hit all deployments, including self-hosted without Stripe; after this change the API boots.

- Old behavior: importing from the billing barrel closed the cycle `billing.module -> tenant.module -> auth.module -> billing/index -> billing.module`, leaving `TenantModule` undefined at module evaluation and failing boot. New behavior: import `../shared/billing/stripe-subscription.service`, avoiding the cycle (same pattern as `tenant.module.ts`).
- Scope and safety: only `auth.module.ts` changed; `app.module.ts`’s barrel import remains safe because nothing imports it. No config or migration changes required.

<sup>Written for commit 9b1ce35ad68055f70610940abc417bd387872569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

