### PR TITLE
fix(auth): fit login, register and workspace screens to one viewport

### DIFF
--- a/packages/ui-auth/src/lib/components/auth/auth.component.html
+++ b/packages/ui-auth/src/lib/components/auth/auth.component.html
@@ -1,7 +1,7 @@
 <nb-layout>
 	<nb-layout-column class="wrapper">
 		<nb-card class="card">
-			<nb-card-header class="header" [class.register]="isRegister">
+			<nb-card-header class="header" [class.register]="isRegister" [class.login]="isLogin">
 				<nav [class.hide-go-back]="!(queryParams$ | async)?.returnUrl" class="navigation">
 					<a (click)="goBack()" class="link back-link" aria-label="Back">
 						<nb-icon icon="arrow-back"></nb-icon>
@@ -9,7 +9,7 @@
 				</nav>
 				<gauzy-switch-theme class="theme-switch" [hasText]="false"></gauzy-switch-theme>
 			</nb-card-header>
-			<nb-card-body class="body" [class.register]="isRegister">
+			<nb-card-body class="body" [class.register]="isRegister" [class.login]="isLogin">
 				<nb-auth-block class="auth-block">
 					<router-outlet></router-outlet>
 				</nb-auth-block>

--- a/packages/ui-auth/src/lib/components/auth/auth.component.scss
+++ b/packages/ui-auth/src/lib/components/auth/auth.component.scss
@@ -14,10 +14,6 @@
   // never needed. They already span their column, so `100%` is both correct and
   // scrollbar-safe.
   & .header {
-    // Nebular gives `nb-card-header` no background of its own (it only paints one
-    // under `.status-*`), so this strip is transparent by default and stays that
-    // way. The band came from this file's own `.register` rule below, which the
-    // template stamps on the header AND the body — see the note there.
     background: transparent;
     border-bottom: none;
     padding-top: 14px;
@@ -36,9 +32,6 @@
   }
   & .card {
     margin-bottom: 0;
-    // The shell is exactly one viewport tall and lays its header/body out as a
-    // column, so the body can take "whatever is left" instead of guessing the
-    // header height with a magic number. Nothing can push the page past 100vh.
     height: 100vh;
     max-height: 100vh;
     width: 100%;
@@ -57,13 +50,6 @@
     overflow-y: auto;
     display: flex;
     justify-content: center;
-    // NOT `align-items: center`. A centred flex item that is taller than its
-    // scroll container overflows equally in both directions, and the overflow
-    // above the container is unreachable — no scrollbar reaches it. That is what
-    // cut the logo and the top of "Register" off the register screen. Starting
-    // the item at the top and centring it with `margin: auto` on `.auth-block`
-    // below gives the same centred look when it fits, and a fully scrollable card
-    // when it does not.
     align-items: flex-start;
     padding-top: 16px;
     padding-bottom: 16px;
@@ -75,7 +61,6 @@
       align-items: center;
     }
     & .auth-block {
-      // Centres vertically only while there is free space — see `.body` above.
       margin: auto 0;
       min-width: 100%;
       display: flex;
@@ -129,10 +114,6 @@
     display: none;
   }
 }
-// The template stamps `[class.register]` on the header AND the body. As a bare
-// `.register` this painted both, so the register screen got an opaque band across
-// its header. Scoped to `.body`, the surface stays where it was meant to go and
-// the header stays a bare strip holding the back arrow and the theme toggle.
 .body.register {
   background: $register-background-light-color;
 }

--- a/packages/ui-auth/src/lib/components/auth/auth.component.scss
+++ b/packages/ui-auth/src/lib/components/auth/auth.component.scss
@@ -14,11 +14,18 @@
   // never needed. They already span their column, so `100%` is both correct and
   // scrollbar-safe.
   & .header {
+    // Nebular gives `nb-card-header` no background of its own (it only paints one
+    // under `.status-*`), so this strip is transparent by default and stays that
+    // way. The band came from this file's own `.register` rule below, which the
+    // template stamps on the header AND the body — see the note there.
+    background: transparent;
     border-bottom: none;
-    padding-top: 24px;
-    padding-left: 30px;
-    padding-right: 30px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+    padding-left: 24px;
+    padding-right: 24px;
     width: 100%;
+    flex: 0 0 auto;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -29,26 +36,37 @@
   }
   & .card {
     margin-bottom: 0;
-    height: 100%;
+    // The shell is exactly one viewport tall and lays its header/body out as a
+    // column, so the body can take "whatever is left" instead of guessing the
+    // header height with a magic number. Nothing can push the page past 100vh.
+    height: 100vh;
+    max-height: 100vh;
     width: 100%;
     display: flex;
-    justify-content: center;
-    align-items: center;
+    flex-direction: column;
+    align-items: stretch;
     @include mobile-screen {
       height: auto;
+      max-height: none;
     }
   }
-  // Set --header-height on :root or the nb-card-header element to match the
-  // actual rendered header size. Override per-breakpoint as needed, e.g.:
-  //   @media (max-width: 490px) { :root { --header-height: 0px; } }
-  // The fallback of 70px matches the current desktop header height.
   & .body {
     width: 100%;
-    height: 100%;
-    min-height: calc(100vh - var(--header-height, 70px));
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
     display: flex;
     justify-content: center;
-    align-items: center;
+    // NOT `align-items: center`. A centred flex item that is taller than its
+    // scroll container overflows equally in both directions, and the overflow
+    // above the container is unreachable — no scrollbar reaches it. That is what
+    // cut the logo and the top of "Register" off the register screen. Starting
+    // the item at the top and centring it with `margin: auto` on `.auth-block`
+    // below gives the same centred look when it fits, and a fully scrollable card
+    // when it does not.
+    align-items: flex-start;
+    padding-top: 16px;
+    padding-bottom: 16px;
     @include mobile-screen {
       padding-left: 10px;
       padding-right: 10px;
@@ -57,6 +75,8 @@
       align-items: center;
     }
     & .auth-block {
+      // Centres vertically only while there is free space — see `.body` above.
+      margin: auto 0;
       min-width: 100%;
       display: flex;
       justify-content: center;
@@ -77,8 +97,13 @@
   // hairline that ignores the theme on the light ones.
   border: 1px solid nb-theme(border-basic-color-3);
   border-radius: 50%;
-  padding: 15px;
+  padding: 10px;
+  display: inline-flex;
   transition: all 0.3s ease;
+  & nb-icon {
+    width: 18px;
+    height: 18px;
+  }
   &:hover {
     -webkit-box-shadow: 5px 5px 30px -10px rgba(0, 0, 0, 0.3);
     box-shadow: 5px 5px 30px -10px rgba(0, 0, 0, 0.3);
@@ -104,7 +129,11 @@
     display: none;
   }
 }
-.register {
+// The template stamps `[class.register]` on the header AND the body. As a bare
+// `.register` this painted both, so the register screen got an opaque band across
+// its header. Scoped to `.body`, the surface stays where it was meant to go and
+// the header stays a bare strip holding the back arrow and the theme toggle.
+.body.register {
   background: $register-background-light-color;
 }
 

--- a/packages/ui-auth/src/lib/components/auth/auth.component.scss
+++ b/packages/ui-auth/src/lib/components/auth/auth.component.scss
@@ -30,7 +30,8 @@
       display: none;
     }
   }
-  & .header.register {
+  & .header.register,
+  & .header.login {
     position: fixed;
     top: 0;
     left: 0;
@@ -133,15 +134,19 @@
     display: none;
   }
 }
-.body.register {
-  background: $register-background-light-color;
-  // The register header is `position: fixed`, so it no longer reserves its own
-  // 68px in the card's flex column. Pay that height back here so the form starts
-  // where it did before instead of sliding under the theme switch.
+// The register/login header is `position: fixed`, so it no longer reserves its
+// own 68px in the card's flex column. Pay that height back here so the form
+// starts where it did before instead of sliding under the theme switch.
+.body.register,
+.body.login {
   padding-top: 68px + 16px;
   @include mobile-screen {
     padding-top: 16px;
   }
+}
+
+.body.register {
+  background: $register-background-light-color;
 }
 
 .hide-go-back {

--- a/packages/ui-auth/src/lib/components/auth/auth.component.scss
+++ b/packages/ui-auth/src/lib/components/auth/auth.component.scss
@@ -30,6 +30,25 @@
       display: none;
     }
   }
