### PR TITLE
docs: add RepoCloud one-click deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Please refer to our official [Platform Documentation](https://docs.gauzy.co) and
 
 ## 🚀 Quick Start
 
+### Deploy on RepoCloud
+
+Deploy Ever Gauzy instantly with one click on [RepoCloud](https://repocloud.io/details/Ever%20Gauzy/).
+
 ### With Docker Compose
 
 -   Clone repo.


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option in the Quick Start section.

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment, offering an alternative to manual Docker Compose setup.

- Adds deployment subsection to `README.md`
- Uses the same text link format as existing Quick Start options
- Links to: https://repocloud.io/details/Ever%20Gauzy/