### PR TITLE
Feat/professional panel UI

### DIFF
--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
@@ -53,11 +53,11 @@ $menu-row-color: var(--gauzy-text-color-2, var(--text-hint-color));
 $menu-row-weight: 400;
 $menu-row-active-weight: 500;
 
-// 14px for every label in the nav — deliberately NOT `menu-text-font-size`
+// 12px for every label in the nav — deliberately NOT `menu-text-font-size`
 // (0.8125rem / 13px), which is the app's shared CONTROL text size and is also
 // what overlay menus, ng-select rows and the settings menu resolve. The sidebar
-// is read at a glance and from a distance; the shared token stays where it is.
-$menu-row-font-size: 0.875rem;
+// runs on its own step; the shared token stays where it is.
+$menu-row-font-size: 0.75rem;
 
 // Row padding, one step tighter than the shared `menu-item-padding`
 // (0.5rem 0.75rem). The bigger label would otherwise push a row from 36px to
@@ -139,7 +139,7 @@ $menu-child-indent: 1.25rem;
     > i {
       flex: 0 0 auto;
       width: $menu-icon-column;
-      font-size: 0.8125rem;
+      font-size: 0.75rem;
       text-align: center;
       color: inherit;
       opacity: 0.85;
@@ -393,7 +393,7 @@ $menu-child-indent: 1.25rem;
   i {
     flex: 0 0 auto;
     width: $menu-icon-column;
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
     text-align: center;
     color: inherit;
     opacity: 0.85;
@@ -461,7 +461,7 @@ $menu-child-indent: 1.25rem;
 // Which section this is — in the rail the parent row has no label of its own,
 // so without this the panel is a list of links from nowhere. Same treatment as
 // the group captions in the overlay menus, but at 10px: it is a caption over
-// the list, and the wider the gap to the 14px rows under it, the more clearly
+// the list, and the wider the gap to the rows under it, the more clearly
 // it reads as a label rather than as the first entry.
 .rail-flyout-title {
   padding: 0.375rem $menu-row-inline-padding 0.25rem;

--- a/packages/ui-core/i18n/assets/i18n/ach.json
+++ b/packages/ui-core/i18n/assets/i18n/ach.json
@@ -1099,7 +1099,9 @@
 		"TABLE": "crwdns7056:0crwdne7056:0",
 		"CARDS_GRID": "crwdns7058:0crwdne7058:0",
 		"SPRINT_VIEW": "crwdns8236:0crwdne8236:0",
-		"QUICK_SETTINGS": "crwdns11022:0crwdne11022:0"
+		"QUICK_SETTINGS": "crwdns11022:0crwdne11022:0",
+		"PREFERENCES": "Preferences",
+		"SUPPORT": "Support"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "crwdns10190:0crwdne10190:0",
@@ -4679,7 +4681,10 @@
 		"HOTKEYS": "crwdns11044:0crwdne11044:0",
 		"HELP": "crwdns11046:0crwdne11046:0",
 		"SIGN_OUT": "crwdns11048:0crwdne11048:0",
-		"PROFILE": "crwdns11050:0crwdne11050:0"
+		"PROFILE": "crwdns11050:0crwdne11050:0",
+		"ACCOUNT": "Account",
+		"PREFERENCES": "Preferences",
+		"DOWNLOAD_APPS": "Download apps"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/ach.json
+++ b/packages/ui-core/i18n/assets/i18n/ach.json
@@ -1100,8 +1100,8 @@
 		"CARDS_GRID": "crwdns7058:0crwdne7058:0",
 		"SPRINT_VIEW": "crwdns8236:0crwdne8236:0",
 		"QUICK_SETTINGS": "crwdns11022:0crwdne11022:0",
-		"PREFERENCES": "Preferences",
-		"SUPPORT": "Support"
+		"PREFERENCES": "Gin ma imito",
+		"SUPPORT": "Kony"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "crwdns10190:0crwdne10190:0",
@@ -4682,14 +4682,14 @@
 		"HELP": "crwdns11046:0crwdne11046:0",
 		"SIGN_OUT": "crwdns11048:0crwdne11048:0",
 		"PROFILE": "crwdns11050:0crwdne11050:0",
-		"ACCOUNT": "Account",
-		"PREFERENCES": "Preferences",
-		"DOWNLOAD_APPS": "Download apps",
-		"DOWNLOAD_MACOS": "Download for macOS",
-		"DOWNLOAD_WINDOWS": "Download for Windows",
-		"DOWNLOAD_LINUX": "Download for Linux",
-		"DOWNLOAD_MOBILE": "Download the mobile app",
-		"DOWNLOAD_BROWSER_EXTENSION": "Download the browser extension"
+		"ACCOUNT": "Akaunt",
+		"PREFERENCES": "Gin ma imito",
+		"DOWNLOAD_APPS": "Gam apps",
+		"DOWNLOAD_MACOS": "Gam pi macOS",
+		"DOWNLOAD_WINDOWS": "Gam pi Windows",
+		"DOWNLOAD_LINUX": "Gam pi Linux",
+		"DOWNLOAD_MOBILE": "Gam app me cim",
+		"DOWNLOAD_BROWSER_EXTENSION": "Gam lamed me browser"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/ach.json
+++ b/packages/ui-core/i18n/assets/i18n/ach.json
@@ -4684,7 +4684,12 @@
 		"PROFILE": "crwdns11050:0crwdne11050:0",
 		"ACCOUNT": "Account",
 		"PREFERENCES": "Preferences",
-		"DOWNLOAD_APPS": "Download apps"
+		"DOWNLOAD_APPS": "Download apps",
+		"DOWNLOAD_MACOS": "Download for macOS",
+		"DOWNLOAD_WINDOWS": "Download for Windows",
+		"DOWNLOAD_LINUX": "Download for Linux",
+		"DOWNLOAD_MOBILE": "Download the mobile app",
+		"DOWNLOAD_BROWSER_EXTENSION": "Download the browser extension"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/ach.json
+++ b/packages/ui-core/i18n/assets/i18n/ach.json
@@ -4678,6 +4678,7 @@
 		"CUSTOM": "crwdns11038:0crwdne11038:0",
 		"SET_AS_NOTIFICATION_SCHEDULE": "crwdns11040:0crwdne11040:0",
 		"SET_YOURSELF_AS_AWAY": "crwdns11042:0crwdne11042:0",
+		"SET_YOURSELF_AS_ACTIVE": "Ket keni calo <strong>ma itye</strong>",
 		"HOTKEYS": "crwdns11044:0crwdne11044:0",
 		"HELP": "crwdns11046:0crwdne11046:0",
 		"SIGN_OUT": "crwdns11048:0crwdne11048:0",

--- a/packages/ui-core/i18n/assets/i18n/ar.json
+++ b/packages/ui-core/i18n/assets/i18n/ar.json
@@ -5383,7 +5383,12 @@
 		"PROFILE": "الملف الشخصي",
 		"ACCOUNT": "الحساب",
 		"PREFERENCES": "التفضيلات",
-		"DOWNLOAD_APPS": "تنزيل التطبيقات"
+		"DOWNLOAD_APPS": "تنزيل التطبيقات",
+		"DOWNLOAD_MACOS": "التنزيل لنظام macOS",
+		"DOWNLOAD_WINDOWS": "التنزيل لنظام Windows",
+		"DOWNLOAD_LINUX": "التنزيل لنظام Linux",
+		"DOWNLOAD_MOBILE": "تنزيل تطبيق الهاتف المحمول",
+		"DOWNLOAD_BROWSER_EXTENSION": "تنزيل إضافة المتصفح"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/ar.json
+++ b/packages/ui-core/i18n/assets/i18n/ar.json
@@ -1202,7 +1202,7 @@
 		"CARDS_GRID": "شبكة البطاقات",
 		"SPRINT_VIEW": "عرض السبرينت",
 		"QUICK_SETTINGS": "الإعدادات السريعة",
-		"NO_LAYOUT": "No data layout available",
+		"NO_LAYOUT": "لا يوجد تخطيط بيانات متاح",
 		"PREFERENCES": "التفضيلات",
 		"SUPPORT": "الدعم"
 	},

--- a/packages/ui-core/i18n/assets/i18n/ar.json
+++ b/packages/ui-core/i18n/assets/i18n/ar.json
@@ -1202,7 +1202,9 @@
 		"CARDS_GRID": "شبكة البطاقات",
 		"SPRINT_VIEW": "عرض السبرينت",
 		"QUICK_SETTINGS": "الإعدادات السريعة",
-		"NO_LAYOUT": "No data layout available"
+		"NO_LAYOUT": "No data layout available",
+		"PREFERENCES": "التفضيلات",
+		"SUPPORT": "الدعم"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "ما الجديد؟",
@@ -5378,7 +5380,10 @@
 		"HOTKEYS": "مفاتيح الاختصار",
 		"HELP": "مساعدة",
 		"SIGN_OUT": "تسجيل الخروج",
-		"PROFILE": "الملف الشخصي"
+		"PROFILE": "الملف الشخصي",
+		"ACCOUNT": "الحساب",
+		"PREFERENCES": "التفضيلات",
+		"DOWNLOAD_APPS": "تنزيل التطبيقات"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/bg.json
+++ b/packages/ui-core/i18n/assets/i18n/bg.json
@@ -5425,7 +5425,12 @@
 		"PROFILE": "Profile",
 		"ACCOUNT": "Акаунт",
 		"PREFERENCES": "Предпочитания",
-		"DOWNLOAD_APPS": "Изтегляне на приложения"
+		"DOWNLOAD_APPS": "Изтегляне на приложения",
+		"DOWNLOAD_MACOS": "Изтегляне за macOS",
+		"DOWNLOAD_WINDOWS": "Изтегляне за Windows",
+		"DOWNLOAD_LINUX": "Изтегляне за Linux",
+		"DOWNLOAD_MOBILE": "Изтегляне на мобилното приложение",
+		"DOWNLOAD_BROWSER_EXTENSION": "Изтегляне на разширението за браузър"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/bg.json
+++ b/packages/ui-core/i18n/assets/i18n/bg.json
@@ -1232,7 +1232,9 @@
 		"CARDS_GRID": "Карти и мрежа",
 		"SPRINT_VIEW": "Визуализация на спринт",
 		"QUICK_SETTINGS": "Бързи настройки",
-		"NO_LAYOUT": "Няма наличен изглед за данни"
+		"NO_LAYOUT": "Няма наличен изглед за данни",
+		"PREFERENCES": "Предпочитания",
+		"SUPPORT": "Поддръжка"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "Какво ново?",
@@ -5420,7 +5422,10 @@
 		"HOTKEYS": "Hotkeys",
 		"HELP": "Помощ",
 		"SIGN_OUT": "Sign Out",
-		"PROFILE": "Profile"
+		"PROFILE": "Profile",
+		"ACCOUNT": "Акаунт",
+		"PREFERENCES": "Предпочитания",
+		"DOWNLOAD_APPS": "Изтегляне на приложения"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/de.json
+++ b/packages/ui-core/i18n/assets/i18n/de.json
@@ -5394,7 +5394,12 @@
 		"PROFILE": "Profil",
 		"ACCOUNT": "Konto",
 		"PREFERENCES": "Einstellungen",
-		"DOWNLOAD_APPS": "Apps herunterladen"
+		"DOWNLOAD_APPS": "Apps herunterladen",
+		"DOWNLOAD_MACOS": "Für macOS herunterladen",
+		"DOWNLOAD_WINDOWS": "Für Windows herunterladen",
+		"DOWNLOAD_LINUX": "Für Linux herunterladen",
+		"DOWNLOAD_MOBILE": "Mobile App herunterladen",
+		"DOWNLOAD_BROWSER_EXTENSION": "Browser-Erweiterung herunterladen"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/de.json
+++ b/packages/ui-core/i18n/assets/i18n/de.json
@@ -1203,7 +1203,9 @@
 		"CARDS_GRID": "Kartenraster",
 		"SPRINT_VIEW": "Sprint-Ansicht",
 		"QUICK_SETTINGS": "Schnelleinstellungen",
-		"NO_LAYOUT": "Kein Datenlayout verfügbar"
+		"NO_LAYOUT": "Kein Datenlayout verfügbar",
+		"PREFERENCES": "Einstellungen",
+		"SUPPORT": "Support"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "Was gibt es Neues?",
@@ -5389,7 +5391,10 @@
 		"HOTKEYS": "Tastenkombinationen",
 		"HELP": "Hilfe",
 		"SIGN_OUT": "Abmelden",
-		"PROFILE": "Profil"
+		"PROFILE": "Profil",
+		"ACCOUNT": "Konto",
+		"PREFERENCES": "Einstellungen",
+		"DOWNLOAD_APPS": "Apps herunterladen"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -1269,7 +1269,9 @@
 		"BILLING_PORTAL_HINT": "Open the secure Stripe portal to update payment details, download receipts and manage your subscription.",
 		"BILLING_OPEN_PORTAL": "Open billing portal",
 		"BILLING_LOAD_FAILED": "Some billing details could not be loaded. What you see may be incomplete.",
-		"BILLING_RETRY": "Try again"
+		"BILLING_RETRY": "Try again",
+		"PREFERENCES": "Preferences",
+		"SUPPORT": "Support"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "What's new?",
@@ -5976,7 +5978,10 @@
 		"HOTKEYS": "Hotkeys",
 		"HELP": "Help",
 		"SIGN_OUT": "Sign Out",
-		"PROFILE": "Profile"
+		"PROFILE": "Profile",
+		"ACCOUNT": "Account",
+		"PREFERENCES": "Preferences",
+		"DOWNLOAD_APPS": "Download apps"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -5981,7 +5981,12 @@
 		"PROFILE": "Profile",
 		"ACCOUNT": "Account",
 		"PREFERENCES": "Preferences",
-		"DOWNLOAD_APPS": "Download apps"
+		"DOWNLOAD_APPS": "Download apps",
+		"DOWNLOAD_MACOS": "Download for macOS",
+		"DOWNLOAD_WINDOWS": "Download for Windows",
+		"DOWNLOAD_LINUX": "Download for Linux",
+		"DOWNLOAD_MOBILE": "Download the mobile app",
+		"DOWNLOAD_BROWSER_EXTENSION": "Download the browser extension"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/es.json
+++ b/packages/ui-core/i18n/assets/i18n/es.json
@@ -5400,7 +5400,12 @@
 		"PROFILE": "Perfil",
 		"ACCOUNT": "Cuenta",
 		"PREFERENCES": "Preferencias",
-		"DOWNLOAD_APPS": "Descargar aplicaciones"
+		"DOWNLOAD_APPS": "Descargar aplicaciones",
+		"DOWNLOAD_MACOS": "Descargar para macOS",
+		"DOWNLOAD_WINDOWS": "Descargar para Windows",
+		"DOWNLOAD_LINUX": "Descargar para Linux",
+		"DOWNLOAD_MOBILE": "Descargar la aplicación móvil",
+		"DOWNLOAD_BROWSER_EXTENSION": "Descargar la extensión del navegador"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/es.json
+++ b/packages/ui-core/i18n/assets/i18n/es.json
@@ -1205,7 +1205,9 @@
 		"CARDS_GRID": "Cuadrícula de Tarjetas",
 		"SPRINT_VIEW": "Sprint View",
 		"QUICK_SETTINGS": "Configuración rápida",
-		"NO_LAYOUT": "No hay diseño de datos disponible"
+		"NO_LAYOUT": "No hay diseño de datos disponible",
+		"PREFERENCES": "Preferencias",
+		"SUPPORT": "Soporte"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "¿Qué hay de nuevo?",
@@ -5395,7 +5397,10 @@
 		"HOTKEYS": "Atajos de teclado.",
 		"HELP": "Ayuda",
 		"SIGN_OUT": "Cerrar sesión",
-		"PROFILE": "Perfil"
+		"PROFILE": "Perfil",
+		"ACCOUNT": "Cuenta",
+		"PREFERENCES": "Preferencias",
+		"DOWNLOAD_APPS": "Descargar aplicaciones"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/fr.json
+++ b/packages/ui-core/i18n/assets/i18n/fr.json
@@ -5389,7 +5389,12 @@
 		"PROFILE": "Profil",
 		"ACCOUNT": "Compte",
 		"PREFERENCES": "Préférences",
-		"DOWNLOAD_APPS": "Télécharger les applications"
+		"DOWNLOAD_APPS": "Télécharger les applications",
+		"DOWNLOAD_MACOS": "Télécharger pour macOS",
+		"DOWNLOAD_WINDOWS": "Télécharger pour Windows",
+		"DOWNLOAD_LINUX": "Télécharger pour Linux",
+		"DOWNLOAD_MOBILE": "Télécharger l'application mobile",
+		"DOWNLOAD_BROWSER_EXTENSION": "Télécharger l'extension de navigateur"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/fr.json
+++ b/packages/ui-core/i18n/assets/i18n/fr.json
@@ -1204,7 +1204,9 @@
 		"CARDS_GRID": "Grille de cartes",
 		"SPRINT_VIEW": "Vue Sprint",
 		"QUICK_SETTINGS": "Paramètres rapides",
-		"NO_LAYOUT": "Aucun modèle de données disponible"
+		"NO_LAYOUT": "Aucun modèle de données disponible",
+		"PREFERENCES": "Préférences",
+		"SUPPORT": "Assistance"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "Quoi de neuf?",
@@ -5384,7 +5386,10 @@
 		"HOTKEYS": "Raccourcis clavier",
 		"HELP": "Aidez-moi",
 		"SIGN_OUT": "Déconnecter",
-		"PROFILE": "Profil"
+		"PROFILE": "Profil",
+		"ACCOUNT": "Compte",
+		"PREFERENCES": "Préférences",
+		"DOWNLOAD_APPS": "Télécharger les applications"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/he.json
+++ b/packages/ui-core/i18n/assets/i18n/he.json
@@ -5388,7 +5388,12 @@
 		"PROFILE": "Profile",
 		"ACCOUNT": "חשבון",
 		"PREFERENCES": "העדפות",
-		"DOWNLOAD_APPS": "הורדת אפליקציות"
+		"DOWNLOAD_APPS": "הורדת אפליקציות",
+		"DOWNLOAD_MACOS": "הורדה עבור macOS",
+		"DOWNLOAD_WINDOWS": "הורדה עבור Windows",
+		"DOWNLOAD_LINUX": "הורדה עבור Linux",
+		"DOWNLOAD_MOBILE": "הורדת אפליקציית המובייל",
+		"DOWNLOAD_BROWSER_EXTENSION": "הורדת תוסף הדפדפן"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/he.json
+++ b/packages/ui-core/i18n/assets/i18n/he.json
@@ -1207,7 +1207,9 @@
 		"CARDS_GRID": "Cards Grid",
 		"SPRINT_VIEW": "Sprint View",
 		"QUICK_SETTINGS": "Quick Settings",
-		"NO_LAYOUT": "אין פריסת נתונים זמינה"
+		"NO_LAYOUT": "אין פריסת נתונים זמינה",
+		"PREFERENCES": "העדפות",
+		"SUPPORT": "תמיכה"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "What's new?",
@@ -5383,7 +5385,10 @@
 		"HOTKEYS": "Hotkeys",
 		"HELP": "עזרה",
 		"SIGN_OUT": "Sign Out",
-		"PROFILE": "Profile"
+		"PROFILE": "Profile",
+		"ACCOUNT": "חשבון",
+		"PREFERENCES": "העדפות",
+		"DOWNLOAD_APPS": "הורדת אפליקציות"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/it.json
+++ b/packages/ui-core/i18n/assets/i18n/it.json
@@ -5398,7 +5398,12 @@
 		"PROFILE": "Profilo",
 		"ACCOUNT": "Account",
 		"PREFERENCES": "Preferenze",
-		"DOWNLOAD_APPS": "Scarica le app"
+		"DOWNLOAD_APPS": "Scarica le app",
+		"DOWNLOAD_MACOS": "Scarica per macOS",
+		"DOWNLOAD_WINDOWS": "Scarica per Windows",
+		"DOWNLOAD_LINUX": "Scarica per Linux",
+		"DOWNLOAD_MOBILE": "Scarica l'app mobile",
+		"DOWNLOAD_BROWSER_EXTENSION": "Scarica l'estensione del browser"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/it.json
+++ b/packages/ui-core/i18n/assets/i18n/it.json
@@ -1203,7 +1203,9 @@
 		"CARDS_GRID": "Griglia di carte",
 		"SPRINT_VIEW": "Vista della sprint",
 		"QUICK_SETTINGS": "Impostazioni rapide",
-		"NO_LAYOUT": "Nessun layout di dati disponibile"
+		"NO_LAYOUT": "Nessun layout di dati disponibile",
+		"PREFERENCES": "Preferenze",
+		"SUPPORT": "Supporto"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "Cosa c'è di nuovo?",
@@ -5393,7 +5395,10 @@
 		"HOTKEYS": "Tasti di scelta rapida",
 		"HELP": "Aiuto",
 		"SIGN_OUT": "Esci",
-		"PROFILE": "Profilo"
+		"PROFILE": "Profilo",
+		"ACCOUNT": "Account",
+		"PREFERENCES": "Preferenze",
+		"DOWNLOAD_APPS": "Scarica le app"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/nl.json
+++ b/packages/ui-core/i18n/assets/i18n/nl.json
@@ -5398,7 +5398,12 @@
 		"PROFILE": "Profiel",
 		"ACCOUNT": "Account",
 		"PREFERENCES": "Voorkeuren",
-		"DOWNLOAD_APPS": "Apps downloaden"
+		"DOWNLOAD_APPS": "Apps downloaden",
+		"DOWNLOAD_MACOS": "Downloaden voor macOS",
+		"DOWNLOAD_WINDOWS": "Downloaden voor Windows",
+		"DOWNLOAD_LINUX": "Downloaden voor Linux",
+		"DOWNLOAD_MOBILE": "Mobiele app downloaden",
+		"DOWNLOAD_BROWSER_EXTENSION": "Browserextensie downloaden"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/nl.json
+++ b/packages/ui-core/i18n/assets/i18n/nl.json
@@ -1203,7 +1203,9 @@
 		"CARDS_GRID": "Kaartenraster",
 		"SPRINT_VIEW": "Sprintweergave",
 		"QUICK_SETTINGS": "Snelle instellingen",
-		"NO_LAYOUT": "Geen gegevenslay-out beschikbaar"
+		"NO_LAYOUT": "Geen gegevenslay-out beschikbaar",
+		"PREFERENCES": "Voorkeuren",
+		"SUPPORT": "Ondersteuning"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "Wat is er nieuw?",
@@ -5393,7 +5395,10 @@
 		"HOTKEYS": "Sneltoetsen",
 		"HELP": "Help",
 		"SIGN_OUT": "Afmelden",
-		"PROFILE": "Profiel"
+		"PROFILE": "Profiel",
+		"ACCOUNT": "Account",
+		"PREFERENCES": "Voorkeuren",
+		"DOWNLOAD_APPS": "Apps downloaden"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/pl.json
+++ b/packages/ui-core/i18n/assets/i18n/pl.json
@@ -1202,7 +1202,9 @@
 		"CARDS_GRID": "Siatka kart",
 		"SPRINT_VIEW": "Widok sprintu",
 		"QUICK_SETTINGS": "Szybkie ustawienia",
-		"NO_LAYOUT": "Brak dostępnego układu danych"
+		"NO_LAYOUT": "Brak dostępnego układu danych",
+		"PREFERENCES": "Preferencje",
+		"SUPPORT": "Wsparcie"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "Co nowego?",
@@ -5392,7 +5394,10 @@
 		"HOTKEYS": "Skróty klawiszowe",
 		"HELP": "Pomoc",
 		"SIGN_OUT": "Wyloguj się",
-		"PROFILE": "Profil"
+		"PROFILE": "Profil",
+		"ACCOUNT": "Konto",
+		"PREFERENCES": "Preferencje",
+		"DOWNLOAD_APPS": "Pobierz aplikacje"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/pl.json
+++ b/packages/ui-core/i18n/assets/i18n/pl.json
@@ -5397,7 +5397,12 @@
 		"PROFILE": "Profil",
 		"ACCOUNT": "Konto",
 		"PREFERENCES": "Preferencje",
-		"DOWNLOAD_APPS": "Pobierz aplikacje"
+		"DOWNLOAD_APPS": "Pobierz aplikacje",
+		"DOWNLOAD_MACOS": "Pobierz dla macOS",
+		"DOWNLOAD_WINDOWS": "Pobierz dla Windows",
+		"DOWNLOAD_LINUX": "Pobierz dla Linux",
+		"DOWNLOAD_MOBILE": "Pobierz aplikację mobilną",
+		"DOWNLOAD_BROWSER_EXTENSION": "Pobierz rozszerzenie przeglądarki"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/pt.json
+++ b/packages/ui-core/i18n/assets/i18n/pt.json
@@ -1203,7 +1203,9 @@
 		"CARDS_GRID": "Grade de Cartões",
 		"SPRINT_VIEW": "Sprint View",
 		"QUICK_SETTINGS": "Configurações rápidas",
-		"NO_LAYOUT": "Nenhum layout de dados disponível"
+		"NO_LAYOUT": "Nenhum layout de dados disponível",
+		"PREFERENCES": "Preferências",
+		"SUPPORT": "Suporte"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "O que há de novo?",
@@ -5393,7 +5395,10 @@
 		"HOTKEYS": "Atalhos de teclado",
 		"HELP": "Ajuda",
 		"SIGN_OUT": "Sair",
-		"PROFILE": "Perfil"
+		"PROFILE": "Perfil",
+		"ACCOUNT": "Conta",
+		"PREFERENCES": "Preferências",
+		"DOWNLOAD_APPS": "Baixar aplicativos"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/pt.json
+++ b/packages/ui-core/i18n/assets/i18n/pt.json
@@ -5398,7 +5398,12 @@
 		"PROFILE": "Perfil",
 		"ACCOUNT": "Conta",
 		"PREFERENCES": "Preferências",
-		"DOWNLOAD_APPS": "Baixar aplicativos"
+		"DOWNLOAD_APPS": "Baixar aplicativos",
+		"DOWNLOAD_MACOS": "Baixar para macOS",
+		"DOWNLOAD_WINDOWS": "Baixar para Windows",
+		"DOWNLOAD_LINUX": "Baixar para Linux",
+		"DOWNLOAD_MOBILE": "Baixar o aplicativo móvel",
+		"DOWNLOAD_BROWSER_EXTENSION": "Baixar a extensão do navegador"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/ru.json
+++ b/packages/ui-core/i18n/assets/i18n/ru.json
@@ -1211,7 +1211,9 @@
 		"CARDS_GRID": "Сетка карт",
 		"SPRINT_VIEW": "Просмотр спринта",
 		"QUICK_SETTINGS": "Быстрые настройки",
-		"NO_LAYOUT": "Нет доступного макета данных"
+		"NO_LAYOUT": "Нет доступного макета данных",
+		"PREFERENCES": "Предпочтения",
+		"SUPPORT": "Поддержка"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "Что нового?",
@@ -5390,7 +5392,10 @@
 		"HOTKEYS": "Горячие клавиши",
 		"HELP": "Помогите",
 		"SIGN_OUT": "Выйти",
-		"PROFILE": "Профиль"
+		"PROFILE": "Профиль",
+		"ACCOUNT": "Аккаунт",
+		"PREFERENCES": "Предпочтения",
+		"DOWNLOAD_APPS": "Скачать приложения"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/ru.json
+++ b/packages/ui-core/i18n/assets/i18n/ru.json
@@ -5395,7 +5395,12 @@
 		"PROFILE": "Профиль",
 		"ACCOUNT": "Аккаунт",
 		"PREFERENCES": "Предпочтения",
-		"DOWNLOAD_APPS": "Скачать приложения"
+		"DOWNLOAD_APPS": "Скачать приложения",
+		"DOWNLOAD_MACOS": "Скачать для macOS",
+		"DOWNLOAD_WINDOWS": "Скачать для Windows",
+		"DOWNLOAD_LINUX": "Скачать для Linux",
+		"DOWNLOAD_MOBILE": "Скачать мобильное приложение",
+		"DOWNLOAD_BROWSER_EXTENSION": "Скачать расширение для браузера"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/zh.json
+++ b/packages/ui-core/i18n/assets/i18n/zh.json
@@ -1203,7 +1203,9 @@
 		"CARDS_GRID": "卡片网格",
 		"SPRINT_VIEW": "Sprint View 时事回顾",
 		"QUICK_SETTINGS": "快捷设置",
-		"NO_LAYOUT": "没有可用的数据布局"
+		"NO_LAYOUT": "没有可用的数据布局",
+		"PREFERENCES": "偏好设置",
+		"SUPPORT": "支持"
 	},
 	"CHANGELOG_MENU": {
 		"HEADER": "有什么新的吗？",
@@ -5393,7 +5395,10 @@
 		"HOTKEYS": "快捷键",
 		"HELP": "帮助",
 		"SIGN_OUT": "退出",
-		"PROFILE": "个人资料"
+		"PROFILE": "个人资料",
+		"ACCOUNT": "账户",
+		"PREFERENCES": "偏好设置",
+		"DOWNLOAD_APPS": "下载应用"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/i18n/assets/i18n/zh.json
+++ b/packages/ui-core/i18n/assets/i18n/zh.json
@@ -5398,7 +5398,12 @@
 		"PROFILE": "个人资料",
 		"ACCOUNT": "账户",
 		"PREFERENCES": "偏好设置",
-		"DOWNLOAD_APPS": "下载应用"
+		"DOWNLOAD_APPS": "下载应用",
+		"DOWNLOAD_MACOS": "下载 macOS 版",
+		"DOWNLOAD_WINDOWS": "下载 Windows 版",
+		"DOWNLOAD_LINUX": "下载 Linux 版",
+		"DOWNLOAD_MOBILE": "下载移动应用",
+		"DOWNLOAD_BROWSER_EXTENSION": "下载浏览器扩展"
 	},
 	"WORKSPACES": {
 		"MENUS": {

--- a/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
+++ b/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
@@ -147,6 +147,9 @@
 	}
 }
 
-:host(.compact:last-of-type) .entry {
+// `.last` is set by the list that renders these entries. Keying off the class
+// rather than `:last-of-type` keeps the rule correct if the panel ever renders
+// a sibling of another element type, or a non-compact entry, after the list.
+:host(.compact.last) .entry {
 	border-bottom: 0;
 }

--- a/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
+++ b/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
@@ -81,3 +81,72 @@
 		margin-bottom: 10px;
 	}
 }
