### PR TITLE
style(sales): share the Documents-hub table treatment across sales pages

### DIFF
--- a/apps/gauzy/src/app/pages/invoices/invoices.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.html
@@ -1,4 +1,4 @@
-<nb-card>
+<nb-card [class.estimate-page]="isEstimate">
 	<nb-card-header class="card-header-title">
 		<div class="col-auto">
 			<h4>

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.scss
@@ -1,6 +1,7 @@
 @forward 'report';
 @use 'gauzy/_gauzy-cards' as *;
 @use 'gauzy/_gauzy-overrides' as ga-overrides;
+@use 'gauzy/_gauzy-table-hub' as ga-hub;
 
 .popover-container {
   display: flex;
@@ -404,7 +405,7 @@ nb-tab {
   ::ng-deep {
     @include card_overrides(auto, $default-card-height, $default-radius);
     @include ga-overrides.ng-select-overrides(
-	  ga-overrides.$default-height,
+      ga-overrides.$default-height,
       $default-radius,
       ga-overrides.$default-box-shadow-inset
     );
@@ -465,7 +466,7 @@ nb-tab {
       }
       & .history-item.history-comment {
         margin-top: 6px;
-        font-size: .85rem;
+        font-size: 0.85rem;
         &.history-comment::first-letter {
           text-transform: capitalize;
         }
@@ -474,7 +475,7 @@ nb-tab {
 
     // border bottom
     & nb-list-item::after {
-      content: "";
+      content: '';
       display: block;
       width: 100%;
       border-bottom: thin solid var(--accordion-header-border-color);
@@ -482,4 +483,64 @@ nb-tab {
       bottom: 0;
     }
   }
+}
+
+:host {
+  @include ga-hub.density-tokens();
+}
+
+:host .estimate-page ::ng-deep .ga-page-title-trail {
+  margin-top: -0.25rem;
+  font-size: 0.75rem;
+
+  .ga-breadcrumb-list {
+    gap: 0.125rem;
+  }
+
+  .ga-breadcrumb-item {
+    gap: 0.125rem;
+    font-size: 0.75rem;
+    line-height: 1.5rem;
+  }
+
+  .ga-breadcrumb-link,
+  .ga-breadcrumb-text,
+  .ga-breadcrumb-current {
+    height: 1.5rem;
+    max-width: 14rem;
+    padding-inline: 0.375rem;
+    border-radius: var(--gauzy-radius-sm, 0.375rem);
+    font-weight: 500;
+    line-height: 1;
+  }
+
+  .ga-breadcrumb-separator nb-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+}
+
+:host .table-scroll-container {
+  @include ga-hub.surface();
+}
+
+:host ::ng-deep angular2-smart-table {
+  @include ga-hub.rows();
+}
+
+:host ::ng-deep {
+  @include ga-hub.tag-stack-spacing();
+}
+
+:host ::ng-deep ga-status-badge {
+  @include ga-hub.status-badge-tints();
+}
+
+:host .pagination-container {
+  @include ga-hub.pager-container();
+}
+
+:host .pagination-container ::ng-deep ngx-pagination {
+  @include ga-hub.pager();
 }

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.scss
@@ -544,3 +544,195 @@ nb-tab {
 :host .pagination-container ::ng-deep ngx-pagination {
   @include ga-hub.pager();
 }
+
+// ── Tab bar ──────────────────────────────────────────────────────────────────
+// One step down from the app-wide `tabset-tab-text-font-size` (0.875rem) for
+// this page only: Browse / Search / History are three short words, and at the
+// shared size they read heavier than the card title above them.
+//
+// `.tab-link.tab-link` is doubled on purpose. The global rules in
+// `gauzy/_gauzy-overrides.scss` are `nb-tabset .tabset .tab a.tab-link` (0,3,2)
+// and `nb-tabset .tabset .tab.active a.tab-link` (0,4,2); a single `.tab-link`
+// here would only tie with the active one, and a tie between a component sheet
+// and a global sheet is decided by stylesheet order, which is not ours to rely
+// on. Doubling takes both, active and idle, without `!important`.
+:host ::ng-deep nb-tabset .tabset .tab a.tab-link.tab-link {
+  font-size: 0.75rem;
+  line-height: 0.875rem;
+}
+
+// ── Search panel ─────────────────────────────────────────────
+// The search form is an accordion stacked ABOVE the table inside a fixed-height
+// `.custom-content-body` (`calc(100vh - 19.5rem)`), with the table as the flex
+// child that absorbs whatever is left. Expanded, the form's full-size controls —
+// three rows of 42px fields, each with a label and a 1rem gutter — ate nearly all
+// of it, so opening Search left the table only a row or two tall.
+//
+// Scoped to `.search-tab nb-accordion`, NOT to `.search-tab`: the table renders
+// inside the same tab, and a bare `.search-tab ::ng-deep input` would also catch
+// the smart-table filter row and pull it off the shared `ga-hub` density above.
+// Everything here shrinks the FORM; the table just gets the reclaimed height.
+:host .search-tab {
+  // `.mb-3` (1rem) between the form and the table.
+  nb-accordion.mb-3 {
+    margin-bottom: 0.5rem !important;
+  }
+
+  nb-accordion-item-header {
+    font-size: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    min-height: 0;
+  }
+
+  // The chevron box is sized to its glyph in the `nb-accordion-item-header` rule
+  // near the top of this file (1.75rem); it comes down with the header.
+  nb-accordion-item-header ::ng-deep nb-icon {
+    width: 1.375rem;
+    height: 1.375rem;
+    font-size: 0.875rem;
+  }
+
+  nb-accordion-item-body ::ng-deep .item-body {
+    padding: 0.75rem;
+  }
+
+  nb-accordion {
+    .form-group {
+      margin-bottom: 0.5rem;
+    }
+
+    .label {
+      margin-bottom: 0.1875rem;
+    }
+
+    // Wrappers this file pins at 42px for the full-density form.
+    .input-icon,
+    .input-date {
+      height: ga-overrides.$compact-control-height;
+    }
+
+    .input-icon .icon {
+      font-size: 0.875rem;
+    }
+
+    // The `min-height` on these three comes from `input-appearance()` — pulled in
+    // by the `:host nb-accordion` dialog include above — as `!important`, so the
+    // compact floor has to be `!important` too to be reachable at all.
+    ::ng-deep input,
+    ::ng-deep nb-select.appearance-outline.status-basic .select-button,
+    ::ng-deep .ng-select .ng-select-container {
+      min-height: ga-overrides.$compact-control-height !important;
+      height: ga-overrides.$compact-control-height;
+      padding-block: 0;
+      font-size: 0.75rem;
+    }
+
+    // `ng-select` and `nb-tag-list` draw their own text input INSIDE the trigger
+    // the rule above just sized; that inner input must not get a box of its own,
+    // or it stacks a second control height inside the first.
+    ::ng-deep .ng-select .ng-select-container input,
+    ::ng-deep nb-tag-list input {
+      min-height: 0 !important;
+      height: auto;
+      padding-block: 0;
+    }
+
+    ::ng-deep .ng-select .ng-select-container .ng-value-container {
+      font-size: 0.75rem;
+    }
+
+    // The status select pins its own 42px by id (1,1,0) higher up in this file.
+    ::ng-deep #inputStatus .select-button {
+      height: ga-overrides.$compact-control-height;
+      font-size: 0.75rem;
+    }
+
+    // Submit / reset sit in a bare `.row`; the file-wide `button { margin: 5px }`
+    // is the only thing spacing them.
+    button {
+      margin: 0.25rem;
+      font-size: 0.75rem;
+    }
+  }
+}
+
+// ── Search tab: one scroll port on the parent ────────────────────────────────
+// `.custom-content-body` is a fixed-height flex column (`calc(100vh - 19.5rem)`),
+// and inside it the table is a scroll container of its own — so `min-height: auto`
+// resolves to 0 for it and the flex algorithm is free to crush it. With the form
+// expanded that is exactly what happened: the form took its content height, the
+// table got whatever was left (on a short viewport, one clipped row), and nothing
+// anywhere overflowed, so no scrollbar ever appeared to say there was more.
+//
+// The fix is to stop making the two fight over a fixed budget. The table stops
+// scrolling internally in this tab and contributes its full height, the body
+// overflows, and the body scrolls — one scrollbar, form and table in one flow,
+// which is also what makes the sticky `thead` land at the top of the visible area
+// once the form scrolls away (sticky resolves against the nearest scroll port).
+//
+// Only the Search tab: Browse has no form above the table and is better off with
+// the table scrolling in place under a fixed pager.
+:host .search-tab .custom-content-body {
+  overflow-y: auto;
+  // A trackpad flick that reaches the end of this list should not then scroll the
+  // page behind it.
+  overscroll-behavior-y: contain;
+
+  // Natural height, no shrinking — the form is not what should give way.
+  nb-accordion {
+    flex: 0 0 auto;
+  }
+
+  .table-scroll-container {
+    // `overflow-y: auto` + `max-height: calc(100vh - 28rem)` come from the global
+    // `.table-scroll-container` rule in `_overrides.scss`; `flex-grow: 10` from
+    // the `.custom-content-body` block above. All three exist to make the table
+    // scroll inside a fixed box, which is the behaviour being handed to the
+    // parent here.
+    overflow-y: visible;
+    max-height: none;
+    min-height: 0;
+    flex: 0 0 auto;
+  }
+
+  // The pager rides the bottom edge of the scroll port instead of sitting at the
+  // far end of the scrolled content, so paging never requires scrolling first.
+  // `z-index` keeps it over the sticky `thead`, which shares the same port.
+  .pagination-container {
+    position: sticky;
+    bottom: 0;
+    z-index: 3;
+    flex: 0 0 auto;
+  }
+}
+
+// ── Pager: an opaque strip, not a transparent one ────────────────────────────
+// `--gauzy-card-2` — the tab surface, and the obvious pick for a backdrop — is
+// translucent in EVERY theme (alpha 0.02 in gauzy-light, 0.3 in gauzy-dark, 0.5
+// in corporate; see `themes.scss`), so a pager painted with it still shows the
+// table rows through itself. That is invisible while the pager sits below a
+// clipped table and unmissable once it is sticky over a scrolling one.
+//
+// `--gauzy-card-1` is the one card token that is opaque in all of them (an alias
+// of `card-background-color`, or an explicit alpha-1 rgba), and it is already
+// what `ga-hub.surface()` paints the table with — so the pager reads as the foot
+// of the same block rather than a second surface.
+:host .pagination-container {
+  background: var(--gauzy-card-1, var(--background-basic-color-1));
+  border-radius: 0 0 var(--border-radius, 0.5rem) var(--border-radius, 0.5rem);
+  // Covers the 0.25rem `pager-container()` spends on a transparent `margin-top`,
+  // which is a gap the rows would otherwise scroll through underneath.
+  margin-top: 0;
+  padding: 0.375rem 0.5rem;
+}
+
+// ── Search form: controls sized to their content ─────────────────────────────
+// The fields are laid out on a Bootstrap grid (`col-sm-4` / `-3` / `-2`) and every
+// control carries `fullWidth`, so each one stretched to a third or a quarter of
+// the card — a number field nearly 500px wide for a 6-digit estimate number.
+// Capping the COLUMN rather than the control keeps the grid's wrapping and order
+// intact (the cap only bites where the percentage is the larger of the two) and
+// carries the label above the field with it.
+:host .search-tab nb-accordion .row > [class*='col-'] {
+  max-width: 14rem;
+}

--- a/apps/gauzy/src/app/pages/payments/payments.component.scss
+++ b/apps/gauzy/src/app/pages/payments/payments.component.scss
@@ -1,1 +1,30 @@
 @forward '@shared/_pg-card';
+@use 'gauzy/_gauzy-table-hub' as ga-hub;
+
+:host {
+  @include ga-hub.density-tokens();
+}
+
+:host .table-scroll-container {
+  @include ga-hub.surface();
+}
+
+:host ::ng-deep angular2-smart-table {
+  @include ga-hub.rows();
+}
+
+:host ::ng-deep {
+  @include ga-hub.tag-stack-spacing();
+}
+
+:host ::ng-deep ga-status-badge {
+  @include ga-hub.status-badge-tints();
+}
+
+:host .pagination-container {
+  @include ga-hub.pager-container();
+}
+
+:host .pagination-container ::ng-deep ngx-pagination {
+  @include ga-hub.pager();
+}

--- a/apps/gauzy/src/app/pages/pipelines/pipelines.component.scss
+++ b/apps/gauzy/src/app/pages/pipelines/pipelines.component.scss
@@ -1,5 +1,7 @@
 @use '@shared/_pg-card' as *;
 @use 'gauzy/tabset-actions' as *;
+@use 'gauzy/_gauzy-table-hub' as ga-hub;
+@use 'gauzy/_gauzy-overrides' as ga-overrides;
 
 :host {
   height: 100%;
@@ -54,4 +56,185 @@ nb-accordion-item-header ::ng-deep nb-icon {
 .grid {
   overflow: auto;
   height: 100%;
+}
+
+:host {
+  @include ga-hub.density-tokens();
+}
+
+:host .table-scroll-container {
+  @include ga-hub.surface();
+}
+
+:host ::ng-deep angular2-smart-table {
+  @include ga-hub.rows();
+}
+
+:host ::ng-deep {
+  @include ga-hub.tag-stack-spacing();
+}
+
+:host ::ng-deep ga-status-badge {
+  @include ga-hub.status-badge-tints();
+}
+
+:host .pagination-container {
+  @include ga-hub.pager-container();
+}
+
+:host .pagination-container ::ng-deep ngx-pagination {
+  @include ga-hub.pager();
+}
+
+// ── Tab bar ─────────────────────────────────────────────────────────
+// Same step down from the app-wide `tabset-tab-text-font-size` (0.875rem) as the
+// Invoices / Estimates tab strip, so the two sales pages read alike.
+//
+// `.tab-link.tab-link` is doubled on purpose: the global rules in
+// `gauzy/_gauzy-overrides.scss` reach (0,4,2) on the ACTIVE tab, which a single
+// class here would only tie with — and a tie between a component sheet and a
+// global one is settled by stylesheet order, which is not ours to rely on.
+:host ::ng-deep nb-tabset .tabset .tab a.tab-link.tab-link {
+  font-size: 0.75rem;
+  line-height: 0.875rem;
+}
+
+// ── Search form ───────────────────────────────────────────────────
+// The form is an accordion stacked above the table inside `nb-tab.content-active`,
+// which `tabset-fills-height()` makes a flex column with `min-height: 0` — so the
+// table, a scroll container, is the child free to be crushed to nothing when the
+// form is open. Same shape as the Invoices / Estimates Search tab, and the same
+// treatment, down to the shared `$compact-control-height`.
+//
+// Scoped to `nb-tab.search-tab`, so the smart-table's own filter row (which
+// renders in both tabs and takes its density from `ga-hub` above) is untouched.
+:host nb-tab.search-tab {
+  nb-accordion.mb-3 {
+    margin-bottom: 0.5rem !important;
+  }
+
+  nb-accordion-item-header {
+    font-size: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    min-height: 0;
+  }
+
+  // The chevron box is sized to its glyph by the unscoped rule near the top of
+  // this file (1.75rem); it comes down with the header it sits in.
+  nb-accordion-item-header ::ng-deep nb-icon {
+    width: 1.375rem;
+    height: 1.375rem;
+    font-size: 0.875rem;
+  }
+
+  nb-accordion-item-body ::ng-deep .item-body {
+    padding: 0.75rem;
+  }
+
+  label {
+    margin-bottom: 0.1875rem;
+  }
+
+  // Only the field row — the form's second `.row` holds Search / Reset, and the
+  // fields there share the `col-12` class with two of the field columns, so
+  // `:not(.col-12)` could not tell them apart. Capping the COLUMN rather than the
+  // control keeps the grid's order and wrapping (`col-xl-4 col-lg-12`) intact:
+  // the cap only bites where the percentage is the wider of the two.
+  form > .row:first-child > [class*='col-'] {
+    max-width: 14rem;
+    margin-bottom: 0.5rem;
+  }
+
+  // Bootstrap's spacing utilities are `!important`, so `.mt-3` can only be met
+  // in kind.
+  form > .row .col-12.mt-3 {
+    margin-top: 0.25rem !important;
+  }
+
+  // `min-height` on an `input` is `!important` app-wide — `gauzy-overrides()`
+  // includes `input-appearance()` at the top level, where `::ng-deep` is stripped
+  // and the rule lands as a bare `input { min-height: … !important }`. The compact
+  // floor has to be `!important` too to be reachable at all. The other two are
+  // plain rules and are out-ranked on specificity alone.
+  ::ng-deep input {
+    min-height: ga-overrides.$compact-control-height !important;
+    height: ga-overrides.$compact-control-height;
+    padding-block: 0;
+    font-size: 0.75rem;
+  }
+
+  ::ng-deep nb-select.shape-rectangle .select-button,
+  ::ng-deep .ng-select .ng-select-container {
+    min-height: ga-overrides.$compact-control-height;
+    height: ga-overrides.$compact-control-height;
+    padding-block: 0;
+    font-size: 0.75rem;
+  }
+
+  // `ng-select` draws its own text input INSIDE the trigger the rule above just
+  // sized; that inner input must not get a box of its own, or it stacks a second
+  // control height inside the first.
+  ::ng-deep .ng-select .ng-select-container input {
+    min-height: 0 !important;
+    height: auto;
+  }
+
+  button {
+    font-size: 0.75rem;
+  }
+}
+
+// ── Search tab: one scroll port on the tab body ────────────────────────
+// With the form expanded the tab body has no room left for the table, and because
+// the table scrolls internally (`min-height` resolves to 0 for a scroll container)
+// nothing overflows — so it is silently crushed instead of producing a scrollbar.
+// Handing the scroll to the parent puts form and table in one flow, and parks the
+// sticky `thead` at the top of the port once the form scrolls away.
+//
+// Browse keeps the table scrolling in place: it has no form above it.
+:host nb-tab.search-tab.content-active {
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+
+  nb-accordion {
+    flex: 0 0 auto;
+  }
+
+  // `flex: 1 1 auto; min-height: 0` comes from `@shared/_pg-card`, and
+  // `overflow-y: auto` + a viewport cap from the global `.table-scroll-container`
+  // rule in `_overrides.scss` — all of it to make the table scroll inside a fixed
+  // box, which is the job being handed to the parent here.
+  .table-scroll-container {
+    overflow-y: visible;
+    max-height: none;
+    min-height: 0;
+    flex: 0 0 auto;
+  }
+
+  // The pager rides the bottom edge of the port rather than the far end of the
+  // scrolled content, so paging never requires scrolling first. `z-index` keeps
+  // it over the sticky `thead`, which shares the port.
+  .pagination-container {
+    position: sticky;
+    bottom: 0;
+    z-index: 3;
+    flex: 0 0 auto;
+  }
+}
+
+// ── Pager: an opaque strip, not a transparent one ────────────────────
+// `--gauzy-card-2` — this tab body's own background, and the obvious pick for a
+// backdrop — is translucent in EVERY theme (alpha 0.02 in gauzy-light, 0.3 in
+// gauzy-dark, 0.5 in corporate; see `themes.scss`), so a pager painted with it
+// still shows the table rows through itself once it is sticky over a scrolling
+// table. `--gauzy-card-1` is the one card token opaque in all of them, and is
+// already what `ga-hub.surface()` paints the table with, so the pager reads as
+// the foot of the same block.
+:host .pagination-container {
+  background: var(--gauzy-card-1, var(--background-basic-color-1));
+  border-radius: 0 0 var(--border-radius, 0.5rem) var(--border-radius, 0.5rem);
+  // Covers the 0.25rem `pager-container()` spends on a transparent `margin-top`,
+  // which is a gap the rows would otherwise scroll through underneath.
+  margin-top: 0;
+  padding: 0.375rem 0.5rem;
 }

--- a/packages/plugins/docs-ui/src/lib/components/table/docs-table.component.scss
+++ b/packages/plugins/docs-ui/src/lib/components/table/docs-table.component.scss
@@ -7,7 +7,7 @@
   --gauzy-table-line-height: 1rem;
   --gauzy-table-cell-padding-y: 0.1875rem;
   --gauzy-table-cell-padding-x: 0.4375rem;
-  --gauzy-table-header-font-size: 0.625rem;
+  --gauzy-table-header-font-size: 0.75rem;
   --gauzy-table-header-line-height: 0.8125rem;
   --gauzy-table-header-padding-y: 0.3125rem;
   --gauzy-table-header-padding-x: 0.4375rem;

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
@@ -53,11 +53,11 @@ $menu-row-color: var(--gauzy-text-color-2, var(--text-hint-color));
 $menu-row-weight: 400;
 $menu-row-active-weight: 500;
 
-// 12px for every label in the nav — deliberately NOT `menu-text-font-size`
+// 14px for every label in the nav — deliberately NOT `menu-text-font-size`
 // (0.8125rem / 13px), which is the app's shared CONTROL text size and is also
 // what overlay menus, ng-select rows and the settings menu resolve. The sidebar
 // runs on its own step; the shared token stays where it is.
-$menu-row-font-size: 0.75rem;
+$menu-row-font-size: 0.875rem;
 
 // Row padding, one step tighter than the shared `menu-item-padding`
 // (0.5rem 0.75rem). The bigger label would otherwise push a row from 36px to
@@ -139,7 +139,7 @@ $menu-child-indent: 1.25rem;
     > i {
       flex: 0 0 auto;
       width: $menu-icon-column;
-      font-size: 0.75rem;
+      font-size: 0.875rem;
       text-align: center;
       color: inherit;
       opacity: 0.85;
@@ -393,7 +393,7 @@ $menu-child-indent: 1.25rem;
   i {
     flex: 0 0 auto;
     width: $menu-icon-column;
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     text-align: center;
     color: inherit;
     opacity: 0.85;

--- a/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
+++ b/packages/ui-core/shared/src/lib/components/changelog-entry/changelog-entry.component.scss
@@ -99,9 +99,9 @@
 
 			.icon {
 				margin: 0.0625rem 0 0;
-				width: 0.875rem;
-				height: 0.875rem;
-				font-size: 0.875rem;
+				width: 1rem;
+				height: 1rem;
+				font-size: 1rem;
 				color: nb-theme(text-hint-color);
 			}
 
@@ -110,14 +110,14 @@
 			}
 
 			.entry-header {
-				font-size: 0.625rem;
+				font-size: 0.75rem;
 				line-height: 0.875rem;
 				letter-spacing: -0.004em;
 				margin-bottom: 0.125rem;
 			}
 
 			.entry-header-date {
-				font-size: 0.4375rem;
+				font-size: 0.5625rem;
 				font-weight: 500;
 				line-height: 1;
 				letter-spacing: 0.06em;
@@ -128,7 +128,7 @@
 
 		.paragraph {
 			margin: 0;
-			font-size: 0.625rem;
+			font-size: 0.75rem;
 			line-height: 0.9375rem;
 			color: nb-theme(text-hint-color);
 		}
@@ -140,7 +140,7 @@
 
 		.learn-more-hint {
 			margin: 0.25rem 0 0;
-			font-size: 0.5625rem;
+			font-size: 0.6875rem;
 			font-weight: 600;
 			letter-spacing: 0.01em;
 		}

--- a/packages/ui-core/static/styles/@shared/_panel.scss
+++ b/packages/ui-core/static/styles/@shared/_panel.scss
@@ -10,10 +10,10 @@ $panel-active-tint: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
 $panel-radius: var(--border-radius, 8px);
 $panel-row-radius: var(--gauzy-radius-sm, 6px);
 
-$panel-text-micro: 0.5625rem; //  9px
-$panel-text-label: 0.625rem; //  10px
-$panel-text-row: 0.625rem; //    10px
-$panel-text-title: 0.75rem; //   12px
+$panel-text-micro: 0.6875rem; // 11px
+$panel-text-label: 0.75rem; //   12px
+$panel-text-row: 0.75rem; //     12px
+$panel-text-title: 0.875rem; //  14px
 
 $panel-pad: 0.375rem; //      6px
 $panel-gutter: 0.625rem; //  10px
@@ -79,9 +79,9 @@ $panel-gap: 0.125rem; //      2px
 
   nb-icon,
   i {
-    font-size: 0.75rem;
-    width: 0.75rem;
-    height: 0.75rem;
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
     line-height: 1;
   }
 }
@@ -134,9 +134,9 @@ $panel-gap: 0.125rem; //      2px
   nb-icon,
   i {
     flex: 0 0 auto;
-    font-size: 0.8125rem;
-    width: 0.8125rem;
-    height: 0.8125rem;
+    font-size: 0.9375rem;
+    width: 0.9375rem;
+    height: 0.9375rem;
     color: nb-theme(text-hint-color);
   }
 }

--- a/packages/ui-core/static/styles/_overlays.scss
+++ b/packages/ui-core/static/styles/_overlays.scss
@@ -334,7 +334,7 @@ $overlay-item-padding-x: 0.625rem; // 10px
   .cdk-overlay-container nb-option-list.gz-panel-options {
     nb-option {
       padding: 0.3125rem 0.5rem;
-      font-size: 0.625rem;
+      font-size: 0.75rem;
       line-height: 0.875rem;
     }
 

--- a/packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss
+++ b/packages/ui-core/static/styles/gauzy/_gauzy-overrides.scss
@@ -66,6 +66,13 @@ $control-padding-x: 1rem;
 // One line box plus both block insets — i.e. the height `nb-select` computes for
 // itself, so both combobox flavours land on the same size instead of 36 vs 42.
 $default-height: calc(#{nb-theme(select-medium-text-line-height)} + #{$control-padding-y} * 2);
+// One step under `$default-height` for the search / filter forms that sit ABOVE a
+// table inside a fixed-height tab body, where every pixel the form takes comes
+// straight out of the rows. A literal rather than a derivation of `$default-height`
+// for the same reason that value is a `calc()`: it is opaque to Sass, so there is
+// no way to take a step off it. Shared so the pages that compact a filter panel
+// cannot drift apart on what "compact" means.
+$compact-control-height: 1.875rem;
 $default-radius: nb-theme(border-radius);
 // Was `calc(button-rectangle-border-radius / 1.625)` — an arithmetic dodge that
 // only existed to walk the old 2rem stadium back to something usable (~19.7px).

--- a/packages/ui-core/static/styles/gauzy/_gauzy-table-hub.scss
+++ b/packages/ui-core/static/styles/gauzy/_gauzy-table-hub.scss
@@ -1,0 +1,165 @@
+@mixin density-tokens() {
+  --gauzy-table-font-size: 0.6875rem;
+  --gauzy-table-line-height: 1rem;
+  --gauzy-table-cell-padding-y: 0.1875rem;
+  --gauzy-table-cell-padding-x: 0.4375rem;
+  --gauzy-table-header-font-size: 0.75rem;
+  --gauzy-table-header-line-height: 0.8125rem;
+  --gauzy-table-header-padding-y: 0.3125rem;
+  --gauzy-table-header-padding-x: 0.4375rem;
+  --gauzy-table-filter-padding-y: 0.1875rem;
+  --gauzy-table-control-height: 1.5rem;
+  --gauzy-table-badge-height: 1rem;
+  --gauzy-table-chip-font-size: 0.625rem;
+  --gauzy-table-chip-line-height: 0.75rem;
+  --gauzy-table-chip-padding-y: 0;
+  --gauzy-table-chip-padding-x: 0.3125rem;
+  --gauzy-table-chip-gap: 0.125rem;
+  --gauzy-table-chip-block-gap: 0.5rem;
+  --gauzy-people-avatar-size: 1rem;
+  --gauzy-people-font-size: 0.6875rem;
+}
+
+@mixin surface() {
+  background: var(--gauzy-card-1, var(--background-basic-color-1));
+  box-shadow: inset 0 0 0 1px var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+  border-radius: var(--border-radius, 0.5rem);
+}
+
+@mixin rows() {
+  tr.angular2-smart-titles > th {
+    border-bottom: 1px solid var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
+    vertical-align: middle;
+  }
+
+  tbody tr {
+    background: transparent;
+
+    > td {
+      vertical-align: middle;
+    }
+
+    &:hover:not(.selected) {
+      background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12)) !important;
+    }
+
+    &.selected {
+      background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2)) !important;
+      box-shadow: none !important;
+    }
+  }
+}
+
+@mixin tag-stack-spacing() {
+  ga-notes-with-tags .tags:has(nb-badge) {
+    margin-bottom: 0.5rem;
+  }
+}
+
+@mixin status-badge-tints() {
+  .badge-success {
+    color: var(--gauzy-action-success-text, #047857);
+    background-color: var(--gauzy-action-success-tint, rgba(4, 120, 87, 0.08));
+  }
+
+  .badge-warning {
+    color: var(--gauzy-action-warning-text, #b45309);
+    background-color: var(--gauzy-action-warning-tint, rgba(180, 83, 9, 0.08));
+  }
+
+  .badge-danger {
+    color: var(--gauzy-action-danger-text, #dc2626);
+    background-color: var(--gauzy-action-danger-tint, rgba(220, 38, 38, 0.08));
+  }
+}
+
+@mixin pager-container() {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+
+  @media (max-width: 767px) {
+    justify-content: center;
+  }
+}
+
+@mixin pager() {
+  width: auto;
+
+  nav {
+    margin-top: 0 !important;
+    gap: 0.75rem;
+  }
+
+  .pagination {
+    gap: 0.125rem;
+    font-size: 0.75rem;
+  }
+
+  li {
+    a,
+    span {
+      margin: 0;
+    }
+
+    span {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 1.75rem;
+      height: 1.75rem;
+      padding: 0 0.375rem;
+      font-size: 0.75rem;
+      line-height: 1;
+      border-radius: var(--gauzy-radius-sm, 0.375rem);
+    }
+
+    span.icon {
+      padding: 0;
+      background: var(--gauzy-hover-tint, rgba(126, 126, 143, 0.12));
+      box-shadow: none;
+      border-radius: var(--gauzy-radius-sm, 0.375rem);
+
+      nb-icon {
+        font-size: 0.875rem;
+      }
+    }
+
+    &:hover span.icon {
+      background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+    }
+
+    &.disabled {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+
+    &.active span {
+      width: auto;
+      min-width: 1.75rem;
+      height: 1.75rem;
+      padding: 0 0.375rem !important;
+      border-radius: var(--gauzy-radius-sm, 0.375rem);
+      line-height: 1;
+      background: var(--gauzy-active-tint, rgba(126, 126, 143, 0.2));
+      color: var(--text-basic-color);
+      font-weight: 600;
+    }
+  }
+
+  > nav > div {
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--gauzy-text-color-2, var(--text-hint-color));
+  }
+
+  nb-select .select-button {
+    min-width: 4rem;
+    height: 1.75rem;
+    padding: 0 0.5rem;
+    border-radius: var(--gauzy-radius-sm, 0.375rem);
+    font-size: 0.75rem;
+  }
+}

--- a/packages/ui-core/theme/src/lib/components/gauzy-logo/gauzy-logo.component.scss
+++ b/packages/ui-core/theme/src/lib/components/gauzy-logo/gauzy-logo.component.scss
@@ -43,7 +43,7 @@
         // Unpressured, both resolve to the same width (text, capped below).
         width: auto;
         max-width: 150px;
-        font-size: 0.75rem;
+        font-size: 0.875rem;
         font-weight: 400;
         color: nb-theme(text-basic-color);
       }
@@ -167,7 +167,7 @@ nb-accordion-item:first-child.collapsed nb-accordion-item-header.principal:hover
 
 .text {
   margin: 0 10px;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   font-style: normal;
   font-weight: 500;
   line-height: 16px;

--- a/packages/ui-core/theme/src/lib/components/header/header.component.scss
+++ b/packages/ui-core/theme/src/lib/components/header/header.component.scss
@@ -340,7 +340,7 @@ $header-text-color: var(--gauzy-text-color-2, var(--text-hint-color));
 }
 
 :host .actions nb-action > nb-icon {
-  font-size: 0.875rem;
+  font-size: 1rem;
   color: $header-text-color;
 }
 

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/components/theme-selector/theme-selector-image/theme-selector-image.component.scss
@@ -74,9 +74,9 @@
 
 .theme-trigger-chevron {
   flex: 0 0 auto;
-  width: 0.75rem;
-  height: 0.75rem;
-  font-size: 0.75rem;
+  width: 0.875rem;
+  height: 0.875rem;
+  font-size: 0.875rem;
   color: nb-theme(text-hint-color);
   transition: transform 0.15s ease-in-out;
 
@@ -157,9 +157,9 @@
 
 .theme-check {
   flex: 0 0 auto;
-  width: 0.75rem;
-  height: 0.75rem;
-  font-size: 0.75rem;
+  width: 0.875rem;
+  height: 0.875rem;
+  font-size: 0.875rem;
   color: nb-theme(text-basic-color);
   visibility: hidden;
 

--- a/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.scss
+++ b/packages/ui-core/theme/src/lib/components/theme-sidebar/theme-settings/theme-settings.component.scss
@@ -65,9 +65,9 @@
       gap: 0.375rem;
 
       nb-icon {
-        font-size: 0.875rem;
-        width: 0.875rem;
-        height: 0.875rem;
+        font-size: 1rem;
+        width: 1rem;
+        height: 1rem;
       }
     }
   }
@@ -84,9 +84,9 @@
     }
 
     .preferred-layout nb-icon {
-      font-size: 0.75rem;
-      width: 0.75rem;
-      height: 0.75rem;
+      font-size: 0.875rem;
+      width: 0.875rem;
+      height: 0.875rem;
       color: nb-theme(text-hint-color);
     }
 

--- a/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user-menu/user-menu.component.scss
@@ -107,7 +107,7 @@
       }
 
       i {
-        font-size: 0.75rem;
+        font-size: 0.875rem;
         line-height: 1;
       }
     }

--- a/packages/ui-core/theme/src/lib/components/user/user.component.scss
+++ b/packages/ui-core/theme/src/lib/components/user/user.component.scss
@@ -116,7 +116,7 @@ $avatar-size: 1.5rem;
 
     .email {
       color: nb-theme(text-hint-color);
-      font-size: var(--gz-user-email-size, 0.625rem);
+      font-size: var(--gz-user-email-size, 0.75rem);
       font-weight: 400;
     }
   }

--- a/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
+++ b/packages/ui-core/theme/src/lib/layouts/one-column/one-column.layout.scss
@@ -193,7 +193,7 @@ $chat-hairline: var(--gauzy-overlay-border-color, rgba(126, 126, 143, 0.18));
     padding: 0.5rem 0.75rem;
     --gz-user-surface: #{nb-theme(gauzy-sidebar-background-2)};
     --gz-user-presence: none;
-    --gz-user-email-size: 0.75rem;
+    --gz-user-email-size: 0.875rem;
 
     gauzy-user {
       flex: 1 1 auto;


### PR DESCRIPTION
- [ ] Before

<img width="1918" height="876" alt="Screenshot 2026-08-26 031039" src="https://github.com/user-attachments/assets/42be4b89-e0d0-4d23-9b4b-972072bd836d" />

- [ ] After

<img width="1918" height="866" alt="Screenshot 2026-08-26 033039" src="https://github.com/user-attachments/assets/ef762aed-bf1e-4475-8e1d-d0d9670403a2" />


- [ ] Before

<img width="1918" height="872" alt="Screenshot 2026-08-26 031009" src="https://github.com/user-attachments/assets/3bd2af6f-a952-4e35-b812-78ce44cc860c" />

- [ ] After

<img width="1912" height="868" alt="Screenshot 2026-08-26 032013" src="https://github.com/user-attachments/assets/1f618bbe-e250-4e14-a7af-d37e205d0ee0" />

- [ ] Before

<img width="1918" height="868" alt="Screenshot 2026-08-26 030837" src="https://github.com/user-attachments/assets/13776735-6e84-4c9c-9832-edd82bf3abdd" />

- [ ] After

<img width="1913" height="868" alt="Screenshot 2026-08-26 032044" src="https://github.com/user-attachments/assets/421168c5-d286-4321-854b-1b41dd830bb1" />
