### PR TITLE
fix(billing): let the unique-index migration survive pre-existing duplicates

### DIFF
--- a/packages/core/src/lib/database/migrations/1790000009000-UniqueTenantStripeCustomer.ts
+++ b/packages/core/src/lib/database/migrations/1790000009000-UniqueTenantStripeCustomer.ts
@@ -33,6 +33,31 @@ export class UniqueTenantStripeCustomer1790000009000 implements MigrationInterfa
 		// so switching on the raw value will not narrow. The sibling migration does the same.
 		const type = queryRunner.connection.options.type as DatabaseTypeEnum;
 
+		// Release any duplicate before the unique index is created.
+		//
+		// In theory there are none: the column arrived one migration ago and is only written when a
+		// Stripe key is configured. But a migration that aborts here does not merely fail — it stops the
+		// API booting, on an environment where billing is live enough to have produced the duplicate.
+		// Trading a hypothetical for a possible outage is a bad deal, so the collision is resolved
+		// rather than hit.
+		//
+		// The oldest row keeps the customer and the others are set back to NULL. That is the safe
+		// direction: a tenant with no link simply shows no billing and can be relinked, whereas leaving
+		// two tenants pointed at one customer is the exact state this index exists to forbid. Anything
+		// cleared is logged loudly, because it means two tenants were sharing a billing account and
+		// somebody needs to know which.
+		const duplicates = await this.findDuplicates(queryRunner, type);
+		if (duplicates.length) {
+			console.log(
+				chalk.red(
+					`${this.name}: ${duplicates.length} tenant(s) shared a Stripe customer with another tenant. ` +
+						`Their link has been cleared and must be re-established deliberately: ` +
+						`${duplicates.join(', ')}`
+				)
+			);
+			await queryRunner.query(this.clearDuplicatesSql(type));
+		}
+
 		switch (type) {
 			case DatabaseTypeEnum.postgres:
 				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
@@ -60,6 +85,23 @@ export class UniqueTenantStripeCustomer1790000009000 implements MigrationInterfa
 			default:
 				throw new Error(`Unsupported database: ${type}`);
 		}
+	}
+
+	/** Tenant ids that would violate the unique index, oldest row per customer excluded. */
+	private async findDuplicates(queryRunner: QueryRunner, type: DatabaseTypeEnum): Promise<string[]> {
+		const q =
+			type === DatabaseTypeEnum.mysql
+				? 'SELECT `id` FROM `tenant` WHERE `stripeCustomerId` IS NOT NULL AND `id` NOT IN (SELECT id FROM (SELECT MIN(`id`) AS id FROM `tenant` WHERE `stripeCustomerId` IS NOT NULL GROUP BY `stripeCustomerId`) keep)'
+				: `SELECT "id" FROM "tenant" WHERE "stripeCustomerId" IS NOT NULL AND "id" NOT IN (SELECT MIN("id") FROM "tenant" WHERE "stripeCustomerId" IS NOT NULL GROUP BY "stripeCustomerId")`;
+		const rows: Array<{ id: string }> = await queryRunner.query(q);
+		return (rows ?? []).map((r) => r.id);
+	}
+
+	/** Sets those same rows back to NULL. Same predicate, so the two cannot drift apart. */
+	private clearDuplicatesSql(type: DatabaseTypeEnum): string {
+		return type === DatabaseTypeEnum.mysql
+			? 'UPDATE `tenant` SET `stripeCustomerId` = NULL WHERE `stripeCustomerId` IS NOT NULL AND `id` NOT IN (SELECT id FROM (SELECT MIN(`id`) AS id FROM `tenant` WHERE `stripeCustomerId` IS NOT NULL GROUP BY `stripeCustomerId`) keep)'
+			: `UPDATE "tenant" SET "stripeCustomerId" = NULL WHERE "stripeCustomerId" IS NOT NULL AND "id" NOT IN (SELECT MIN("id") FROM "tenant" WHERE "stripeCustomerId" IS NOT NULL GROUP BY "stripeCustomerId")`;
 	}
 
 	public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
Hardening #10041 before it cascades to stage.

That migration creates a UNIQUE index on `tenant.stripeCustomerId`. If a duplicate already exists it aborts — and an aborting migration does not merely fail, **it stops the API booting**, on exactly the environment where billing has been live long enough to produce the duplicate.

In theory there are none: the column arrived one migration earlier and is written only when a Stripe key is configured. But "in theory none" is what I'd have said about the require cycle that took stage down yesterday behind a green build. Trading a hypothetical against a possible outage is a bad deal.

## What it does now

Duplicates are released before the index is built: the **oldest row keeps** the customer, the others go back to NULL. That is the safe direction — a tenant with no link shows no billing and can be relinked deliberately, whereas two tenants sharing one customer is the exact state the index exists to forbid.

Anything cleared is logged in red with the tenant ids, because it means two tenants were sharing a billing account and a human has to decide which keeps it.

The find and the clear share one predicate so they cannot drift apart. MySQL gets its own spelling — it cannot select from the table it is updating without a derived table in between.

## Verified from the dangerous state

better-sqlite3, seeded with three tenants on one customer, one on another, and two with none:

```
PASS  finds exactly the offending rows — t2,t3
PASS  oldest row KEEPS the customer
PASS  the others are released to NULL
PASS  an unrelated link is untouched
PASS  rows that were already NULL are untouched
PASS  unique index now creates successfully — boot is no longer at risk
PASS  re-running the cleanup is a no-op
PASS  duplicates remain impossible afterwards
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents API boot failures by making the `tenant.stripeCustomerId` unique-index migration tolerate pre-existing duplicates. Previously the migration aborted on duplicates and blocked startup; now it clears duplicates first, keeping the oldest tenant’s link and setting the others to NULL.

- Logs cleared tenant IDs at migration time; review and relink the intended tenant to the correct Stripe customer.
- Duplicate detection and clearing share one predicate; MySQL uses a derived-table form to allow updating from the same table.
- Idempotent: safe to re-run; no change when no duplicates exist.
- Validated locally (e.g., with `better-sqlite3`): unrelated links and existing NULLs remain untouched; index creation proceeds afterward.

<sup>Written for commit 470346bdf90fa725bb228b1c38c80d911b268f28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

