### PR TITLE
fix(ci): surface git's stderr in the configure-registry reset guard

### DIFF
--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -129,9 +129,12 @@ runs:
           fi
         done
         if [ -n "$reset_failed" ]; then
-          # The runner percent-DECODES workflow-command data (%25 -> %, %0A -> LF), so a
-          # literal % in git's message must be re-encoded or the annotation mangles it.
+          # The runner percent-DECODES workflow-command data (%25 -> %, %0D -> CR,
+          # %0A -> LF), so encode literal percent and line controls before emission.
+          # Percent must go first so the generated escape sequences stay intact.
           reset_err="${reset_err//%/%25}"
+          reset_err="${reset_err//$'\r'/%0D}"
+          reset_err="${reset_err//$'\n'/%0A}"
           echo "::error title=Could not reset registry configuration::git checkout -- failed for:$reset_failed.${reset_err:+ First git error: $reset_err.} The previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
           exit 1
         fi

--- a/.github/actions/configure-registry/action.yml
+++ b/.github/actions/configure-registry/action.yml
@@ -91,6 +91,7 @@ runs:
         # turned 'this repo has no cache configured' into 'this repo's CI is red'. Tracked files are
         # restored; untracked leftovers from a previous run on a clean:false runner are removed.
         reset_failed=""
+        reset_err=""
         for f in .npmrc .yarnrc yarn.lock package-lock.json; do
           # Exit status matters: 0 = tracked, 1 = genuinely absent, anything else (128 = git
           # metadata unavailable) means we CANNOT tell. Treating every nonzero as absent would
@@ -100,21 +101,38 @@ runs:
           # `git ls-files ...; tracked=$?` form never reaches the assignment on any repo
           # where $f is untracked - the step dies with exit 1 and no output at all
           # (measured on the first pnpm consumer repo of this action, 2026-08-21).
-          if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+          # Stderr is CAPTURED, not discarded (`2>&1 >/dev/null` = stderr into the
+          # substitution, git's stdout dropped). On 2026-08-27 three self-hosted Windows
+          # runners failed here with a bare "(git-exit-128)" and finding the real error -
+          # "fatal: detected dubious ownership", after the runner service account changed
+          # out from under a NETWORK SERVICE-owned workspace - took a remote login to the
+          # machines, because this log never showed it. The first stderr line now rides
+          # along in the ::error below so the annotation self-diagnoses. The exit-status
+          # handling and fail-closed behavior are unchanged.
+          if probe_err=$(git ls-files --error-unmatch "$f" 2>&1 >/dev/null); then
             tracked=0
           else
             tracked=$?
           fi
           if [ "$tracked" -eq 0 ]; then
-            git checkout -- "$f" || reset_failed="$reset_failed $f"
+            if ! restore_err=$(git checkout -- "$f" 2>&1); then
+              # Re-emit so the raw log keeps the full message it has always shown.
+              if [ -n "$restore_err" ]; then printf '%s\n' "$restore_err" >&2; fi
+              reset_failed="$reset_failed $f"
+              if [ -z "$reset_err" ]; then reset_err="${restore_err%%$'\n'*}"; fi
+            fi
           elif [ "$tracked" -eq 1 ]; then
             rm -f "$f"
           else
             reset_failed="$reset_failed $f(git-exit-$tracked)"
+            if [ -z "$reset_err" ]; then reset_err="${probe_err%%$'\n'*}"; fi
           fi
         done
         if [ -n "$reset_failed" ]; then
-          echo "::error title=Could not reset registry configuration::git checkout -- failed for:$reset_failed. The previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
+          # The runner percent-DECODES workflow-command data (%25 -> %, %0A -> LF), so a
+          # literal % in git's message must be re-encoded or the annotation mangles it.
+          reset_err="${reset_err//%/%25}"
+          echo "::error title=Could not reset registry configuration::git checkout -- failed for:$reset_failed.${reset_err:+ First git error: $reset_err.} The previous run's registry settings may still be in place. Refusing to select a registry from an unknown state."
           exit 1
         fi
 

--- a/.github/actions/configure-registry/test-workflow-command-escaping.sh
+++ b/.github/actions/configure-registry/test-workflow-command-escaping.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+action_file="${1:-$(dirname "$0")/action.yml}"
+
+# Execute the production escaping and annotation-emission lines so this test
+# fails if the action ever stops encoding workflow-command control characters.
+escape_block="$({
+	awk '
+		/reset_err="\$\{reset_err\/\/%\/%25\}"/ { capture = 1 }
+		capture {
+			sub(/^          /, "")
+			print
+		}
+		capture && /echo "::error title=/ { exit }
+	' "$action_file"
+})"
+
+if [[ -z "$escape_block" ]]; then
+	echo "Could not find the workflow-command escaping block in $action_file" >&2
+	exit 1
+fi
+
+assert_encoded() {
+	local diagnostic="$1"
+	local expected="$2"
+	local output
+
+	reset_failed=" .npmrc(git-exit-128)"
+	reset_err="$diagnostic"
+	output="$(eval "$escape_block")"
+
+	if [[ "$output" == *$'\r'* || "$output" == *$'\n'* ]]; then
+		echo "Workflow command contains an unescaped CR or LF" >&2
+		printf '%q\n' "$output" >&2
+		exit 1
+	fi
+	if [[ "$output" != *"$expected"* ]]; then
+		echo "Workflow command does not contain expected encoding: $expected" >&2
+		printf '%q\n' "$output" >&2
+		exit 1
+	fi
+}
+
+assert_encoded 'fatal: progress 100% complete' 'fatal: progress 100%25 complete'
+assert_encoded $'fatal: CR\r::warning title=injected::message' 'fatal: CR%0D::warning title=injected::message'
+assert_encoded $'fatal: LF\n::warning title=injected::message' 'fatal: LF%0A::warning title=injected::message'
+
+echo "workflow-command escaping contract: PASS"

