### PR TITLE
fix(build): use bundled Node headers for native modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,9 @@ jobs:
         with:
           node-version: 24
 
+      - name: Test native rebuild setup
+        run: yarn test:postinstall
+
       - name: Restore node_modules archive
         id: cache
         uses: actions/cache/restore@v4

--- a/.scripts/postinstall.js
+++ b/.scripts/postinstall.js
@@ -19,6 +19,8 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
+// cspell:ignore nodedir
+
 const nodeModulesPath = path.resolve('node_modules');
 const foundScripts = [];
 
@@ -155,6 +157,29 @@ function findNativeBinary(packagePath) {
 }
 
 /**
+ * Reuse the Node runtime headers already shipped in the official Docker image.
+ *
+ * Alpine has no prebuilt better-sqlite3 binary for every Node release, so
+ * node-gyp otherwise downloads the same headers from
+ * unofficial-builds.nodejs.org. A timeout there must not make the image build
+ * fail when /usr/local/include/node/node.h is already available locally.
+ */
+function getNativeBuildEnvironment({
+	execPath = process.execPath,
+	environment = process.env,
+	fileExists = fs.existsSync
+} = {}) {
+	const nodeRoot = path.resolve(path.dirname(execPath), '..');
+	const bundledHeader = path.join(nodeRoot, 'include', 'node', 'node.h');
+
+	if (!fileExists(bundledHeader)) {
+		return environment;
+	}
+
+	return { ...environment, npm_config_nodedir: nodeRoot };
+}
+
+/**
  * Builds the native packages that `--ignore-scripts` skipped, and FAILS if one of
  * them ends up without a binary.
  *
@@ -195,7 +220,10 @@ function handleNativePackages() {
 	console.log(`Rebuilding native packages: ${names.join(', ')}`);
 	try {
 		// Root cwd, not the package's own directory.
-		execSync(`npm rebuild ${names.join(' ')}`, { stdio: 'inherit' });
+		execSync(`npm rebuild ${names.join(' ')}`, {
+			stdio: 'inherit',
+			env: getNativeBuildEnvironment()
+		});
 	} catch (error) {
 		// Not fatal on its own — the verification below decides. A package that
 		// already carries a valid prebuilt binary can fail `npm rebuild` (no
@@ -229,15 +257,22 @@ function handleNativePackages() {
 	}
 }
 
-// Main execution
-findPostInstallScripts();
+function main() {
+	findPostInstallScripts();
 
-if (foundScripts.length > 0) {
-	console.log(`Found ${foundScripts.length} postinstall scripts. Executing them sequentially...`);
-	runScriptsSequentially();
-} else {
-	console.log('No postinstall scripts found.');
+	if (foundScripts.length > 0) {
+		console.log(`Found ${foundScripts.length} postinstall scripts. Executing them sequentially...`);
+		runScriptsSequentially();
+	} else {
+		console.log('No postinstall scripts found.');
+	}
+
+	// Always handle native packages after running postinstall scripts
+	handleNativePackages();
 }
 
-// Always handle native packages after running postinstall scripts
-handleNativePackages();
+if (require.main === module) {
+	main();
+}
+
+module.exports = { getNativeBuildEnvironment };

--- a/.scripts/postinstall.test.js
+++ b/.scripts/postinstall.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+// cspell:ignore disturl nodedir
+
+const { getNativeBuildEnvironment } = require('./postinstall');
+
+test('uses the Node image bundled headers for native rebuilds', () => {
+	const nodeRoot = path.resolve('/usr/local');
+	const environment = { npm_config_disturl: 'http://127.0.0.1:9' };
+	const result = getNativeBuildEnvironment({
+		execPath: path.join(nodeRoot, 'bin', 'node'),
+		environment,
+		fileExists: (candidate) => candidate === path.join(nodeRoot, 'include', 'node', 'node.h')
+	});
+
+	assert.deepEqual(result, {
+		npm_config_disturl: 'http://127.0.0.1:9',
+		npm_config_nodedir: nodeRoot
+	});
+});
+
+test('preserves the environment when the runtime does not bundle headers', () => {
+	const environment = { CI: 'true' };
+	const result = getNativeBuildEnvironment({
+		execPath: '/opt/node/bin/node',
+		environment,
+		fileExists: () => false
+	});
+
+	assert.equal(result, environment);
+});

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
 		"doc:build-serve": "compodoc -p tsconfig.json -d docs -s",
 		"postinstall": "patch-package",
 		"postinstall.manual": "patch-package && yarn node ./.scripts/postinstall.js",
+		"test:postinstall": "node --test .scripts/postinstall.test.js",
 		"postinstall.electron": "yarn electron-builder install-app-deps && yarn node tools/electron/postinstall",
 		"postinstall.web": "yarn node ./decorate-angular-cli.js && yarn node tools/web/postinstall",
 		"build:desktop": "cross-env NODE_ENV=production yarn run copy-files-i18n-desktop && yarn run postinstall.electron && yarn run config:prod && yarn run config:desktop:prod && yarn run pack:desktop && yarn run generate:icons:desktop --environment=prod && yarn run build:package:all:prod && yarn ng:prod run gauzy:desktop-ui --base-href ./ && yarn ng:prod run api:desktop-api && yarn ng:prod build desktop-api --configuration=production --output-path=dist/apps/desktop/desktop-api && yarn ng:prod build desktop --configuration=production --base-href ./ && yarn run prepare:desktop && yarn run copy-files-desktop && yarn run copy-assets-gauzy",


### PR DESCRIPTION
# PR

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

## What changed

- Reuse the Node runtime headers bundled in the official Docker image when rebuilding native modules.
- Preserve the existing strict native-binary verification for `better-sqlite3` and `bcrypt`.
- Add a cross-platform regression test for bundled-header detection and fallback behavior.
- Run the regression test early in the required `build-monorepo-root` job, before the expensive dependency restore/install path.

## Why

Develop run 32652282228 failed while building both the API and worker images. `better-sqlite3@11.10.0` has no matching prebuilt binary for this Node 24 Alpine/musl combination, so node-gyp compiled it from source. The rebuild unnecessarily attempted to download Node 24.16.0 headers from `unofficial-builds.nodejs.org`; that request timed out even though `/usr/local/include/node/node.h` was already present in the official Node image. The strict postinstall guard then correctly rejected the image because no native binary was produced.

This change removes that external header download from the source-build path without weakening or bypassing the binary guard.

Failed job: https://github.com/ever-co/ever-gauzy/actions/runs/32652282228/job/97225641878

## Verification

- `yarn test:postinstall` — 2/2 passed on Windows.
- Same test under `node:24.16.0-alpine3.23` — 2/2 passed.
- Controlled `better-sqlite3@11.10.0` rebuild using Node 24.16.0 Alpine, npm 9.9.4, the Dockerfile build toolchain, and an intentionally unreachable header distribution URL — native binary produced successfully from bundled headers.
- Prettier, CSpell, `node --check`, and `git diff --check` passed.
- Independent review found no remaining critical, important, or minor issues.

A full clean `prod-dependencies` Docker target was also attempted locally, but remained in the monorepo dependency-linking phase and never reached native compilation. The focused reproduction above verifies the failing path; the PR build should validate the complete image path on the configured runners.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use bundled Node headers for native module rebuilds to remove flaky external header downloads during Docker builds. Previously `node-gyp` fetched headers from `unofficial-builds.nodejs.org`; now we set `npm_config_nodedir` to the runtime’s bundled headers when present. The strict binary check for `better-sqlite3` and `bcrypt` remains unchanged.

- Refactors `.scripts/postinstall.js` to detect bundled headers (`getNativeBuildEnvironment`) and pass the env to `npm rebuild`; exports the helper and wraps execution in `main()` for testability.
- Adds `.scripts/postinstall.test.js` and `yarn test:postinstall`; runs this test early in `build.yml` before dependency restore to catch regressions fast.
- Behavior when headers are not bundled is unchanged (falls back to existing env); native-binary verification still fails the build if no binary is produced.

<sup>Written for commit b6287c86b77b09b32455beb034e95295f289ca72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

