### PR TITLE
ci: run the existing jest unit tests on stage

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -46,7 +46,14 @@ jobs:
     # path, which is a cache lookup.
     timeout-minutes: 360
     steps:
+      # Action versions deliberately match `build.yml` rather than the newer majors used elsewhere in
+      # the repository: this job consumes the node_modules cache that workflow writes, so the
+      # producer and the consumer are kept on the same actions.
       - uses: actions/checkout@v4
+        with:
+          # This job only reads the tree — it never pushes — so the checkout credential does not need
+          # to outlive the step in `.git/config`.
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -81,8 +88,11 @@ jobs:
         run: .github/scripts/restore-node-modules.sh
 
       - name: Run unit tests
-        # `--continue` so one failing project still lets every other project report; without it the
-        # first failure hides the rest and each fix needs another full run to find the next problem.
+        # `--nxBail=false` so one failing project still lets every other project report; without that
+        # the first failure hides the rest and each fix costs another full run to find the next
+        # problem. It is the real flag name — nx has no `--continue`, and an unknown option is
+        # forwarded to the executor, so `--continue` would have reached jest instead of doing this.
+        #
         # `--parallel=2` rather than the nx default of 3: jest already forks per project, and this
         # fleet has a documented history of Node heap exhaustion when several suites run at once.
-        run: yarn nx run-many -t test --continue --parallel=2
+        run: yarn nx run-many -t test --nxBail=false --parallel=2

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,88 @@
+name: Unit Tests
+
+# The repository has ~330 `*.spec.ts` files and an `nx` `test` target on 20+ projects
+# (`@nx/jest:jest`, already cached via `nx.json` targetDefaults) — but until now NO workflow ever
+# invoked any of them. CI ran builds plus Playwright/Cypress end-to-end suites only, so a green pull
+# request proved the code COMPILED and said nothing about the unit tests. This workflow wires the
+# existing targets up; it adds no test tooling of its own.
+#
+# Scope is deliberately `stage` only (owner, 2026-08-28). Stage is where the cascade lands before
+# production, pushes to it are infrequent, and keeping the job off `develop` and every pull request
+# means this cannot slow the day-to-day loop while the suites' true state is still unknown.
+#
+# NOT a required status check, on purpose. These suites have never run in CI, so the first runs may
+# well be red — that is the information this workflow exists to surface, and it should surface it
+# without blocking the cascade. Promote it to a required check once it has been green for a while.
+on:
+  push:
+    branches:
+      - stage
+  # So the suites can be exercised on demand from any branch that carries this file, without
+  # waiting for a cascade to land on stage.
+  workflow_dispatch:
+
+concurrency:
+  group: gauzy-unit-tests-${{ github.ref }}
+  # Deliberately NOT `cancel-in-progress: true`. A cancelled test run produces no verdict, and a
+  # gate that reports nothing is worse than no gate: this repository's sibling project already lost
+  # a stage e2e gate that way — six consecutive runs cancelled by the next push, so the gate never
+  # once said pass or fail. Pushes to `stage` are infrequent, so queueing costs very little here.
+  cancel-in-progress: false
+
+# Least-privilege scope for the automatic GITHUB_TOKEN: this job only reads the checkout.
+permissions:
+  contents: read
+
+env:
+  # Same archive name the build workflow uses, so the restore script finds what it expects.
+  NODE_MODULES_ARCHIVE: node-modules.tar.zst
+
+jobs:
+  unit-tests:
+    name: unit-tests
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    # A cold dependency install on this fleet is measured in hours, not minutes (the build workflow
+    # documents 88 min / 3h20m / 3h46m for the same work). The ceiling costs nothing on the warm
+    # path, which is a cache lookup.
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Restore node_modules archive
+        # Best effort: the same key the build workflow writes, so a stage push that already built
+        # this exact lockfile reuses that tree instead of installing again. `restore-node-modules.sh`
+        # below installs from scratch when the archive is not there, so a miss is not fatal.
+        uses: actions/cache/restore@v4
+        continue-on-error: true
+        with:
+          path: ${{ env.NODE_MODULES_ARCHIVE }}
+          key: ${{ runner.os }}-${{ runner.arch }}-node-modules-${{ hashFiles('yarn.lock', 'package.json', 'patches/**', '.scripts/postinstall.js') }}
+
+      # Route any install through the internal Verdaccio cache. Placed AFTER the cache restore
+      # because this action rewrites yarn.lock's resolved URLs, and `hashFiles()` in the key above
+      # evaluates at step runtime — configuring the registry first would move the key and split the
+      # cache namespace by VIP reachability.
+      - name: Configure Registry
+        uses: ever-co/ever-gauzy/.github/actions/configure-registry@aa4ee19926fabcf820aa1294385a76aec6bdb548
+        with:
+          verdaccio-registry: ${{ vars.VERDACCIO_REGISTRY }}
+          verdaccio-token: ${{ secrets.VERDACCIO_TOKEN }}
+          force-public: ${{ vars.VERDACCIO_FORCE_PUBLIC }}
+          expect-vip: ${{ vars.RUNNER_LINUX_X64_8 != '' }}
+
+      - name: Restore node_modules
+        shell: bash
+        # Unpacks the archive, or installs from scratch when it is unavailable. One step, so there
+        # is no `if:` on a previous step's outcome to get wrong.
+        run: .github/scripts/restore-node-modules.sh
+
+      - name: Run unit tests
+        # `--continue` so one failing project still lets every other project report; without it the
+        # first failure hides the rest and each fix needs another full run to find the next problem.
+        # `--parallel=2` rather than the nx default of 3: jest already forks per project, and this
+        # fleet has a documented history of Node heap exhaustion when several suites run at once.
+        run: yarn nx run-many -t test --continue --parallel=2


