### PR TITLE
fix(billing): break the require cycle that stops the API booting (#10…

### DIFF
--- a/packages/core/src/lib/auth/auth.module.ts
+++ b/packages/core/src/lib/auth/auth.module.ts
@@ -13,7 +13,14 @@ import { PasswordResetModule } from '../password-reset/password-reset.module';
 import { RefreshTokenModule } from '../refresh-token/refresh-token.module';
 import { RolePermissionModule } from '../role-permission/role-permission.module';
 import { RoleModule } from '../role/role.module';
-import { StripeSubscriptionService } from '../shared/billing';
+// Deep path, not the '../shared/billing' barrel. The barrel re-exports BillingModule, which
+// imports TenantModule, which imports this module — so importing the barrel here closes a
+// require cycle (billing.module -> tenant.module -> auth.module -> billing/index ->
+// billing.module). TenantModule is then still mid-evaluation when BillingModule's @Module()
+// decorator runs, and its imports array gets `undefined` where TenantModule should be, which
+// Nest rejects at boot on every deployment — including self-hosted installs that never
+// configure Stripe. tenant.module.ts imports this service by the deep path for the same reason.
+import { StripeSubscriptionService } from '../shared/billing/stripe-subscription.service';
 import { UserOrganizationModule } from '../user-organization/user-organization.module';
 import { UserOrganizationService } from '../user-organization/user-organization.services';
 import { UserModule } from '../user/user.module';


### PR DESCRIPTION
…038)

auth.module.ts imported StripeSubscriptionService from the '../shared/billing' barrel. That barrel re-exports BillingModule, which imports TenantModule, which imports AuthModule — closing a cycle:

  billing.module -> tenant.module -> auth.module -> billing/index -> billing.module

TenantModule is therefore still mid-evaluation when BillingModule's @Module() decorator runs, so its imports array receives `undefined` where TenantModule belongs and Nest rejects it at boot. BillingModule is registered unconditionally in app.module, so this does not depend on STRIPE_SECRET_KEY being set: it breaks the plainest self-hosted install, which is the invariant this work was most careful about everywhere else.

The fix is the one the codebase already uses — tenant.module.ts imports the same service by its deep path for exactly this reason. Only auth.module.ts reached for the barrel; app.module.ts also imports from it, but nothing imports app.module, so it sits outside the cycle and is fine.

Worth recording how this was missed. I checked for cycles when the claim was first raised, concluded there were none, and said so confidently. The check was wrong: it matched only `import ... from`, and this barrel contains nothing but `export * from './billing.module'`. Re-exports compile to a runtime require, so the one edge that closes the cycle was the one edge the tool could not see — and barrels are precisely how cycles like this form. With re-exports included, billing.module shows as sharing a cycle with 28 files; after this change, zero.

# PR

- [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Breaks a circular import that prevented the API from booting by switching `auth.module.ts` from the `../shared/billing` barrel to a deep import of `StripeSubscriptionService`. Previously, the barrel re-export pulled in `BillingModule` while `TenantModule` was mid-evaluation, making `BillingModule.imports` contain `undefined` and causing startup failure even without Stripe; now the cycle is removed with no behavior changes.

**Review notes**
- Confirm `auth.module.ts` imports `../shared/billing/stripe-subscription.service` (consistent with `tenant.module.ts`).
- Boot the API without Stripe env vars; it should start successfully.
- Optional: run your cycle check; `billing.module` should not appear in any cycle.

<sup>Written for commit 0c5048ec56a7c5ddc135ec12384051401d2ad383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