+
+:host(.compact) {
+	.entry {
+		border-bottom: 1px solid var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+		border-radius: var(--gauzy-radius-sm, 6px);
+		padding: 0.5rem 0.625rem 0.625rem;
+
+		&.linked:hover {
+			background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+		}
+
+		.entry-headings-wrapper {
+			align-items: flex-start;
+			gap: 0.5rem;
+			margin-bottom: 0.1875rem;
+
+			.icon {
+				margin: 0.0625rem 0 0;
+				width: 0.875rem;
+				height: 0.875rem;
+				font-size: 0.875rem;
+				color: nb-theme(text-hint-color);
+			}
+
+			.entry-headings {
+				min-width: 0;
+			}
+
+			.entry-header {
+				font-size: 0.625rem;
+				line-height: 0.875rem;
+				letter-spacing: -0.004em;
+				margin-bottom: 0.125rem;
+			}
+
+			.entry-header-date {
+				font-size: 0.4375rem;
+				font-weight: 500;
+				line-height: 1;
+				letter-spacing: 0.06em;
+				text-transform: uppercase;
+				color: nb-theme(text-hint-color);
+			}
+		}
+
+		.paragraph {
+			margin: 0;
+			font-size: 0.625rem;
+			line-height: 0.9375rem;
+			color: nb-theme(text-hint-color);
+		}
+
+		.entry-img {
+			margin: 0.375rem 0 0;
+			border-radius: var(--gauzy-radius-sm, 6px);
+		}
+
+		.learn-more-hint {
+			margin: 0.25rem 0 0;
+			font-size: 0.5625rem;
+			font-weight: 600;
+			letter-spacing: 0.01em;
+		}
+	}
+}
+
+:host(.compact:last-of-type) .entry {
+	border-bottom: 0;
+}