### PR DESCRIPTION
## Why

The repository already has the tests **and** the tooling — it just never ran them:

- **~330 `*.spec.ts` files** (53 in `packages/core`, 154 in `packages/plugins`, 41 in `packages/ui-core`, …)
- an nx **`test` target on 20+ projects**, using `@nx/jest:jest`, already cached via `nx.json` `targetDefaults`
- **no workflow invokes any of it.** CI runs builds plus Playwright/Cypress e2e only.

So a green pull request today proves the code *compiles*. It says nothing about the unit tests.

This PR adds no test tooling and changes no test code — it wires the existing targets into CI.

## Scope: `stage` only

Triggered by `push` to `stage`, plus `workflow_dispatch` so the suites can be exercised on demand from any branch carrying the file without waiting for a cascade.

Stage is where the cascade lands before production and pushes to it are infrequent, so this cannot slow the day-to-day loop while the suites' true state is still unknown.

## Deliberately not a required check

These suites have never run in CI, so **the first runs may well be red**. That is exactly the information this workflow exists to surface, and it should surface it without blocking the cascade. Promote it to a required check once it has been green for a while.

## Two choices worth calling out

**`cancel-in-progress: false`.** A cancelled test run produces no verdict, and a gate that reports nothing is worse than no gate — this org already lost a stage e2e gate exactly that way, with six consecutive runs cancelled by the next push so the gate never once said pass or fail. Stage pushes are infrequent, so queueing costs very little.

**`--continue --parallel=2`.** `--continue` so one failing project still lets every other project report; without it the first failure hides the rest and each fix costs another full run. `--parallel=2` rather than nx's default 3 because jest already forks per project and this fleet has a documented history of Node heap exhaustion when several suites run at once.

## Cost

Dependencies come from the **same lockfile-keyed cache `build.yml` writes**, via the same `restore-node-modules.sh` the build jobs use — so a stage push that already built this tree reuses it instead of paying for another install. A cold miss still installs from scratch, which is why the job keeps the same 360-minute ceiling the build workflow documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI workflow that runs the repository's existing Jest unit tests on pushes to `stage`. CI previously ran only builds and Playwright/Cypress e2e, so nothing ever executed the ~330 `*.spec.ts` files; this wires the existing nx `test` targets into the pipeline without adding test tooling or changing test code.

- Scope is `stage` only plus manual `workflow_dispatch`, so it can't slow day-to-day PR work.
- Deliberately not a required check: the first runs may be red, and surfacing that without blocking the cascade is the point.
- Runs queue rather than cancel (`cancel-in-progress: false`) so in-progress runs always produce a pass or fail verdict.
- `--nxBail=false --parallel=2` lets a failing project report alongside every other project and avoids Node heap exhaustion.
- Reuses the build workflow's lockfile-keyed `node_modules` cache, so a stage push that already built this tree skips reinstalling.

<sup>Written for commit 5aa7b2739226668bb6d6c66e287181bb3d163a9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

