### PR TITLE
fix(tasks): avoid errors for empty issue type scopes

### DIFF
--- a/packages/core/src/lib/tasks/issue-type/issue-type.service.spec.ts
+++ b/packages/core/src/lib/tasks/issue-type/issue-type.service.spec.ts
@@ -1,0 +1,35 @@
+import { MultiORMEnum } from '../../core/utils';
+import { IssueTypeService } from './issue-type.service';
+
+describe('IssueTypeService', () => {
+	it('returns system defaults without logging an error when a TypeORM scope has no issue types', async () => {
+		const queryBuilder = {
+			where: jest.fn().mockReturnThis(),
+			getOne: jest.fn().mockResolvedValue(null),
+			getManyAndCount: jest.fn()
+		};
+		const typeOrmRepository = {
+			metadata: { tableName: 'issue_type' },
+			createQueryBuilder: jest.fn().mockReturnValue(queryBuilder)
+		};
+		const service = new IssueTypeService(typeOrmRepository as never, {} as never, {} as never);
+		const defaults = { items: [], total: 0 };
+
+		jest.spyOn(service, 'ormType', 'get').mockReturnValue(MultiORMEnum.TypeORM);
+		jest.spyOn(service, 'getDefaultEntities').mockResolvedValue(defaults);
+		const errorLogger = jest.spyOn(service.logger, 'error').mockImplementation(() => undefined);
+
+		await expect(
+			service.fetchAll({
+				tenantId: 'tenant-id',
+				organizationId: 'organization-id',
+				organizationTeamId: 'team-id'
+			})
+		).resolves.toStrictEqual(defaults);
+
+		expect(queryBuilder.getOne).toHaveBeenCalledTimes(1);
+		expect(queryBuilder.getManyAndCount).not.toHaveBeenCalled();
+		expect(service.getDefaultEntities).toHaveBeenCalledTimes(1);
+		expect(errorLogger).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/lib/tasks/issue-type/issue-type.service.ts
+++ b/packages/core/src/lib/tasks/issue-type/issue-type.service.ts
@@ -47,8 +47,7 @@ export class IssueTypeService extends TaskMetadataService<IssueType> {
 	 * Fetches issue types based on specified parameters.
 	 *
 	 * @param params - Parameters for finding issue types (IIssueTypeFindInput).
-	 * @returns A Promise resolving to an object with items (array of issue types) and total count.
-	 * @throws Error if no records are found or an error occurs during the query.
+	 * @returns The matching issue types, or system defaults when the requested scope has none.
 	 */
 	public async fetchAll(params: IIssueTypeFindInput): Promise<IPagination<IIssueType>> {
 		try {

--- a/packages/core/src/lib/tasks/issue-type/issue-type.service.ts
+++ b/packages/core/src/lib/tasks/issue-type/issue-type.service.ts
@@ -73,7 +73,10 @@ export class IssueTypeService extends TaskMetadataService<IssueType> {
 					cqb.where((qb: SelectQueryBuilder<IssueType>) => {
 						this.getFilterQuery(qb, params);
 					});
-					await cqb.getOneOrFail();
+					const exists = await cqb.getOne();
+					if (!exists) {
+						return await this.getDefaultEntities();
+					}
 
 					/**
 					 * Find task issue types for given params


### PR DESCRIPTION
## What changed
- treat an empty scoped issue-type query as a normal system-default fallback
- avoid throwing and logging EntityNotFoundError during task metadata bootstrap
- add a focused TypeORM regression test

## Why
Authenticated demo.ever.team probes showed successful task-metadata/bootstrap requests emitting IssueTypeService EntityNotFoundError whenever a team had no custom issue types. Empty scoped metadata is expected and the MikroORM path already handles it without exceptions.

## Verification
- focused IssueTypeService regression: pass
- core suite: 560 existing tests passed; the new fixture was then corrected and its focused rerun passed
- core build and dependencies: pass
- core lint currently stops before file linting on the existing eslint.config.js baseConfig-is-not-iterable loader error