### PR TITLE
fix(billing): stop the webhook adopting a Stripe customer another tenant holds

### DIFF
--- a/packages/core/src/lib/database/migrations/1790000009000-UniqueTenantStripeCustomer.ts
+++ b/packages/core/src/lib/database/migrations/1790000009000-UniqueTenantStripeCustomer.ts
@@ -1,0 +1,95 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import * as chalk from 'chalk';
+import { DatabaseTypeEnum } from '@gauzy/config';
+
+/**
+ * Make `tenant.stripeCustomerId` unique.
+ *
+ * Two tenants must never point at one Stripe customer. Whichever of them opened the billing page
+ * would be reading the other's invoices, card and subscription, and could cancel it — so this is a
+ * tenant-isolation boundary, not a tidiness constraint, and it belongs in the schema rather than
+ * only in the two code paths that write the column.
+ *
+ * Both of those paths already refuse to create a duplicate. They are checks-then-write, though, so
+ * two concurrent requests can both pass the check before either writes; the database is the only
+ * place that can actually make it impossible. Application code keeps the friendly refusal, this
+ * keeps the guarantee.
+ *
+ * A UNIQUE index still permits many NULLs on every dialect we support (Postgres, MySQL and SQLite
+ * all treat NULLs as distinct here), which matters because NULL is the normal state: every
+ * self-hosted install and every tenant created before billing was configured leaves it unset.
+ *
+ * There is nothing to clean up first. The column was introduced one migration ago and is written
+ * only when a Stripe key is configured, so no deployment can hold a duplicate yet — which is exactly
+ * why this is worth doing now rather than after the first collision.
+ */
+export class UniqueTenantStripeCustomer1790000009000 implements MigrationInterface {
+	name = 'UniqueTenantStripeCustomer1790000009000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		console.log(chalk.yellow(`${this.name} start running!`));
+
+		// Cast first: TypeORM's own option union does not include every DatabaseTypeEnum member,
+		// so switching on the raw value will not narrow. The sibling migration does the same.
+		const type = queryRunner.connection.options.type as DatabaseTypeEnum;
+
+		switch (type) {
+			case DatabaseTypeEnum.postgres:
+				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
+				await queryRunner.query(
+					`CREATE UNIQUE INDEX "IDX_tenant_stripe_customer_id" ON "tenant" ("stripeCustomerId")`
+				);
+				break;
+
+			case DatabaseTypeEnum.sqlite:
+			case DatabaseTypeEnum.betterSqlite3:
+				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
+				await queryRunner.query(
+					`CREATE UNIQUE INDEX "IDX_tenant_stripe_customer_id" ON "tenant" ("stripeCustomerId")`
+				);
+				break;
+
+			case DatabaseTypeEnum.mysql:
+				// MySQL alone cannot drop an index without naming its table.
+				await queryRunner.query('DROP INDEX `IDX_tenant_stripe_customer_id` ON `tenant`');
+				await queryRunner.query(
+					'CREATE UNIQUE INDEX `IDX_tenant_stripe_customer_id` ON `tenant` (`stripeCustomerId`)'
+				);
+				break;
+
+			default:
+				throw new Error(`Unsupported database: ${type}`);
+		}
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		console.log(chalk.yellow(`${this.name} reverting changes!`));
+
+		// Cast first: TypeORM's own option union does not include every DatabaseTypeEnum member,
+		// so switching on the raw value will not narrow. The sibling migration does the same.
+		const type = queryRunner.connection.options.type as DatabaseTypeEnum;
+
+		switch (type) {
+			case DatabaseTypeEnum.postgres:
+				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
+				await queryRunner.query(`CREATE INDEX "IDX_tenant_stripe_customer_id" ON "tenant" ("stripeCustomerId")`);
+				break;
+
+			case DatabaseTypeEnum.sqlite:
+			case DatabaseTypeEnum.betterSqlite3:
+				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
+				await queryRunner.query(`CREATE INDEX "IDX_tenant_stripe_customer_id" ON "tenant" ("stripeCustomerId")`);
+				break;
+
+			case DatabaseTypeEnum.mysql:
+				await queryRunner.query('DROP INDEX `IDX_tenant_stripe_customer_id` ON `tenant`');
+				await queryRunner.query(
+					'CREATE INDEX `IDX_tenant_stripe_customer_id` ON `tenant` (`stripeCustomerId`)'
+				);
+				break;
+
+			default:
+				throw new Error(`Unsupported database: ${type}`);
+		}
+	}
+}

--- a/packages/core/src/lib/shared/billing/stripe-webhook.controller.ts
+++ b/packages/core/src/lib/shared/billing/stripe-webhook.controller.ts
@@ -143,6 +143,23 @@ export class StripeWebhookController {
 			return;
 		}
 
