### PR TITLE
chore: cascade develop -> stage (tenant-isolation on the webhook + safer unique-index migration)

### DIFF
--- a/packages/core/src/lib/database/migrations/1790000009000-UniqueTenantStripeCustomer.ts
+++ b/packages/core/src/lib/database/migrations/1790000009000-UniqueTenantStripeCustomer.ts
@@ -33,6 +33,31 @@ export class UniqueTenantStripeCustomer1790000009000 implements MigrationInterfa
 		// so switching on the raw value will not narrow. The sibling migration does the same.
 		const type = queryRunner.connection.options.type as DatabaseTypeEnum;
 
+		// Release any duplicate before the unique index is created.
+		//
+		// In theory there are none: the column arrived one migration ago and is only written when a
+		// Stripe key is configured. But a migration that aborts here does not merely fail — it stops the
+		// API booting, on an environment where billing is live enough to have produced the duplicate.
+		// Trading a hypothetical for a possible outage is a bad deal, so the collision is resolved
+		// rather than hit.
+		//
+		// The oldest row keeps the customer and the others are set back to NULL. That is the safe
+		// direction: a tenant with no link simply shows no billing and can be relinked, whereas leaving
+		// two tenants pointed at one customer is the exact state this index exists to forbid. Anything
+		// cleared is logged loudly, because it means two tenants were sharing a billing account and
+		// somebody needs to know which.
+		const duplicates = await this.findDuplicates(queryRunner, type);
+		if (duplicates.length) {
+			console.log(
+				chalk.red(
+					`${this.name}: ${duplicates.length} tenant(s) shared a Stripe customer with another tenant. ` +
+						`Their link has been cleared and must be re-established deliberately: ` +
+						`${duplicates.join(', ')}`
+				)
+			);
+			await queryRunner.query(this.clearDuplicatesSql(type));
+		}
+
 		switch (type) {
 			case DatabaseTypeEnum.postgres:
 				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
@@ -60,6 +85,23 @@ export class UniqueTenantStripeCustomer1790000009000 implements MigrationInterfa
 			default:
 				throw new Error(`Unsupported database: ${type}`);
 		}
+	}
+
+	/** Tenant ids that would violate the unique index, oldest row per customer excluded. */
+	private async findDuplicates(queryRunner: QueryRunner, type: DatabaseTypeEnum): Promise<string[]> {
+		const q =
+			type === DatabaseTypeEnum.mysql
+				? 'SELECT `id` FROM `tenant` WHERE `stripeCustomerId` IS NOT NULL AND `id` NOT IN (SELECT id FROM (SELECT MIN(`id`) AS id FROM `tenant` WHERE `stripeCustomerId` IS NOT NULL GROUP BY `stripeCustomerId`) keep)'
+				: `SELECT "id" FROM "tenant" WHERE "stripeCustomerId" IS NOT NULL AND "id" NOT IN (SELECT MIN("id") FROM "tenant" WHERE "stripeCustomerId" IS NOT NULL GROUP BY "stripeCustomerId")`;
+		const rows: Array<{ id: string }> = await queryRunner.query(q);
+		return (rows ?? []).map((r) => r.id);
+	}
+
+	/** Sets those same rows back to NULL. Same predicate, so the two cannot drift apart. */
+	private clearDuplicatesSql(type: DatabaseTypeEnum): string {
+		return type === DatabaseTypeEnum.mysql
+			? 'UPDATE `tenant` SET `stripeCustomerId` = NULL WHERE `stripeCustomerId` IS NOT NULL AND `id` NOT IN (SELECT id FROM (SELECT MIN(`id`) AS id FROM `tenant` WHERE `stripeCustomerId` IS NOT NULL GROUP BY `stripeCustomerId`) keep)'
+			: `UPDATE "tenant" SET "stripeCustomerId" = NULL WHERE "stripeCustomerId" IS NOT NULL AND "id" NOT IN (SELECT MIN("id") FROM "tenant" WHERE "stripeCustomerId" IS NOT NULL GROUP BY "stripeCustomerId")`;
 	}
 
 	public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/core/src/lib/database/migrations/1790000009000-UniqueTenantStripeCustomer.ts