--- a/packages/ui-core/static/styles/@shared/_panel.scss
+++ b/packages/ui-core/static/styles/@shared/_panel.scss
@@ -1,0 +1,272 @@
+// ── Chrome panels ────────────────────────────────────────────────────────────
+// The three panels that open out of the app shell — "What's New" (the gift
+// action in the header), "Quick Settings" (the gear action beside it) and the
+// account menu (the user button at the foot of the sidebar) — are the same KIND
+// of surface: a small, dense popup of flat rows, opened from an icon and
+// dismissed by clicking away.
+//
+// Each had grown its own scale (an 18px heading over a peach-tinted card, a
+// 16px heading over 14px list rows, a 36x18rem box with a brand-tinted half),
+// so the three read as three different products. This partial is the ONE scale
+// they share, in the same spirit as `_overlays.scss`: that file owns the
+// overlays the CDK renders at <body> level, this one owns the panels the layout
+// positions itself, and both describe the same container/item split —
+//
+//   CONTAINER  one hairline + one soft shadow + the surface radius + small pad
+//   ITEMS      flat rows: no border, no fill at rest, a neutral tint on hover
+//
+// Type is deliberately SMALL and tight: chrome should read as chrome and stay
+// out of the way of the page it frames. Nothing here is a raw hex — every
+// colour resolves a registered token (see `_gauzy-theme-maps.scss`) with an
+// alpha-neutral fallback, so one value reads correctly on the light AND the
+// dark themes without a per-theme branch.
+// ─────────────────────────────────────────────────────────────────────────────
+@use 'themes' as *;
+
+// ── Chrome ───────────────────────────────────────────────────────────────────
+// The same values the overlay menus and the workspace switcher use. The shadow
+// is an interpolated literal because a `var()` fallback swallows every comma
+// after the first, so the two-layer list has to be emitted verbatim.
+$panel-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+$panel-shadow: #{'var(--gauzy-overlay-shadow, 0 8px 24px -6px rgba(0, 0, 0, 0.16), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
+$panel-hover-tint: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+$panel-active-tint: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+
+// Surface radius for the panel itself, row radius for the things inside it —
+// the same two-step scale as the cards and the overlay menus, never a literal.
+$panel-radius: var(--border-radius, 8px);
+$panel-row-radius: var(--gauzy-radius-sm, 6px);
+
+// ── Type scale ───────────────────────────────────────────────────────────────
+// THREE visible steps — 9px, 10px, 12px. Five names, because five jobs share
+// them; a fourth SIZE is a sign the panel is doing too much.
+//
+// The panel above the page is not the page: 12px is the TITLE here, while the
+// page's own body copy is 14px. Anything in a panel that reads at page size is
+// competing with the page it floats over.
+$panel-text-micro: 0.5625rem; //  9px — timestamps, hint text, footnotes
+$panel-text-body: 0.5625rem; //   9px — running copy inside a card
+$panel-text-label: 0.625rem; //  10px — section overlines, captions
+$panel-text-row: 0.625rem; //    10px — row labels, control labels
+$panel-text-title: 0.75rem; //   12px — the panel's own title
+
+// ── Spacing ──────────────────────────────────────────────────────────────────
+// One small rhythm. `$panel-gutter` is the inline inset EVERY row, header and
+// footer shares, so every label lines up down the left edge of the panel.
+$panel-pad: 0.375rem; //      6px — inset of the container
+$panel-gutter: 0.625rem; //  10px — inline padding of a row / header / footer
+$panel-row-pad-y: 0.375rem; // 6px — block padding of a row
+$panel-gap: 0.125rem; //      2px — between sibling rows
+
+/**
+ * The container chrome: one hairline, one soft shadow, the surface radius.
+ * `background-basic-color-1` rather than a transparent inherit — these panels
+ * float over page content, so the surface has to be opaque.
+ */
+@mixin gauzy-panel-surface() {
+  border: 1px solid #{$panel-hairline};
+  border-radius: $panel-radius;
+  box-shadow: #{$panel-shadow};
+  background-color: nb-theme(background-basic-color-1);
+  color: nb-theme(text-basic-color);
+  // Chrome sets its own scale; it must not inherit the page's 14px body.
+  font-family: nb-theme(font-family-primary);
+  font-size: $panel-text-row;
+  line-height: 1.4;
+}
+
+/**
+ * The title bar: a 12px title on the left, the close affordance on the right,
+ * separated from the body by a hairline rather than by empty space (the body
+ * scrolls under it, so the line is what tells the eye where the panel starts).
+ */
+@mixin gauzy-panel-header() {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  // Flush with the panel edge, cancelling the container's own inset. The
+  // title then keeps the gutter every row below it uses, so the whole panel
+  // reads off one left edge; the trailing side is one step tighter because
+  // the close button carries its own padding out to the corner.
+  margin: calc(-1 * #{$panel-pad}) calc(-1 * #{$panel-pad}) 0;
+  padding: 0.5rem $panel-gutter 0.5rem calc(#{$panel-gutter} + #{$panel-pad});
+  border-bottom: 1px solid #{$panel-hairline};
+}
+
+@mixin gauzy-panel-title() {
+  margin: 0;
+  font-size: $panel-text-title;
+  font-weight: 600;
+  // Tightened: small semibold type otherwise reads loose at this size.
+  letter-spacing: -0.006em;
+  line-height: 1.125rem;
+  color: nb-theme(text-basic-color);
+}
+
+/**
+ * Close affordance. A real square target with a hover tint — these panels used
+ * to close on a bare 12px glyph absolutely positioned in the corner, which is
+ * both a ~12px hit area and invisible to the keyboard.
+ */
+@mixin gauzy-panel-close() {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 1.375rem;
+  height: 1.375rem;
+  padding: 0;
+  border: 0;
+  border-radius: $panel-row-radius;
+  background: transparent;
+  color: nb-theme(text-hint-color);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease-in-out,
+    color 0.12s ease-in-out;
+
+  &:hover {
+    background-color: #{$panel-hover-tint};
+    color: nb-theme(text-basic-color);
+  }
+
+  &:focus-visible {
+    outline: 2px solid nb-theme(color-primary-default);
+    outline-offset: -2px;
+  }
+
+  nb-icon,
+  i {
+    font-size: 0.75rem;
+    width: 0.75rem;
+    height: 0.75rem;
+    line-height: 1;
+  }
+}
+
+/**
+ * Section overline — the 10px muted, tracked-out caps label that groups a run
+ * of rows. This is what replaces the panels' second and third heading levels:
+ * one title per panel, and everything below it is a group label.
+ */
+@mixin gauzy-panel-overline() {
+  display: block;
+  margin: 0;
+  padding: 0.5rem $panel-gutter 0.25rem;
+  font-size: $panel-text-label;
+  font-weight: 600;
+  // Caps need back the tracking that uppercasing takes away.
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1;
+  color: nb-theme(text-hint-color);
+  user-select: none;
+}
+
+/**
+ * A flat menu row. The same contract as `gauzy-overlay-item()` in
+ * `_overlays.scss`, one step tighter: these panels are chrome, not menus opened
+ * over the page.
+ */
+@mixin gauzy-panel-row() {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  margin: 0;
+  padding: $panel-row-pad-y $panel-gutter;
+  border: 0;
+  border-radius: $panel-row-radius;
+  box-shadow: none;
+  background-color: transparent;
+  color: nb-theme(text-basic-color);
+  font-size: $panel-text-row;
+  font-weight: 400;
+  line-height: 1rem;
+  text-align: start;
+  text-decoration: none;
+  cursor: pointer;
+  // Colour only: transitioning `all` animates the radius too and makes the row
+  // look like it is inflating into a block.
+  transition:
+    background-color 0.12s ease-in-out,
+    color 0.12s ease-in-out;
+
+  &:hover {
+    background-color: #{$panel-hover-tint};
+    color: nb-theme(text-basic-color);
+  }
+
+  &:focus-visible {
+    outline: 2px solid nb-theme(color-primary-default);
+    outline-offset: -2px;
+  }
+
+  // One step above the label, not two: a 14px glyph next to 11px text reads
+  // as the row's subject rather than as its marker.
+  nb-icon,
+  i {
+    flex: 0 0 auto;
+    font-size: 0.8125rem;
+    width: 0.8125rem;
+    height: 0.8125rem;
+    color: nb-theme(text-hint-color);
+  }
+}
+
+/**
+ * A row that HOSTS a control (a select, a toggle) instead of being one: label
+ * on the left, widget on the right, and no hover tint — the target is the
+ * widget, so lighting up the whole row would be a lie.
+ */
+@mixin gauzy-panel-control-row() {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  margin: 0;
+  padding: $panel-row-pad-y $panel-gutter;
+  font-size: $panel-text-row;
+  font-weight: 400;
+  line-height: 1rem;
+  color: nb-theme(text-basic-color);
+}
+
+/**
+ * Hairline between two groups of rows. Never `divider-color`: that resolves to
+ * #edf1f7 on the light themes and vanishes on the dark ones.
+ */
+@mixin gauzy-panel-divider() {
+  height: 1px;
+  margin: $panel-pad 0;
+  border: 0;
+  background-color: #{$panel-hairline};
+}
+
+/**
+ * Scroll port for a panel body. `overscroll-behavior: contain` stops the page
+ * behind the panel from taking over the wheel once the list hits its end.
+ */
+@mixin gauzy-panel-scroll() {
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+}
+
+/**
+ * Footer strip — 9px muted meta at the foot of a panel, above a hairline.
+ */
+@mixin gauzy-panel-footer() {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin: $panel-pad calc(-1 * #{$panel-pad}) calc(-1 * #{$panel-pad});
+  padding: 0.4375rem calc(#{$panel-gutter} + #{$panel-pad});
+  border-top: 1px solid #{$panel-hairline};
+  font-size: $panel-text-micro;
+  line-height: 1;
+  color: nb-theme(text-hint-color);
+}

--- a/packages/ui-core/static/styles/@shared/_panel.scss
+++ b/packages/ui-core/static/styles/@shared/_panel.scss
@@ -1,94 +1,41 @@
-// ── Chrome panels ────────────────────────────────────────────────────────────
-// The three panels that open out of the app shell — "What's New" (the gift
-// action in the header), "Quick Settings" (the gear action beside it) and the
-// account menu (the user button at the foot of the sidebar) — are the same KIND
-// of surface: a small, dense popup of flat rows, opened from an icon and
-// dismissed by clicking away.
-//
-// Each had grown its own scale (an 18px heading over a peach-tinted card, a
-// 16px heading over 14px list rows, a 36x18rem box with a brand-tinted half),
-// so the three read as three different products. This partial is the ONE scale
-// they share, in the same spirit as `_overlays.scss`: that file owns the
-// overlays the CDK renders at <body> level, this one owns the panels the layout
-// positions itself, and both describe the same container/item split —
-//
-//   CONTAINER  one hairline + one soft shadow + the surface radius + small pad
-//   ITEMS      flat rows: no border, no fill at rest, a neutral tint on hover
-//
-// Type is deliberately SMALL and tight: chrome should read as chrome and stay
-// out of the way of the page it frames. Nothing here is a raw hex — every
-// colour resolves a registered token (see `_gauzy-theme-maps.scss`) with an
-// alpha-neutral fallback, so one value reads correctly on the light AND the
-// dark themes without a per-theme branch.
-// ─────────────────────────────────────────────────────────────────────────────
+// Shared design language for the shell chrome panels: What's New, Quick
+// Settings and the account menu.
 @use 'themes' as *;
 
-// ── Chrome ───────────────────────────────────────────────────────────────────
-// The same values the overlay menus and the workspace switcher use. The shadow
-// is an interpolated literal because a `var()` fallback swallows every comma
-// after the first, so the two-layer list has to be emitted verbatim.
 $panel-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
 $panel-shadow: #{'var(--gauzy-overlay-shadow, 0 8px 24px -6px rgba(0, 0, 0, 0.16), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
 $panel-hover-tint: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
 $panel-active-tint: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
 
-// Surface radius for the panel itself, row radius for the things inside it —
-// the same two-step scale as the cards and the overlay menus, never a literal.
 $panel-radius: var(--border-radius, 8px);
 $panel-row-radius: var(--gauzy-radius-sm, 6px);
 
-// ── Type scale ───────────────────────────────────────────────────────────────
-// THREE visible steps — 9px, 10px, 12px. Five names, because five jobs share
-// them; a fourth SIZE is a sign the panel is doing too much.
-//
-// The panel above the page is not the page: 12px is the TITLE here, while the
-// page's own body copy is 14px. Anything in a panel that reads at page size is
-// competing with the page it floats over.
-$panel-text-micro: 0.5625rem; //  9px — timestamps, hint text, footnotes
-$panel-text-body: 0.5625rem; //   9px — running copy inside a card
-$panel-text-label: 0.625rem; //  10px — section overlines, captions
-$panel-text-row: 0.625rem; //    10px — row labels, control labels
-$panel-text-title: 0.75rem; //   12px — the panel's own title
+$panel-text-micro: 0.5625rem; //  9px
+$panel-text-label: 0.625rem; //  10px
+$panel-text-row: 0.625rem; //    10px
+$panel-text-title: 0.75rem; //   12px
 
-// ── Spacing ──────────────────────────────────────────────────────────────────
-// One small rhythm. `$panel-gutter` is the inline inset EVERY row, header and
-// footer shares, so every label lines up down the left edge of the panel.
-$panel-pad: 0.375rem; //      6px — inset of the container
-$panel-gutter: 0.625rem; //  10px — inline padding of a row / header / footer
-$panel-row-pad-y: 0.375rem; // 6px — block padding of a row
-$panel-gap: 0.125rem; //      2px — between sibling rows
+$panel-pad: 0.375rem; //      6px
+$panel-gutter: 0.625rem; //  10px
+$panel-row-pad-y: 0.375rem; // 6px
+$panel-gap: 0.125rem; //      2px
 
-/**
- * The container chrome: one hairline, one soft shadow, the surface radius.
- * `background-basic-color-1` rather than a transparent inherit — these panels
- * float over page content, so the surface has to be opaque.
- */
 @mixin gauzy-panel-surface() {
   border: 1px solid #{$panel-hairline};
   border-radius: $panel-radius;
   box-shadow: #{$panel-shadow};
   background-color: nb-theme(background-basic-color-1);
   color: nb-theme(text-basic-color);
-  // Chrome sets its own scale; it must not inherit the page's 14px body.
   font-family: nb-theme(font-family-primary);
   font-size: $panel-text-row;
   line-height: 1.4;
 }
 
-/**
- * The title bar: a 12px title on the left, the close affordance on the right,
- * separated from the body by a hairline rather than by empty space (the body
- * scrolls under it, so the line is what tells the eye where the panel starts).
- */
 @mixin gauzy-panel-header() {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  // Flush with the panel edge, cancelling the container's own inset. The
-  // title then keeps the gutter every row below it uses, so the whole panel
-  // reads off one left edge; the trailing side is one step tighter because
-  // the close button carries its own padding out to the corner.
   margin: calc(-1 * #{$panel-pad}) calc(-1 * #{$panel-pad}) 0;
   padding: 0.5rem $panel-gutter 0.5rem calc(#{$panel-gutter} + #{$panel-pad});
   border-bottom: 1px solid #{$panel-hairline};
@@ -98,17 +45,11 @@ $panel-gap: 0.125rem; //      2px — between sibling rows
   margin: 0;
   font-size: $panel-text-title;
   font-weight: 600;
-  // Tightened: small semibold type otherwise reads loose at this size.
   letter-spacing: -0.006em;
   line-height: 1.125rem;
   color: nb-theme(text-basic-color);
 }
 
-/**
- * Close affordance. A real square target with a hover tint — these panels used
- * to close on a bare 12px glyph absolutely positioned in the corner, which is
- * both a ~12px hit area and invisible to the keyboard.
- */
 @mixin gauzy-panel-close() {
   display: inline-flex;
   align-items: center;
@@ -145,18 +86,12 @@ $panel-gap: 0.125rem; //      2px — between sibling rows
   }
 }
 
-/**
- * Section overline — the 10px muted, tracked-out caps label that groups a run
- * of rows. This is what replaces the panels' second and third heading levels:
- * one title per panel, and everything below it is a group label.
- */
 @mixin gauzy-panel-overline() {
   display: block;
   margin: 0;
   padding: 0.5rem $panel-gutter 0.25rem;
   font-size: $panel-text-label;
   font-weight: 600;
-  // Caps need back the tracking that uppercasing takes away.
   letter-spacing: 0.06em;
   text-transform: uppercase;
   line-height: 1;
@@ -164,11 +99,6 @@ $panel-gap: 0.125rem; //      2px — between sibling rows
   user-select: none;
 }
 
-/**
- * A flat menu row. The same contract as `gauzy-overlay-item()` in
- * `_overlays.scss`, one step tighter: these panels are chrome, not menus opened
- * over the page.
- */
 @mixin gauzy-panel-row() {
   display: flex;
   align-items: center;
@@ -187,8 +117,6 @@ $panel-gap: 0.125rem; //      2px — between sibling rows
   text-align: start;
   text-decoration: none;
   cursor: pointer;
-  // Colour only: transitioning `all` animates the radius too and makes the row
-  // look like it is inflating into a block.
   transition:
     background-color 0.12s ease-in-out,
     color 0.12s ease-in-out;
@@ -203,8 +131,6 @@ $panel-gap: 0.125rem; //      2px — between sibling rows
     outline-offset: -2px;
   }
 
-  // One step above the label, not two: a 14px glyph next to 11px text reads
-  // as the row's subject rather than as its marker.
   nb-icon,
   i {
     flex: 0 0 auto;
@@ -215,11 +141,6 @@ $panel-gap: 0.125rem; //      2px — between sibling rows
   }
 }
 
-/**
- * A row that HOSTS a control (a select, a toggle) instead of being one: label
- * on the left, widget on the right, and no hover tint — the target is the
- * widget, so lighting up the whole row would be a lie.
- */
 @mixin gauzy-panel-control-row() {
   display: flex;
   align-items: center;
@@ -234,10 +155,6 @@ $panel-gap: 0.125rem; //      2px — between sibling rows
   color: nb-theme(text-basic-color);
 }
 
-/**
- * Hairline between two groups of rows. Never `divider-color`: that resolves to
- * #edf1f7 on the light themes and vanishes on the dark ones.
- */
 @mixin gauzy-panel-divider() {
   height: 1px;
   margin: $panel-pad 0;
@@ -245,19 +162,12 @@ $panel-gap: 0.125rem; //      2px — between sibling rows
   background-color: #{$panel-hairline};
 }
 
-/**
- * Scroll port for a panel body. `overscroll-behavior: contain` stops the page
- * behind the panel from taking over the wheel once the list hits its end.
- */
 @mixin gauzy-panel-scroll() {
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: contain;
 }
 
-/**
- * Footer strip — 9px muted meta at the foot of a panel, above a hairline.
- */
 @mixin gauzy-panel-footer() {
   display: flex;
   align-items: center;

--- a/packages/ui-core/static/styles/_overlays.scss
+++ b/packages/ui-core/static/styles/_overlays.scss
@@ -330,6 +330,45 @@ $overlay-item-padding-x: 0.625rem; // 10px
     text-transform: uppercase;
   }
 
+  // ── Overlays opened FROM a chrome panel ─────────────────────────────────
+  // The Quick Settings and account panels run on their own small scale (see
+  // `@shared/_panel`: 10px rows), so a dropdown of theirs rendering at the
+  // app-wide 13px menu size lands on the screen a size and a half larger than
+  // the trigger it just came out of. These two classes are opted INTO by the
+  // handful of controls that live in those panels (`optionsListClass`,
+  // `nbPopoverClass`), so every other dropdown in the app keeps the standard
+  // size — this is a panel-local step down, not a global one.
+  .cdk-overlay-container nb-option-list.gz-panel-options {
+    nb-option {
+      padding: 0.3125rem 0.5rem;
+      font-size: 0.625rem;
+      line-height: 0.875rem;
+    }
+
+    // The language options carry a flag chip; at 10px the stock 18x12 is
+    // taller than the line it sits on.
+    nb-option .flag-icon {
+      width: 0.875rem;
+      height: 0.625rem;
+    }
+  }
+
+  // The theme picker's list. It is a popover rather than an inline panel
+  // because expanding eight rows INSIDE Quick Settings gave that panel its own
+  // scrollbar and pushed the Settings button out of reach; an overlay opens
+  // over the page instead and leaves the panel exactly as it was.
+  .cdk-overlay-container .gz-theme-popover nb-popover {
+    // Its own rows carry the padding, so the container only insets enough that
+    // a hovered row's radius never touches the edge.
+    padding: #{$overlay-padding};
+
+    // No arrow: this is a menu hanging off a control, not a speech bubble —
+    // the same call as the rail flyout above.
+    .arrow {
+      display: none;
+    }
+  }
+
   // ── Separators ──────────────────────────────────────────────────────────
   // 1px hairlines at low alpha, never a thick divider. Bootstrap's reboot
   // gives every `hr` a 1px `currentColor` border at 25% opacity, which reads

--- a/packages/ui-core/static/styles/_overlays.scss
+++ b/packages/ui-core/static/styles/_overlays.scss
@@ -331,13 +331,6 @@ $overlay-item-padding-x: 0.625rem; // 10px
   }
 
   // ── Overlays opened FROM a chrome panel ─────────────────────────────────
-  // The Quick Settings and account panels run on their own small scale (see
-  // `@shared/_panel`: 10px rows), so a dropdown of theirs rendering at the
-  // app-wide 13px menu size lands on the screen a size and a half larger than
-  // the trigger it just came out of. These two classes are opted INTO by the
-  // handful of controls that live in those panels (`optionsListClass`,
-  // `nbPopoverClass`), so every other dropdown in the app keeps the standard
-  // size — this is a panel-local step down, not a global one.
   .cdk-overlay-container nb-option-list.gz-panel-options {
     nb-option {
       padding: 0.3125rem 0.5rem;
@@ -345,25 +338,15 @@ $overlay-item-padding-x: 0.625rem; // 10px
       line-height: 0.875rem;
     }
 
-    // The language options carry a flag chip; at 10px the stock 18x12 is
-    // taller than the line it sits on.
     nb-option .flag-icon {
       width: 0.875rem;
       height: 0.625rem;
     }
   }
 
-  // The theme picker's list. It is a popover rather than an inline panel
-  // because expanding eight rows INSIDE Quick Settings gave that panel its own
-  // scrollbar and pushed the Settings button out of reach; an overlay opens
-  // over the page instead and leaves the panel exactly as it was.
   .cdk-overlay-container .gz-theme-popover nb-popover {
-    // Its own rows carry the padding, so the container only insets enough that
-    // a hovered row's radius never touches the edge.
     padding: #{$overlay-padding};
 
-    // No arrow: this is a menu hanging off a control, not a speech bubble —
-    // the same call as the rail flyout above.
     .arrow {
       display: none;
     }

--- a/packages/ui-core/static/styles/_overlays.scss
+++ b/packages/ui-core/static/styles/_overlays.scss
@@ -344,7 +344,7 @@ $overlay-item-padding-x: 0.625rem; // 10px
     }
   }
 
-  .cdk-overlay-container .gz-theme-popover nb-popover {
+  .cdk-overlay-container nb-popover.gz-theme-popover {
     padding: #{$overlay-padding};
 
     .arrow {

--- a/packages/ui-core/theme/src/lib/components/gauzy-logo/gauzy-logo.component.scss
+++ b/packages/ui-core/theme/src/lib/components/gauzy-logo/gauzy-logo.component.scss
@@ -43,7 +43,7 @@
         // Unpressured, both resolve to the same width (text, capped below).
         width: auto;
         max-width: 150px;
-        font-size: 0.875rem;
+        font-size: 0.75rem;
         font-weight: 400;
         color: nb-theme(text-basic-color);
       }
@@ -167,7 +167,7 @@ nb-accordion-item:first-child.collapsed nb-accordion-item-header.principal:hover
 
 .text {
   margin: 0 10px;
-  font-size: 13px;
+  font-size: 0.75rem;
   font-style: normal;
   font-weight: 500;
   line-height: 16px;

--- a/packages/ui-core/theme/src/lib/components/header/header.component.scss
+++ b/packages/ui-core/theme/src/lib/components/header/header.component.scss
@@ -54,7 +54,9 @@ $header-text-color: var(--gauzy-text-color-2, var(--text-hint-color));
       // Underline only on hover: a permanently underlined link in a strip this
       // thin turns the whole band into a rule.
       border-bottom: 1px solid transparent;
-      transition: color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+      transition:
+        color 0.15s ease-in-out,
+        border-color 0.15s ease-in-out;
     }
 
     a:hover,
@@ -338,8 +340,26 @@ $header-text-color: var(--gauzy-text-color-2, var(--text-hint-color));
 }
 
 :host .actions nb-action > nb-icon {
-  font-size: 1rem;
+  font-size: 0.875rem;
   color: $header-text-color;
+}
+
+// The icon-only triggers at the end of the cluster (What's New, Quick Settings,
+// the small-screen selector toggle). Nebular sizes an nb-action from the
+// actions-medium padding, which makes each one a wide slab beside the compact
+// selector pills; a square the height of the pills reads as an icon button.
+:host .actions nb-action.toggle-layout {
+  width: var(--gauzy-header-control-height, 1.75rem);
+  height: var(--gauzy-header-control-height, 1.75rem);
+  padding: 0;
+  justify-content: center;
+  border-radius: var(--gauzy-radius-sm, 6px);
+  cursor: pointer;
+  transition: background-color 0.12s ease-in-out;
+
+  &:hover {
+    background-color: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+  }
 }
 
 .employee-selector,

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
@@ -1,4 +1,4 @@
-<section class="whats-new-panel">
+<section class="whats-new-panel" gauzyOutside (clickOutside)="onClickOutside($event)">
 	<header class="panel-header">
 		<h3 class="panel-title">{{ 'CHANGELOG_MENU.HEADER' | translate }}</h3>
 		<button

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
@@ -1,9 +1,20 @@
-<section class="section-wrapper">
-	<span class="cancel"><i class="fas fa-times" (click)="closeSidebar()"></i></span>
-	<div class="whats-new-wrapper">
-		<h3 class="main-header">
-			{{ 'CHANGELOG_MENU.HEADER' | translate }}
-		</h3>
+<section class="whats-new-panel">
+	<header class="panel-header">
+		<h3 class="panel-title">{{ 'CHANGELOG_MENU.HEADER' | translate }}</h3>
+		<!-- A real button, not the bare glyph this used to be: that was a ~12px
+		     hit area, absolutely positioned over the first entry, and unreachable
+		     from the keyboard. -->
+		<button
+			type="button"
+			class="panel-close"
+			[attr.aria-label]="'BUTTONS.CLOSE' | translate"
+			(click)="closeSidebar()"
+		>
+			<nb-icon icon="close-outline"></nb-icon>
+		</button>
+	</header>
+
+	<div class="panel-body">
 		@for (item of items$ | async; track item.id) {
 			<ngx-changelog-entry [entry]="item" />
 		}

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
@@ -1,9 +1,6 @@
 <section class="whats-new-panel">
 	<header class="panel-header">
 		<h3 class="panel-title">{{ 'CHANGELOG_MENU.HEADER' | translate }}</h3>
-		<!-- A real button, not the bare glyph this used to be: that was a ~12px
-		     hit area, absolutely positioned over the first entry, and unreachable
-		     from the keyboard. -->
 		<button
 			type="button"
 			class="panel-close"
@@ -16,7 +13,7 @@
 
 	<div class="panel-body">
 		@for (item of items$ | async; track item.id) {
-			<ngx-changelog-entry [entry]="item" />
+			<ngx-changelog-entry class="compact" [entry]="item" />
 		}
 	</div>
 </section>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.html
@@ -13,7 +13,7 @@
 
 	<div class="panel-body">
 		@for (item of items$ | async; track item.id) {
-			<ngx-changelog-entry class="compact" [entry]="item" />
+			<ngx-changelog-entry class="compact" [class.last]="$last" [entry]="item" />
 		}
 	</div>
 </section>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.scss
@@ -1,13 +1,146 @@
-@use '@shared/_whats-new';
-@use 'gauzy/_gauzy-dialogs';
+@use 'themes' as *;
+@use '@shared/panel' as *;
 
-::ng-deep.changelog-sidebar {
-  .main-container {
-    width: 33rem !important;
-  }
+// This used to pull in `@shared/_whats-new`, the partial the LOGIN page's
+// What's New panel also uses — so the two surfaces shared a peach-tinted card,
+// a 25px pad and an 18px heading. They are not the same surface: the login one
+// is a marketing panel on an empty page, this one is app chrome hanging off a
+// header icon. It now follows the panel scale (`@shared/_panel`) instead, and
+// the login panel keeps the old partial untouched.
+//
+// The container box — radius, hairline, shadow, surface colour — is drawn by
+// the nb-sidebar this renders into (`.changelog-sidebar.expanded
+// .main-container-fixed` in one-column.layout.scss), so everything here is
+// inset, rhythm and type.
+
+:host {
+  display: block;
+  width: 100%;
 }
-i {
-  position: absolute;
-  right: 0.75rem;
-  top: 0.75rem;
+
+.whats-new-panel {
+  display: flex;
+  flex-direction: column;
+  padding: $panel-pad;
+  box-sizing: border-box;
+  font-family: nb-theme(font-family-primary);
+  font-size: $panel-text-row;
+  line-height: 1.4;
+  color: nb-theme(text-basic-color);
+}
+
+.panel-header {
+  @include gauzy-panel-header();
+  flex: 0 0 auto;
+  // The scroll port is the sidebar's `.scrollable` (see one-column.layout.scss
+  // for why it cannot be this component), so the title bar holds its place by
+  // sticking to the top of it. It needs the opaque surface and a z-index of
+  // its own, or the entries scroll through it.
+  position: sticky;
+  top: calc(-1 * #{$panel-pad});
+  z-index: 1;
+  background-color: nb-theme(background-basic-color-1);
+}
+
+.panel-title {
+  @include gauzy-panel-title();
+}
+
+.panel-close {
+  @include gauzy-panel-close();
+}
+
+.panel-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding-top: $panel-pad;
+}
+
+// ── Entry cards ──────────────────────────────────────────────────────────────
+// `ngx-changelog-entry` is the SHARED card (ui-core/shared), rendered here and
+// on the login page, so its own stylesheet stays as it is and the sidebar's
+// denser reading of it lives here, scoped to this panel. Everything below is a
+// step down the panel scale: 10px title, 9px date, 9px copy.
+.panel-body ::ng-deep {
+  ngx-changelog-entry {
+    display: block;
+
+    // The divider belongs BETWEEN cards, so the last one does not draw a
+    // line against the panel's bottom edge.
+    &:last-of-type .entry {
+      border-bottom: 0;
+    }
+  }
+
+  .entry {
+    // Was `1px solid lightgray` — a fixed grey that is a hard line on a
+    // white surface and nearly invisible on the dark themes.
+    border-bottom: 1px solid #{$panel-hairline};
+    border-radius: $panel-row-radius;
+    padding: 0.5rem $panel-gutter 0.625rem;
+
+    &.linked:hover {
+      background-color: #{$panel-hover-tint};
+    }
+
+    .entry-headings-wrapper {
+      align-items: flex-start;
+      gap: 0.5rem;
+      margin-bottom: 0.1875rem;
+
+      .icon {
+        // Was a 15px right margin; the flex `gap` above owns the space
+        // now, so the icon only has to sit on the title's cap height.
+        margin: 0.0625rem 0 0;
+        width: 0.875rem;
+        height: 0.875rem;
+        font-size: 0.875rem;
+        color: nb-theme(text-hint-color);
+      }
+
+      .entry-headings {
+        min-width: 0;
+      }
+
+      .entry-header {
+        font-size: $panel-text-label;
+        font-weight: 600;
+        line-height: 0.875rem;
+        letter-spacing: -0.004em;
+        margin-bottom: 0.125rem;
+      }
+
+      .entry-header-date {
+        // The smallest step on the scale, tracked out and in caps: a
+        // date is metadata, and at 9px it reads as a stamp rather than
+        // as a second line of the title.
+        font-size: $panel-text-micro;
+        font-weight: 500;
+        line-height: 1;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: nb-theme(text-hint-color);
+      }
+    }
+
+    .paragraph {
+      margin: 0;
+      font-size: $panel-text-body;
+      line-height: 0.8125rem;
+      color: nb-theme(text-hint-color);
+    }
+
+    .entry-img {
+      margin: 0.375rem 0 0;
+      border-radius: $panel-row-radius;
+    }
+
+    .learn-more-hint {
+      margin: 0.3125rem 0 0;
+      // Sits with the copy it follows, not with the title above it.
+      font-size: $panel-text-micro;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+    }
+  }
 }

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.scss
@@ -1,18 +1,6 @@
 @use 'themes' as *;
 @use '@shared/panel' as *;
 
-// This used to pull in `@shared/_whats-new`, the partial the LOGIN page's
-// What's New panel also uses — so the two surfaces shared a peach-tinted card,
-// a 25px pad and an 18px heading. They are not the same surface: the login one
-// is a marketing panel on an empty page, this one is app chrome hanging off a
-// header icon. It now follows the panel scale (`@shared/_panel`) instead, and
-// the login panel keeps the old partial untouched.
-//
-// The container box — radius, hairline, shadow, surface colour — is drawn by
-// the nb-sidebar this renders into (`.changelog-sidebar.expanded
-// .main-container-fixed` in one-column.layout.scss), so everything here is
-// inset, rhythm and type.
-
 :host {
   display: block;
   width: 100%;
@@ -32,10 +20,6 @@
 .panel-header {
   @include gauzy-panel-header();
   flex: 0 0 auto;
-  // The scroll port is the sidebar's `.scrollable` (see one-column.layout.scss
-  // for why it cannot be this component), so the title bar holds its place by
-  // sticking to the top of it. It needs the opaque surface and a z-index of
-  // its own, or the entries scroll through it.
   position: sticky;
   top: calc(-1 * #{$panel-pad});
   z-index: 1;
@@ -54,93 +38,4 @@
   flex: 1 1 auto;
   min-height: 0;
   padding-top: $panel-pad;
-}
-
-// ── Entry cards ──────────────────────────────────────────────────────────────
-// `ngx-changelog-entry` is the SHARED card (ui-core/shared), rendered here and
-// on the login page, so its own stylesheet stays as it is and the sidebar's
-// denser reading of it lives here, scoped to this panel. Everything below is a
-// step down the panel scale: 10px title, 9px date, 9px copy.
-.panel-body ::ng-deep {
-  ngx-changelog-entry {
-    display: block;
-
-    // The divider belongs BETWEEN cards, so the last one does not draw a
-    // line against the panel's bottom edge.
-    &:last-of-type .entry {
-      border-bottom: 0;
-    }
-  }
-
-  .entry {
-    // Was `1px solid lightgray` — a fixed grey that is a hard line on a
-    // white surface and nearly invisible on the dark themes.
-    border-bottom: 1px solid #{$panel-hairline};
-    border-radius: $panel-row-radius;
-    padding: 0.5rem $panel-gutter 0.625rem;
-
-    &.linked:hover {
-      background-color: #{$panel-hover-tint};
-    }
-
-    .entry-headings-wrapper {
-      align-items: flex-start;
-      gap: 0.5rem;
-      margin-bottom: 0.1875rem;
-
-      .icon {
-        // Was a 15px right margin; the flex `gap` above owns the space
-        // now, so the icon only has to sit on the title's cap height.
-        margin: 0.0625rem 0 0;
-        width: 0.875rem;
-        height: 0.875rem;
-        font-size: 0.875rem;
-        color: nb-theme(text-hint-color);
-      }
-
-      .entry-headings {
-        min-width: 0;
-      }
-
-      .entry-header {
-        font-size: $panel-text-label;
-        font-weight: 600;
-        line-height: 0.875rem;
-        letter-spacing: -0.004em;
-        margin-bottom: 0.125rem;
-      }
-
-      .entry-header-date {
-        // The smallest step on the scale, tracked out and in caps: a
-        // date is metadata, and at 9px it reads as a stamp rather than
-        // as a second line of the title.
-        font-size: $panel-text-micro;
-        font-weight: 500;
-        line-height: 1;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-        color: nb-theme(text-hint-color);
-      }
-    }
-
-    .paragraph {
-      margin: 0;
-      font-size: $panel-text-body;
-      line-height: 0.8125rem;
-      color: nb-theme(text-hint-color);
-    }
-
-    .entry-img {
-      margin: 0.375rem 0 0;
-      border-radius: $panel-row-radius;
-    }
-
-    .learn-more-hint {
-      margin: 0.3125rem 0 0;
-      // Sits with the copy it follows, not with the title above it.
-      font-size: $panel-text-micro;
-      font-weight: 600;
-      letter-spacing: 0.01em;
-    }
-  }
 }

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/changelog/changelog.component.ts
@@ -2,8 +2,12 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { IChangelog } from '@gauzy/contracts';
 import { NbSidebarService } from '@nebular/theme';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { Observable } from 'rxjs';
+import { asyncScheduler, merge, Observable } from 'rxjs';
+import { filter, observeOn, take, tap } from 'rxjs/operators';
 import { ChangelogService } from '@gauzy/ui-core/core';
+
+/** Tag of the Nebular sidebar this component is rendered into. */
+export const CHANGELOG_SIDEBAR_TAG = 'changelog_sidebar';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -15,6 +19,9 @@ import { ChangelogService } from '@gauzy/ui-core/core';
 export class ChangelogComponent implements OnInit, OnDestroy {
 	items$: Observable<IChangelog[]> = this._changelogService.changelogs$;
 
+	/** Whether the panel is on screen, i.e. whether an outside click has anything to dismiss. */
+	private state: boolean;
+
 	constructor(
 		private readonly _changelogService: ChangelogService,
 		private readonly _sidebarService: NbSidebarService
@@ -22,10 +29,55 @@ export class ChangelogComponent implements OnInit, OnDestroy {
 
 	ngOnInit() {
 		this._changelogService.getAll({ isFeature: 0 }).pipe(untilDestroyed(this)).subscribe();
+
+		this.syncState();
+		merge(
+			this._sidebarService.onToggle(),
+			this._sidebarService.onExpand(),
+			this._sidebarService.onCollapse(),
+			this._sidebarService.onCompact()
+		)
+			.pipe(
+				filter(({ tag }) => tag === CHANGELOG_SIDEBAR_TAG),
+				// DO NOT make this synchronous. The header action calls the sidebar service from a
+				// click handler, and `OutsideDirective` listens on `document:click` WITHOUT capture, so
+				// it runs later in that same dispatch. If `state` were already true by then, the panel
+				// would collapse on the very click that opened it. Same reasoning as the Quick Settings
+				// panel next door, which hit exactly that.
+				observeOn(asyncScheduler),
+				untilDestroyed(this)
+			)
+			.subscribe(() => this.syncState());
 	}
 
+	/**
+	 * Read the panel's current state. `take(1)` is what makes this safe to call repeatedly:
+	 * `getSidebarState()` returns a ReplaySubject that receives exactly one value.
+	 */
+	private syncState(): void {
+		this._sidebarService
+			.getSidebarState(CHANGELOG_SIDEBAR_TAG)
+			.pipe(
+				take(1),
+				tap((state) => (this.state = state === 'expanded')),
+				untilDestroyed(this)
+			)
+			.subscribe();
+	}
+
+	/**
+	 * Collapses rather than toggles: this is only ever called to close the panel,
+	 * from the X button and from a click outside it.
+	 */
 	public closeSidebar() {
-		this._sidebarService.toggle(false, 'changelog_sidebar');
+		this._sidebarService.collapse(CHANGELOG_SIDEBAR_TAG);
+	}
+
+	/** `gauzyOutside` emits whether the click landed INSIDE the host, not outside it. */
+	public onClickOutside(clickedInside: boolean) {
+		if (!clickedInside && this.state) {
+			this.closeSidebar();
+		}
 	}
 
 	ngOnDestroy(): void {}

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/layout-selector/layout-selector.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/layout-selector/layout-selector.component.html
@@ -1,40 +1,37 @@
 <div class="theme-container">
-  <span class="preferred-layout"
-    >{{ 'SETTINGS_MENU.PREFERRED_LAYOUT' | translate }}
-    <nb-icon
-      [nbTooltip]="'SETTINGS_MENU.PREFERRED_LAYOUT_TOOLTIP' | translate"
-      icon="question-mark-circle-outline"
-      ></nb-icon
-    ></span>
-    <div class="layout-control">
-      <nb-select
-        [placeholder]="'SETTINGS_MENU.PREFERRED_LAYOUT' | translate"
-        (selectedChange)="switchComponentLayout()"
-        [(selected)]="preferredComponentLayout"
-        [(ngModel)]="preferredComponentLayout"
-        status="basic"
-        size="small"
-        outline
-        >
-        @for (componentLayout of componentLayouts; track componentLayout) {
-          <nb-option
-            [value]="componentLayout"
-            >
-            {{ 'SETTINGS_MENU.' + componentLayout | translate }}</nb-option
-            >
-          }
-        </nb-select>
-        <button
-          class="reset-layout"
-          type="button"
-          [nbTooltip]="'SETTINGS_MENU.RESET_LAYOUT_TOOLTIP' | translate"
-          status="basic"
-          nbButton
-          outline
-          size="tiny"
-          (click)="resetLayoutForAllComponents()"
-          >
-          {{ 'SETTINGS_MENU.RESET_LAYOUT' | translate }}
-        </button>
-      </div>
-    </div>
+	<span class="preferred-layout"
+		>{{ 'SETTINGS_MENU.PREFERRED_LAYOUT' | translate }}
+		<nb-icon
+			[nbTooltip]="'SETTINGS_MENU.PREFERRED_LAYOUT_TOOLTIP' | translate"
+			icon="question-mark-circle-outline"
+		></nb-icon
+	></span>
+	<div class="layout-control">
+		<nb-select
+			[placeholder]="'SETTINGS_MENU.PREFERRED_LAYOUT' | translate"
+			(selectedChange)="switchComponentLayout()"
+			[(selected)]="preferredComponentLayout"
+			[(ngModel)]="preferredComponentLayout"
+			status="basic"
+			size="small"
+			outline
+			optionsListClass="gz-panel-options"
+		>
+			@for (componentLayout of componentLayouts; track componentLayout) {
+				<nb-option [value]="componentLayout"> {{ 'SETTINGS_MENU.' + componentLayout | translate }}</nb-option>
+			}
+		</nb-select>
+		<button
+			class="reset-layout"
+			type="button"
+			[nbTooltip]="'SETTINGS_MENU.RESET_LAYOUT_TOOLTIP' | translate"
+			status="basic"
+			nbButton
+			outline
+			size="tiny"
+			(click)="resetLayoutForAllComponents()"
+		>
+			{{ 'SETTINGS_MENU.RESET_LAYOUT' | translate }}
+		</button>
+	</div>
+</div>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-language-selector/theme-language-selector.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-language-selector/theme-language-selector.component.html
@@ -1,32 +1,32 @@
 <div class="theme-container">
-  {{ 'SETTINGS_MENU.LANGUAGE' | translate }}
-  <div>
-    @if (languages.length) {
-      <nb-select
-        [(selected)]="preferredLanguage"
-        [(ngModel)]="preferredLanguage"
-        [placeholder]="'SETTINGS_MENU.ENGLISH' | translate"
-        (selectedChange)="switchLanguage()"
-        status="basic"
-        size="small"
-        outline
-        optionsListClass="fit-content"
-        >
-        <nb-select-label>
-          @if (getFlagUrl(selectedLanguage?.code); as flagUrl) {
-            <img class="flag-icon" [src]="flagUrl" (error)="onFlagError($event)" alt="" />
-          }
-          {{ selectedLanguage?.name | translate }}
-        </nb-select-label>
-        @for (lang of languages; track lang) {
-          <nb-option [value]="lang.value">
-            @if (getFlagUrl(lang.code); as flagUrl) {
-              <img class="flag-icon" [src]="flagUrl" (error)="onFlagError($event)" alt="" />
-            }
-            {{ lang.name | translate }}
-          </nb-option>
-        }
-      </nb-select>
-    }
-  </div>
+	{{ 'SETTINGS_MENU.LANGUAGE' | translate }}
+	<div>
+		@if (languages.length) {
+			<nb-select
+				[(selected)]="preferredLanguage"
+				[(ngModel)]="preferredLanguage"
+				[placeholder]="'SETTINGS_MENU.ENGLISH' | translate"
+				(selectedChange)="switchLanguage()"
+				status="basic"
+				size="small"
+				outline
+				optionsListClass="fit-content gz-panel-options"
+			>
+				<nb-select-label>
+					@if (getFlagUrl(selectedLanguage?.code); as flagUrl) {
+						<img class="flag-icon" [src]="flagUrl" (error)="onFlagError($event)" alt="" />
+					}
+					{{ selectedLanguage?.name | translate }}
+				</nb-select-label>
+				@for (lang of languages; track lang) {
+					<nb-option [value]="lang.value">
+						@if (getFlagUrl(lang.code); as flagUrl) {
+							<img class="flag-icon" [src]="flagUrl" (error)="onFlagError($event)" alt="" />
+						}
+						{{ lang.name | translate }}
+					</nb-option>
+				}
+			</nb-select>
+		}
+	</div>
 </div>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.html
@@ -1,13 +1,4 @@
 <div class="theme-card">
-	<!-- A disclosure button, not a combobox. This used to be an `nb-select` with
-	     ZERO options, used purely as a toggle: clicking it opened Nebular's own
-	     (empty) option-list overlay next to the inline list it was revealing, so
-	     the control promised a dropdown and delivered an empty box.
-
-	     The list itself is a POPOVER rather than the inline block it replaced.
-	     Eight rows expanding inside Quick Settings gave that panel its own
-	     scrollbar and pushed the Settings button below the fold; an overlay
-	     opens over the page and leaves the panel exactly the size it was. -->
 	<button
 		type="button"
 		class="theme-trigger"
@@ -27,8 +18,6 @@
 	</button>
 </div>
 
-<!-- Rendered into `.cdk-overlay-container`, so only rules written WITHOUT a
-     `:host` prefix reach it — see the component's stylesheet. -->
 <ng-template #themeList>
 	<div class="gz-theme-list" role="listbox">
 		@for (theme of themes; track theme.value) {

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.html
@@ -3,6 +3,7 @@
 		type="button"
 		class="theme-trigger"
 		[class.open]="isOpen"
+		aria-haspopup="true"
 		[attr.aria-expanded]="isOpen"
 		[nbPopover]="themeList"
 		nbPopoverTrigger="click"
@@ -19,14 +20,13 @@
 </div>
 
 <ng-template #themeList>
-	<div class="gz-theme-list" role="listbox">
+	<div class="gz-theme-list" role="group" [attr.aria-label]="'SETTINGS_MENU.THEMES' | translate">
 		@for (theme of themes; track theme.value) {
 			<button
 				type="button"
 				class="theme-option"
-				role="option"
 				[class.selected]="(selected | async)?.value === theme.value"
-				[attr.aria-selected]="(selected | async)?.value === theme.value"
+				[attr.aria-pressed]="(selected | async)?.value === theme.value"
 				(click)="selectTheme(theme.value)"
 			>
 				<span class="theme-thumb">

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.html
@@ -1,33 +1,51 @@
 <div class="theme-card">
-	<div class="theme-container">
-		{{ 'SETTINGS_MENU.THEMES' | translate }}
-		<nb-select
-			status="basic"
-			size="small"
-			outline
-			placeholder="{{ (selected | async)?.name | translate }}"
-			(click)="isOpen = !isOpen"
-			[class.open]="isOpen"
-		></nb-select>
-	</div>
-	@if (isOpen) {
-	<div class="themes">
-		@for (theme of themes; track theme) {
-		<div
-			[class.card-container]="(selected | async)?.value === theme.value"
-			[class.selected]="(selected | async)?.value === theme.value"
-			[class.card-container]="!((selected | async)?.value === theme.value)"
-			(click)="onSelectedTheme(theme.value)"
-		>
-			<span>
-				{{ theme.name | translate }}
-				<div class="check"></div
-			></span>
-			<div class="image-container">
-				<img [src]="theme.imageUrl" />
-			</div>
-		</div>
+	<!-- A disclosure button, not a combobox. This used to be an `nb-select` with
+	     ZERO options, used purely as a toggle: clicking it opened Nebular's own
+	     (empty) option-list overlay next to the inline list it was revealing, so
+	     the control promised a dropdown and delivered an empty box.
+
+	     The list itself is a POPOVER rather than the inline block it replaced.
+	     Eight rows expanding inside Quick Settings gave that panel its own
+	     scrollbar and pushed the Settings button below the fold; an overlay
+	     opens over the page and leaves the panel exactly the size it was. -->
+	<button
+		type="button"
+		class="theme-trigger"
+		[class.open]="isOpen"
+		[attr.aria-expanded]="isOpen"
+		[nbPopover]="themeList"
+		nbPopoverTrigger="click"
+		nbPopoverPlacement="bottom-end"
+		[nbPopoverOffset]="4"
+		nbPopoverClass="gz-theme-popover"
+	>
+		<span class="theme-trigger-label">{{ 'SETTINGS_MENU.THEMES' | translate }}</span>
+		<span class="theme-trigger-value">
+			<span class="theme-trigger-name">{{ (selected | async)?.name | translate }}</span>
+			<nb-icon class="theme-trigger-chevron" icon="chevron-down-outline"></nb-icon>
+		</span>
+	</button>
+</div>
+
+<!-- Rendered into `.cdk-overlay-container`, so only rules written WITHOUT a
+     `:host` prefix reach it — see the component's stylesheet. -->
+<ng-template #themeList>
+	<div class="gz-theme-list" role="listbox">
+		@for (theme of themes; track theme.value) {
+			<button
+				type="button"
+				class="theme-option"
+				role="option"
+				[class.selected]="(selected | async)?.value === theme.value"
+				[attr.aria-selected]="(selected | async)?.value === theme.value"
+				(click)="selectTheme(theme.value)"
+			>
+				<span class="theme-thumb">
+					<img [src]="theme.imageUrl" [alt]="" />
+				</span>
+				<span class="theme-name">{{ theme.name | translate }}</span>
+				<nb-icon class="theme-check" icon="checkmark-outline"></nb-icon>
+			</button>
 		}
 	</div>
-	}
-</div>
+</ng-template>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
@@ -1,24 +1,6 @@
 @use 'themes' as *;
 @use '@shared/panel' as *;
 
-// This component renders in exactly ONE place — the Quick Settings panel, via
-// `ngx-theme-selector-container [isClassic]="false"` — so it is styled on the
-// panel scale directly instead of being overridden from its parent.
-//
-// What it replaces: an empty `nb-select` used as a toggle (see the template),
-// and 48px rows carrying a 120px-wide screenshot each. Eight of those is a
-// filmstrip inside a 22.5rem panel; the thumbnail only has to say "light" or
-// "dark" and roughly which palette, which a 44px chip does.
-//
-// NOTE ON SELECTORS: the list is rendered by a popover, i.e. into
-// `.cdk-overlay-container` at the end of the document. Angular bakes this
-// component's `_ngcontent` attribute into those elements when it creates them,
-// so plain class selectors still reach them — but anything written under
-// `:host` does NOT, because the elements are no longer inside the host. Every
-// rule below the trigger is therefore deliberately top-level. The popover
-// CONTAINER itself (`nb-popover`) comes from Nebular, not from this template,
-// so its chrome lives in the global `_overlays.scss` under `.gz-theme-popover`.
-
 :host {
   display: block;
   width: 100%;
@@ -30,9 +12,6 @@
   width: 100%;
 }
 
-// ── Trigger ──────────────────────────────────────────────────────────────────
-// Laid out like the control rows above it (label left, value right) so the four
-// preference rows share one left edge and one right edge.
 .theme-trigger {
   display: flex;
   align-items: center;
@@ -58,8 +37,6 @@
   }
 }
 
-// The right half is the actual control surface: same 1.75rem hairline box as
-// the selects in the rows above, so the column has one right edge.
 .theme-trigger-value {
   display: flex;
   align-items: center;
@@ -97,9 +74,6 @@
   }
 }
 
-// ── Options ──────────────────────────────────────────────────────────────────
-// Sized here rather than on the popover: the overlay is width-fit-to-content,
-// so the list is what decides how wide the panel comes out.
 .gz-theme-list {
   display: flex;
   flex-direction: column;
@@ -109,10 +83,6 @@
   @include gauzy-panel-scroll();
 }
 
-// A flat row like every other row in the panel — a thumbnail chip, the name,
-// and a check on the current one. No resting fill and no per-row card: eight
-// filled cards in a column was the "list of blocks" look the rest of the app
-// has already moved away from.
 .theme-option {
   display: flex;
   align-items: center;
@@ -155,8 +125,6 @@
   height: 1.5rem;
   overflow: hidden;
   border-radius: 0.25rem;
-  // The screenshots are mostly flat colour at this size, so the chip needs its
-  // own hairline to stay legible against a surface of the same tone.
   box-shadow: inset 0 0 0 1px #{$panel-hairline};
 
   img {
@@ -176,8 +144,6 @@
   text-overflow: ellipsis;
 }
 
-// Only the current theme carries the mark. It keeps its box either way, so the
-// names do not shift horizontally when the selection moves.
 .theme-check {
   flex: 0 0 auto;
   width: 0.75rem;

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
@@ -37,6 +37,16 @@
   }
 }
 
+.theme-trigger-label {
+  // The value box beside it is a fixed 8.75rem, so the label is the only part
+  // that can give: without min-width it refuses to shrink past its longest word
+  // and a long translation pushes the trigger wider than the panel.
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .theme-trigger-value {
   display: flex;
   align-items: center;
@@ -56,6 +66,7 @@
 }
 
 .theme-trigger-name {
+  min-width: 0;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
@@ -1,93 +1,192 @@
-@use 'gauzy/_gauzy-overrides' as *;
+@use 'themes' as *;
+@use '@shared/panel' as *;
+
+// This component renders in exactly ONE place — the Quick Settings panel, via
+// `ngx-theme-selector-container [isClassic]="false"` — so it is styled on the
+// panel scale directly instead of being overridden from its parent.
+//
+// What it replaces: an empty `nb-select` used as a toggle (see the template),
+// and 48px rows carrying a 120px-wide screenshot each. Eight of those is a
+// filmstrip inside a 22.5rem panel; the thumbnail only has to say "light" or
+// "dark" and roughly which palette, which a 44px chip does.
+//
+// NOTE ON SELECTORS: the list is rendered by a popover, i.e. into
+// `.cdk-overlay-container` at the end of the document. Angular bakes this
+// component's `_ngcontent` attribute into those elements when it creates them,
+// so plain class selectors still reach them — but anything written under
+// `:host` does NOT, because the elements are no longer inside the host. Every
+// rule below the trigger is therefore deliberately top-level. The popover
+// CONTAINER itself (`nb-popover`) comes from Nebular, not from this template,
+// so its chrome lives in the global `_overlays.scss` under `.gz-theme-popover`.
+
+:host {
+  display: block;
+  width: 100%;
+}
 
 .theme-card {
   display: flex;
   flex-direction: column;
   width: 100%;
 }
-.theme-container {
+
+// ── Trigger ──────────────────────────────────────────────────────────────────
+// Laid out like the control rows above it (label left, value right) so the four
+// preference rows share one left edge and one right edge.
+.theme-trigger {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
+  gap: 0.75rem;
   width: 100%;
-}
-.themes{
-  max-height: calc(100vh - 25rem);
-  overflow-y: auto;
-}
-.card-container {
-  background: nb-theme(gauzy-card-2);
-  margin-top: 8px;
-  border-radius: nb-theme(border-radius);
-  // Compact option: small thumbnail on the left, theme name on the right
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  height: 48px;
-  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: nb-theme(text-basic-color);
+  font-family: inherit;
+  font-size: $panel-text-row;
+  font-weight: 400;
+  line-height: 1rem;
+  text-align: start;
   cursor: pointer;
-  &.selected {
-    .check {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: nb-theme(text-primary-color);
-      font-size: 8px;
-      font-weight: 900;
-      &:before {
-        font-family: 'Font Awesome 7 Free';
-        content: '\f00c';
-      }
-    }
-  }
-  .image-container {
-    order: -1; // thumbnail sits left of the name (markup keeps the name first)
-    flex: 0 0 auto;
-    width: 120px;
-    height: 100%;
-    overflow: hidden;
-    position: relative;
-    img {
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      object-position: left top;
-    }
-  }
-  span {
-    padding: 0 8px;
-    font-size: 13px;
-    flex: 1 1 auto;
-    min-width: 0;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-  .check {
-    width: 1rem;
-    height: 1rem;
-    background-color: white;
-    border-radius: 50%;
-    box-shadow: var(--gauzy-shadow) inset;
+
+  &:focus-visible {
+    outline: 2px solid nb-theme(color-primary-default);
+    outline-offset: 2px;
+    border-radius: $panel-row-radius;
   }
 }
-:host .theme-card ::ng-deep {
-  nb-select.appearance-outline .select-button {
-    border-width: 2px;
-    border-color: rgba($color: rgba(126, 126, 143), $alpha: 0.5);
+
+// The right half is the actual control surface: same 1.75rem hairline box as
+// the selects in the rows above, so the column has one right edge.
+.theme-trigger-value {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.375rem;
+  flex: 0 0 auto;
+  width: 8.75rem;
+  height: 1.75rem;
+  padding: 0 0.5rem;
+  border-radius: $panel-row-radius;
+  box-shadow: inset 0 0 0 1px #{$panel-hairline};
+  transition: background-color 0.12s ease-in-out;
+
+  .theme-trigger:hover & {
+    background-color: #{$panel-hover-tint};
   }
-  nb-select.appearance-outline.status-basic .select-button.placeholder {
-    color: rgba($color: rgba(126, 126, 143), $alpha: 1);
+}
+
+.theme-trigger-name {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.theme-trigger-chevron {
+  flex: 0 0 auto;
+  width: 0.75rem;
+  height: 0.75rem;
+  font-size: 0.75rem;
+  color: nb-theme(text-hint-color);
+  transition: transform 0.15s ease-in-out;
+
+  .theme-trigger.open & {
+    transform: rotate(180deg);
   }
-  nb-select.size-small .select-button {
-    font-size: nb-theme(select-small-text-font-size);
-    font-weight: nb-theme(select-small-text-font-weight);
-    line-height: nb-theme(select-small-text-line-height);
+}
+
+// ── Options ──────────────────────────────────────────────────────────────────
+// Sized here rather than on the popover: the overlay is width-fit-to-content,
+// so the list is what decides how wide the panel comes out.
+.gz-theme-list {
+  display: flex;
+  flex-direction: column;
+  gap: $panel-gap;
+  width: 13.5rem;
+  max-height: min(24rem, 60vh);
+  @include gauzy-panel-scroll();
+}
+
+// A flat row like every other row in the panel — a thumbnail chip, the name,
+// and a check on the current one. No resting fill and no per-row card: eight
+// filled cards in a column was the "list of blocks" look the rest of the app
+// has already moved away from.
+.theme-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  margin: 0;
+  padding: 0.25rem $panel-row-pad-y;
+  border: 0;
+  border-radius: $panel-row-radius;
+  background-color: transparent;
+  color: nb-theme(text-basic-color);
+  font-family: inherit;
+  font-size: $panel-text-row;
+  font-weight: 400;
+  line-height: 1rem;
+  text-align: start;
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease-in-out,
+    color 0.12s ease-in-out;
+
+  &:hover {
+    background-color: #{$panel-hover-tint};
   }
-  @include nb-select-overrides(2rem, $default-button-radius, $default-box-shadow);
+
+  &:focus-visible {
+    outline: 2px solid nb-theme(color-primary-default);
+    outline-offset: -2px;
+  }
+
+  &.selected {
+    background-color: #{$panel-active-tint};
+    font-weight: 600;
+  }
+}
+
+.theme-thumb {
+  flex: 0 0 auto;
+  width: 2.75rem;
+  height: 1.5rem;
+  overflow: hidden;
+  border-radius: 0.25rem;
+  // The screenshots are mostly flat colour at this size, so the chip needs its
+  // own hairline to stay legible against a surface of the same tone.
+  box-shadow: inset 0 0 0 1px #{$panel-hairline};
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: left top;
+  }
+}
+
+.theme-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+// Only the current theme carries the mark. It keeps its box either way, so the
+// names do not shift horizontally when the selection moves.
+.theme-check {
+  flex: 0 0 auto;
+  width: 0.75rem;
+  height: 0.75rem;
+  font-size: 0.75rem;
+  color: nb-theme(text-basic-color);
+  visibility: hidden;
+
+  .theme-option.selected & {
+    visibility: visible;
+  }
 }

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.ts
@@ -20,11 +20,11 @@ export class ThemeSelectorImageComponent extends ThemeSelectorComponent {
 		this.ngOnInit();
 	}
 
-	public get isOpen(): boolean {
+	protected get isOpen(): boolean {
 		return !!this._popover?.isShown;
 	}
 
-	public selectTheme(theme: string): void {
+	protected selectTheme(theme: string): void {
 		this.onSelectedTheme(theme);
 		this._popover?.hide();
 	}

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.ts
@@ -1,19 +1,51 @@
-import { Component } from '@angular/core';
-import { NbThemeService } from '@nebular/theme';
+import { Component, ViewChild } from '@angular/core';
+import { NbPopoverDirective, NbThemeService } from '@nebular/theme';
 import { Store } from '@gauzy/ui-core/core';
 import { ThemeSelectorComponent } from '../theme-selector.component';
 
 @Component({
-    selector: 'gauzy-theme-selector-image',
-    templateUrl: './theme-selector-image.component.html',
-    styleUrls: ['./theme-selector-image.component.scss'],
-    standalone: false
+	selector: 'gauzy-theme-selector-image',
+	templateUrl: './theme-selector-image.component.html',
+	styleUrls: ['./theme-selector-image.component.scss'],
+	standalone: false
 })
 export class ThemeSelectorImageComponent extends ThemeSelectorComponent {
-	isOpen: boolean = false;
+	/**
+	 * The theme list, rendered as a popover so it opens OVER the page instead of
+	 * expanding inside the Quick Settings panel (which gave that panel a
+	 * scrollbar and pushed its Settings button below the fold).
+	 */
+	@ViewChild(NbPopoverDirective) private readonly _popover: NbPopoverDirective;
 
-	constructor(readonly themeService: NbThemeService, readonly store: Store) {
+	constructor(
+		readonly themeService: NbThemeService,
+		readonly store: Store
+	) {
 		super(themeService, store);
 		this.ngOnInit();
+	}
+
+	/**
+	 * Whether the theme list is on screen.
+	 *
+	 * Read straight off the popover rather than mirrored into a field: the panel
+	 * is also dismissed by paths this component never sees (a click outside, the
+	 * trigger's own toggle), and a cached flag would leave the chevron pointing
+	 * up over a list that is already gone.
+	 */
+	public get isOpen(): boolean {
+		return !!this._popover?.isShown;
+	}
+
+	/**
+	 * Apply a theme and close the list.
+	 *
+	 * Closing is explicit because the click lands INSIDE the popover, which its
+	 * own outside-click strategy does not treat as a dismissal — without this the
+	 * list would stay open over the panel after a choice was made.
+	 */
+	public selectTheme(theme: string): void {
+		this.onSelectedTheme(theme);
+		this._popover?.hide();
 	}
 }

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.ts
@@ -10,11 +10,6 @@ import { ThemeSelectorComponent } from '../theme-selector.component';
 	standalone: false
 })
 export class ThemeSelectorImageComponent extends ThemeSelectorComponent {
-	/**
-	 * The theme list, rendered as a popover so it opens OVER the page instead of
-	 * expanding inside the Quick Settings panel (which gave that panel a
-	 * scrollbar and pushed its Settings button below the fold).
-	 */
 	@ViewChild(NbPopoverDirective) private readonly _popover: NbPopoverDirective;
 
 	constructor(
@@ -25,25 +20,10 @@ export class ThemeSelectorImageComponent extends ThemeSelectorComponent {
 		this.ngOnInit();
 	}
 
-	/**
-	 * Whether the theme list is on screen.
-	 *
-	 * Read straight off the popover rather than mirrored into a field: the panel
-	 * is also dismissed by paths this component never sees (a click outside, the
-	 * trigger's own toggle), and a cached flag would leave the chevron pointing
-	 * up over a list that is already gone.
-	 */
 	public get isOpen(): boolean {
 		return !!this._popover?.isShown;
 	}
 
-	/**
-	 * Apply a theme and close the list.
-	 *
-	 * Closing is explicit because the click lands INSIDE the popover, which its
-	 * own outside-click strategy does not treat as a dismissal — without this the
-	 * list would stay open over the panel after a choice was made.
-	 */
 	public selectTheme(theme: string): void {
 		this.onSelectedTheme(theme);
 		this._popover?.hide();

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector.component.html
@@ -1,15 +1,16 @@
 <div class="theme-container">
-  {{ 'SETTINGS_MENU.THEMES' | translate }}
-  <nb-select
-    [(selected)]="currentTheme"
-    placeholder="{{ themes[0] | translate }}"
-    (selectedChange)="toggleTheme()"
-    status="basic"
-    size="small"
-    outline
-    >
-    @for (theme of themes; track theme) {
-      <nb-option [value]="theme.value"> {{ theme.name | translate }}</nb-option>
-    }
-  </nb-select>
+	{{ 'SETTINGS_MENU.THEMES' | translate }}
+	<nb-select
+		[(selected)]="currentTheme"
+		placeholder="{{ themes[0] | translate }}"
+		(selectedChange)="toggleTheme()"
+		status="basic"
+		size="small"
+		outline
+		optionsListClass="gz-panel-options"
+	>
+		@for (theme of themes; track theme) {
+			<nb-option [value]="theme.value"> {{ theme.name | translate }}</nb-option>
+		}
+	</nb-select>
 </div>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector.module.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { NbButtonModule, NbSelectModule, NbToggleModule } from '@nebular/theme';
+import { NbButtonModule, NbIconModule, NbPopoverModule, NbSelectModule, NbToggleModule } from '@nebular/theme';
 import { TranslateModule } from '@ngx-translate/core';
 import { ThemeSelectorContainerComponent } from './container/theme-selector-container.component';
 import { SwitchThemeComponent } from './switch-theme/switch-theme.component';
@@ -20,6 +20,16 @@ import { ThemeSelectorComponent } from './theme-selector.component';
 		ThemeSelectorImageComponent,
 		ThemeSelectorContainerComponent
 	],
-	imports: [CommonModule, NbSelectModule, NbToggleModule, TranslateModule.forChild(), NbButtonModule]
+	imports: [
+		CommonModule,
+		NbSelectModule,
+		NbToggleModule,
+		TranslateModule.forChild(),
+		NbButtonModule,
+		NbIconModule,
+		// The theme list opens as a popover so it does not expand inside — and
+		// scroll — the Quick Settings panel it is rendered in.
+		NbPopoverModule
+	]
 })
 export class ThemeSelectorModule {}

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector.module.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector.module.ts
@@ -27,8 +27,6 @@ import { ThemeSelectorComponent } from './theme-selector.component';
 		TranslateModule.forChild(),
 		NbButtonModule,
 		NbIconModule,
-		// The theme list opens as a popover so it does not expand inside — and
-		// scroll — the Quick Settings panel it is rendered in.
 		NbPopoverModule
 	]
 })

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.html
@@ -30,8 +30,10 @@
 
 	<div class="panel-divider"></div>
 
-	<!-- Support / help entries, moved here from the speech-bubble header menu. -->
-	<div class="panel-section">
+	<!-- Support / help entries, moved here from the speech-bubble header menu.
+	     `support-links` carries no styling — it is the scope the message-button E2E
+	     spec locates these entries by (MessageButtonPageObject.supportLinksCss). -->
+	<div class="panel-section support-links">
 		<span class="panel-overline">{{ 'SETTINGS_MENU.SUPPORT' | translate }}</span>
 
 		@if (isSupportChatAvailable) {

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.html
@@ -11,9 +11,6 @@
 		</button>
 	</header>
 
-	<!-- Two groups under one title, separated by a hairline, each introduced by a
-	     10px overline — instead of the flat `nb-list` of same-weight rows this
-	     used to be, where a theme picker and a link to the FAQ read as peers. -->
 	<div class="panel-section">
 		<span class="panel-overline">{{ 'SETTINGS_MENU.PREFERENCES' | translate }}</span>
 

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.html
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.html
@@ -1,68 +1,71 @@
-<div gauzyOutside (clickOutside)="onClickOutside($event)">
-	<div class="header">
-		<span class="cancel">
-			<i class="fas fa-times" (click)="closeSidebar()"></i>
-		</span>
-		<p>{{ 'SETTINGS_MENU.QUICK_SETTINGS' | translate }}</p>
-	</div>
-	<nb-list>
-		<nb-list-item>
+<div gauzyOutside (clickOutside)="onClickOutside($event)" class="quick-settings-panel">
+	<header class="panel-header">
+		<h3 class="panel-title">{{ 'SETTINGS_MENU.QUICK_SETTINGS' | translate }}</h3>
+		<button
+			type="button"
+			class="panel-close"
+			[attr.aria-label]="'BUTTONS.CLOSE' | translate"
+			(click)="closeSidebar()"
+		>
+			<nb-icon icon="close-outline"></nb-icon>
+		</button>
+	</header>
+
+	<!-- Two groups under one title, separated by a hairline, each introduced by a
+	     10px overline — instead of the flat `nb-list` of same-weight rows this
+	     used to be, where a theme picker and a link to the FAQ read as peers. -->
+	<div class="panel-section">
+		<span class="panel-overline">{{ 'SETTINGS_MENU.PREFERENCES' | translate }}</span>
+
+		<div class="control-row">
 			<gauzy-switch-theme class="theme"></gauzy-switch-theme>
-		</nb-list-item>
-		<nb-list-item>
-			<ngx-theme-language-selector class="theme"></ngx-theme-language-selector>
-		</nb-list-item>
-		<nb-list-item>
+		</div>
+		<div class="control-row">
 			<ngx-theme-selector-container [isClassic]="false" class="theme"></ngx-theme-selector-container>
-		</nb-list-item>
-		<nb-list-item>
+		</div>
+		<div class="control-row">
+			<ngx-theme-language-selector class="theme"></ngx-theme-language-selector>
+		</div>
+		<div class="control-row">
 			<gauzy-layout-selector class="theme"></gauzy-layout-selector>
-		</nb-list-item>
-		<!-- Support / help entries, moved here from the speech-bubble header menu. -->
-		<nb-list-item>
-			<div class="support-links theme">
-				@if (isSupportChatAvailable) {
-					<button type="button" nbButton ghost size="small" class="support-link" (click)="openSupportChat()">
-						<nb-icon icon="message-square-outline"></nb-icon>
-						<span>{{ 'CONTEXT_MENU.CHAT' | translate }}</span>
-					</button>
-				}
-				<!-- FAQ had neither a link nor a click handler in the header menu — it was a
-				     dead entry there. It points at the published FAQ on the docs site, which is
-				     the only FAQ that exists (there is no in-app `faq` route). An <a> rather
-				     than a <button>: it leaves the app, so it should behave like a link
-				     (middle-click, ctrl-click, "copy link address"). `a[nbButton]` is a
-				     supported Nebular selector, so the styling matches its siblings. -->
-				<a
-					nbButton
-					ghost
-					size="small"
-					class="support-link"
-					[href]="faqUrl"
-					target="_blank"
-					rel="noopener noreferrer"
-					(click)="closeSidebar()"
-				>
-					<nb-icon icon="clipboard-outline"></nb-icon>
-					<span>{{ 'CONTEXT_MENU.FAQ' | translate }}</span>
-				</a>
-				<button type="button" nbButton ghost size="small" class="support-link" (click)="navigateTo(['/pages/help'])">
-					<nb-icon icon="question-mark-circle-outline"></nb-icon>
-					<span>{{ 'CONTEXT_MENU.HELP' | translate }}</span>
-				</button>
-				<button type="button" nbButton ghost size="small" class="support-link" (click)="navigateTo(['/pages/about'])">
-					<nb-icon icon="droplet-outline"></nb-icon>
-					<span>{{ 'MENU.ABOUT' | translate }}</span>
-				</button>
-			</div>
-		</nb-list-item>
-		<nb-list-item>
-			<div class="settings-link theme">
-				<button nbButton fullWidth status="primary" size="small" (click)="navigateToSettings()">
-					<nb-icon icon="settings-2-outline"></nb-icon>
-					{{ 'SETTINGS_MENU.SETTINGS' | translate }}
-				</button>
-			</div>
-		</nb-list-item>
-	</nb-list>
+		</div>
+	</div>
+
+	<div class="panel-divider"></div>
+
+	<!-- Support / help entries, moved here from the speech-bubble header menu. -->
+	<div class="panel-section">
+		<span class="panel-overline">{{ 'SETTINGS_MENU.SUPPORT' | translate }}</span>
+
+		@if (isSupportChatAvailable) {
+			<button type="button" class="panel-row" (click)="openSupportChat()">
+				<nb-icon icon="message-square-outline"></nb-icon>
+				<span>{{ 'CONTEXT_MENU.CHAT' | translate }}</span>
+			</button>
+		}
+		<!-- FAQ had neither a link nor a click handler in the header menu — it was a
+		     dead entry there. It points at the published FAQ on the docs site, which is
+		     the only FAQ that exists (there is no in-app `faq` route). An <a> rather
+		     than a <button>: it leaves the app, so it should behave like a link
+		     (middle-click, ctrl-click, "copy link address"). -->
+		<a class="panel-row" [href]="faqUrl" target="_blank" rel="noopener noreferrer" (click)="closeSidebar()">
+			<nb-icon icon="clipboard-outline"></nb-icon>
+			<span>{{ 'CONTEXT_MENU.FAQ' | translate }}</span>
+		</a>
+		<button type="button" class="panel-row" (click)="navigateTo(['/pages/help'])">
+			<nb-icon icon="question-mark-circle-outline"></nb-icon>
+			<span>{{ 'CONTEXT_MENU.HELP' | translate }}</span>
+		</button>
+		<button type="button" class="panel-row" (click)="navigateTo(['/pages/about'])">
+			<nb-icon icon="droplet-outline"></nb-icon>
+			<span>{{ 'MENU.ABOUT' | translate }}</span>
+		</button>
+	</div>
+
+	<footer class="panel-actions">
+		<button nbButton fullWidth status="primary" size="small" (click)="navigateToSettings()">
+			<nb-icon icon="settings-2-outline"></nb-icon>
+			{{ 'SETTINGS_MENU.SETTINGS' | translate }}
+		</button>
+	</footer>
 </div>

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.scss
@@ -1,162 +1,159 @@
 @use 'themes' as *;
-@use 'gauzy/_gauzy-dialogs' as *;
+@use '@shared/panel' as *;
+
+// Quick Settings, opened by the gear action in the header. The container box —
+// radius, hairline, elevation, surface — is drawn by the nb-sidebar this renders
+// into (`.settings-sidebar.expanded .main-container-fixed` in
+// one-column.layout.scss); everything here is rhythm, type and the way the
+// embedded selector widgets are made to agree with each other.
+//
+// What this replaces: a 16px heading, `nb-list` rows at the page's 14px with a
+// 5%-black divider under each, four ghost buttons for the support links, and a
+// pile of dead rules (`.settings-row`, `.switcher`, `.title-uppercase`,
+// `.language-select`) left over from a settings PAGE this panel never was.
 
 @include nb-install-component() {
-  h6 {
-    margin-bottom: 0.5rem;
-    font-weight: 500;
-    font-size: 1rem;
-  }
-
-  nb-select, ngx-language-selector {
-    width: 12.5rem;
-  }
-
-  nb-select ::ng-deep {
-    .select-button {
-      text-overflow: inherit;
-      padding-left: 0.5rem !important;
-    }
-  }
-
-  nb-list{
-    overflow-y: overlay;
-  }
-
-  p {
-    color: nb-theme(text-primary-color);
-    font-size: 16px;
-    font-weight: 600;
-    line-height: 16px;
-    letter-spacing: 0em;
-    text-align: left;
-	padding: 0 1rem;
-  }
-
-  .cancel{
-	  align-self: flex-end;
-	  cursor: pointer;
-  }
-
-  .header{
-	  display: flex;
-	  flex-direction: column;
-	  align-items: flex-start;
-  }
-
-  nb-list-item{
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-bottom: 1px solid rgba(50, 50, 50, 0.05);
-    &:last-child{
-      border-bottom: unset;
-    }
-    .theme{
-      width: 100%;
-    }
-  }
-
-  // Support / help entries, moved here from the speech-bubble header menu.
-  // A left aligned stack of ghost rows, so they read as menu items instead of
-  // four buttons competing with the primary Settings action below them.
-  .support-links {
+  .quick-settings-panel {
     display: flex;
     flex-direction: column;
-    align-items: stretch;
-    gap: 0.125rem;
+    padding: $panel-pad;
+    box-sizing: border-box;
+    font-family: nb-theme(font-family-primary);
+    font-size: $panel-text-row;
+    line-height: 1.4;
+    color: nb-theme(text-basic-color);
+  }
 
-    .support-link {
+  .panel-header {
+    @include gauzy-panel-header();
+    // The sidebar's `.scrollable` is the scroll port (the panel is
+    // `height: auto` under a `max-height`), so the title bar holds its
+    // place by sticking to the top of it.
+    position: sticky;
+    top: calc(-1 * #{$panel-pad});
+    z-index: 1;
+    background-color: nb-theme(background-basic-color-1);
+  }
+
+  .panel-title {
+    @include gauzy-panel-title();
+  }
+
+  .panel-close {
+    @include gauzy-panel-close();
+  }
+
+  .panel-divider {
+    @include gauzy-panel-divider();
+  }
+
+  .panel-overline {
+    @include gauzy-panel-overline();
+  }
+
+  .panel-section {
+    display: flex;
+    flex-direction: column;
+    gap: $panel-gap;
+  }
+
+  // A row that hosts a control. The label comes from the embedded component's
+  // own template, so the row only owns the box; `.theme` is the widget inside.
+  .control-row {
+    @include gauzy-panel-control-row();
+    // The widgets lay out their own label/control pair edge to edge.
+    padding-inline: 0;
+
+    .theme {
       width: 100%;
-      justify-content: flex-start;
-      padding: 0.375rem 0.5rem;
-      text-align: left;
-      text-transform: none;
+    }
+  }
+
+  // Support / help entries: flat rows, not the four ghost buttons they were —
+  // those competed with the primary Settings action underneath them.
+  .panel-row {
+    @include gauzy-panel-row();
+    font-family: inherit;
+  }
+
+  .panel-actions {
+    margin-top: 0.5rem;
+    padding: 0 $panel-gutter;
+
+    [nbButton] {
+      font-size: $panel-text-row;
+      gap: 0.375rem;
 
       nb-icon {
-        @include nb-ltr(margin-right, 0.5rem);
-        @include nb-rtl(margin-left, 0.5rem);
+        font-size: 0.875rem;
+        width: 0.875rem;
+        height: 0.875rem;
       }
     }
   }
 
-  .settings-row {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    flex-wrap: wrap;
+  // ── Embedded widgets ─────────────────────────────────────────────────────
+  // The theme switch, theme picker, language picker and layout picker are
+  // shared components (the auth pages and the desktop app render them too), so
+  // their own stylesheets stay as they are and the panel's reading of them
+  // lives here. Each had pinned its own trigger — 120px / 129px wide, a 2px
+  // grey border, a 2rem box — so four controls in one column lined up on four
+  // different edges. One extra class of specificity is enough to win: those
+  // rules are `[_nghost-x] nb-select.appearance-outline .select-button`, and
+  // these are the same thing under `.quick-settings-panel`.
+  .quick-settings-panel ::ng-deep {
+    // The label half of every widget's own `.theme-container` row. (The theme
+    // picker is not in this list: it renders only here, so it is styled on the
+    // panel scale in its own stylesheet rather than being overridden.)
+    .theme-container,
+    .switch-container {
+      font-size: $panel-text-row;
+      font-weight: 400;
+      line-height: 1rem;
+      color: nb-theme(text-basic-color);
+      gap: 0.75rem;
+      flex-wrap: nowrap;
+    }
 
-    width: 100%;
-    margin: 0 0 1rem;
+    .preferred-layout nb-icon {
+      font-size: 0.75rem;
+      width: 0.75rem;
+      height: 0.75rem;
+      color: nb-theme(text-hint-color);
+    }
 
-    a {
-      text-decoration: none;
-      font-size: 2.25rem;
+    nb-select.appearance-outline .select-button {
+      // The same width as the theme picker's trigger below, so the four
+      // preference rows share one right edge.
+      width: 8.75rem;
+      min-width: 8.75rem;
+      height: 1.75rem;
+      min-height: 1.75rem;
+      padding: 0 0.5rem;
+      // A 1px hairline, the same line weight as every other control and as
+      // the panel's own edge — not the 2px 50%-grey each widget had pinned.
+      border: 0;
+      box-shadow: inset 0 0 0 1px #{$panel-hairline};
+      border-radius: $panel-row-radius;
+      background-color: transparent;
+      font-size: $panel-text-row;
+      font-weight: 400;
+      color: nb-theme(text-basic-color);
+    }
 
-      color: #a4abb3;
+    nb-select.appearance-outline.status-basic .select-button.placeholder {
+      font-size: $panel-text-row;
+      color: nb-theme(text-basic-color);
+    }
 
-      &.selected {
-        color: #40dc7e;
-      }
-
-      @include nb-for-theme(cosmic) {
-        &.selected {
-          color: #3dcc6d;
-        }
-      }
+    // The layout picker's tiny "Reset layout" escape hatch, tucked under its
+    // select. A text-weight control, so it reads as secondary to the row.
+    .reset-layout {
+      font-size: $panel-text-label;
+      padding: 0.1875rem 0.375rem;
+      min-width: 0;
+      border-color: transparent;
+      color: nb-theme(text-hint-color);
     }
   }
-
-  .settings {
-    margin-bottom: 1em;
-  }
-
-  .switcher {
-    margin-bottom: 1rem;
-
-    ::ng-deep ngx-switcher {
-      .switch-label span {
-        font-size: 1em;
-        font-weight: normal;
-      }
-
-      .switch {
-        height: 1.5em;
-        width: 3em;
-
-        .slider::before {
-          height: 1.5em;
-          width: 1.5em;
-        }
-
-        input:checked + .slider::before {
-          @include nb-ltr(transform, translateX(1.5rem) !important);
-          @include nb-rtl(transform, translateX(-1.5rem) !important);
-        }
-      }
-
-      @include nb-for-theme(cosmic) {
-        // .switch .slider {
-        // background-color: nb-theme(color-bg);
-        // }
-      }
-    }
-  }
-
-  .title-uppercase {
-    text-transform: uppercase;
-
-    .settings-row select {
-      max-height: 40px;
-      padding: 0;
-      padding-left: 10px;
-      font-size: 0.9rem;
-    }
-  }
-
-  .language-select {
-    margin-right: 65px;
-  }
-
-  @include input-appearance(2rem, var(--gauzy-sidebar-background-4));
 }

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.scss
@@ -1,17 +1,6 @@
 @use 'themes' as *;
 @use '@shared/panel' as *;
 
-// Quick Settings, opened by the gear action in the header. The container box —
-// radius, hairline, elevation, surface — is drawn by the nb-sidebar this renders
-// into (`.settings-sidebar.expanded .main-container-fixed` in
-// one-column.layout.scss); everything here is rhythm, type and the way the
-// embedded selector widgets are made to agree with each other.
-//
-// What this replaces: a 16px heading, `nb-list` rows at the page's 14px with a
-// 5%-black divider under each, four ghost buttons for the support links, and a
-// pile of dead rules (`.settings-row`, `.switcher`, `.title-uppercase`,
-// `.language-select`) left over from a settings PAGE this panel never was.
-
 @include nb-install-component() {
   .quick-settings-panel {
     display: flex;
@@ -26,9 +15,6 @@
 
   .panel-header {
     @include gauzy-panel-header();
-    // The sidebar's `.scrollable` is the scroll port (the panel is
-    // `height: auto` under a `max-height`), so the title bar holds its
-    // place by sticking to the top of it.
     position: sticky;
     top: calc(-1 * #{$panel-pad});
     z-index: 1;
@@ -57,11 +43,8 @@
     gap: $panel-gap;
   }
 
-  // A row that hosts a control. The label comes from the embedded component's
-  // own template, so the row only owns the box; `.theme` is the widget inside.
   .control-row {
     @include gauzy-panel-control-row();
-    // The widgets lay out their own label/control pair edge to edge.
     padding-inline: 0;
 
     .theme {
@@ -69,8 +52,6 @@
     }
   }
 
-  // Support / help entries: flat rows, not the four ghost buttons they were —
-  // those competed with the primary Settings action underneath them.
   .panel-row {
     @include gauzy-panel-row();
     font-family: inherit;
@@ -92,19 +73,7 @@
     }
   }
 
-  // ── Embedded widgets ─────────────────────────────────────────────────────
-  // The theme switch, theme picker, language picker and layout picker are
-  // shared components (the auth pages and the desktop app render them too), so
-  // their own stylesheets stay as they are and the panel's reading of them
-  // lives here. Each had pinned its own trigger — 120px / 129px wide, a 2px
-  // grey border, a 2rem box — so four controls in one column lined up on four
-  // different edges. One extra class of specificity is enough to win: those
-  // rules are `[_nghost-x] nb-select.appearance-outline .select-button`, and
-  // these are the same thing under `.quick-settings-panel`.
   .quick-settings-panel ::ng-deep {
-    // The label half of every widget's own `.theme-container` row. (The theme
-    // picker is not in this list: it renders only here, so it is styled on the
-    // panel scale in its own stylesheet rather than being overridden.)
     .theme-container,
     .switch-container {
       font-size: $panel-text-row;
@@ -123,15 +92,11 @@
     }
 
     nb-select.appearance-outline .select-button {
-      // The same width as the theme picker's trigger below, so the four
-      // preference rows share one right edge.
       width: 8.75rem;
       min-width: 8.75rem;
       height: 1.75rem;
       min-height: 1.75rem;
       padding: 0 0.5rem;
-      // A 1px hairline, the same line weight as every other control and as
-      // the panel's own edge — not the 2px 50%-grey each widget had pinned.
       border: 0;
       box-shadow: inset 0 0 0 1px #{$panel-hairline};
       border-radius: $panel-row-radius;
@@ -146,8 +111,6 @@
       color: nb-theme(text-basic-color);
     }
 
-    // The layout picker's tiny "Reset layout" escape hatch, tucked under its
-    // select. A text-weight control, so it reads as secondary to the row.
     .reset-layout {
       font-size: $panel-text-label;
       padding: 0.1875rem 0.375rem;

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.scss
@@ -45,7 +45,6 @@
 
   .control-row {
     @include gauzy-panel-control-row();
-    padding-inline: 0;
 
     .theme {
       width: 100%;

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { NbSidebarService } from '@nebular/theme';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
@@ -20,13 +20,36 @@ export const QUICK_SETTINGS_SIDEBAR_TAG = 'settings_sidebar';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
-    selector: 'ngx-theme-settings',
-    styleUrls: ['./theme-settings.component.scss'],
-    templateUrl: './theme-settings.component.html',
-    standalone: false
+	selector: 'ngx-theme-settings',
+	styleUrls: ['./theme-settings.component.scss'],
+	templateUrl: './theme-settings.component.html',
+	standalone: false
 })
 export class ThemeSettingsComponent implements OnInit, OnDestroy {
 	private state: boolean;
+
+	/**
+	 * Whether the document click currently being dispatched landed inside a CDK
+	 * overlay rather than on the page.
+	 *
+	 * `OutsideDirective` reports only "inside the panel / outside the panel", and
+	 * every dropdown this panel hosts — the language list, the layout list, the
+	 * theme popover — renders into `.cdk-overlay-container` at the END of the
+	 * document, i.e. outside the panel element. Without this, picking a language
+	 * closed Quick Settings, and the theme popover could never be used at all: the
+	 * click that chose a theme would take the panel down with it.
+	 *
+	 * Set from a listener on THIS component's host, which is registered before the
+	 * directive's (the directive sits on an element inside this component's
+	 * template), so it is already up to date when `onClickOutside` runs for the
+	 * same event.
+	 */
+	private clickedInOverlay = false;
+
+	@HostListener('document:click', ['$event.target'])
+	public trackOverlayClick(target: EventTarget | null): void {
+		this.clickedInOverlay = target instanceof Element && !!target.closest('.cdk-overlay-container');
+	}
 
 	/**
 	 * Support chat is only offered when this deployment configured a Chatwoot
@@ -47,7 +70,10 @@ export class ThemeSettingsComponent implements OnInit, OnDestroy {
 	 */
 	public readonly faqUrl: string = 'https://docs.gauzy.co/reference/faq';
 
-	constructor(private readonly sidebarService: NbSidebarService, private readonly router: Router) {}
+	constructor(
+		private readonly sidebarService: NbSidebarService,
+		private readonly router: Router
+	) {}
 
 	ngOnInit(): void {
 		// This ran in ngAfterViewChecked — i.e. after every change-detection pass — opening a new
@@ -126,7 +152,7 @@ export class ThemeSettingsComponent implements OnInit, OnDestroy {
 	 * @param event
 	 */
 	public onClickOutside(event: boolean) {
-		if (!event && this.state) this.closeSidebar();
+		if (!event && !this.clickedInOverlay && this.state) this.closeSidebar();
 	}
 
 	/**

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.ts
@@ -28,22 +28,6 @@ export const QUICK_SETTINGS_SIDEBAR_TAG = 'settings_sidebar';
 export class ThemeSettingsComponent implements OnInit, OnDestroy {
 	private state: boolean;
 
-	/**
-	 * Whether the document click currently being dispatched landed inside a CDK
-	 * overlay rather than on the page.
-	 *
-	 * `OutsideDirective` reports only "inside the panel / outside the panel", and
-	 * every dropdown this panel hosts — the language list, the layout list, the
-	 * theme popover — renders into `.cdk-overlay-container` at the END of the
-	 * document, i.e. outside the panel element. Without this, picking a language
-	 * closed Quick Settings, and the theme popover could never be used at all: the
-	 * click that chose a theme would take the panel down with it.
-	 *
-	 * Set from a listener on THIS component's host, which is registered before the
-	 * directive's (the directive sits on an element inside this component's
-	 * template), so it is already up to date when `onClickOutside` runs for the
-	 * same event.
-	 */
 	private clickedInOverlay = false;
 
 	@HostListener('document:click', ['$event.target'])

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.module.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.module.ts
@@ -1,14 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { DirectivesModule } from '@gauzy/ui-core/shared';
-import {
-	NbButtonModule,
-	NbCardModule,
-	NbIconModule,
-	NbListModule,
-	NbSelectModule,
-	NbTooltipModule
-} from '@nebular/theme';
+import { NbButtonModule, NbCardModule, NbIconModule, NbSelectModule, NbTooltipModule } from '@nebular/theme';
 import { TranslateModule } from '@ngx-translate/core';
 import { LayoutSelectorModule } from './components/layout-selector/layout-selector.module';
 import { ThemeLanguageSelectorModule } from './components/theme-language-selector/theme-language-selector.module';
@@ -27,7 +20,6 @@ import { ThemeSettingsComponent } from './theme-settings.component';
 		LayoutSelectorModule,
 		ThemeSelectorModule,
 		NbCardModule,
-		NbListModule,
 		DirectivesModule
 	],
 	exports: [ThemeSettingsComponent],

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-sidebar.module.ts
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-sidebar.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NbButtonModule, NbIconModule, NbSelectModule, NbTooltipModule } from '@nebular/theme';
 import { TranslateModule } from '@ngx-translate/core';
-import { ChangelogEntryComponent } from '@gauzy/ui-core/shared';
+import { ChangelogEntryComponent, DirectivesModule } from '@gauzy/ui-core/shared';
 import { ThemeSidebarComponent } from './theme-sidebar.component';
 import { ThemeSettingsModule } from './theme-settings/theme-settings.module';
 import { ChangelogComponent } from './changelog/changelog.component';
@@ -17,6 +17,7 @@ import { ThemeSettingsComponent } from './theme-settings/theme-settings.componen
 		NbTooltipModule,
 		TranslateModule.forChild(),
 		ThemeSettingsModule,
+		DirectivesModule,
 		// Standalone card shared with the login page's What's New panel
 		ChangelogEntryComponent
 	],

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.html
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.html
@@ -1,4 +1,4 @@
-<div gauzyOutside (clickOutside)="onClickOutside($event)" class="account-panel" [nbSpinner]="isSubmit$ | async">
+<div gauzyOutside (clickOutside)="onClickOutside($event)" class="account-panel">
 	<header class="panel-header">
 		<gauzy-user showIdentity="true" [user$]="user$" (clicked)="onClick()"></gauzy-user>
 		<button type="button" class="panel-close" [attr.aria-label]="'BUTTONS.CLOSE' | translate" (click)="onClick()">
@@ -9,19 +9,21 @@
 	<div class="panel-section">
 		<span class="panel-overline">{{ 'USER_MENU.ACCOUNT' | translate }}</span>
 
-		@if (employee$ | async) {
-			<button type="button" class="panel-row" [class.disabled-row]="isSubmit$ | async" (click)="onChangeStatus()">
-				<nb-icon icon="moon-outline"></nb-icon>
-				<span
-					[innerHTML]="
-						((employee$ | async)?.isAway
-							? 'USER_MENU.SET_YOURSELF_AS_ACTIVE'
-							: 'USER_MENU.SET_YOURSELF_AS_AWAY'
-						) | translate
-					"
-				></span>
-			</button>
-		}
+		<div class="status-control" [nbSpinner]="isSubmit$ | async" nbSpinnerSize="tiny">
+			@if (employee$ | async) {
+				<button type="button" class="panel-row" [disabled]="isSubmit$ | async" (click)="onChangeStatus()">
+					<nb-icon icon="moon-outline"></nb-icon>
+					<span
+						[innerHTML]="
+							((employee$ | async)?.isAway
+								? 'USER_MENU.SET_YOURSELF_AS_ACTIVE'
+								: 'USER_MENU.SET_YOURSELF_AS_AWAY'
+							) | translate
+						"
+					></span>
+				</button>
+			}
+		</div>
 		<a class="panel-row" routerLink="/pages/auth/profile" (click)="onClick()">
 			<nb-icon icon="person-outline"></nb-icon>
 			<span>{{ 'USER_MENU.PROFILE' | translate }}</span>
@@ -64,9 +66,9 @@
 	<footer class="panel-footer">
 		<span class="download-label">{{ 'USER_MENU.DOWNLOAD_APPS' | translate }}</span>
 		<span class="download-icons">
-			@for (app of downloadApps; track app) {
-				<a target="_blank" [href]="app.link" rel="noopener">
-					<i [class]="app.icon"></i>
+			@for (app of downloadApps; track app.label) {
+				<a target="_blank" [href]="app.link" rel="noopener" [attr.aria-label]="app.label | translate">
+					<i [class]="app.icon" aria-hidden="true"></i>
 				</a>
 			}
 		</span>

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.html
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.html
@@ -1,7 +1,4 @@
 <div gauzyOutside (clickOutside)="onClickOutside($event)" class="account-panel" [nbSpinner]="isSubmit$ | async">
-	<!-- Identity first, the way every account menu opens: who you are signed in
-	     as, then what you can do about it. It used to be tucked into the bottom
-	     of the left half of a two-column box. -->
 	<header class="panel-header">
 		<gauzy-user showIdentity="true" [user$]="user$" (clicked)="onClick()"></gauzy-user>
 		<button type="button" class="panel-close" [attr.aria-label]="'BUTTONS.CLOSE' | translate" (click)="onClick()">
@@ -15,7 +12,6 @@
 		@if (employee$ | async) {
 			<button type="button" class="panel-row" [class.disabled-row]="isSubmit$ | async" (click)="onChangeStatus()">
 				<nb-icon icon="moon-outline"></nb-icon>
-				<!-- The label carries a <strong> in every locale, hence innerHTML. -->
 				<span
 					[innerHTML]="
 						((employee$ | async)?.isAway
@@ -77,10 +73,7 @@
 	</footer>
 </div>
 
-<!-- TODO: Implement commented features. Kept from the previous markup so the
-     intent is not lost; the styles that went with it (`.sub-menu`, `.status`,
-     `.notifications`, `.button`) were dropped with the two-column layout and
-     have to come back as panel rows if these are ever built.
+<!-- TODO: Implement commented features
 
 <div underConstruction class="sub-menu">
   <span><i class="far fa-smile"></i>{{ 'USER_MENU.STATUS' | translate }}</span>

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.html
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.html
@@ -1,89 +1,105 @@
-<div gauzyOutside (clickOutside)="onClickOutside($event)" class="main-menu">
-	<div [nbSpinner]="isSubmit$ | async" class="left-menu">
-		<!-- TODO: Implement commented features -->
-		<!-- <div underConstruction class="sub-menu">
-    <span><i class="far fa-smile"></i>
-  {{ 'USER_MENU.STATUS' | translate }}</span>
+<div gauzyOutside (clickOutside)="onClickOutside($event)" class="account-panel" [nbSpinner]="isSubmit$ | async">
+	<!-- Identity first, the way every account menu opens: who you are signed in
+	     as, then what you can do about it. It used to be tucked into the bottom
+	     of the left half of a two-column box. -->
+	<header class="panel-header">
+		<gauzy-user showIdentity="true" [user$]="user$" (clicked)="onClick()"></gauzy-user>
+		<button type="button" class="panel-close" [attr.aria-label]="'BUTTONS.CLOSE' | translate" (click)="onClick()">
+			<nb-icon icon="close-outline"></nb-icon>
+		</button>
+	</header>
+
+	<div class="panel-section">
+		<span class="panel-overline">{{ 'USER_MENU.ACCOUNT' | translate }}</span>
+
+		@if (employee$ | async) {
+			<button type="button" class="panel-row" [class.disabled-row]="isSubmit$ | async" (click)="onChangeStatus()">
+				<nb-icon icon="moon-outline"></nb-icon>
+				<!-- The label carries a <strong> in every locale, hence innerHTML. -->
+				<span
+					[innerHTML]="
+						((employee$ | async)?.isAway
+							? 'USER_MENU.SET_YOURSELF_AS_ACTIVE'
+							: 'USER_MENU.SET_YOURSELF_AS_AWAY'
+						) | translate
+					"
+				></span>
+			</button>
+		}
+		<a class="panel-row" routerLink="/pages/auth/profile" (click)="onClick()">
+			<nb-icon icon="person-outline"></nb-icon>
+			<span>{{ 'USER_MENU.PROFILE' | translate }}</span>
+		</a>
+	</div>
+
+	<div class="panel-divider"></div>
+
+	<div class="panel-section">
+		<span class="panel-overline">{{ 'USER_MENU.PREFERENCES' | translate }}</span>
+
+		<div class="control-row">
+			<gauzy-switch-theme class="theme"></gauzy-switch-theme>
+		</div>
+		<div class="control-row">
+			<ngx-theme-selector-container class="theme"></ngx-theme-selector-container>
+		</div>
+		<div class="control-row">
+			<ngx-theme-language-selector class="theme"></ngx-theme-language-selector>
+		</div>
+	</div>
+
+	<div class="panel-divider"></div>
+
+	<div class="panel-section">
+		<a class="panel-row" target="_blank" rel="noopener" [href]="platFormWebSiteUrl" (click)="onClick()">
+			<nb-icon icon="question-mark-circle-outline"></nb-icon>
+			<span>{{ 'USER_MENU.HELP' | translate }}</span>
+		</a>
+		<button type="button" class="panel-row" underConstruction>
+			<nb-icon icon="keypad-outline"></nb-icon>
+			<span>{{ 'USER_MENU.HOTKEYS' | translate }}</span>
+		</button>
+		<a class="panel-row" routerLink="/auth/logout">
+			<nb-icon icon="log-out-outline"></nb-icon>
+			<span>{{ 'USER_MENU.SIGN_OUT' | translate }}</span>
+		</a>
+	</div>
+
+	<footer class="panel-footer">
+		<span class="download-label">{{ 'USER_MENU.DOWNLOAD_APPS' | translate }}</span>
+		<span class="download-icons">
+			@for (app of downloadApps; track app) {
+				<a target="_blank" [href]="app.link" rel="noopener">
+					<i [class]="app.icon"></i>
+				</a>
+			}
+		</span>
+	</footer>
+</div>
+
+<!-- TODO: Implement commented features. Kept from the previous markup so the
+     intent is not lost; the styles that went with it (`.sub-menu`, `.status`,
+     `.notifications`, `.button`) were dropped with the two-column layout and
+     have to come back as panel rows if these are ever built.
+
+<div underConstruction class="sub-menu">
+  <span><i class="far fa-smile"></i>{{ 'USER_MENU.STATUS' | translate }}</span>
   <div class="status">
-    <div class="button selected">
-      {{ 'USER_MENU.AVAILABLE' | translate }}
-    </div>
-    <div class="button">
-      {{ 'USER_MENU.UNAVAILABLE' | translate }}
-    </div>
+    <div class="button selected">{{ 'USER_MENU.AVAILABLE' | translate }}</div>
+    <div class="button">{{ 'USER_MENU.UNAVAILABLE' | translate }}</div>
   </div>
 </div>
 <div underConstruction class="sub-menu">
   <span>{{ 'USER_MENU.PAUSE_NOTIFICATIONS' | translate }}</span>
   <div class="notifications">
-    <div class="button">
-      {{ 'USER_MENU.FOR_1_HOUR' | translate }}
-    </div>
-    <div class="button">
-      {{ 'USER_MENU.FOR_2_HOURS' | translate }}
-    </div>
-    <div class="button selected">
-      {{ 'USER_MENU.UNTIL_TOMORROW' | translate }}
-    </div>
+    <div class="button">{{ 'USER_MENU.FOR_1_HOUR' | translate }}</div>
+    <div class="button">{{ 'USER_MENU.FOR_2_HOURS' | translate }}</div>
+    <div class="button selected">{{ 'USER_MENU.UNTIL_TOMORROW' | translate }}</div>
     <div class="button">{{ 'USER_MENU.CUSTOM' | translate }}</div>
     <div class="button">
       <i class="far fa-calendar"></i>
       {{ 'USER_MENU.SET_AS_NOTIFICATION_SCHEDULE' | translate }}
     </div>
   </div>
-</div> -->
-		<div class="links">
-			@if (employee$ | async) {
-			<p
-				[class.disabled-table]="isSubmit$ | async"
-				class="link"
-				[innerHTML]="
-					((employee$ | async)?.isAway
-						? 'USER_MENU.SET_YOURSELF_AS_ACTIVE'
-						: 'USER_MENU.SET_YOURSELF_AS_AWAY'
-					) | translate
-				"
-				(click)="onChangeStatus()"
-			></p>
-			}
-			<p class="link" routerLink="/pages/auth/profile">
-				{{ 'USER_MENU.PROFILE' | translate }}
-			</p>
-			<p class="link" routerLink="/auth/logout">
-				{{ 'USER_MENU.SIGN_OUT' | translate }}
-			</p>
-		</div>
-		<div class="sub-user-menu">
-			<gauzy-user showIdentity="true" [user$]="user$" (clicked)="onClick()"></gauzy-user>
-		</div>
-	</div>
-
-	<div class="right-menu">
-		<span><i (click)="onClick()" class="fas fa-times"></i></span>
-		<div class="download-apps-content">
-			<span class="download-apps-label">Download Apps:</span>
-			<span class="download-apps-icons">
-				@for (app of downloadApps; track app) {
-				<a target="_blank" [href]="app.link" rel="noopener">
-					<i [class]="app.icon"></i>
-				</a>
-				}
-			</span>
-		</div>
-		<p>
-			<a target="_blank" href="{{ platFormWebSiteUrl }}">{{ 'USER_MENU.HELP' | translate }}</a>
-		</p>
-		<p class="link" underConstruction>
-			{{ 'USER_MENU.HOTKEYS' | translate }}
-		</p>
-		<p>
-			<ngx-theme-language-selector class="theme"></ngx-theme-language-selector>
-		</p>
-		<p>
-			<gauzy-switch-theme class="theme"></gauzy-switch-theme>
-		</p>
-		<p>
-			<ngx-theme-selector-container class="theme"></ngx-theme-selector-container>
-		</p>
-	</div>
 </div>
+-->

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
@@ -1,175 +1,172 @@
 @use 'themes' as *;
+@use '@shared/panel' as *;
 
-// The account dropdown is a popup, so it follows the same shadcn rules as the
-// overlay menus in `packages/ui-core/static/styles/_overlays.scss`: ONE soft
-// container wrapping FLAT rows. Like the workspace switcher it is absolutely
+// The account menu, opened by the user button at the foot of the sidebar.
+//
+// It used to be a 36 x 18rem box split down the middle: menu rows on the left,
+// a brand-tinted half on the right holding the download links, Help, Hotkeys
+// and three theme/language controls. Two columns of unrelated things at two
+// different visual weights, pinned flush into the bottom-left corner of the
+// viewport, is not what an account menu looks like — it is a dialog.
+//
+// One narrow column instead, on the panel scale shared with What's New and
+// Quick Settings (`@shared/_panel`): identity, then rows grouped by 10px
+// overlines and separated by hairlines, then a 9px footer strip. This popup is
 // positioned by the layout rather than rendered into `.cdk-overlay-container`,
-// so the container chrome is repeated here. `--gauzy-overlay-border-color` and
-// `--gauzy-hover-tint` resolve from themes.scss; the alpha-neutral fallbacks
-// cover the material-* themes and read correctly on light AND dark surfaces.
-$overlay-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
-$overlay-shadow: #{'var(--gauzy-overlay-shadow, 0 4px 12px -2px rgba(0, 0, 0, 0.14), 0 2px 6px -2px rgba(0, 0, 0, 0.08))'};
-$overlay-item-hover-bg: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+// so it draws its own container chrome (same as `gauzy-workspace-menu`).
 
 :host {
-  .main-menu {
-    width: 36rem;
-    //height: 30.5625rem; // After implement features revert to this height
-    height: 18rem;
-    border: 1px solid #{$overlay-hairline};
-    box-shadow: #{$overlay-shadow};
-    border-radius: var(--border-radius, 8px);
-    background: nb-theme(background-basic-color-1);
-    display: flex;
-    .right-menu {
-      background: nb-theme(color-primary-transparent-default);
-      // `direction: rtl` reverses the flex row, so this column moves to the
-      // LEFT edge under RTL while physical corner radii stay put — mirror them
-      // or the panel ends up with two squared outer corners.
-      @include nb-ltr(border-radius, 0 var(--border-radius, 8px) var(--border-radius, 8px) 0);
-      @include nb-rtl(border-radius, var(--border-radius, 8px) 0 0 var(--border-radius, 8px));
-      width: 50%;
-      padding: 13.5px 15.5px 13.5px 26px;
-      span {
-        display: flex;
-        justify-content: flex-end;
-      }
-      p {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        position: relative;
-        cursor: pointer;
-        .theme {
-          width: 100%;
-        }
-      }
-    }
-    .left-menu {
-      width: 50%;
-      // Mirrored for the same reason as `.right-menu` above.
-      @include nb-ltr(border-radius, var(--border-radius, 8px) 0 0 var(--border-radius, 8px));
-      @include nb-rtl(border-radius, 0 var(--border-radius, 8px) var(--border-radius, 8px) 0);
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      // Trimmed from 11px/47px: each row now carries its own 10px inline
-      // padding (see `p.link` below), so the column only needs a small inset.
-      @include nb-ltr(padding, 14px 16px 10px 6px);
-      @include nb-rtl(padding, 14px 6px 10px 16px);
-      .sub-menu {
-        background: rgba(126, 126, 143, 0.05);
-        padding: 10px;
-        border-radius: nb-theme(border-radius);
-        align-items: flex-start;
-        display: flex;
-        flex-direction: column;
-      }
-      .button {
-        padding: 10px;
-        background: nb-theme(background-basic-color-1);
-        border-radius: nb-theme(border-radius);
-        margin: 4px 3px 0px 0px;
-        width: fit-content;
-        font-size: 0.6875rem;
-        &.selected {
-          background: nb-theme(background-primary-color-1);
-          color: nb-theme(text-control-color);
-        }
-      }
+  display: block;
+}
+
+.account-panel {
+  @include gauzy-panel-surface();
+  display: flex;
+  flex-direction: column;
+  // Narrow on purpose: every row is one short label, so a wider box would only
+  // add whitespace between the label and the edge.
+  width: 17.5rem;
+  max-width: calc(100vw - 1.5rem);
+  max-height: calc(100vh - 6rem);
+  @include gauzy-panel-scroll();
+  padding: $panel-pad;
+  box-sizing: border-box;
+}
+
+.panel-header {
+  @include gauzy-panel-header();
+
+  // `gauzy-user` brings its own row padding and hover tint. The header already
+  // carries the panel's gutter, so the identity row drops its inline padding
+  // and its avatar lands on the same x as the icons of the rows below.
+  gauzy-user {
+    flex: 1 1 auto;
+    min-width: 0;
+
+    ::ng-deep .user-container.with-identity {
+      padding-inline: 0;
     }
   }
-  .notifications,
-  .status {
-    display: flex;
-    flex-wrap: wrap;
+}
+
+.panel-close {
+  @include gauzy-panel-close();
+}
+
+.panel-section {
+  display: flex;
+  flex-direction: column;
+  gap: $panel-gap;
+}
+
+.panel-overline {
+  @include gauzy-panel-overline();
+}
+
+.panel-divider {
+  @include gauzy-panel-divider();
+}
+
+.panel-row {
+  @include gauzy-panel-row();
+  font-family: inherit;
+
+  // The away/active label is translated with a <strong> inside it; without
+  // this the emphasis jumps a weight class above the row it sits in.
+  ::ng-deep strong {
+    font-weight: 600;
   }
 
-  p.link,
-  .button,
-  i,
-  a {
-    cursor: pointer;
-    text-decoration: none;
-    color: nb-theme(text-basic-color);
+  &.disabled-row {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+}
+
+.control-row {
+  @include gauzy-panel-control-row();
+  padding-inline: 0;
+
+  .theme {
+    width: 100%;
+  }
+}
+
+.panel-footer {
+  @include gauzy-panel-footer();
+
+  .download-label {
+    white-space: nowrap;
   }
 
-  .links {
-    // `stretch` (was `flex-start`) so a hovered row's tint spans the column
-    // instead of hugging the label.
-    align-items: stretch;
+  .download-icons {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     gap: 0.125rem;
 
-    // Flat menu rows: no border, no shadow, no resting fill — only a subtle
-    // background tint on a 6px radius when hovered. Scoped to `.links` so the
-    // right-hand column (whose `p`s wrap full-width selector widgets, not menu
-    // entries) keeps its own alignment.
-    p.link {
-      margin: 0;
-      padding: 0.375rem 0.625rem;
-      border-radius: var(--gauzy-radius-sm, 6px);
-      font-size: nb-theme(menu-text-font-size);
-      font-weight: nb-theme(menu-text-font-weight);
-      line-height: 1.25rem;
-      // Colour only: transitioning `all` would animate the radius and make the
-      // row look like it is inflating into a block.
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.25rem;
+      height: 1.25rem;
+      border-radius: $panel-row-radius;
+      color: nb-theme(text-hint-color);
+      text-decoration: none;
       transition:
         background-color 0.12s ease-in-out,
         color 0.12s ease-in-out;
 
+      // Was a `scale(1.5)` plus a 1px box on hover — a 9px glyph growing
+      // into a bordered chip, and the row reflowing around it.
       &:hover {
-        background-color: #{$overlay-item-hover-bg};
+        background-color: #{$panel-hover-tint};
+        color: nb-theme(text-basic-color);
+      }
+
+      i {
+        font-size: 0.75rem;
+        line-height: 1;
       }
     }
   }
+}
 
-  .right-menu {
-    .download-apps-content {
-      display: flex;
-      align-items: center;
-      font-size: 12px;
-      font-weight: 500;
-      line-height: 15px;
-      letter-spacing: 0em;
-      text-align: left;
-      min-height: 20px;
-      margin-top: 0.5rem;
-      margin-bottom: 1rem;
-
-      .download-apps-label {
-        // Token, not a raw hex: `#7e7e8f` was a fixed grey that does not lift
-        // on the dark themes.
-        color: nb-theme(text-hint-color);
-      }
-
-      .download-apps-icons {
-        margin-left: 0.3rem;
-        a {
-          margin: 0 0.2rem;
-          transition: 0.2s;
-          padding: 0.1rem 0.2rem;
-          border: 1px solid transparent;
-
-          i {
-            padding: 0;
-            margin: 0;
-            color: nb-theme(text-hint-color);
-          }
-
-          &:hover {
-            color: nb-theme(text-primary-color);
-            border: 1px solid nb-theme(text-primary-color);
-            border-radius: calc(nb-theme(border-radius) - 4px);
-            transform: scale(1.5);
-          }
-        }
-      }
-    }
+// ── Embedded widgets ─────────────────────────────────────────────────────────
+// Same treatment as in Quick Settings, and for the same reason: the theme
+// switch, theme picker and language picker are shared components whose own
+// stylesheets pin a 120px/129px trigger with a 2px grey border, so in a 17.5rem
+// column they neither fit nor line up. One extra class of specificity — these
+// selectors sit under `.account-panel`, theirs do not — is enough to win
+// without an `!important`.
+.account-panel ::ng-deep {
+  .theme-container,
+  .switch-container {
+    font-size: $panel-text-row;
+    font-weight: 400;
+    line-height: 1rem;
+    color: nb-theme(text-basic-color);
+    gap: 0.75rem;
+    flex-wrap: nowrap;
   }
-  .disabled-table {
-    pointer-events: none;
-    opacity: 0.5;
+
+  nb-select.appearance-outline .select-button {
+    width: 8.25rem;
+    min-width: 8.25rem;
+    height: 1.75rem;
+    min-height: 1.75rem;
+    padding: 0 0.5rem;
+    border: 0;
+    box-shadow: inset 0 0 0 1px #{$panel-hairline};
+    border-radius: $panel-row-radius;
+    background-color: transparent;
+    font-size: $panel-text-row;
+    font-weight: 400;
+    color: nb-theme(text-basic-color);
+  }
+
+  nb-select.appearance-outline.status-basic .select-button.placeholder {
+    font-size: $panel-text-row;
+    color: nb-theme(text-basic-color);
   }
 }

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
@@ -64,7 +64,6 @@
 
 .control-row {
   @include gauzy-panel-control-row();
-  padding-inline: 0;
 
   .theme {
     width: 100%;

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
@@ -1,20 +1,6 @@
 @use 'themes' as *;
 @use '@shared/panel' as *;
 
-// The account menu, opened by the user button at the foot of the sidebar.
-//
-// It used to be a 36 x 18rem box split down the middle: menu rows on the left,
-// a brand-tinted half on the right holding the download links, Help, Hotkeys
-// and three theme/language controls. Two columns of unrelated things at two
-// different visual weights, pinned flush into the bottom-left corner of the
-// viewport, is not what an account menu looks like — it is a dialog.
-//
-// One narrow column instead, on the panel scale shared with What's New and
-// Quick Settings (`@shared/_panel`): identity, then rows grouped by 10px
-// overlines and separated by hairlines, then a 9px footer strip. This popup is
-// positioned by the layout rather than rendered into `.cdk-overlay-container`,
-// so it draws its own container chrome (same as `gauzy-workspace-menu`).
-
 :host {
   display: block;
 }
@@ -23,8 +9,6 @@
   @include gauzy-panel-surface();
   display: flex;
   flex-direction: column;
-  // Narrow on purpose: every row is one short label, so a wider box would only
-  // add whitespace between the label and the edge.
   width: 17.5rem;
   max-width: calc(100vw - 1.5rem);
   max-height: calc(100vh - 6rem);
@@ -36,9 +20,6 @@
 .panel-header {
   @include gauzy-panel-header();
 
-  // `gauzy-user` brings its own row padding and hover tint. The header already
-  // carries the panel's gutter, so the identity row drops its inline padding
-  // and its avatar lands on the same x as the icons of the rows below.
   gauzy-user {
     flex: 1 1 auto;
     min-width: 0;
@@ -71,8 +52,6 @@
   @include gauzy-panel-row();
   font-family: inherit;
 
-  // The away/active label is translated with a <strong> inside it; without
-  // this the emphasis jumps a weight class above the row it sits in.
   ::ng-deep strong {
     font-weight: 600;
   }
@@ -117,8 +96,6 @@
         background-color 0.12s ease-in-out,
         color 0.12s ease-in-out;
 
-      // Was a `scale(1.5)` plus a 1px box on hover — a 9px glyph growing
-      // into a bordered chip, and the row reflowing around it.
       &:hover {
         background-color: #{$panel-hover-tint};
         color: nb-theme(text-basic-color);
@@ -132,13 +109,6 @@
   }
 }
 
-// ── Embedded widgets ─────────────────────────────────────────────────────────
-// Same treatment as in Quick Settings, and for the same reason: the theme
-// switch, theme picker and language picker are shared components whose own
-// stylesheets pin a 120px/129px trigger with a 2px grey border, so in a 17.5rem
-// column they neither fit nor line up. One extra class of specificity — these
-// selectors sit under `.account-panel`, theirs do not — is enough to win
-// without an `!important`.
 .account-panel ::ng-deep {
   .theme-container,
   .switch-container {

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
@@ -56,10 +56,16 @@
     font-weight: 600;
   }
 
-  &.disabled-row {
-    pointer-events: none;
+  &:disabled {
+    cursor: default;
     opacity: 0.5;
   }
+}
+
+.status-control {
+  display: flex;
+  flex-direction: column;
+  min-height: 1.5rem;
 }
 
 .control-row {

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, HostListener, Input, OnDestroy, OnInit, Output, EventEmitter } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { environment } from '@gauzy/ui-config';
 import { IEmployee, IUser, IEmployeeUpdateInput } from '@gauzy/contracts';
@@ -8,10 +8,10 @@ import { BehaviorSubject, tap, Observable, filter, firstValueFrom } from 'rxjs';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
-    selector: 'gauzy-user-menu',
-    templateUrl: './user-menu.component.html',
-    styleUrls: ['./user-menu.component.scss'],
-    standalone: false
+	selector: 'gauzy-user-menu',
+	templateUrl: './user-menu.component.html',
+	styleUrls: ['./user-menu.component.scss'],
+	standalone: false
 })
 export class UserMenuComponent implements OnInit, OnDestroy {
 	private _user$: Observable<IUser>;
@@ -32,6 +32,21 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 	 */
 	private armed = false;
 	private armTimer: ReturnType<typeof setTimeout> | undefined;
+
+	/**
+	 * Whether the document click being dispatched landed inside a CDK overlay.
+	 *
+	 * Same reason as `ngx-theme-settings`: this panel hosts the language and
+	 * theme selectors, whose option lists render into `.cdk-overlay-container` at
+	 * the end of the document — outside this element, so `gauzyOutside` calls
+	 * them an outside click and the menu closed the moment a language was picked.
+	 */
+	private clickedInOverlay = false;
+
+	@HostListener('document:click', ['$event.target'])
+	public trackOverlayClick(target: EventTarget | null): void {
+		this.clickedInOverlay = target instanceof Element && !!target.closest('.cdk-overlay-container');
+	}
 
 	public downloadApps = [
 		{
@@ -90,7 +105,7 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 	}
 
 	public onClickOutside(clickedInside: boolean) {
-		if (!clickedInside && this.armed) {
+		if (!clickedInside && !this.clickedInOverlay && this.armed) {
 			this.onClick();
 		}
 	}

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
@@ -4,7 +4,16 @@ import { environment } from '@gauzy/ui-config';
 import { IEmployee, IUser, IEmployeeUpdateInput } from '@gauzy/contracts';
 import { EmployeesService, ErrorHandlingService } from '@gauzy/ui-core/core';
 import { distinctUntilChange } from '@gauzy/ui-core/common';
-import { BehaviorSubject, tap, Observable, filter, firstValueFrom } from 'rxjs';
+import {
+	BehaviorSubject,
+	tap,
+	Observable,
+	filter,
+	firstValueFrom,
+	combineLatest,
+	map,
+	distinctUntilChanged
+} from 'rxjs';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -16,7 +25,16 @@ import { BehaviorSubject, tap, Observable, filter, firstValueFrom } from 'rxjs';
 export class UserMenuComponent implements OnInit, OnDestroy {
 	private _user$: Observable<IUser>;
 	private _employee$: BehaviorSubject<IEmployee>;
-	private _isSubmit$: BehaviorSubject<boolean>;
+	/**
+	 * The employee lookup and the status update run independently — a user or
+	 * organization switch can start a lookup while `onChangeStatus()` is still
+	 * waiting on the server — so each keeps its own in-flight flag. With a single
+	 * shared flag, whichever request settled first re-enabled the status control
+	 * while the other was still running.
+	 */
+	private _isLoadingEmployee$: BehaviorSubject<boolean>;
+	private _isUpdatingStatus$: BehaviorSubject<boolean>;
+	private _isSubmit$: Observable<boolean>;
 	platFormWebSiteUrl: string;
 
 	@Output()
@@ -86,7 +104,12 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 	) {
 		this._user$ = new Observable();
 		this._employee$ = new BehaviorSubject(null);
-		this._isSubmit$ = new BehaviorSubject(false);
+		this._isLoadingEmployee$ = new BehaviorSubject(false);
+		this._isUpdatingStatus$ = new BehaviorSubject(false);
+		this._isSubmit$ = combineLatest([this._isLoadingEmployee$, this._isUpdatingStatus$]).pipe(
+			map(([isLoadingEmployee, isUpdatingStatus]) => isLoadingEmployee || isUpdatingStatus),
+			distinctUntilChanged()
+		);
 		this.platFormWebSiteUrl = environment.PLATFORM_WEBSITE_URL;
 	}
 
@@ -96,11 +119,22 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 		this.user$
 			.pipe(
 				distinctUntilChange(),
-				filter(({ employee }) => !!employee),
+				tap((user: IUser) => {
+					// A user without an employee still has to invalidate the lookup in
+					// flight: the filter below drops the emission, so without this an
+					// earlier request could settle afterwards and repopulate the menu with
+					// the previous employee, letting onChangeStatus() update that record.
+					if (!user?.employee) {
+						this.lookupId++;
+						this._employee$.next(null);
+						this._isLoadingEmployee$.next(false);
+					}
+				}),
+				filter((user: IUser) => !!user?.employee),
 				tap(async (user: IUser) => {
-					const employeeId = user?.employee?.id;
+					const employeeId = user.employee.id;
 					const lookupId = ++this.lookupId;
-					this._isSubmit$.next(true);
+					this._isLoadingEmployee$.next(true);
 					try {
 						const employee = await firstValueFrom(this._employeeService.getEmployeeById(employeeId));
 						if (lookupId !== this.lookupId) {
@@ -108,12 +142,16 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 						}
 						this._employee$.next(employee);
 					} catch (error) {
-						// Only a still-current failure may clear the cached employee, and only
-						// when that cache belongs to someone else: keeping a stale employee
-						// would let onChangeStatus() write the away flag to the wrong one,
-						// while a failed refresh of the same employee should leave the status
-						// control on the data it already has.
-						if (lookupId === this.lookupId && this.employee?.id !== employeeId) {
+						// A superseded lookup owns nothing on screen any more: neither its
+						// failure nor its error message belongs to the employee now shown.
+						if (lookupId !== this.lookupId) {
+							return;
+						}
+						// Clear the cached employee only when it belongs to someone else:
+						// keeping a stale employee would let onChangeStatus() write the away
+						// flag to the wrong one, while a failed refresh of the same employee
+						// should leave the status control on the data it already has.
+						if (this.employee?.id !== employeeId) {
 							this._employee$.next(null);
 						}
 						this._errorHandler.handleError(error);
@@ -122,7 +160,7 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 						// the status control stuck behind a spinner for the whole session.
 						// A superseded lookup leaves it to the newer one still running.
 						if (lookupId === this.lookupId) {
-							this._isSubmit$.next(false);
+							this._isLoadingEmployee$.next(false);
 						}
 					}
 				}),
@@ -149,10 +187,11 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 	public async onChangeStatus(): Promise<void> {
 		// Guard against a second activation while a request is already in flight:
 		// the disabled attribute covers pointer and keyboard, this covers the rest.
-		if (!this.employee || this._isSubmit$.getValue()) {
+		// A lookup in flight counts too — the employee on screen is about to change.
+		if (!this.employee || this._isLoadingEmployee$.getValue() || this._isUpdatingStatus$.getValue()) {
 			return;
 		}
-		this._isSubmit$.next(true);
+		this._isUpdatingStatus$.next(true);
 		try {
 			const { id, isAway, tenantId, organizationId } = this.employee;
 			const payload: IEmployeeUpdateInput = {
@@ -161,11 +200,15 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 				organizationId
 			};
 			await this._employeeService.updateProfile(id, payload);
-			this._employee$.next({ ...this.employee, ...payload });
+			// A lookup may have swapped the employee while this update was in flight;
+			// applying the payload then would show one employee's away flag on another.
+			if (this.employee?.id === id) {
+				this._employee$.next({ ...this.employee, ...payload });
+			}
 		} catch (error) {
 			this._errorHandler.handleError(error);
 		} finally {
-			this._isSubmit$.next(false);
+			this._isUpdatingStatus$.next(false);
 		}
 	}
 
@@ -189,6 +232,6 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 	}
 
 	public get isSubmit$(): Observable<boolean> {
-		return this._isSubmit$.asObservable();
+		return this._isSubmit$;
 	}
 }

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
@@ -40,26 +40,35 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 		this.clickedInOverlay = target instanceof Element && !!target.closest('.cdk-overlay-container');
 	}
 
+	/**
+	 * Each entry carries a `label` translation key because the anchors render an
+	 * icon only — without it a screen reader announces five identical links.
+	 */
 	public downloadApps = [
 		{
 			link: environment.DESKTOP_APP_DOWNLOAD_LINK_APPLE,
-			icon: 'fab fa-apple'
+			icon: 'fab fa-apple',
+			label: 'USER_MENU.DOWNLOAD_MACOS'
 		},
 		{
 			link: environment.DESKTOP_APP_DOWNLOAD_LINK_WINDOWS,
-			icon: 'fa-brands fa-windows'
+			icon: 'fa-brands fa-windows',
+			label: 'USER_MENU.DOWNLOAD_WINDOWS'
 		},
 		{
 			link: environment.DESKTOP_APP_DOWNLOAD_LINK_LINUX,
-			icon: 'fa-brands fa-linux'
+			icon: 'fa-brands fa-linux',
+			label: 'USER_MENU.DOWNLOAD_LINUX'
 		},
 		{
 			link: environment.MOBILE_APP_DOWNLOAD_LINK,
-			icon: 'fas fa-mobile'
+			icon: 'fas fa-mobile',
+			label: 'USER_MENU.DOWNLOAD_MOBILE'
 		},
 		{
 			link: environment.EXTENSION_DOWNLOAD_LINK,
-			icon: 'fa-brands fa-chrome'
+			icon: 'fa-brands fa-chrome',
+			label: 'USER_MENU.DOWNLOAD_BROWSER_EXTENSION'
 		}
 	];
 
@@ -82,9 +91,18 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 				filter(({ employee }) => !!employee),
 				tap(async (user: IUser) => {
 					this._isSubmit$.next(true);
-					const employee = await firstValueFrom(this._employeeService.getEmployeeById(user?.employee?.id));
-					this._employee$.next(employee);
-					this._isSubmit$.next(false);
+					try {
+						const employee = await firstValueFrom(
+							this._employeeService.getEmployeeById(user?.employee?.id)
+						);
+						this._employee$.next(employee);
+					} catch (error) {
+						this._errorHandler.handleError(error);
+					} finally {
+						// Always release the loading state, otherwise a failed load leaves
+						// the status control stuck behind a spinner for the whole session.
+						this._isSubmit$.next(false);
+					}
 				}),
 
 				untilDestroyed(this)
@@ -107,11 +125,13 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 	}
 
 	public async onChangeStatus(): Promise<void> {
+		// Guard against a second activation while a request is already in flight:
+		// the disabled attribute covers pointer and keyboard, this covers the rest.
+		if (!this.employee || this._isSubmit$.getValue()) {
+			return;
+		}
+		this._isSubmit$.next(true);
 		try {
-			if (!this.employee) {
-				return;
-			}
-			this._isSubmit$.next(true);
 			const { id, isAway, tenantId, organizationId } = this.employee;
 			const payload: IEmployeeUpdateInput = {
 				isAway: !isAway,
@@ -122,8 +142,9 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 			this._employee$.next({ ...this.employee, ...payload });
 		} catch (error) {
 			this._errorHandler.handleError(error);
+		} finally {
+			this._isSubmit$.next(false);
 		}
-		this._isSubmit$.next(false);
 	}
 
 	public get employee(): IEmployee {

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
@@ -194,15 +194,21 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 		this._isUpdatingStatus$.next(true);
 		try {
 			const { id, isAway, tenantId, organizationId } = this.employee;
+			// The guard above rules out a lookup in flight, so this is the lookup the
+			// employee on screen came from. A user switch starting mid-update advances
+			// the counter, which is how the write below spots that it is obsolete.
+			const lookupId = this.lookupId;
 			const payload: IEmployeeUpdateInput = {
 				isAway: !isAway,
 				tenantId,
 				organizationId
 			};
 			await this._employeeService.updateProfile(id, payload);
-			// A lookup may have swapped the employee while this update was in flight;
-			// applying the payload then would show one employee's away flag on another.
-			if (this.employee?.id === id) {
+			// A user switch may have happened while this update was in flight. The
+			// cached employee alone cannot tell: it still holds the previous one until
+			// the new lookup settles, so the counter has to agree as well — otherwise
+			// the away flag of the user who just left lands on the menu.
+			if (lookupId === this.lookupId && this.employee?.id === id) {
 				this._employee$.next({ ...this.employee, ...payload });
 			}
 		} catch (error) {

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
@@ -35,6 +35,14 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 
 	private clickedInOverlay = false;
 
+	/**
+	 * Identifies the employee lookup currently in flight. The panel can stay open
+	 * across a user or organization switch, so a slow earlier request can settle
+	 * after a newer one; anything that no longer matches this counter is stale and
+	 * must not touch the employee or the loading state.
+	 */
+	private lookupId = 0;
+
 	@HostListener('document:click', ['$event.target'])
 	public trackOverlayClick(target: EventTarget | null): void {
 		this.clickedInOverlay = target instanceof Element && !!target.closest('.cdk-overlay-container');
@@ -90,22 +98,32 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 				distinctUntilChange(),
 				filter(({ employee }) => !!employee),
 				tap(async (user: IUser) => {
+					const employeeId = user?.employee?.id;
+					const lookupId = ++this.lookupId;
 					this._isSubmit$.next(true);
 					try {
-						const employee = await firstValueFrom(
-							this._employeeService.getEmployeeById(user?.employee?.id)
-						);
+						const employee = await firstValueFrom(this._employeeService.getEmployeeById(employeeId));
+						if (lookupId !== this.lookupId) {
+							return;
+						}
 						this._employee$.next(employee);
 					} catch (error) {
-						// Drop the previously loaded employee: the panel can stay open across a
-						// user or organization switch, and keeping the old one would let
-						// onChangeStatus() write the away flag to the wrong employee.
-						this._employee$.next(null);
+						// Only a still-current failure may clear the cached employee, and only
+						// when that cache belongs to someone else: keeping a stale employee
+						// would let onChangeStatus() write the away flag to the wrong one,
+						// while a failed refresh of the same employee should leave the status
+						// control on the data it already has.
+						if (lookupId === this.lookupId && this.employee?.id !== employeeId) {
+							this._employee$.next(null);
+						}
 						this._errorHandler.handleError(error);
 					} finally {
 						// Always release the loading state, otherwise a failed load leaves
 						// the status control stuck behind a spinner for the whole session.
-						this._isSubmit$.next(false);
+						// A superseded lookup leaves it to the newer one still running.
+						if (lookupId === this.lookupId) {
+							this._isSubmit$.next(false);
+						}
 					}
 				}),
 

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
@@ -97,6 +97,10 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 						);
 						this._employee$.next(employee);
 					} catch (error) {
+						// Drop the previously loaded employee: the panel can stay open across a
+						// user or organization switch, and keeping the old one would let
+						// onChangeStatus() write the away flag to the wrong employee.
+						this._employee$.next(null);
 						this._errorHandler.handleError(error);
 					} finally {
 						// Always release the loading state, otherwise a failed load leaves

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.ts
@@ -33,14 +33,6 @@ export class UserMenuComponent implements OnInit, OnDestroy {
 	private armed = false;
 	private armTimer: ReturnType<typeof setTimeout> | undefined;
 
-	/**
-	 * Whether the document click being dispatched landed inside a CDK overlay.
-	 *
-	 * Same reason as `ngx-theme-settings`: this panel hosts the language and
-	 * theme selectors, whose option lists render into `.cdk-overlay-container` at
-	 * the end of the document — outside this element, so `gauzyOutside` calls
-	 * them an outside click and the menu closed the moment a language was picked.
-	 */
 	private clickedInOverlay = false;
 
 	@HostListener('document:click', ['$event.target'])

--- a/packages/ui-core/theme/src/lib/components/user/user.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user/user.component.scss
@@ -116,7 +116,7 @@ $avatar-size: 1.5rem;
 
     .email {
       color: nb-theme(text-hint-color);
-      font-size: 0.625rem;
+      font-size: var(--gz-user-email-size, 0.625rem);
       font-weight: 400;
     }
   }

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -193,6 +193,7 @@ $chat-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
     padding: 0.5rem 0.75rem;
     --gz-user-surface: #{nb-theme(gauzy-sidebar-background-2)};
     --gz-user-presence: none;
+    --gz-user-email-size: 0.75rem;
 
     gauzy-user {
       flex: 1 1 auto;

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -1,8 +1,5 @@
 @use '@nebular/theme/styles/global/breakpoints' as *;
 @use 'themes' as *;
-// The chrome the three shell panels share — this file draws the BOX for two of
-// them (What's New / Quick Settings), so it resolves the same hairline and
-// elevation their contents are styled against.
 @use '@shared/panel' as *;
 
 // Same hairline as cards, overlays and the user/workspace menus — a translucent
@@ -33,10 +30,6 @@ $chat-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
     z-index: 1042;
   }
 
-  // Same width as the Quick Settings panel beside it: the two open from
-  // adjacent header actions, and 29.5rem here against 22.5rem there made them
-  // look like panels from two different applications. (The inner
-  // `.main-container-fixed` was already 22.5rem, so only the host was wide.)
   .changelog-sidebar.expanded {
     width: 22.5rem !important;
     height: fit-content;
@@ -176,14 +169,6 @@ $chat-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
     }
   }
 
-  // The account menu opens FROM the user button in the sidebar footer, so it is
-  // anchored just above it and inset from the edge — the same relationship the
-  // workspace switcher below has with the logo row it opens from. It used to be
-  // pinned flush into the corner (`bottom: 0; left: 0`), where a 36 x 18rem
-  // panel covered the lower-left of the page and read as a docked dialog.
-  //
-  // 3.25rem clears the footer: 2 x 0.5rem of its padding plus the 2.25rem user
-  // row inside it (a 1.5rem avatar with 0.375rem above and below).
   gauzy-user-menu {
     position: absolute;
     bottom: 3.25rem;
@@ -399,10 +384,6 @@ nb-sidebar[tag='menu-sidebar'] {
     // the trailing edge on narrow windows. `max-width` still wins over an
     // `!important` width, which is why the width above can stay as it was.
     max-width: calc(100vw - 2.5rem);
-    // The panel chrome the popups share (see `@shared/_panel`): a hairline plus
-    // a two-layer soft elevation. The single `0 6px 30px rgba(0,0,0,.2)` this
-    // replaces is a heavy grey cloud on a light theme and an undefined edge on a
-    // dark one, where nothing then said where the panel stopped.
     border: 1px solid #{$panel-hairline};
     box-shadow: #{$panel-shadow};
     z-index: 1041;
@@ -418,11 +399,6 @@ nb-sidebar[tag='menu-sidebar'] {
       overflow-x: hidden;
     }
   }
-  // "What's New", opened by the gift action in the header. Anchored exactly like
-  // the Quick Settings panel above — it used to sit at `var(--header-height) - 27px`,
-  // a hardcoded offset that ignored the measured band (so it overlapped the header
-  // whenever the demo banner was up) and a `max-height: 100vh` measured from there,
-  // which let a long changelog run off the bottom of the viewport.
   nb-layout .layout .layout-container nb-sidebar.changelog-sidebar.expanded .main-container-fixed {
     top: calc(var(--gz-header-height, var(--header-height, 4.5rem)) + 0.5rem);
     height: auto;
@@ -438,11 +414,6 @@ nb-sidebar[tag='menu-sidebar'] {
     .scrollable {
       background-color: nb-theme(background-basic-color-1);
       border-radius: nb-theme(border-radius);
-      // The scroll port is HERE rather than inside the panel: the container is
-      // `height: auto` under a `max-height`, so a percentage height on the
-      // component would resolve to auto and its own overflow box would never
-      // get a size to scroll against. The panel's title bar stays put by being
-      // `position: sticky` inside this port instead.
       overflow-y: auto;
       overflow-x: hidden;
       overscroll-behavior: contain;
@@ -640,9 +611,6 @@ nb-sidebar[tag='menu-sidebar'] {
   padding: 0 0.5rem;
 }
 
-// Both header popups hang off the trailing edge with the same inset — the
-// changelog used to sit flush against it while Quick Settings, opened from the
-// icon next to it, floated 20px in.
 :host ::ng-deep nb-layout .layout .layout-container nb-sidebar.settings-sidebar.expanded .main-container-fixed,
 :host ::ng-deep nb-layout .layout .layout-container nb-sidebar.changelog-sidebar.expanded .main-container-fixed {
   @include nb-ltr(right, 20px);

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -1,5 +1,9 @@
 @use '@nebular/theme/styles/global/breakpoints' as *;
 @use 'themes' as *;
+// The chrome the three shell panels share — this file draws the BOX for two of
+// them (What's New / Quick Settings), so it resolves the same hairline and
+// elevation their contents are styled against.
+@use '@shared/panel' as *;
 
 // Same hairline as cards, overlays and the user/workspace menus — a translucent
 // grey that darkens light surfaces and lightens dark ones, so ONE value is
@@ -29,8 +33,12 @@ $chat-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
     z-index: 1042;
   }
 
+  // Same width as the Quick Settings panel beside it: the two open from
+  // adjacent header actions, and 29.5rem here against 22.5rem there made them
+  // look like panels from two different applications. (The inner
+  // `.main-container-fixed` was already 22.5rem, so only the host was wide.)
   .changelog-sidebar.expanded {
-    width: 29.5rem !important;
+    width: 22.5rem !important;
     height: fit-content;
     z-index: 1042;
   }
@@ -168,11 +176,19 @@ $chat-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
     }
   }
 
+  // The account menu opens FROM the user button in the sidebar footer, so it is
+  // anchored just above it and inset from the edge — the same relationship the
+  // workspace switcher below has with the logo row it opens from. It used to be
+  // pinned flush into the corner (`bottom: 0; left: 0`), where a 36 x 18rem
+  // panel covered the lower-left of the page and read as a docked dialog.
+  //
+  // 3.25rem clears the footer: 2 x 0.5rem of its padding plus the 2.25rem user
+  // row inside it (a 1.5rem avatar with 0.375rem above and below).
   gauzy-user-menu {
     position: absolute;
-    bottom: 0px;
-    @include nb-ltr(left, 0px);
-    @include nb-rtl(right, 0px);
+    bottom: 3.25rem;
+    @include nb-ltr(left, 0.75rem);
+    @include nb-rtl(right, 0.75rem);
     z-index: 1041;
   }
 
@@ -383,7 +399,12 @@ nb-sidebar[tag='menu-sidebar'] {
     // the trailing edge on narrow windows. `max-width` still wins over an
     // `!important` width, which is why the width above can stay as it was.
     max-width: calc(100vw - 2.5rem);
-    box-shadow: 0px 6px 30px 0px rgba(0, 0, 0, 0.2);
+    // The panel chrome the popups share (see `@shared/_panel`): a hairline plus
+    // a two-layer soft elevation. The single `0 6px 30px rgba(0,0,0,.2)` this
+    // replaces is a heavy grey cloud on a light theme and an undefined edge on a
+    // dark one, where nothing then said where the panel stopped.
+    border: 1px solid #{$panel-hairline};
+    box-shadow: #{$panel-shadow};
     z-index: 1041;
     border-radius: nb-theme(border-radius);
     // Opaque against the page behind it: the rounded box itself carries the
@@ -397,17 +418,34 @@ nb-sidebar[tag='menu-sidebar'] {
       overflow-x: hidden;
     }
   }
+  // "What's New", opened by the gift action in the header. Anchored exactly like
+  // the Quick Settings panel above — it used to sit at `var(--header-height) - 27px`,
+  // a hardcoded offset that ignored the measured band (so it overlapped the header
+  // whenever the demo banner was up) and a `max-height: 100vh` measured from there,
+  // which let a long changelog run off the bottom of the viewport.
   nb-layout .layout .layout-container nb-sidebar.changelog-sidebar.expanded .main-container-fixed {
-    top: calc(var(--header-height) - 27px);
-    height: fit-content;
-    max-height: 100vh;
+    top: calc(var(--gz-header-height, var(--header-height, 4.5rem)) + 0.5rem);
+    height: auto;
+    max-height: calc(100vh - var(--gz-header-height, var(--header-height, 4.5rem)) - 1rem);
     width: 22.5rem !important;
-    box-shadow: 0px 6px 30px 0px rgba(0, 0, 0, 0.2);
+    max-width: calc(100vw - 2.5rem);
+    border: 1px solid #{$panel-hairline};
+    box-shadow: #{$panel-shadow};
     z-index: 1041;
     border-radius: nb-theme(border-radius);
+    background-color: nb-theme(background-basic-color-1);
+    overflow: hidden;
     .scrollable {
       background-color: nb-theme(background-basic-color-1);
       border-radius: nb-theme(border-radius);
+      // The scroll port is HERE rather than inside the panel: the container is
+      // `height: auto` under a `max-height`, so a percentage height on the
+      // component would resolve to auto and its own overflow box would never
+      // get a size to scroll against. The panel's title bar stays put by being
+      // `position: sticky` inside this port instead.
+      overflow-y: auto;
+      overflow-x: hidden;
+      overscroll-behavior: contain;
       padding: 0;
     }
   }
@@ -602,7 +640,11 @@ nb-sidebar[tag='menu-sidebar'] {
   padding: 0 0.5rem;
 }
 
-:host ::ng-deep nb-layout .layout .layout-container nb-sidebar.settings-sidebar.expanded .main-container-fixed {
+// Both header popups hang off the trailing edge with the same inset — the
+// changelog used to sit flush against it while Quick Settings, opened from the
+// icon next to it, floated 20px in.
+:host ::ng-deep nb-layout .layout .layout-container nb-sidebar.settings-sidebar.expanded .main-container-fixed,
+:host ::ng-deep nb-layout .layout .layout-container nb-sidebar.changelog-sidebar.expanded .main-container-fixed {
   @include nb-ltr(right, 20px);
   @include nb-rtl(left, 20px);
 }


### PR DESCRIPTION
- [ ] Before
<img width="1908" height="870" alt="Screenshot 2026-08-24 190211" src="https://github.com/user-attachments/assets/09620a0c-5a6e-405d-9a5d-7d3f839f32f6" />

- [ ] After

<img width="1915" height="867" alt="Screenshot 2026-08-24 190951" src="https://github.com/user-attachments/assets/6c849663-8936-4fc2-985e-f9029b8502a3" />

- [ ] Before

<img width="1913" height="867" alt="Screenshot 2026-08-24 190250" src="https://github.com/user-attachments/assets/732dd90b-bb5c-44e9-9d96-c62d7b44c903" />


- [ ] After

<img width="1917" height="871" alt="Screenshot 2026-08-24 190830" src="https://github.com/user-attachments/assets/54df9427-2910-4502-b9ed-590c13dedccf" />

- [ ] Before

<img width="1911" height="870" alt="Screenshot 2026-08-24 190406" src="https://github.com/user-attachments/assets/0e646a64-ab7e-43ba-98d3-aef7357a1f2f" />


- [ ] After

<img width="1915" height="870" alt="Screenshot 2026-08-24 190926" src="https://github.com/user-attachments/assets/33c2aa3c-22a7-4302-983f-9770375b70d0" />

- [ ] Before

<img width="1912" height="867" alt="Screenshot 2026-08-24 190509" src="https://github.com/user-attachments/assets/f1c6a155-6491-4dcf-805a-51d35998115e" />

- [ ] After

<img width="1915" height="868" alt="Screenshot 2026-08-24 191023" src="https://github.com/user-attachments/assets/96892401-cf2c-423e-a646-42c9f8b47087" />