+		// Never adopt a Stripe customer that another tenant already bills through. The write below
+		// guards the *target* tenant from being repointed, but says nothing about the customer: two
+		// tenants could end up sharing one billing account, and whichever opened /billing would be
+		// looking at the other's invoices, card and subscription. The onboarding path has refused
+		// this since it was written; the webhook reaches the same column and had no equivalent.
+		const claimedBy = await this.typeOrmTenantRepository.findOne({
+			where: { stripeCustomerId: customerId },
+			select: { id: true }
+		});
+		if (claimedBy && claimedBy.id !== user.tenantId) {
+			this.logger.warn(
+				`Stripe ${event.type} would link tenant ${user.tenantId} to a customer already held by ` +
+					`tenant ${claimedBy.id}; declining.`
+			);
+			return;
+		}
+
 		// Only fill a gap; never repoint a tenant that already has a customer. Overwriting that link
 		// from a webhook would let a stray event move a tenant's billing onto another account.
 		const updated = await this.typeOrmTenantRepository.update(

--- a/packages/core/src/lib/tenant/tenant.entity.ts
+++ b/packages/core/src/lib/tenant/tenant.entity.ts
@@ -35,7 +35,10 @@ export class Tenant extends BaseEntity implements ITenant {
 	// Named to match the migration. Left unnamed, TypeORM derives a hashed name of its own, which
 	// will not match the one the migration creates — and the schema comparison then wants to add a
 	// second index over the same column.
-	@ColumnIndex('IDX_tenant_stripe_customer_id')
+	// Unique: two tenants sharing one Stripe customer would each be able to read and cancel the
+	// other's subscription. The name is stated so it matches the migration — left to TypeORM, the
+	// derived hash would not, and schema comparison would ask for a second index.
+	@ColumnIndex('IDX_tenant_stripe_customer_id', { unique: true })
 	@MultiORMColumn({ nullable: true })
 	stripeCustomerId?: string;
 


### PR DESCRIPTION
The last finding from the delivery audit, and a tenant-isolation gap.

## What was wrong

Two tenants must never point at one Stripe customer — whichever opened the billing page would be reading the other's invoices and card, and could change their plan or cancel their subscription.

The onboarding path has refused this since it was written. The webhook reaches the same column and had no equivalent: its only condition was `{ id: user.tenantId, stripeCustomerId: IsNull() }`, which protects the **target tenant** from being repointed but says nothing about who already owns the customer being assigned.

## The fix, in two layers

**The check** is now on both paths, with a log line naming both tenants.

**The constraint** matters more. Both paths are check-then-write, so two concurrent events can each pass the check before either writes; only the database can make the state impossible. The index over `stripeCustomerId` becomes UNIQUE.

A UNIQUE index still permits many NULLs on Postgres, MySQL and SQLite alike — which is what makes this safe, because NULL is the *normal* state: every self-hosted install and every tenant created before billing was configured leaves it unset.

Nothing needs migrating around. The column landed one migration ago and is written only when a Stripe key is configured, so no deployment can hold a duplicate yet — precisely why this is worth doing now rather than after the first collision.

## Verified against a real database

Replaying the prior migration's state in better-sqlite3, then applying this one:

```
PASS  before: two tenants CAN share one customer
PASS  migration refuses to run over existing duplicates — errors rather than silently skipping
PASS  migration applies on clean data
PASS  after: a second tenant CANNOT take that customer
PASS  many tenants may still have NO customer (NULLs allowed)
PASS  a distinct customer is accepted
PASS  down() reverts — duplicates possible again
```

The entity's index is named explicitly to match the migration; left to TypeORM the derived hash would differ and schema comparison would ask for a second index over the same column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents two tenants from sharing a Stripe customer by rejecting webhook links to already-claimed customers and enforcing a unique DB constraint. Previously the webhook could adopt a customer owned by another tenant; now it logs and declines, and the schema forbids duplicates while still allowing NULLs.

**Review and rollout**
- Controller: add a pre-check in `stripe-webhook.controller.ts` to refuse linking when `stripeCustomerId` is already held by another tenant; logs both tenant IDs.
- Schema: make `tenant.stripeCustomerId` unique and name the index explicitly to match the migration; leaves many NULLs allowed.
- Migration: run `1790000009000-UniqueTenantStripeCustomer` (drops the old index and recreates it as UNIQUE across supported dialects). No data changes expected; if duplicates exist, the migration will fail and must be resolved before deploy.

<sup>Written for commit e26950f9b9d70b8676564d2f8398c40d4e6cb246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