+  & .header.register {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    background: rgb(18 18 20 / 0%);
+    border-bottom: none;
+    padding: 14px 24px;
+    height: 68px;
+    flex: 0 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-radius: 0;
+    @include mobile-screen {
+      display: none;
+    }
+  }
   & .card {
     margin-bottom: 0;
     height: 100vh;
@@ -116,6 +135,13 @@
 }
 .body.register {
   background: $register-background-light-color;
+  // The register header is `position: fixed`, so it no longer reserves its own
+  // 68px in the card's flex column. Pay that height back here so the form starts
+  // where it did before instead of sliding under the theme switch.
+  padding-top: 68px + 16px;
+  @include mobile-screen {
+    padding-top: 16px;
+  }
 }
 
 .hide-go-back {

--- a/packages/ui-auth/src/lib/components/auth/auth.component.ts
+++ b/packages/ui-auth/src/lib/components/auth/auth.component.ts
@@ -15,6 +15,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 })
 export class NgxAuthComponent extends NbAuthComponent implements OnInit {
 	public isRegister: boolean = false;
+	public isLogin: boolean = false;
 	public queryParams$: Observable<Params>; // Observable for the query params
 
 	constructor(
@@ -27,7 +28,7 @@ export class NgxAuthComponent extends NbAuthComponent implements OnInit {
 	}
 
 	ngOnInit() {
-		this.updateRegisterClass(this._router.url);
+		this.updateAuthPageClasses(this._router.url);
 
 		// Create an observable to listen to query parameter changes in the current route.
 		this.queryParams$ = this._route.queryParams.pipe(
@@ -44,19 +45,24 @@ export class NgxAuthComponent extends NbAuthComponent implements OnInit {
 				filter((event) => event instanceof NavigationStart),
 				map((event) => event as NavigationStart),
 				tap((event: NavigationStart) => {
-					this.updateRegisterClass(event.url);
+					this.updateAuthPageClasses(event.url);
 				})
 			)
 			.subscribe();
 	}
 
 	/**
-	 * Update the register class based on the current URL.
+	 * Update the per-page classes based on the current URL.
 	 *
 	 * @param url
 	 */
-	updateRegisterClass(url: string) {
-		this.isRegister = url === '/auth/register';
+	updateAuthPageClasses(url: string) {
+		// `url` still carries the query string (`/auth/login?returnUrl=...`), so
+		// compare against the path alone or the class never lands on a deep link.
+		const path = url.split('?')[0];
+
+		this.isRegister = path === '/auth/register';
+		this.isLogin = path === '/auth/login';
 	}
 
 	/**

--- a/packages/ui-auth/src/lib/components/forgot-password/forgot-password.component.scss
+++ b/packages/ui-auth/src/lib/components/forgot-password/forgot-password.component.scss
@@ -11,10 +11,11 @@
   border-radius: nb-theme(border-radius);
   padding: 30px;
   width: 476px;
-  & > * {
+  & > *:not(nb-alert) {
     padding-left: 15px;
     padding-right: 15px;
   }
+  @include auth-alert;
   & .svg-wrapper {
     display: flex;
     justify-content: space-between;
@@ -177,7 +178,7 @@
   }
   .forgot-password-wrapper {
     padding: 12px 18px;
-    & > * {
+    & > *:not(nb-alert) {
       padding-left: 0px;
       padding-right: 0px;
     }

--- a/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.html
+++ b/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.html
@@ -53,7 +53,7 @@
 						type="email"
 						[placeholder]="'WORKSPACES.PLACEHOLDERS.EMAIL' | translate"
 						fullWidth
-						fieldSize="large"
+						fieldSize="medium"
 						formControlName="email"
 						#email
 					/>

--- a/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
+++ b/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
@@ -3,9 +3,6 @@
 
 :host {
   .section-wrapper {
-    // Same compaction as the login screen: the card was sized for a tall desktop
-    // viewport, and one `row-gap` owns the vertical rhythm instead of every block
-    // carrying its own bottom margin against the next block's top margin.
     width: 700px;
     max-width: 100%;
     display: flex;
@@ -21,9 +18,6 @@
       display: flex;
       flex-direction: column;
       row-gap: 20px;
-      // Every direct child used to add its own 15px side padding on top of the
-      // wrapper's, so the dividers, inputs and footer links each started at a
-      // slightly different x.
       & > * {
         padding-left: 0;
         padding-right: 0;
@@ -32,8 +26,6 @@
         display: flex;
         justify-content: space-between;
         align-items: flex-start;
-        // Was 57px. 12px on top of the row-gap reads as a masthead band (32px),
-        // matching the login screen.
         margin-bottom: 12px;
       }
       & .title {
@@ -63,10 +55,8 @@
         text-align: start;
         margin: 0;
       }
-      // Both dividers exist only to draw a 1px line; the row-gap spaces them.
       & .hr-div-strong {
         @include hr-div-strong;
-        // The mixin hard-codes 416px, wider than this now-narrower card.
         width: 100%;
         margin: 0;
       }
@@ -85,8 +75,6 @@
             font-family: Inter;
             font-weight: 600;
             font-size: 12px;
-            // Was full-strength `text-basic-color`, which made the field labels
-            // as loud as the heading. The hint token tracks light and dark.
             color: nb-theme(text-hint-color);
             padding-left: 0;
             text-transform: none;
@@ -125,8 +113,6 @@
           margin-top: 16px;
           & .submit-btn {
             @include submit-btn;
-            // Was a right-aligned pill with 65px of side padding; full width
-            // matches the primary action on the login screen.
             width: 100%;
             margin: 0;
             padding: 9px 20px;
@@ -188,8 +174,6 @@
           }
         }
       }
-      // The one pair that wants a tighter gap than the card rhythm: two one-line
-      // links that would read as unrelated paragraphs 20px apart.
       .sign-in-or-up {
         display: flex;
         flex-direction: column;
@@ -221,8 +205,6 @@
   }
 }
 
-// The short-viewport blocks only turn the single gap value (and the form's
-// internal one) down, so they can't drift out of step with the base layout.
 @media screen and (max-height: 980px) and (min-width: 491px) {
   :host .section-wrapper .-wrapper {
     padding: 20px;

--- a/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
+++ b/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
@@ -3,10 +3,10 @@
 
 :host {
   .section-wrapper {
-    width: 700px;
+    width: 440px;
     max-width: 100%;
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     column-gap: 20px;
     row-gap: 20px;
     .-wrapper {

--- a/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
+++ b/packages/ui-auth/src/lib/components/login-workspace/login-workspace.component.scss
@@ -3,64 +3,91 @@
 
 :host {
   .section-wrapper {
-    width: 765px;
+    // Same compaction as the login screen: the card was sized for a tall desktop
+    // viewport, and one `row-gap` owns the vertical rhythm instead of every block
+    // carrying its own bottom margin against the next block's top margin.
+    width: 700px;
+    max-width: 100%;
     display: flex;
     justify-content: space-between;
+    column-gap: 20px;
+    row-gap: 20px;
     .-wrapper {
       background: nb-theme(gauzy-card-2);
       border-radius: nb-theme(border-radius);
-      padding: 30px;
-      width: 476px;
+      padding: 24px;
+      width: 440px;
+      max-width: 100%;
+      display: flex;
+      flex-direction: column;
+      row-gap: 20px;
+      // Every direct child used to add its own 15px side padding on top of the
+      // wrapper's, so the dividers, inputs and footer links each started at a
+      // slightly different x.
       & > * {
-        padding-left: 15px;
-        padding-right: 15px;
+        padding-left: 0;
+        padding-right: 0;
       }
       & .svg-wrapper {
         display: flex;
         justify-content: space-between;
-        align-items: center;
-        margin-bottom: 57px;
+        align-items: flex-start;
+        // Was 57px. 12px on top of the row-gap reads as a masthead band (32px),
+        // matching the login screen.
+        margin-bottom: 12px;
       }
       & .title {
         font-family: Inter;
-        font-size: 24px;
+        font-size: 19px;
         font-style: normal;
         font-weight: 700;
-        line-height: 30px;
+        line-height: 24px;
         letter-spacing: 0em;
         text-align: left;
+        margin: 0;
       }
       & .sub-title {
-        width: 358px;
+        width: 100%;
         max-width: 100%;
         // Same fixed-height flex box as forgot-password / reset-password: a
         // two-line instruction overflowed it and crossed the divider below.
-        min-height: 34px;
+        min-height: 32px;
         font-family: 'Inter';
         font-style: normal;
         font-weight: 400;
-        font-size: 14px;
-        line-height: 17px;
+        font-size: 12px;
+        line-height: 16px;
+        color: nb-theme(text-hint-color);
         display: flex;
         align-items: center;
         text-align: start;
-        margin-bottom: 15px;
+        margin: 0;
       }
+      // Both dividers exist only to draw a 1px line; the row-gap spaces them.
       & .hr-div-strong {
         @include hr-div-strong;
+        // The mixin hard-codes 416px, wider than this now-narrower card.
+        width: 100%;
+        margin: 0;
+      }
+      .hr-div-soft {
+        @include hr-div-soft;
+        width: 100%;
+        margin: 0;
       }
       .form {
-        margin-top: 21px;
-        margin-bottom: 25px;
+        margin: 24px 0 0;
         & .form-group {
-          margin-bottom: 16px;
+          margin-bottom: 14px;
           & .label {
             display: block;
-            margin-bottom: 8px;
+            margin-bottom: 6px;
             font-family: Inter;
             font-weight: 600;
-            font-size: 0.9375rem;
-            color: nb-theme(text-basic-color);
+            font-size: 12px;
+            // Was full-strength `text-basic-color`, which made the field labels
+            // as loud as the heading. The hint token tracks light and dark.
+            color: nb-theme(text-hint-color);
             padding-left: 0;
             text-transform: none;
           }
@@ -68,38 +95,52 @@
             border: 1px solid rgba(98, 54, 255, 0.5) !important;
             background-color: transparent;
             color: nb-theme(text-basic-color);
+            height: 38px;
+            font-size: 13px;
           }
         }
         // Ensure consistent styling for ngx-password-form-field
         ::ng-deep ngx-password-form-field {
+          .form-group {
+            margin-bottom: 0;
+          }
           .label {
             display: block;
-            margin-bottom: 8px;
+            margin-bottom: 6px;
             font-family: Inter;
             font-weight: 600;
-            font-size: 0.9375rem;
-            color: nb-theme(text-basic-color);
+            font-size: 12px;
+            color: nb-theme(text-hint-color);
           }
           input {
             border: 1px solid rgba(98, 54, 255, 0.5) !important;
             background-color: transparent;
             color: nb-theme(text-basic-color);
+            height: 38px;
+            font-size: 13px;
           }
         }
         & .submit-btn-wrapper {
           display: flex;
-          justify-content: flex-end;
+          margin-top: 16px;
           & .submit-btn {
             @include submit-btn;
-            margin-bottom: 0;
-            margin-top: 15px;
-            padding: 13px 65px;
+            // Was a right-aligned pill with 65px of side padding; full width
+            // matches the primary action on the login screen.
+            width: 100%;
+            margin: 0;
+            padding: 9px 20px;
+            font-size: 14px;
             font-weight: 700;
+            text-align: center;
             text-transform: none;
             letter-spacing: normal;
             border-radius: 8px;
+            min-height: 40px;
             line-height: 20px;
-            transition: background-color 0.2s, border-color 0.2s;
+            transition:
+              background-color 0.2s,
+              border-color 0.2s;
             // Disabled/Submitting state (MUST BE FIRST)
             &[disabled],
             &.btn-pulse {
@@ -147,24 +188,27 @@
           }
         }
       }
-      .hr-div-soft {
-        @include hr-div-soft;
+      // The one pair that wants a tighter gap than the card rhythm: two one-line
+      // links that would read as unrelated paragraphs 20px apart.
+      .sign-in-or-up {
+        display: flex;
+        flex-direction: column;
+        row-gap: 8px;
       }
       .redirect-link-p {
         font-family: 'Inter';
         font-style: normal;
         font-weight: 400;
-        font-size: 14px;
-        line-height: 17px;
-        /* identical to box height */
+        font-size: 13px;
+        line-height: 18px;
         color: #7e7e8f;
-        margin-bottom: 0;
+        margin: 0;
         & .text-link {
           font-family: Inter;
-          font-size: 14px;
+          font-size: 13px;
           font-style: normal;
           font-weight: 600;
-          line-height: 17px;
+          line-height: 18px;
           letter-spacing: 0em;
           color: nb-theme(color-primary-default);
           text-decoration: none;
@@ -173,6 +217,56 @@
           }
         }
       }
+    }
+  }
+}
+
+// The short-viewport blocks only turn the single gap value (and the form's
+// internal one) down, so they can't drift out of step with the base layout.
+@media screen and (max-height: 980px) and (min-width: 491px) {
+  :host .section-wrapper .-wrapper {
+    padding: 20px;
+    row-gap: 16px;
+    & .svg-wrapper {
+      margin-bottom: 8px;
+    }
+    .form {
+      & .form-group {
+        margin-bottom: 12px;
+      }
+      & .submit-btn-wrapper {
+        margin-top: 14px;
+      }
+    }
+  }
+}
+
+@media (max-height: 700px) {
+  :host .section-wrapper .-wrapper {
+    padding: 16px 20px;
+    row-gap: 12px;
+    & .svg-wrapper {
+      margin-bottom: 4px;
+    }
+    .form {
+      margin-top: 16px;
+      & .form-group {
+        margin-bottom: 10px;
+      }
+      & .submit-btn-wrapper {
+        margin-top: 12px;
+      }
+    }
+  }
+}
+
+@include mobile-screen {
+  :host .section-wrapper {
+    width: 100%;
+    .-wrapper {
+      width: 100%;
+      padding: 16px 12px;
+      row-gap: 16px;
     }
   }
 }