--- a/.github/actions/configure-registry/test-workflow-command-escaping.sh
+++ b/.github/actions/configure-registry/test-workflow-command-escaping.sh
@@ -26,9 +26,11 @@ assert_encoded() {
 	local expected="$2"
 	local output
 
-	reset_failed=" .npmrc(git-exit-128)"
-	reset_err="$diagnostic"
-	output="$(eval "$escape_block")"
+	output="$(
+		reset_failed=" .npmrc(git-exit-128)" \
+			reset_err="$diagnostic" \
+			bash -c "$escape_block"
+	)"
 
 	if [[ "$output" == *$'\r'* || "$output" == *$'\n'* ]]; then
 		echo "Workflow command contains an unescaped CR or LF" >&2


### PR DESCRIPTION
## What

When the `configure-registry` reset guard fails, its `::error` annotation now includes the **first line of git's stderr**, so the failure self-diagnoses instead of showing only an exit code. The tracked-restore branch (`git checkout -- <file>`) gets the same treatment, and its full stderr is still re-emitted to the step log.

## Why

On 2026-08-27, all `stage-apps` desktop release-windows jobs that landed on EVERDESK1/3/4 failed with:

```
git checkout -- failed for: .npmrc(git-exit-128) .yarnrc(git-exit-128) yarn.lock(git-exit-128) package-lock.json(git-exit-128). The previous run's registry settings may still be in place. Refusing to select a registry from an unknown state.
```

The guard failed **closed, correctly** — but the probe (`git ls-files --error-unmatch "$f" >/dev/null 2>&1`) discards stderr, so the log never showed *why* git exited 128. Diagnosing it took a remote login to the builder machines, where the same probe printed:

```
fatal: detected dubious ownership in repository at 'C:/actions-runner/_work/ever-gauzy/ever-gauzy'
```

(The workspaces were created while the runner service ran as `NETWORK SERVICE`; the service now runs as `SYSTEM`. Fixed machine-side with a system-level `safe.directory` allow-list.) With this change, the annotation itself would have read:

```
... .npmrc(git-exit-128) ... First git error: fatal: detected dubious ownership in repository at 'C:/actions-runner/_work/ever-gauzy/ever-gauzy'. The previous run's registry settings may still be in place. ...
```

## What did NOT change

- **Fail-closed semantics are identical**: probe exit 0 → restore, 1 → remove untracked leftover, anything else → refuse to select a registry. Same exit codes, same conditions.
- **Per-path tracked/untracked semantics are identical** — this action is consumed cross-repo (ever-teams tracks `.yarnrc`; pnpm repos track none of the four files); all branches behave as before.
- The annotation stays a single line (only the first stderr line is interpolated, via `${var%%$'\n'*}`).

Note: ever-teams pins this action to a fixed SHA (`727973d…`), so it only picks this up on a deliberate pin bump — no cross-repo surprise.

## Tested

The exact loop was extracted from the YAML and exercised under `bash -eo pipefail` on Git-Bash:

| Scenario | Result |
|---|---|
| tracked + modified `.npmrc` | restored, no error |
| untracked leftover `.yarnrc` | removed |
| absent `package-lock.json` | untouched |
| pnpm-repo shape (none of the four tracked/present) | clean pass |
| git exit 128 (broken repo) | fails closed, annotation carries `First git error: fatal: not a git repository …` |
| same fixture on the **old** code (control) | fails closed with bare `(git-exit-128)` and no cause — the gap this closes |
| `git checkout` failure with multi-line stderr (shim) | first line in annotation, second line only in the log, full stderr re-emitted |

Promotion: normal `develop → stage → main` cascade, no cherry-picks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces git's stderr in the `configure-registry` reset guard so CI failures self-diagnose instead of showing only an exit code like `(git-exit-128)`.

- The `git ls-files` probe now captures stderr; the first line is included in the `::error` annotation.
- `git checkout` restore failures get the same treatment, and their full stderr is still re-emitted to the step log.
- Error text is percent-encoded so CR, LF, and `%` can't be interpreted as additional workflow commands; a new test locks in that encoding.
- Fail-closed semantics, exit codes, and per-path tracked/untracked handling are unchanged.

<sup>Written for commit 18816d31abb9b8caf5ddc8b4ec52e3945ac3cc09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