+++ b/packages/core/src/lib/database/migrations/1790000009000-UniqueTenantStripeCustomer.ts
@@ -1,0 +1,95 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import * as chalk from 'chalk';
+import { DatabaseTypeEnum } from '@gauzy/config';
+
+/**
+ * Make `tenant.stripeCustomerId` unique.
+ *
+ * Two tenants must never point at one Stripe customer. Whichever of them opened the billing page
+ * would be reading the other's invoices, card and subscription, and could cancel it — so this is a
+ * tenant-isolation boundary, not a tidiness constraint, and it belongs in the schema rather than
+ * only in the two code paths that write the column.
+ *
+ * Both of those paths already refuse to create a duplicate. They are checks-then-write, though, so
+ * two concurrent requests can both pass the check before either writes; the database is the only
+ * place that can actually make it impossible. Application code keeps the friendly refusal, this
+ * keeps the guarantee.
+ *
+ * A UNIQUE index still permits many NULLs on every dialect we support (Postgres, MySQL and SQLite
+ * all treat NULLs as distinct here), which matters because NULL is the normal state: every
+ * self-hosted install and every tenant created before billing was configured leaves it unset.
+ *
+ * There is nothing to clean up first. The column was introduced one migration ago and is written
+ * only when a Stripe key is configured, so no deployment can hold a duplicate yet — which is exactly
+ * why this is worth doing now rather than after the first collision.
+ */
+export class UniqueTenantStripeCustomer1790000009000 implements MigrationInterface {
+	name = 'UniqueTenantStripeCustomer1790000009000';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		console.log(chalk.yellow(`${this.name} start running!`));
+
+		// Cast first: TypeORM's own option union does not include every DatabaseTypeEnum member,
+		// so switching on the raw value will not narrow. The sibling migration does the same.
+		const type = queryRunner.connection.options.type as DatabaseTypeEnum;
+
+		switch (type) {
+			case DatabaseTypeEnum.postgres:
+				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
+				await queryRunner.query(
+					`CREATE UNIQUE INDEX "IDX_tenant_stripe_customer_id" ON "tenant" ("stripeCustomerId")`
+				);
+				break;
+
+			case DatabaseTypeEnum.sqlite:
+			case DatabaseTypeEnum.betterSqlite3:
+				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
+				await queryRunner.query(
+					`CREATE UNIQUE INDEX "IDX_tenant_stripe_customer_id" ON "tenant" ("stripeCustomerId")`
+				);
+				break;
+
+			case DatabaseTypeEnum.mysql:
+				// MySQL alone cannot drop an index without naming its table.
+				await queryRunner.query('DROP INDEX `IDX_tenant_stripe_customer_id` ON `tenant`');
+				await queryRunner.query(
+					'CREATE UNIQUE INDEX `IDX_tenant_stripe_customer_id` ON `tenant` (`stripeCustomerId`)'
+				);
+				break;
+
+			default:
+				throw new Error(`Unsupported database: ${type}`);
+		}
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		console.log(chalk.yellow(`${this.name} reverting changes!`));
+
+		// Cast first: TypeORM's own option union does not include every DatabaseTypeEnum member,
+		// so switching on the raw value will not narrow. The sibling migration does the same.
+		const type = queryRunner.connection.options.type as DatabaseTypeEnum;
+
+		switch (type) {
+			case DatabaseTypeEnum.postgres:
+				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
+				await queryRunner.query(`CREATE INDEX "IDX_tenant_stripe_customer_id" ON "tenant" ("stripeCustomerId")`);
+				break;
+
+			case DatabaseTypeEnum.sqlite:
+			case DatabaseTypeEnum.betterSqlite3:
+				await queryRunner.query(`DROP INDEX "IDX_tenant_stripe_customer_id"`);
+				await queryRunner.query(`CREATE INDEX "IDX_tenant_stripe_customer_id" ON "tenant" ("stripeCustomerId")`);
+				break;
+
+			case DatabaseTypeEnum.mysql:
+				await queryRunner.query('DROP INDEX `IDX_tenant_stripe_customer_id` ON `tenant`');
+				await queryRunner.query(
+					'CREATE INDEX `IDX_tenant_stripe_customer_id` ON `tenant` (`stripeCustomerId`)'
+				);
+				break;
+
+			default:
+				throw new Error(`Unsupported database: ${type}`);
+		}
+	}
+}

--- a/packages/core/src/lib/shared/billing/stripe-webhook.controller.ts
+++ b/packages/core/src/lib/shared/billing/stripe-webhook.controller.ts
@@ -143,6 +143,23 @@ export class StripeWebhookController {
 			return;
 		}
 