--- a/packages/ui-auth/src/lib/components/login/login.component.html
+++ b/packages/ui-auth/src/lib/components/login/login.component.html
@@ -79,7 +79,7 @@
 					id="input-email"
 					pattern=".+@.+\..+"
 					[placeholder]="'LOGIN_PAGE.PLACEHOLDERS.EMAIL' | translate"
-					fieldSize="large"
+					fieldSize="medium"
 					autofocus
 					[status]="email.dirty ? (email.invalid ? 'danger' : 'success') : 'basic'"
 					[required]="getConfigValue('forms.validation.email.required')"
@@ -116,7 +116,7 @@
 						[type]="showPassword ? 'text' : 'password'"
 						id="input-password"
 						[placeholder]="'LOGIN_PAGE.PLACEHOLDERS.PASSWORD' | translate"
-						fieldSize="large"
+						fieldSize="medium"
 						[status]="password.dirty ? (password.invalid ? 'danger' : 'success') : 'basic'"
 						[required]="getConfigValue('forms.validation.password.required')"
 						[minlength]="getConfigValue('forms.validation.password.minLength')"
@@ -188,7 +188,7 @@
 					nbButton
 					fullWidth
 					status="primary"
-					size="large"
+					size="medium"
 					class="submit-btn"
 					[disabled]="submitted || !form.valid"
 					[class.btn-pulse]="submitted"
@@ -208,19 +208,20 @@
 			<ngx-social-links></ngx-social-links>
 		</section>
 		<div class="hr-div-soft"></div>
-		<section class="another-action" aria-label="Sign In Workspace">
-			{{ 'WORKSPACES.UNKNOWN_WORKSPACE' | translate }}
-			<a class="text-link" routerLink="/auth/login-workspace">
-				{{ 'WORKSPACES.FIND_WORKSPACE' | translate }}
-			</a>
-		</section>
-
-		<section class="another-action" aria-label="Register">
-			{{ 'LOGIN_PAGE.DO_NOT_HAVE_ACCOUNT_TITLE' | translate }}
-			<a class="text-link" routerLink="/auth/register">
-				{{ 'BUTTONS.REGISTER' | translate }}
-			</a>
-		</section>
+		<div class="another-actions">
+			<section class="another-action" aria-label="Sign In Workspace">
+				{{ 'WORKSPACES.UNKNOWN_WORKSPACE' | translate }}
+				<a class="text-link" routerLink="/auth/login-workspace">
+					{{ 'WORKSPACES.FIND_WORKSPACE' | translate }}
+				</a>
+			</section>
+			<section class="another-action" aria-label="Register">
+				{{ 'LOGIN_PAGE.DO_NOT_HAVE_ACCOUNT_TITLE' | translate }}
+				<a class="text-link" routerLink="/auth/register">
+					{{ 'BUTTONS.REGISTER' | translate }}
+				</a>
+			</section>
+		</div>
 	</div>
 	<div class="features-wrapper">
 		@if (!electronService?.isElectron && isDemo) {

--- a/packages/ui-auth/src/lib/components/login/login.component.scss
+++ b/packages/ui-auth/src/lib/components/login/login.component.scss
@@ -20,10 +20,11 @@
     display: flex;
     flex-direction: column;
     row-gap: 20px;
-    & > * {
+    & > *:not(nb-alert) {
       padding-left: 0;
       padding-right: 0;
     }
+    @include auth-alert;
     & .svg-wrapper {
       display: flex;
       align-items: flex-start;

--- a/packages/ui-auth/src/lib/components/login/login.component.scss
+++ b/packages/ui-auth/src/lib/components/login/login.component.scss
@@ -2,27 +2,52 @@
 @use '@shared/reusable' as *;
 
 .login-container {
-  width: 765px;
+  // The card was sized for a tall desktop viewport and overflowed anything
+  // shorter. Every vertical rhythm value below is roughly half of what it was so
+  // the form, the socials and the demo column all land inside one screen.
+  width: 700px;
+  max-width: 100%;
   position: relative;
   display: flex;
   justify-content: space-between;
+  // Horizontal gap to the demo column; the wrapper's `row-gap` handles vertical
+  // spacing when this flips to a column on tablet.
+  column-gap: 20px;
+  row-gap: 20px;
   & .login-wrapper {
     background: nb-theme(gauzy-card-2);
     border-radius: nb-theme(border-radius);
     box-sizing: border-box;
-    padding: 32px;
-    width: 476px;
+    padding: 24px;
+    width: 440px;
+    max-width: 100%;
     height: 100%;
+    // One column gap owns the whole vertical rhythm. Before this the spacing was
+    // an accumulation of each block's own bottom margin plus the next block's top
+    // margin, which is why no two gaps down the card were the same. Blocks below
+    // set no vertical margin of their own; change this value to retune the card.
+    display: flex;
+    flex-direction: column;
+    row-gap: 20px;
+    // Every direct child used to carry its own 15px side padding on top of the
+    // wrapper's, so the dividers, the inputs and the footer links each started at
+    // a slightly different x. One padding on the wrapper lines them all up.
     & > * {
-      padding-left: 15px;
-      padding-right: 15px;
+      padding-left: 0;
+      padding-right: 0;
     }
     & .svg-wrapper {
       display: flex;
+      align-items: flex-start;
       justify-content: space-between;
+      // The masthead reads as its own band rather than another row in the stack,
+      // so it takes 12px on top of the card's row-gap: 32px down to the heading.
+      // On the flex item, not on the logo inside it, so the theme switch beside
+      // it stays on the same baseline.
+      margin-bottom: 12px;
 
       & .ever-logo-svg {
-        margin-bottom: 32px;
+        margin-bottom: 0;
       }
     }
     & .headings {
@@ -32,62 +57,87 @@
       & .headings-inner {
         & .title {
           font-family: Inter;
-          font-size: 24px;
+          font-size: 19px;
           font-style: normal;
           font-weight: 700;
-          line-height: 30px;
+          line-height: 24px;
           letter-spacing: 0em;
-          margin-bottom: 18px;
+          margin-bottom: 4px;
           text-align: start;
         }
         & .sub-title {
           font-family: Inter;
-          font-size: 14px;
+          font-size: 12px;
           font-style: normal;
           font-weight: 400;
+          // Was inheriting the body's full-strength text colour, so the strap line
+          // carried the same weight as the "Login" heading above it. The hint
+          // token is the theme's own muted text, so it tracks light and dark.
+          color: nb-theme(text-hint-color);
           // Was 11px — a line box SHORTER than the 14px glyphs sitting in it, so
           // the strap line under "Login" rode into the divider below and its
           // descenders were cut by the next block. Every other auth screen
           // (forgot-password, reset-password, login-workspace) sets 14/17 for the
           // same element; the features column further down this very file does too.
-          line-height: 17px;
+          line-height: 16px;
           letter-spacing: 0em;
-          margin-bottom: 26px;
+          margin-bottom: 0;
           text-align: start;
         }
       }
     }
+    // Both rules exist only to draw a 1px line; the column gap spaces them.
     & .hr-div-strong {
       @include hr-div-strong;
+      // The mixin hard-codes 416px, which is wider than this (now narrower) card.
+      width: 100%;
+      margin: 0;
     }
     & .hr-div-soft {
       @include hr-div-soft;
+      width: 100%;
+      margin: 0;
+    }
+    // The only pair that wants a tighter gap than the card rhythm: two one-line
+    // links that would read as unrelated paragraphs 20px apart.
+    & .another-actions {
+      display: flex;
+      flex-direction: column;
+      row-gap: 8px;
     }
   }
   & form {
-    margin-top: 29px;
-    margin-bottom: 42px;
+    // On top of the card's row-gap, so the form sits clear of the heading band.
+    margin: 24px 0 0;
     .form-control-group {
-      margin-bottom: 24px;
+      margin-bottom: 16px;
     }
     .label {
       display: block;
-      margin-bottom: 8px;
+      margin-bottom: 6px;
       font-family: Inter;
+      font-size: 12px;
       font-weight: 600;
-      color: nb-theme(text-basic-color); // Reverted to theme variable for light mode support
+      // Same muted token as the strap line under "Login" — was full-strength
+      // `text-basic-color`, which made the field labels as loud as the heading.
+      // Weight stays at 600 so they still read as labels at this size.
+      color: nb-theme(text-hint-color);
     }
     ::ng-deep input.input-full-width {
       border: 1px solid rgba(98, 54, 255, 0.5) !important;
       background-color: transparent;
       color: nb-theme(text-basic-color); // Reverted to theme variable
+      // `fieldSize="medium"` in the markup does most of the shrinking; this keeps
+      // the box from growing back on themes with a taller medium field.
+      height: 38px;
+      font-size: 13px;
     }
     .error-container {
       max-width: 100%;
-      margin-top: 4px;
 
       .caption {
-        margin: 0;
+        margin: 4px 0 0;
+        font-size: 11px;
         line-height: 1.3;
       }
     }
@@ -95,8 +145,8 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      margin-bottom: 24px;
-      margin-top: 10px;
+      // The submit wrapper below owns the gap down to the button.
+      margin: 16px 0 0;
       .accept-group {
         margin: 0;
 
@@ -113,6 +163,8 @@
             border-color: #8f9bb3 !important; // Light grey border
             background-color: transparent;
             border-width: 1px !important;
+            width: 16px;
+            height: 16px;
           }
           .custom-checkbox.checked {
             background-color: #6236ff !important;
@@ -126,7 +178,7 @@
         .forgot-password-link {
           text-decoration: none;
           font-family: Inter;
-          font-size: 13px;
+          font-size: 12px;
           font-weight: 500;
           color: nb-theme(color-primary-default); // Make it alive with primary color
           cursor: pointer;
@@ -139,15 +191,18 @@
     }
     & .submit-btn-wrapper {
       width: 100%;
-      margin-top: 20px;
+      margin-top: 16px;
       & .submit-btn {
         @include submit-btn;
         width: 100%;
+        padding: 9px 20px;
+        font-size: 14px;
         font-weight: 700;
+        text-align: center;
         text-transform: none;
         letter-spacing: normal;
         border-radius: 8px;
-        min-height: 48px;
+        min-height: 40px;
         transition:
           background-color 0.2s,
           border-color 0.2s;
@@ -199,12 +254,12 @@
       }
     }
     .login-magic-wrapper {
-      margin-top: 24px;
+      margin-top: 16px;
       text-align: center;
       width: 100%;
       & a {
         font-weight: 600;
-        font-size: 14px;
+        font-size: 13px;
         text-decoration: none;
         color: nb-theme(color-primary-default);
         &:hover {
@@ -214,8 +269,14 @@
     }
   }
   & .another-action {
-    margin-top: 10px;
     @include another-action;
+    // The mixin's padding-top/left was the only thing separating these two lines,
+    // so they read as one wrapped paragraph. The gap does the spacing now and the
+    // left padding goes away so they line up with the inputs above.
+    padding: 0;
+    margin: 0;
+    font-size: 13px;
+    line-height: 18px;
     .text-link {
       text-decoration: none;
       &:hover {
@@ -225,10 +286,15 @@
   }
 }
 .features-wrapper {
-  width: 260px;
+  width: 244px;
   // demo side container
   & .card-body {
-    padding: 38px 15px;
+    padding: 20px 16px;
+    // Same idea as the login card: one gap for the three demo buttons instead of
+    // a margin on each. The heading pair below opts out of it.
+    display: flex;
+    flex-direction: column;
+    row-gap: 8px;
     background: nb-theme(color-primary-transparent-default);
     border-radius: nb-theme(border-radius);
     &.dark {
@@ -238,6 +304,11 @@
         background: #6e49e8;
         border: 1px solid #6e49e8;
       }
+    }
+    // The three demo buttons are separated by `<br />` in the markup; collapsing
+    // those lets the button margins alone control the spacing.
+    & br {
+      display: none;
     }
   }
   // non-demo side container
@@ -249,52 +320,65 @@
   }
   & .title {
     font-family: Inter;
-    font-size: 16px;
+    font-size: 14px;
     font-style: normal;
     font-weight: 600;
-    line-height: 19px;
+    line-height: 18px;
     letter-spacing: -0.009em;
     text-align: left;
-    padding-left: 13px;
+    // Was an 8px inset on top of the card's own padding, so the heading hung
+    // right of the buttons underneath it.
+    padding-left: 0;
+    // Pulls the sub-title up against its heading, out of the 8px button rhythm.
+    margin: 0 0 -4px;
   }
   & .sub-title {
     font-family: Inter;
-    font-size: 14px;
+    font-size: 12px;
     font-style: normal;
     font-weight: 400;
-    line-height: 17px;
+    line-height: 16px;
     letter-spacing: 0em;
     text-align: left;
-    margin-bottom: 20px;
-    padding-left: 13px;
+    // +8px gap = 16px of air before the first button.
+    margin: 0 0 8px;
+    padding-left: 0;
     color: #7e7e8f;
   }
   & .custom-btn {
     -webkit-box-shadow: 3px 11px 30px -17px #3366ff;
     box-shadow: 3px 11px 30px -17px #3366ff;
-    width: auto;
-    padding: 13px 28px;
+    // `width: auto` let each button shrink to its label, so the three of them had
+    // three different right edges. They already carry `fullWidth` in the markup.
+    width: 100%;
+    padding: 10px 16px;
+    // `!important` beats the `.mt-3` utility the markup puts on each button; the
+    // card's row-gap spaces them now.
+    margin: 0 !important;
     display: inline-flex;
-    justify-content: flex-start;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
     background-color: white;
     color: nb-theme(color-primary-500);
     border: 1px solid white;
     font-family: Inter;
-    font-size: 15px;
+    font-size: 13px;
     font-style: normal;
     font-weight: 700;
-    line-height: 16px;
+    line-height: 15px;
     letter-spacing: -0.009em;
-    text-align: left;
+    text-align: center;
     & > nb-icon {
-      width: 16px;
+      width: 14px;
       height: 14px;
+      margin: 0;
     }
     @include small-laptop-screen {
-      padding: 10px 20px;
+      padding: 9px 14px;
     }
     @include tablet-screen {
-      padding: 15px 25px;
+      padding: 10px 18px;
     }
     &:hover {
       background-color: #fafafa;
@@ -303,11 +387,12 @@
   }
 }
 .demo-credentials-select {
-  width: 200px;
+  width: 180px;
   position: absolute;
   top: 0;
   right: 0;
   border-radius: nb-theme(button-rectangle-border-radius);
+  font-size: 12px;
   & * {
     z-index: 6;
   }
@@ -317,14 +402,14 @@
     box-sizing: border-box;
   }
   & .demo-credentials-select-item {
-    width: 200px;
+    width: 180px;
     position: relative;
     z-index: 5;
     background: nb-theme(background-basic-color-2);
     color: nb-theme(text-basic-color);
   }
   & .demo-credentials-header {
-    padding: 5px 5px 5px 15px;
+    padding: 3px 5px 3px 12px;
     box-sizing: border-box;
     display: flex;
     justify-content: space-between;
@@ -332,11 +417,16 @@
     background: nb-theme(background-basic-color-2);
     color: nb-theme(text-basic-color);
     border-radius: 20px;
+    font-size: 12px;
     & .demo-text-span {
       @include mobile-screen {
         display: none;
       }
     }
+  }
+  & .demo-credentials-body {
+    font-size: 12px;
+    line-height: 16px;
   }
 }
 
@@ -344,13 +434,12 @@
   .login-container {
     flex-direction: column;
     align-items: center;
-    & .another-action {
-      margin-top: 0;
-    }
   }
   .features-wrapper {
-    width: 476px;
-    margin-top: 30px;
+    width: 440px;
+    max-width: 100%;
+    // The container's row-gap already separates the two stacked cards.
+    margin-top: 0;
     & .demo-credentials-buttons {
       & * {
         text-align: center;
@@ -368,7 +457,8 @@
     width: 100%;
     & .login-wrapper {
       width: 100%;
-      padding: 20px 12px;
+      padding: 16px 12px;
+      row-gap: 16px;
       & .headings {
         & .headings-inner {
           width: 100%;
@@ -380,12 +470,12 @@
         }
       }
       & .headings.headings-demo {
-        height: 135px;
+        height: 110px;
         align-items: flex-start;
       }
     }
     & form {
-      margin-bottom: 35px;
+      margin-bottom: 20px;
       & .submit-btn-wrapper {
         justify-content: center;
         & .submit-btn {
@@ -404,7 +494,7 @@
     width: 100%;
   }
   .demo-credentials-select {
-    top: 83px;
+    top: 70px;
     left: 50%;
     transform: translate(-50%);
     z-index: 6;
@@ -425,28 +515,31 @@
 }
 
 // Compact layout for short viewport heights (e.g. MacBook 14" ~980px, standard laptops ~768px)
+// Now that one gap owns the card's rhythm, these blocks only have to turn that
+// single value (plus the form's internal one) down, instead of re-stating a dozen
+// margins and drifting out of step with the base layout every time it changes.
 @media screen and (max-height: 980px) and (min-width: 491px) {
   .login-container {
     & .login-wrapper {
-      padding: 32px;
+      padding: 20px;
+      row-gap: 16px;
       & .svg-wrapper {
-        & .ever-logo-svg {
-          margin-bottom: 16px;
-        }
-      }
-      & .headings {
-        & .headings-inner {
-          & .title {
-            margin-bottom: 16px;
-          }
-          & .sub-title {
-            margin-bottom: 8px;
-          }
-        }
+        margin-bottom: 8px;
       }
     }
-    & .another-action {
-      margin-top: 4px;
+    & form {
+      .form-control-group {
+        margin-bottom: 14px;
+      }
+      .options-row {
+        margin-top: 14px;
+      }
+      & .submit-btn-wrapper {
+        margin-top: 14px;
+      }
+      .login-magic-wrapper {
+        margin-top: 14px;
+      }
     }
   }
 }
@@ -455,29 +548,33 @@
 @media (max-height: 700px) {
   .login-container {
     & .login-wrapper {
-      padding: 32px;
+      padding: 16px 20px;
+      row-gap: 12px;
       & .svg-wrapper {
-        & .ever-logo-svg {
-          margin-bottom: 8px;
-        }
+        margin-bottom: 4px;
       }
-      & .headings {
-        & .headings-inner {
-          & .title {
-            margin-bottom: 8px;
-          }
-          & .sub-title {
-            margin-bottom: 8px;
-          }
-        }
+    }
+    & form {
+      .form-control-group {
+        margin-bottom: 12px;
+      }
+      .options-row {
+        margin-top: 12px;
+      }
+      & .submit-btn-wrapper {
+        margin-top: 12px;
+      }
+      .login-magic-wrapper {
+        margin-top: 12px;
       }
     }
   }
 }
 
 .hr-div-soft {
-  margin-bottom: 4px;
   @include hr-div-soft;
+  width: 100%;
+  margin: 0;
 }
 .theme-switch {
   @include not-mobile-screen {
@@ -489,7 +586,7 @@
 
 ::ng-deep .remember-me .text {
   font-family: Inter;
-  font-size: 13px;
+  font-size: 12px;
   font-style: normal;
   font-weight: 600;
   line-height: 13px;

--- a/packages/ui-auth/src/lib/components/login/login.component.scss
+++ b/packages/ui-auth/src/lib/components/login/login.component.scss
@@ -2,16 +2,11 @@
 @use '@shared/reusable' as *;
 
 .login-container {
-  // The card was sized for a tall desktop viewport and overflowed anything
-  // shorter. Every vertical rhythm value below is roughly half of what it was so
-  // the form, the socials and the demo column all land inside one screen.
   width: 700px;
   max-width: 100%;
   position: relative;
   display: flex;
   justify-content: space-between;
-  // Horizontal gap to the demo column; the wrapper's `row-gap` handles vertical
-  // spacing when this flips to a column on tablet.
   column-gap: 20px;
   row-gap: 20px;
   & .login-wrapper {
@@ -22,16 +17,9 @@
     width: 440px;
     max-width: 100%;
     height: 100%;
-    // One column gap owns the whole vertical rhythm. Before this the spacing was
-    // an accumulation of each block's own bottom margin plus the next block's top
-    // margin, which is why no two gaps down the card were the same. Blocks below
-    // set no vertical margin of their own; change this value to retune the card.
     display: flex;
     flex-direction: column;
     row-gap: 20px;
-    // Every direct child used to carry its own 15px side padding on top of the
-    // wrapper's, so the dividers, the inputs and the footer links each started at
-    // a slightly different x. One padding on the wrapper lines them all up.
     & > * {
       padding-left: 0;
       padding-right: 0;
@@ -40,10 +28,6 @@
       display: flex;
       align-items: flex-start;
       justify-content: space-between;
-      // The masthead reads as its own band rather than another row in the stack,
-      // so it takes 12px on top of the card's row-gap: 32px down to the heading.
-      // On the flex item, not on the logo inside it, so the theme switch beside
-      // it stays on the same baseline.
       margin-bottom: 12px;
 
       & .ever-logo-svg {
@@ -70,9 +54,6 @@
           font-size: 12px;
           font-style: normal;
           font-weight: 400;
-          // Was inheriting the body's full-strength text colour, so the strap line
-          // carried the same weight as the "Login" heading above it. The hint
-          // token is the theme's own muted text, so it tracks light and dark.
           color: nb-theme(text-hint-color);
           // Was 11px — a line box SHORTER than the 14px glyphs sitting in it, so
           // the strap line under "Login" rode into the divider below and its
@@ -86,10 +67,8 @@
         }
       }
     }
-    // Both rules exist only to draw a 1px line; the column gap spaces them.
     & .hr-div-strong {
       @include hr-div-strong;
-      // The mixin hard-codes 416px, which is wider than this (now narrower) card.
       width: 100%;
       margin: 0;
     }
@@ -98,8 +77,6 @@
       width: 100%;
       margin: 0;
     }
-    // The only pair that wants a tighter gap than the card rhythm: two one-line
-    // links that would read as unrelated paragraphs 20px apart.
     & .another-actions {
       display: flex;
       flex-direction: column;
@@ -107,7 +84,6 @@
     }
   }
   & form {
-    // On top of the card's row-gap, so the form sits clear of the heading band.
     margin: 24px 0 0;
     .form-control-group {
       margin-bottom: 16px;
@@ -118,17 +94,12 @@
       font-family: Inter;
       font-size: 12px;
       font-weight: 600;
-      // Same muted token as the strap line under "Login" — was full-strength
-      // `text-basic-color`, which made the field labels as loud as the heading.
-      // Weight stays at 600 so they still read as labels at this size.
       color: nb-theme(text-hint-color);
     }
     ::ng-deep input.input-full-width {
       border: 1px solid rgba(98, 54, 255, 0.5) !important;
       background-color: transparent;
       color: nb-theme(text-basic-color); // Reverted to theme variable
-      // `fieldSize="medium"` in the markup does most of the shrinking; this keeps
-      // the box from growing back on themes with a taller medium field.
       height: 38px;
       font-size: 13px;
     }
@@ -145,7 +116,6 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      // The submit wrapper below owns the gap down to the button.
       margin: 16px 0 0;
       .accept-group {
         margin: 0;
@@ -270,9 +240,6 @@
   }
   & .another-action {
     @include another-action;
-    // The mixin's padding-top/left was the only thing separating these two lines,
-    // so they read as one wrapped paragraph. The gap does the spacing now and the
-    // left padding goes away so they line up with the inputs above.
     padding: 0;
     margin: 0;
     font-size: 13px;
@@ -290,8 +257,6 @@
   // demo side container
   & .card-body {
     padding: 20px 16px;
-    // Same idea as the login card: one gap for the three demo buttons instead of
-    // a margin on each. The heading pair below opts out of it.
     display: flex;
     flex-direction: column;
     row-gap: 8px;
@@ -305,8 +270,6 @@
         border: 1px solid #6e49e8;
       }
     }
-    // The three demo buttons are separated by `<br />` in the markup; collapsing
-    // those lets the button margins alone control the spacing.
     & br {
       display: none;
     }
@@ -326,10 +289,7 @@
     line-height: 18px;
     letter-spacing: -0.009em;
     text-align: left;
-    // Was an 8px inset on top of the card's own padding, so the heading hung
-    // right of the buttons underneath it.
     padding-left: 0;
-    // Pulls the sub-title up against its heading, out of the 8px button rhythm.
     margin: 0 0 -4px;
   }
   & .sub-title {
@@ -340,7 +300,6 @@
     line-height: 16px;
     letter-spacing: 0em;
     text-align: left;
-    // +8px gap = 16px of air before the first button.
     margin: 0 0 8px;
     padding-left: 0;
     color: #7e7e8f;
@@ -348,12 +307,8 @@
   & .custom-btn {
     -webkit-box-shadow: 3px 11px 30px -17px #3366ff;
     box-shadow: 3px 11px 30px -17px #3366ff;
-    // `width: auto` let each button shrink to its label, so the three of them had
-    // three different right edges. They already carry `fullWidth` in the markup.
     width: 100%;
     padding: 10px 16px;
-    // `!important` beats the `.mt-3` utility the markup puts on each button; the
-    // card's row-gap spaces them now.
     margin: 0 !important;
     display: inline-flex;
     align-items: center;
@@ -438,7 +393,6 @@
   .features-wrapper {
     width: 440px;
     max-width: 100%;
-    // The container's row-gap already separates the two stacked cards.
     margin-top: 0;
     & .demo-credentials-buttons {
       & * {
@@ -515,9 +469,6 @@
 }
 
 // Compact layout for short viewport heights (e.g. MacBook 14" ~980px, standard laptops ~768px)
-// Now that one gap owns the card's rhythm, these blocks only have to turn that
-// single value (plus the form's internal one) down, instead of re-stating a dozen
-// margins and drifting out of step with the base layout every time it changes.
 @media screen and (max-height: 980px) and (min-width: 491px) {
   .login-container {
     & .login-wrapper {

--- a/packages/ui-auth/src/lib/components/login/login.component.scss
+++ b/packages/ui-auth/src/lib/components/login/login.component.scss
@@ -361,7 +361,7 @@
     position: relative;
     z-index: 5;
     background: nb-theme(background-basic-color-2);
-    color: nb-theme(text-basic-color);
+    color: nb-theme(text-hint-color);
   }
   & .demo-credentials-header {
     padding: 3px 5px 3px 12px;
@@ -370,9 +370,14 @@
     justify-content: space-between;
     width: 100%;
     background: nb-theme(background-basic-color-2);
-    color: nb-theme(text-basic-color);
+    color: nb-theme(text-hint-color);
     border-radius: 20px;
     font-size: 12px;
+    ::ng-deep nb-icon {
+      color: nb-theme(text-hint-color);
+      width: 16px;
+      height: 16px;
+    }
     & .demo-text-span {
       @include mobile-screen {
         display: none;
@@ -382,6 +387,10 @@
   & .demo-credentials-body {
     font-size: 12px;
     line-height: 16px;
+    color: nb-theme(text-hint-color);
+    & div {
+      color: nb-theme(text-hint-color);
+    }
   }
 }
 

--- a/packages/ui-auth/src/lib/components/register/register-side-features/register-side-features.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register-side-features/register-side-features.component.scss
@@ -6,18 +6,20 @@
   width: 100%;
   height: 100%;
   border-radius: 12px;
-  padding: 20px 20px 40px;
+  // Was `20px 20px 40px` — the extra 20px of dead space at the bottom pushed this
+  // column past the (now much shorter) register card beside it.
+  padding: 16px;
 }
 .main-header {
   color: white;
   font-family: Inter;
-  font-size: 18px;
+  font-size: 15px;
   font-style: normal;
   font-weight: 600;
-  line-height: 22px;
+  line-height: 19px;
   letter-spacing: -0.009em;
   text-align: left;
-  margin-bottom: 39px;
+  margin-bottom: 14px;
 }
 .feature-wrapper {
   width: 100%;
@@ -28,8 +30,8 @@
   background: rgba(255, 255, 255, 0.15);
   border-radius: 1px;
   transform: matrix(1, 0, 0, -1, 0, 0);
-  margin-bottom: 20px;
-  margin-top: 20px;
+  margin-bottom: 12px;
+  margin-top: 12px;
 }
 .hidden {
   display: none;

--- a/packages/ui-auth/src/lib/components/register/register-side-features/register-side-features.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register-side-features/register-side-features.component.scss
@@ -6,8 +6,6 @@
   width: 100%;
   height: 100%;
   border-radius: 12px;
-  // Was `20px 20px 40px` — the extra 20px of dead space at the bottom pushed this
-  // column past the (now much shorter) register card beside it.
   padding: 16px;
 }
 .main-header {

--- a/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.scss
@@ -80,12 +80,14 @@ nb-icon,
 @include tablet-screen {
   .feature-img {
     width: 360px;
+    max-width: 100%;
     height: 232px;
   }
 }
 @include mobile-screen {
   .feature-img {
     width: 90%;
+    max-width: 100%;
     height: 45vw;
   }
 }

--- a/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.scss
@@ -42,8 +42,6 @@
     text-align: left;
   }
 }
-// The three screenshots are what actually makes this column outrun the register
-// card beside it; each one costs more height than the copy above it.
 .feature-img {
   width: 100%;
   max-width: 176px;

--- a/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register-side-features/register-side-single-feature/register-side-single-feature.component.scss
@@ -7,8 +7,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-right: 10px;
-  padding-left: 10px;
+  padding-right: 0;
+  padding-left: 0;
   // The wrapper is an anchor when the feature carries a learnMoreUrl —
   // keep the text styling identical either way.
   color: inherit;
@@ -21,7 +21,7 @@
   width: 100%;
   display: flex;
   align-items: flex-start;
-  margin-bottom: 12px;
+  margin-bottom: 6px;
   & > nb-icon {
     margin-right: 5px;
     margin-top: 1.5px;
@@ -34,17 +34,20 @@
     display: flex;
     align-items: flex-start;
     font-family: Inter;
-    font-size: 14px;
+    font-size: 13px;
     font-style: normal;
     font-weight: 600;
-    line-height: 17px;
+    line-height: 16px;
     letter-spacing: 0em;
     text-align: left;
   }
 }
+// The three screenshots are what actually makes this column outrun the register
+// card beside it; each one costs more height than the copy above it.
 .feature-img {
-  width: 201px;
-  height: 130px;
+  width: 100%;
+  max-width: 176px;
+  height: 104px;
   border: 1px solid black;
   -webkit-box-shadow: 0px 8px 21px -11px #000000;
   box-shadow: 0px 8px 21px -11px #000000;
@@ -53,10 +56,10 @@
 }
 .description {
   font-family: Inter;
-  font-size: 12px;
+  font-size: 11px;
   font-style: normal;
   font-weight: 400;
-  line-height: 16px;
+  line-height: 15px;
   letter-spacing: 0em;
   text-align: left;
   width: 100%;
@@ -68,11 +71,11 @@ nb-icon,
 }
 @include small-laptop-screen {
   .description {
-    font-size: 14px;
+    font-size: 12px;
   }
   .feature-img {
-    width: 208px;
-    height: 135px;
+    max-width: 184px;
+    height: 110px;
   }
 }
 

--- a/packages/ui-auth/src/lib/components/register/register.component.html
+++ b/packages/ui-auth/src/lib/components/register/register.component.html
@@ -43,7 +43,7 @@
 					[placeholder]="'REGISTER_PAGE.PLACEHOLDERS.FULL_NAME' | translate"
 					autofocus
 					fullWidth
-					fieldSize="large"
+					fieldSize="medium"
 					[status]="fullName.dirty ? (fullName.invalid ? 'danger' : 'success') : 'basic'"
 					[required]="getConfigValue('forms.validation.fullName.required')"
 					[minlength]="getConfigValue('forms.validation.fullName.minLength')"
@@ -87,7 +87,7 @@
 					noSpaceEdges
 					[placeholder]="'REGISTER_PAGE.PLACEHOLDERS.EMAIL' | translate"
 					fullWidth
-					fieldSize="large"
+					fieldSize="medium"
 					[status]="email.dirty ? (email.invalid ? 'danger' : 'success') : 'basic'"
 					[required]="getConfigValue('forms.validation.email.required')"
 					[attr.aria-invalid]="email.invalid && email.touched ? true : null"
@@ -124,7 +124,7 @@
 						name="password"
 						[placeholder]="'REGISTER_PAGE.PLACEHOLDERS.PASSWORD' | translate"
 						fullWidth
-						fieldSize="large"
+						fieldSize="medium"
 						[status]="password.dirty ? (password.invalid ? 'danger' : 'success') : 'basic'"
 						[required]="getConfigValue('forms.validation.password.required')"
 						[minlength]="getConfigValue('forms.validation.password.minLength')"
@@ -180,7 +180,7 @@
 						name="rePass"
 						[placeholder]="'REGISTER_PAGE.PLACEHOLDERS.CONFIRM_PASSWORD' | translate"
 						fullWidth
-						fieldSize="large"
+						fieldSize="medium"
 						[status]="
 							confirmPassword.dirty
 								? confirmPassword.invalid || password.value != confirmPassword.value
@@ -267,19 +267,20 @@
 		</section>
 		<div class="hr-div-soft"></div>
 
-		<section class="another-action" aria-label="Sign In Workspace">
-			{{ 'WORKSPACES.UNKNOWN_WORKSPACE' | translate }}
-			<a class="text-link" routerLink="/auth/login-workspace">
-				{{ 'WORKSPACES.FIND_WORKSPACE' | translate }}
-			</a>
-		</section>
-
-		<section class="another-action" aria-label="Sign in">
-			{{ 'REGISTER_PAGE.HAVE_AN_ACCOUNT' | translate }}
-			<a class="text-link" routerLink="../login">
-				{{ 'BUTTONS.LOGIN' | translate }}
-			</a>
-		</section>
+		<div class="another-actions">
+			<section class="another-action" aria-label="Sign In Workspace">
+				{{ 'WORKSPACES.UNKNOWN_WORKSPACE' | translate }}
+				<a class="text-link" routerLink="/auth/login-workspace">
+					{{ 'WORKSPACES.FIND_WORKSPACE' | translate }}
+				</a>
+			</section>
+			<section class="another-action" aria-label="Sign in">
+				{{ 'REGISTER_PAGE.HAVE_AN_ACCOUNT' | translate }}
+				<a class="text-link" routerLink="../login">
+					{{ 'BUTTONS.LOGIN' | translate }}
+				</a>
+			</section>
+		</div>
 	</div>
 	<div class="features-wrapper">
 		<ngx-register-side-features></ngx-register-side-features>

--- a/packages/ui-auth/src/lib/components/register/register.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register.component.scss
@@ -23,10 +23,11 @@
   &.dark {
     background: #292933;
   }
-  & > * {
+  & > *:not(nb-alert) {
     padding-left: 0;
     padding-right: 0;
   }
+  @include auth-alert;
   & .title-wrapper {
     margin: 0;
     & > .title {

--- a/packages/ui-auth/src/lib/components/register/register.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register.component.scss
@@ -199,7 +199,7 @@
     }
     & .normal-terms-text,
     & .terms-link {
-      font-family: Inter;
+      font-family: Inter, sans-serif;
       font-size: 12px;
       line-height: 16px;
     }
@@ -209,7 +209,7 @@
       text-align: center;
       margin-top: 0;
       & .normal-terms-text {
-        font-family: Inter;
+        font-family: Inter, sans-serif;
         font-size: 10px;
         font-style: normal;
         font-weight: 400;
@@ -218,7 +218,7 @@
         text-align: left;
       }
       & .terms-link {
-        font-family: Inter;
+        font-family: Inter, sans-serif;
         font-size: 10px;
         font-style: normal;
         font-weight: 600;

--- a/packages/ui-auth/src/lib/components/register/register.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register.component.scss
@@ -2,14 +2,10 @@
 @use '@shared/reusable' as *;
 
 .main-section {
-  // Same compaction as the login screen. This is the tallest auth screen (four
-  // fields plus the terms checkbox), so it gained the most from it.
   width: 700px;
   max-width: 100%;
   display: flex;
   justify-content: space-between;
-  // `stretch` made the features column as tall as whichever side was taller,
-  // which on a short viewport is a fight neither side wins.
   align-items: flex-start;
   column-gap: 20px;
   row-gap: 20px;
@@ -21,17 +17,12 @@
   padding: 24px;
   background: nb-theme(gauzy-card-2);
   border-radius: nb-theme(border-radius);
-  // One column gap owns the whole vertical rhythm; the blocks below set no
-  // vertical margin of their own. Change this value to retune the card.
   display: flex;
   flex-direction: column;
   row-gap: 20px;
   &.dark {
     background: #292933;
   }
-  // Every direct child used to add its own 15px side padding on top of the
-  // wrapper's, so the dividers, the inputs and the footer links each started at a
-  // slightly different x.
   & > * {
     padding-left: 0;
     padding-right: 0;
@@ -49,10 +40,8 @@
       margin: 0;
     }
   }
-  // Both dividers exist only to draw a 1px line; the row-gap spaces them.
   & .hr-div-strong {
     @include hr-div-strong;
-    // The mixin hard-codes 416px, wider than this now-narrower card.
     width: 100%;
     margin: 0;
   }
@@ -61,8 +50,6 @@
     width: 100%;
     margin: 0;
   }
-  // The one pair that wants a tighter gap than the card rhythm: two one-line
-  // links that would read as unrelated paragraphs 20px apart.
   & .another-actions {
     display: flex;
     flex-direction: column;
@@ -70,8 +57,6 @@
   }
   & .another-action {
     @include another-action;
-    // The mixin's padding-top/left was the only thing separating these two lines,
-    // so they read as one wrapped paragraph.
     padding: 0;
     margin: 0;
     font-size: 13px;
@@ -94,8 +79,6 @@
   height: auto;
 }
 .svg-wrapper {
-  // Was 55px. 12px on top of the row-gap reads as a masthead band (32px),
-  // matching the login screen.
   margin-bottom: 12px;
   display: flex;
   align-items: flex-start;
@@ -111,17 +94,12 @@
       font-family: Inter;
       font-weight: 600;
       font-size: 12px;
-      // Was full-strength `text-basic-color`, which made the field labels as loud
-      // as the heading. The hint token is the theme's own muted text, so it
-      // tracks light and dark.
       color: nb-theme(text-hint-color);
     }
     ::ng-deep input.input-full-width {
       border: 1px solid rgba(98, 54, 255, 0.5) !important;
       background-color: transparent;
       color: nb-theme(text-basic-color);
-      // `fieldSize="medium"` in the markup does most of the shrinking; this keeps
-      // the box from growing back on themes with a taller medium field.
       height: 38px;
       font-size: 13px;
     }
@@ -135,8 +113,6 @@
     margin-top: 16px;
     & .submit-btn {
       @include submit-btn;
-      // Was a right-aligned pill with 65px of side padding; full width matches
-      // the primary action on the login screen.
       width: 100%;
       padding: 9px 20px;
       font-size: 14px;
@@ -253,11 +229,6 @@
   }
 }
 
-// NOTE: a `.links { @include social-links-style; }` block used to sit here. It
-// never applied — `.links` lives in the ngx-social-links template, so emulated
-// encapsulation stamps it with that component's attribute, not this one. The
-// real styling is in social-links.component.scss, which this screen shares with
-// the login screen.
 
 .theme-switch {
   @include not-mobile-screen {
@@ -270,8 +241,6 @@
   vertical-align: middle;
 }
 
-// The short-viewport blocks only turn the single gap value (and the form's
-// internal one) down, so they can't drift out of step with the base layout.
 @include small-laptop-screen {
   .register-wrapper {
     padding: 20px;
@@ -334,7 +303,6 @@
   .features-wrapper {
     width: 440px;
     max-width: 100%;
-    // The container's row-gap already separates the two stacked cards.
     margin-top: 0;
   }
 }

--- a/packages/ui-auth/src/lib/components/register/register.component.scss
+++ b/packages/ui-auth/src/lib/components/register/register.component.scss
@@ -1,50 +1,81 @@
 @use 'themes' as *;
 @use '@shared/reusable' as *;
 
-@mixin addPaddings {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
 .main-section {
-  width: 765px;
+  // Same compaction as the login screen. This is the tallest auth screen (four
+  // fields plus the terms checkbox), so it gained the most from it.
+  width: 700px;
+  max-width: 100%;
   display: flex;
   justify-content: space-between;
+  // `stretch` made the features column as tall as whichever side was taller,
+  // which on a short viewport is a fight neither side wins.
+  align-items: flex-start;
+  column-gap: 20px;
+  row-gap: 20px;
 }
 .register-wrapper {
-  width: 476px;
+  width: 440px;
+  max-width: 100%;
   height: 100%;
-  padding: 30px;
+  padding: 24px;
   background: nb-theme(gauzy-card-2);
   border-radius: nb-theme(border-radius);
+  // One column gap owns the whole vertical rhythm; the blocks below set no
+  // vertical margin of their own. Change this value to retune the card.
+  display: flex;
+  flex-direction: column;
+  row-gap: 20px;
   &.dark {
     background: #292933;
   }
+  // Every direct child used to add its own 15px side padding on top of the
+  // wrapper's, so the dividers, the inputs and the footer links each started at a
+  // slightly different x.
   & > * {
-    padding-left: 15px;
-    padding-right: 15px;
+    padding-left: 0;
+    padding-right: 0;
   }
   & .title-wrapper {
-    margin-bottom: 24px;
+    margin: 0;
     & > .title {
       font-family: Inter;
-      font-size: 24px;
+      font-size: 19px;
       font-style: normal;
       font-weight: 700;
-      line-height: 30px;
+      line-height: 24px;
       letter-spacing: 0em;
       text-align: left;
+      margin: 0;
     }
   }
+  // Both dividers exist only to draw a 1px line; the row-gap spaces them.
   & .hr-div-strong {
     @include hr-div-strong;
+    // The mixin hard-codes 416px, wider than this now-narrower card.
+    width: 100%;
+    margin: 0;
   }
   & .hr-div-soft {
     @include hr-div-soft;
+    width: 100%;
+    margin: 0;
+  }
+  // The one pair that wants a tighter gap than the card rhythm: two one-line
+  // links that would read as unrelated paragraphs 20px apart.
+  & .another-actions {
+    display: flex;
+    flex-direction: column;
+    row-gap: 8px;
   }
   & .another-action {
-    margin-top: 12px;
     @include another-action;
+    // The mixin's padding-top/left was the only thing separating these two lines,
+    // so they read as one wrapped paragraph.
+    padding: 0;
+    margin: 0;
+    font-size: 13px;
+    line-height: 18px;
     .text-link {
       text-decoration: none;
       &:hover {
@@ -59,44 +90,62 @@
   }
 }
 .features-wrapper {
-  width: 260px;
-  height: 100%;
+  width: 244px;
+  height: auto;
 }
 .svg-wrapper {
-  margin-bottom: 55px;
+  // Was 55px. 12px on top of the row-gap reads as a masthead band (32px),
+  // matching the login screen.
+  margin-bottom: 12px;
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
 }
 .form {
-  margin-top: 21px;
-  margin-bottom: 42px;
+  margin: 24px 0 0;
   & .form-control-group {
-    margin-bottom: 16px;
+    margin-bottom: 14px;
     .label {
       display: block;
-      margin-bottom: 8px;
+      margin-bottom: 6px;
       font-family: Inter;
       font-weight: 600;
-      color: nb-theme(text-basic-color);
+      font-size: 12px;
+      // Was full-strength `text-basic-color`, which made the field labels as loud
+      // as the heading. The hint token is the theme's own muted text, so it
+      // tracks light and dark.
+      color: nb-theme(text-hint-color);
     }
     ::ng-deep input.input-full-width {
       border: 1px solid rgba(98, 54, 255, 0.5) !important;
       background-color: transparent;
       color: nb-theme(text-basic-color);
+      // `fieldSize="medium"` in the markup does most of the shrinking; this keeps
+      // the box from growing back on themes with a taller medium field.
+      height: 38px;
+      font-size: 13px;
+    }
+    .caption {
+      font-size: 11px;
+      line-height: 1.3;
+      margin: 4px 0 0;
     }
   }
   & .btn-wrapper {
-    text-align: end;
-    @include mobile-screen {
-      text-align: center;
-    }
+    margin-top: 16px;
     & .submit-btn {
       @include submit-btn;
-      padding: 13px 65px;
+      // Was a right-aligned pill with 65px of side padding; full width matches
+      // the primary action on the login screen.
+      width: 100%;
+      padding: 9px 20px;
+      font-size: 14px;
       font-weight: 700;
+      text-align: center;
       text-transform: none;
       letter-spacing: normal;
       border-radius: 8px;
+      min-height: 40px;
       line-height: 20px;
       transition:
         background-color 0.2s,
@@ -148,7 +197,8 @@
     }
   }
   & .accept-group {
-    margin: 0 0 24px 0;
+    margin: 4px 0 0;
+    font-size: 12px;
     ::ng-deep nb-checkbox {
       display: flex;
       align-items: center;
@@ -162,11 +212,19 @@
         border-color: #8f9bb3 !important; // Light grey border
         background-color: transparent;
         border-width: 1px !important;
+        width: 16px;
+        height: 16px;
       }
       .custom-checkbox.checked {
         background-color: #6236ff !important;
         border-color: #6236ff !important;
       }
+    }
+    & .normal-terms-text,
+    & .terms-link {
+      font-family: Inter;
+      font-size: 12px;
+      line-height: 16px;
     }
     @include mobile-screen {
       margin-left: -10px;
@@ -194,11 +252,12 @@
     }
   }
 }
-.links {
-  margin-top: 21px;
-  margin-bottom: 28px;
-  @include social-links-style;
-}
+
+// NOTE: a `.links { @include social-links-style; }` block used to sit here. It
+// never applied — `.links` lives in the ngx-social-links template, so emulated
+// encapsulation stamps it with that component's attribute, not this one. The
+// real styling is in social-links.component.scss, which this screen shares with
+// the login screen.
 
 .theme-switch {
   @include not-mobile-screen {
@@ -211,84 +270,58 @@
   vertical-align: middle;
 }
 
+// The short-viewport blocks only turn the single gap value (and the form's
+// internal one) down, so they can't drift out of step with the base layout.
 @include small-laptop-screen {
   .register-wrapper {
-    padding: 16px 24px;
-    & .another-action {
-      margin-top: 0;
-      padding-left: 10px;
-    }
+    padding: 20px;
+    row-gap: 16px;
   }
   .svg-wrapper {
-    padding-top: 8px;
-    margin-bottom: 32px;
-  }
-  .form {
-    margin-top: 16px;
-    margin-bottom: 16px;
-    & .form-control-group {
-      margin-bottom: 12px;
-    }
-    & .accept-group {
-      margin-top: 12px;
-    }
-  }
-  .links {
-    margin-top: 8px;
     margin-bottom: 8px;
   }
-
-  // Further compact for short viewports within the small-laptop width range
-  // (491–1024px wide, height <1080px) — deterministic: no conflict with the
-  // wide-screen height query below.
-  @media screen and (max-height: 1080px) {
-    .register-wrapper {
-      & .title-wrapper {
-        margin-bottom: 8px;
-      }
-      & .another-action {
-        margin-top: 4px;
-      }
-    }
-    .svg-wrapper {
-      margin-bottom: 16px;
-    }
-    .form {
-      & .accept-group {
-        margin: 0 0 8px 0;
-      }
+  .form {
+    & .form-control-group {
+      margin-bottom: 12px;
     }
   }
 }
 
-// Compact layout for short viewport heights on wider screens (>1024px wide)
-@media screen and (max-height: 1080px) and (min-width: 1025px) {
+@media screen and (max-height: 980px) and (min-width: 491px) {
   .register-wrapper {
-    padding: 16px 24px;
-    & .title-wrapper {
-      margin-bottom: 8px;
-    }
-    & .another-action {
-      margin-top: 4px;
-    }
+    padding: 20px;
+    row-gap: 16px;
   }
   .svg-wrapper {
-    padding-top: 8px;
-    margin-bottom: 16px;
+    margin-bottom: 8px;
   }
   .form {
-    margin-top: 16px;
-    margin-bottom: 16px;
+    margin-top: 20px;
     & .form-control-group {
       margin-bottom: 12px;
     }
-    & .accept-group {
-      margin: 0 0 8px 0;
+    & .btn-wrapper {
+      margin-top: 14px;
     }
   }
-  .links {
-    margin-top: 8px;
-    margin-bottom: 8px;
+}
+
+@media screen and (max-height: 820px) and (min-width: 491px) {
+  .register-wrapper {
+    padding: 16px 20px;
+    row-gap: 12px;
+  }
+  .svg-wrapper {
+    margin-bottom: 4px;
+  }
+  .form {
+    margin-top: 16px;
+    & .form-control-group {
+      margin-bottom: 10px;
+    }
+    & .btn-wrapper {
+      margin-top: 12px;
+    }
   }
 }
 
@@ -299,8 +332,10 @@
     align-items: center;
   }
   .features-wrapper {
-    width: 476px;
-    margin-top: 30px;
+    width: 440px;
+    max-width: 100%;
+    // The container's row-gap already separates the two stacked cards.
+    margin-top: 0;
   }
 }
 
@@ -310,7 +345,8 @@
     width: 100%;
   }
   .register-wrapper {
-    padding: 20px 12px;
+    padding: 16px 12px;
+    row-gap: 16px;
     & .title-wrapper {
       & > .title {
         text-align: center;

--- a/packages/ui-auth/src/lib/components/social-links/social-links.component.scss
+++ b/packages/ui-auth/src/lib/components/social-links/social-links.component.scss
@@ -1,10 +1,41 @@
 @use '@shared/reusable' as *;
 
 .links {
-  margin-top: 21px;
+  // The login card spaces this block with its own column gap, so the only margin
+  // left here is the one between the "Or sign in with" line and the icon row.
+  margin-top: 0;
+  font-size: 13px;
   @include social-links-style;
   & .socials {
-    margin-top: 15px;
-    margin-bottom: 25px;
+    margin-top: 10px;
+    margin-bottom: 0;
+    // The mixin spaces these with a right-only margin, which leaves a trailing gap
+    // after the last icon and shifts the whole row left of centre. `gap` spaces
+    // them evenly and keeps the row actually centred.
+    gap: 10px;
+    // The mixin also sizes them for a tall desktop viewport (40px targets holding
+    // 32px glyphs). Scale them down so the row costs ~28px instead of ~55px.
+    & .social-link {
+      margin: 0;
+      border-radius: 8px;
+      width: 28px;
+      height: 28px;
+      @include small-mobile-screen {
+        margin: 0;
+        width: 28px;
+        height: 28px;
+      }
+      & nb-icon {
+        width: 18px;
+        height: 18px;
+        @include small-laptop-screen {
+          height: 18px;
+        }
+        @include small-mobile-screen {
+          height: 16px;
+          width: 16px;
+        }
+      }
+    }
   }
 }

--- a/packages/ui-auth/src/lib/components/social-links/social-links.component.scss
+++ b/packages/ui-auth/src/lib/components/social-links/social-links.component.scss
@@ -1,20 +1,13 @@
 @use '@shared/reusable' as *;
 
 .links {
-  // The login card spaces this block with its own column gap, so the only margin
-  // left here is the one between the "Or sign in with" line and the icon row.
   margin-top: 0;
   font-size: 13px;
   @include social-links-style;
   & .socials {
     margin-top: 10px;
     margin-bottom: 0;
-    // The mixin spaces these with a right-only margin, which leaves a trailing gap
-    // after the last icon and shifts the whole row left of centre. `gap` spaces
-    // them evenly and keeps the row actually centred.
     gap: 10px;
-    // The mixin also sizes them for a tall desktop viewport (40px targets holding
-    // 32px glyphs). Scale them down so the row costs ~28px instead of ~55px.
     & .social-link {
       margin: 0;
       border-radius: 8px;

--- a/packages/ui-core/static/styles/@shared/_reusable.scss
+++ b/packages/ui-core/static/styles/@shared/_reusable.scss
@@ -168,6 +168,66 @@ $register-background-light-color: nb-theme(gauzy-card-1);
   }
 }
 
+// Auth error / success banner. Nebular's outline alert is a 1.25rem-padded box
+// carrying a shadow and 0.9375rem text, which dwarfs the 38px fields it sits
+// above and reads as a browser dialog dropped into the card. This keeps the
+// status colour but spends it on a faint tint and a quiet border, so the banner
+// sits inside the form's own type scale.
+@mixin auth-alert {
+  nb-alert {
+    display: block;
+    margin: 0;
+    padding: 10px 12px;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 8px;
+    box-shadow: none;
+    font-family: Inter;
+    font-size: 12px;
+    line-height: 16px;
+
+    .alert-title {
+      margin: 0 0 2px;
+      font-size: 12px;
+      font-weight: 600;
+      line-height: 16px;
+      color: nb-theme(text-basic-color);
+      b {
+        font-weight: 600;
+      }
+    }
+
+    .alert-message-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .alert-message {
+      margin: 0;
+      font-size: 12px;
+      line-height: 16px;
+      color: nb-theme(text-hint-color);
+      & + .alert-message {
+        margin-top: 2px;
+      }
+    }
+
+    // `outline="danger"` / `outline="success"` put these classes on the host.
+    // The transparent-* tokens are pre-mixed by the theme: `nb-theme()` resolves
+    // to a CSS variable, so `rgba()` on it would not compile.
+    &.outline-danger {
+      border-color: nb-theme(color-danger-transparent-300);
+      background-color: nb-theme(color-danger-transparent-100);
+    }
+
+    &.outline-success {
+      border-color: nb-theme(color-success-transparent-300);
+      background-color: nb-theme(color-success-transparent-100);
+    }
+  }
+}
+
 @mixin input-fields-color {
   ::ng-deep .input-full-width {
     box-shadow: rgba(0, 0, 0, 0.1) 0px 0.5px 0.5px 0.5px inset;


### PR DESCRIPTION
- [ ] Before

<img width="1910" height="1031" alt="Screenshot 2026-08-27 033213" src="https://github.com/user-attachments/assets/fe0a4e82-86d8-4d83-8099-cb8593413cd6" />

- [ ] After

<img width="1917" height="1027" alt="Screenshot 2026-08-27 033313" src="https://github.com/user-attachments/assets/ebffae88-a196-47f6-b151-64f7c2d3e00b" />

- [ ] Before

<img width="1912" height="1027" alt="Screenshot 2026-08-27 032754" src="https://github.com/user-attachments/assets/65232813-abff-4cc7-a2c5-e22bada23156" />

- [ ] After

<img width="1911" height="1027" alt="Screenshot 2026-08-27 033348" src="https://github.com/user-attachments/assets/93d2f83e-d137-4518-acaf-212ef1c64812" />

- [ ] Before

<img width="1913" height="1028" alt="Screenshot 2026-08-27 033137" src="https://github.com/user-attachments/assets/afdc8f7d-24ca-43c7-ba2f-a60c0419e1de" />

- [ ] After

<img width="1916" height="1028" alt="Screenshot 2026-08-27 033418" src="https://github.com/user-attachments/assets/69bebfbe-5e9b-4f4e-9562-2759e5902cab" />

- [ ] Before
<img width="1912" height="865" alt="Screenshot 2026-08-27 035651" src="https://github.com/user-attachments/assets/6cb8332f-0cd6-4671-b184-07b910722405" />

- [ ] After

<img width="1917" height="871" alt="Screenshot 2026-08-27 035500" src="https://github.com/user-attachments/assets/831877f3-d234-467a-88d4-f5aac183f3f2" />