+		// Never adopt a Stripe customer that another tenant already bills through. The write below
+		// guards the *target* tenant from being repointed, but says nothing about the customer: two
+		// tenants could end up sharing one billing account, and whichever opened /billing would be
+		// looking at the other's invoices, card and subscription. The onboarding path has refused
+		// this since it was written; the webhook reaches the same column and had no equivalent.
+		const claimedBy = await this.typeOrmTenantRepository.findOne({
+			where: { stripeCustomerId: customerId },
+			select: { id: true }
+		});
+		if (claimedBy && claimedBy.id !== user.tenantId) {
+			this.logger.warn(
+				`Stripe ${event.type} would link tenant ${user.tenantId} to a customer already held by ` +
+					`tenant ${claimedBy.id}; declining.`
+			);
+			return;
+		}
+
 		// Only fill a gap; never repoint a tenant that already has a customer. Overwriting that link
 		// from a webhook would let a stray event move a tenant's billing onto another account.
 		const updated = await this.typeOrmTenantRepository.update(

--- a/packages/core/src/lib/tenant/tenant.entity.ts
+++ b/packages/core/src/lib/tenant/tenant.entity.ts
@@ -35,7 +35,10 @@ export class Tenant extends BaseEntity implements ITenant {
 	// Named to match the migration. Left unnamed, TypeORM derives a hashed name of its own, which
 	// will not match the one the migration creates — and the schema comparison then wants to add a
 	// second index over the same column.
-	@ColumnIndex('IDX_tenant_stripe_customer_id')
+	// Unique: two tenants sharing one Stripe customer would each be able to read and cancel the
+	// other's subscription. The name is stated so it matches the migration — left to TypeORM, the
+	// derived hash would not, and schema comparison would ask for a second index.
+	@ColumnIndex('IDX_tenant_stripe_customer_id', { unique: true })
 	@MultiORMColumn({ nullable: true })
 	stripeCustomerId?: string;
 


### PR DESCRIPTION
Promotes `develop` to `stage`. Two commits, deliberately travelling together.

**[#10041](https://github.com/ever-co/ever-gauzy/pull/10041) — the webhook could adopt a Stripe customer another tenant holds.** The onboarding path has always refused this; the webhook reaches the same column and had no equivalent check. Two tenants sharing one Stripe customer means either can read the other's invoices and card, and cancel their subscription. Fixed in two layers: the check on both paths, and a UNIQUE index, because check-then-write cannot be made safe by checking harder.

**[#10042](https://github.com/ever-co/ever-gauzy/pull/10042) — that migration must not be able to stop the API booting.** Creating the unique index over pre-existing duplicates would abort the migration, which stops boot on exactly the environment where billing has run long enough to produce one. Duplicates are now released first (oldest row keeps the customer, others go back to NULL, all of it logged in red with the tenant ids).

The second exists because of what happened to this environment yesterday: a require cycle in the billing module stopped the API booting behind a **green build**, and stage was down for hours. The migration was the next thing in this changeset that could fail the same way, so it was hardened before shipping rather than after.

Verified against better-sqlite3 from the dangerous starting state — duplicates already present — that the migration now completes where it would previously have aborted, and that NULLs and unrelated links are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents tenants from sharing a Stripe customer and makes the index migration safe to run. Previously the webhook could link a tenant to a customer already held by another tenant; now both paths refuse it and the schema enforces it with a UNIQUE index that resolves duplicates first.

- Adds a pre-claim check in the Stripe webhook so it declines linking when another tenant already holds the `customerId`.
- Creates a UNIQUE index on `tenant.stripeCustomerId`; before creating it, the migration clears newer duplicates back to NULL, keeping the oldest per customer. Handles Postgres, MySQL, and `better-sqlite3`. Updates the entity to `unique: true` with a fixed index name to match the migration.

**Rollout and migration**
- The migration (`1790000009000-UniqueTenantStripeCustomer`) may reset `stripeCustomerId` on newer duplicate tenants; required: re-link those tenants deliberately. Watch for red logs listing affected tenant ids.
- No config changes. No downtime expected; the migration avoids aborting API boot.

<sup>Written for commit c665bb0848724928bf5c56549afc55dcdda279f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

