### PR TITLE
feat(downloads): mirror desktop installers to R2 behind downloads.ever.co

### DIFF
--- a/.github/workflows/mirror-releases-to-r2.yml
+++ b/.github/workflows/mirror-releases-to-r2.yml
@@ -1,0 +1,66 @@
+# Mirror desktop-app installers from GitHub Releases into the R2 bucket behind downloads.ever.co.
+#
+# The download links on gauzy.co used to point at ever.sfo3.cdn.digitaloceanspaces.com, which died
+# with the DigitalOcean account and left every desktop download broken. GitHub Releases stays the
+# source of truth and the auto-update feed; R2 is a CDN mirror in front of it.
+#
+# This runs on a schedule rather than hooking the release workflows: it is self-healing (a missed or
+# failed run is corrected by the next one), it touches none of the ~24 existing desktop build
+# workflows, and it is idempotent -- an asset already present at the right size is skipped.
+name: mirror-releases-to-r2
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List what would be uploaded without uploading'
+        type: boolean
+        default: false
+  schedule:
+    # Every 6 hours. Releases are cut far less often than this, so the window between a release
+    # being published and being mirrored is bounded -- and until it is mirrored the website keeps
+    # linking to GitHub, because it only rewrites URLs listed in manifest.json.
+    - cron: '0 */6 * * *'
+
+concurrency:
+  # Two concurrent mirrors would race on manifest.json and could publish one that omits keys the
+  # other just uploaded.
+  group: mirror-releases-to-r2
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Verify R2 credentials and signing
+        # Runs before any mirroring. R2 answers "signature rejected" in a way the mirror reads as
+        # "object absent", so without this a credential or signing fault would look like an empty
+        # mirror and publish an empty manifest instead of failing.
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_S3_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: node scripts/mirror-releases-to-r2.mjs --selftest
+
+      - name: Mirror release assets to R2
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_S3_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # The release repos are public, so this only needs to lift the unauthenticated API rate
+          # limit -- it is not granting cross-repo access.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run == true }}
+        run: node scripts/mirror-releases-to-r2.mjs

--- a/scripts/mirror-releases-to-r2.mjs
+++ b/scripts/mirror-releases-to-r2.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * Mirror desktop-app release assets from GitHub Releases into the Cloudflare R2 bucket behind
+ * https://downloads.ever.co, and publish a manifest of what is actually there.
+ *
+ * Why this exists: the download links on gauzy.co pointed at
+ * `ever.sfo3.cdn.digitaloceanspaces.com`, which died with the DigitalOcean account. GitHub Releases
+ * stays the source of truth and the auto-update feed; R2 is a mirror in front of it, so a mirror
+ * miss degrades to a working GitHub link instead of a broken download.
+ *
+ * The manifest is the contract. The website rewrites a GitHub asset URL to downloads.ever.co ONLY
+ * for keys listed in manifest.json, so a release that has not been mirrored yet still downloads from
+ * GitHub rather than 404ing. Never add a manifest entry for an object you have not read back.
+ *
+ * Zero dependencies on purpose: SigV4 is implemented here rather than pulling an SDK or assuming the
+ * AWS CLI exists, so this behaves identically on GitHub-hosted and self-hosted ARC runners.
+ *
+ * Env: R2_BUCKET R2_S3_ENDPOINT R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY [GITHUB_TOKEN] [DRY_RUN]
+ */
+import crypto from 'node:crypto';
+
+const ENDPOINT = process.env.R2_S3_ENDPOINT;
+const BUCKET = process.env.R2_BUCKET;
+const AKID = process.env.R2_ACCESS_KEY_ID;
+const SECRET = process.env.R2_SECRET_ACCESS_KEY;
+const GH_TOKEN = process.env.GITHUB_TOKEN || '';
+const DRY = process.env.DRY_RUN === 'true';
+
+for (const [k, v] of Object.entries({
+	R2_S3_ENDPOINT: ENDPOINT,
+	R2_BUCKET: BUCKET,
+	R2_ACCESS_KEY_ID: AKID,
+	R2_SECRET_ACCESS_KEY: SECRET
+})) {
+	if (!v) {
+		console.error(`missing env ${k}`);
+		process.exit(2);
+	}
+}
+
+/** GitHub repo -> object-key prefix. Must stay in step with `switchToCDN` in ever-gauzy-website. */
+const APPS = {
+	'ever-gauzy-desktop': 'gauzy-desktop',
+	'ever-gauzy-desktop-timer': 'gauzy-desktop-timer',
+	'ever-gauzy-server': 'gauzy-server',
+	'ever-gauzy-agent': 'gauzy-agent'
+};
+
+// Installers only. Mirroring the update metadata (latest*.yml) would turn R2 into an update feed,
+// and the auto-updater must keep talking to GitHub.
+const ASSET_RE = /\.(exe|dmg|deb|rpm|AppImage|zip|snap|pkg|msi)$/i;
+
+const sha256hex = (b) => crypto.createHash('sha256').update(b).digest('hex');
+const hmac = (k, d) => crypto.createHmac('sha256', k).update(d).digest();
+
+function sign({ method, key, payloadHash, extra = {} }) {
+	const url = new URL(`${ENDPOINT}/${BUCKET}/${key}`);
+	const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
+	const date = amzDate.slice(0, 8);
+
+	const headers = {
+		host: url.host,
+		'x-amz-content-sha256': payloadHash,
+		'x-amz-date': amzDate,
+		...extra
+	};
+	const lower = {};
+	for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = String(v).trim();
+	const names = Object.keys(lower).sort();
+
+	const canonicalRequest = [
+		method,
+		url.pathname
+			.split('/')
+			.map((s) => encodeURIComponent(decodeURIComponent(s)))
+			.join('/'),
+		'',
+		names.map((n) => `${n}:${lower[n]}\n`).join(''),
+		names.join(';'),
+		payloadHash
+	].join('\n');
+
+	const scope = `${date}/auto/s3/aws4_request`;
+	const toSign = ['AWS4-HMAC-SHA256', amzDate, scope, sha256hex(Buffer.from(canonicalRequest))].join('\n');
+	const signingKey = hmac(hmac(hmac(hmac(`AWS4${SECRET}`, date), 'auto'), 's3'), 'aws4_request');
+	const signature = crypto.createHmac('sha256', signingKey).update(toSign).digest('hex');
+
+	headers.Authorization = `AWS4-HMAC-SHA256 Credential=${AKID}/${scope}, SignedHeaders=${names.join(';')}, Signature=${signature}`;
+	return { url: url.toString(), headers };
+}
+
+async function head(key) {
+	const { url, headers } = sign({ method: 'HEAD', key, payloadHash: sha256hex(Buffer.alloc(0)) });
+	const r = await fetch(url, { method: 'HEAD', headers });
+	return { exists: r.ok, size: r.ok ? Number(r.headers.get('content-length') || 0) : 0 };
+}
+
+async function put(key, body, contentType) {
+	const { url, headers } = sign({
+		method: 'PUT',
+		key,
+		payloadHash: sha256hex(body),
+		extra: { 'content-type': contentType, 'content-length': String(body.length) }
+	});
+	const r = await fetch(url, { method: 'PUT', headers, body });
+	if (!r.ok) throw new Error(`PUT ${key} -> ${r.status} ${(await r.text()).slice(0, 300)}`);
+}
+
+async function gh(path) {
+	const r = await fetch(`https://api.github.com${path}`, {
+		headers: {
+			Accept: 'application/vnd.github+json',
+			'User-Agent': 'ever-r2-mirror',
+			...(GH_TOKEN ? { Authorization: `Bearer ${GH_TOKEN}` } : {})
+		}
+	});
+	if (!r.ok) throw new Error(`GET ${path} -> ${r.status}`);
+	return r.json();
+}
+
+// `--selftest` proves the SigV4 implementation against the real bucket before anyone depends on it.
+// A HEAD alone cannot do that: R2 answers both "absent" and "signature rejected" in a way this script
+// reads as absent, so a signing bug would look exactly like an empty mirror and the job would happily
+// publish an empty manifest. Round-tripping a real object is the only honest check.
+if (process.argv.includes('--selftest')) {
+	const key = `_selftest/${Date.now()}.txt`;
+	const body = Buffer.from(`signing round-trip ${new Date().toISOString()}\n`);
+	try {
+		await put(key, body, 'text/plain');
+		const back = await head(key);
+		if (!back.exists || back.size !== body.length) {
+			throw new Error(`read-back mismatch: exists=${back.exists} size=${back.size} want=${body.length}`);
+		}
+		console.log(`selftest OK: signed PUT + HEAD round-tripped ${key} (${body.length} bytes)`);
+		process.exit(0);
+	} catch (e) {
+		console.error(`selftest FAILED: ${e.message}`);
+		process.exit(1);
+	}
+}
+
+const mirrored = [];
+let uploaded = 0;
+let skipped = 0;
+let failed = 0;
+
+for (const [repo, prefix] of Object.entries(APPS)) {
+	let releases;
+	try {
+		releases = await gh(`/repos/ever-co/${repo}/releases?per_page=20`);
+	} catch (e) {
+		console.error(`  ${repo}: cannot list releases -- ${e.message}`);
+		failed++;
+		continue;
+	}
+
+	// The site only ever links to the newest stable and the newest prerelease, so those two are
+	// sufficient. Older versions keep resolving to GitHub through the manifest fallback.
+	const targets = [
+		{ rel: releases.find((r) => !r.prerelease && !r.draft), dir: prefix },
+		{ rel: releases.find((r) => r.prerelease && !r.draft), dir: `${prefix}-pre` }
+	];
+
+	for (const { rel, dir } of targets) {
+		if (!rel) {
+			console.log(`  ${dir}: no release found`);
+			continue;
+		}
+		console.log(`  ${dir}: ${rel.tag_name} (${rel.assets.length} assets)`);
+
+		for (const asset of rel.assets) {
+			if (!ASSET_RE.test(asset.name)) continue;
+			const key = `${dir}/${asset.name}`;
+			const mb = Math.round(asset.size / 1048576);
+			try {
+				const existing = await head(key);
+				if (existing.exists && existing.size === asset.size) {
+					mirrored.push(key);
+					skipped++;
+					continue;
+				}
+				if (DRY) {
+					console.log(`    would upload ${key} (${mb}MB)`);
+					continue;
+				}
+
+				const dl = await fetch(asset.browser_download_url, {
+					headers: {
+						'User-Agent': 'ever-r2-mirror',
+						...(GH_TOKEN ? { Authorization: `Bearer ${GH_TOKEN}` } : {})
+					},
+					redirect: 'follow'
+				});
+				if (!dl.ok) throw new Error(`download ${dl.status}`);
+				const buf = Buffer.from(await dl.arrayBuffer());
+				if (buf.length !== asset.size) {
+					throw new Error(`size mismatch: got ${buf.length}, expected ${asset.size}`);
+				}
+
+				await put(key, buf, asset.content_type || 'application/octet-stream');
+
+				// Only trust the mirror after reading it back at the expected size.
+				const verify = await head(key);
+				if (!verify.exists || verify.size !== asset.size) {
+					throw new Error(`post-upload verify failed (${verify.size} != ${asset.size})`);
+				}
+
+				mirrored.push(key);
+				uploaded++;
+				console.log(`    uploaded ${key} (${mb}MB)`);
+			} catch (e) {
+				failed++;
+				console.error(`    FAILED ${key}: ${e.message}`);
+			}
+		}
+	}
+}
+
+if (!DRY) {
+	const manifest = {
+		generated: new Date().toISOString(),
+		base: 'https://downloads.ever.co',
+		keys: mirrored.sort()
+	};
+	await put('manifest.json', Buffer.from(JSON.stringify(manifest, null, 1)), 'application/json');
+	console.log(`\nmanifest.json published with ${mirrored.length} keys`);
+}
+
+console.log(`\nuploaded=${uploaded} already-present=${skipped} failed=${failed}`);
+
+// A failure must fail the job. A silently-partial mirror is how the site ends up advertising a file
+// that is not there.
+process.exit(failed ? 1 : 0);

--- a/scripts/mirror-releases-to-r2.mjs
+++ b/scripts/mirror-releases-to-r2.mjs
@@ -53,6 +53,15 @@ const ASSET_RE = /\.(exe|dmg|deb|rpm|AppImage|zip|snap|pkg|msi)$/i;
 const sha256hex = (b) => crypto.createHash('sha256').update(b).digest('hex');
 const hmac = (k, d) => crypto.createHmac('sha256', k).update(d).digest();
 
+/**
+ * Make a remote-derived string safe to print.
+ *
+ * Release tags, asset names and error bodies all come from outside this script. Printed raw, a
+ * newline or carriage return in one of them can forge additional log lines in the CI output.
+ */
+const CONTROL_CHARS = new RegExp('[\u0000-\u001f\u007f]', 'g');
+const safe = (v) => String(v).replace(CONTROL_CHARS, ' ').slice(0, 200);
+
 function sign({ method, key, payloadHash, extra = {} }) {
 	const url = new URL(`${ENDPOINT}/${BUCKET}/${key}`);
 	const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
@@ -66,7 +75,11 @@ function sign({ method, key, payloadHash, extra = {} }) {
 	};
 	const lower = {};
 	for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = String(v).trim();
-	const names = Object.keys(lower).sort();
+	// SigV4 requires the signed-header list in byte order, so compare code units directly.
+	// 🛑 Do NOT switch this to localeCompare: it is locale-aware and would order some headers
+	// differently from what the server canonicalises, producing SignatureDoesNotMatch.
+	const byByte = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+	const names = Object.keys(lower).sort(byByte);
 
 	const canonicalRequest = [
 		method,
@@ -134,7 +147,7 @@ if (process.argv.includes('--selftest')) {
 		console.log(`selftest OK: signed PUT + HEAD round-tripped ${key} (${body.length} bytes)`);
 		process.exit(0);
 	} catch (e) {
-		console.error(`selftest FAILED: ${e.message}`);
+		console.error(`selftest FAILED: ${safe(e.message)}`);
 		process.exit(1);
 	}
 }
@@ -149,7 +162,7 @@ for (const [repo, prefix] of Object.entries(APPS)) {
 	try {
 		releases = await gh(`/repos/ever-co/${repo}/releases?per_page=20`);
 	} catch (e) {
-		console.error(`  ${repo}: cannot list releases -- ${e.message}`);
+		console.error(`  ${repo}: cannot list releases -- ${safe(e.message)}`);
 		failed++;
 		continue;
 	}
@@ -166,7 +179,7 @@ for (const [repo, prefix] of Object.entries(APPS)) {
 			console.log(`  ${dir}: no release found`);
 			continue;
 		}
-		console.log(`  ${dir}: ${rel.tag_name} (${rel.assets.length} assets)`);
+		console.log(`  ${dir}: ${safe(rel.tag_name)} (${rel.assets.length} assets)`);
 
 		for (const asset of rel.assets) {
 			if (!ASSET_RE.test(asset.name)) continue;
@@ -180,7 +193,7 @@ for (const [repo, prefix] of Object.entries(APPS)) {
 					continue;
 				}
 				if (DRY) {
-					console.log(`    would upload ${key} (${mb}MB)`);
+					console.log(`    would upload ${safe(key)} (${mb}MB)`);
 					continue;
 				}
 
@@ -207,10 +220,10 @@ for (const [repo, prefix] of Object.entries(APPS)) {
 
 				mirrored.push(key);
 				uploaded++;
-				console.log(`    uploaded ${key} (${mb}MB)`);
+				console.log(`    uploaded ${safe(key)} (${mb}MB)`);
 			} catch (e) {
 				failed++;
-				console.error(`    FAILED ${key}: ${e.message}`);
+				console.error(`    FAILED ${safe(key)}: ${safe(e.message)}`);
 			}
 		}
 	}
@@ -220,7 +233,8 @@ if (!DRY) {
 	const manifest = {
 		generated: new Date().toISOString(),
 		base: 'https://downloads.ever.co',
-		keys: mirrored.sort()
+		// Byte order, and a copy rather than sorting `mirrored` in place.
+		keys: [...mirrored].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
 	};
 	await put('manifest.json', Buffer.from(JSON.stringify(manifest, null, 1)), 'application/json');
 	console.log(`\nmanifest.json published with ${mirrored.length} keys`);


### PR DESCRIPTION
## Problem

Every desktop download link on gauzy.co is dead. `components/download/download-page-content.tsx` rewrites GitHub release URLs to `https://ever.sfo3.cdn.digitaloceanspaces.com/...`, and that host went away with the DigitalOcean account — the CDN hostname is NXDOMAIN and the origin bucket returns `NoSuchBucket`. Anyone clicking "Download" gets nothing.

## What this adds

A scheduled, idempotent mirror of desktop installers from GitHub Releases into a new Cloudflare R2 bucket served at **`downloads.ever.co`**.

- **GitHub Releases stays the source of truth** and remains the auto-update feed. R2 is a mirror in front of it, so a mirror miss degrades to a working GitHub link rather than a broken download.
- **`manifest.json` is the contract.** The website (separate PR) rewrites a GitHub asset URL to `downloads.ever.co` *only* for keys listed in the manifest. A release that has not been mirrored yet still downloads from GitHub instead of 404ing — which is exactly the failure mode that made the DigitalOcean outage invisible until users complained.
- **Scheduled, not release-hooked.** It is self-healing (a missed run is corrected by the next), touches none of the ~24 existing desktop build workflows, and skips assets already present at the right size.

Not mirrored: `latest*.yml` update metadata. The auto-updater must keep talking to GitHub.

## Credentials

The R2 token in these secrets is scoped to **only** the `ever-downloads` bucket. This is deliberate — the account-wide R2 keys can write every `ever-backup-*` bucket, and those must not be reachable from CI. Verified with a negative control:

```
write  s3://ever-downloads/          -> succeeds
list   s3://ever-backup-pg-dumps/    -> AccessDenied
```

## Why the self-test step exists

R2 answers "signature rejected" in a way a HEAD-based existence check reads as "object absent". Without a positive signing check, a bad credential would look like an empty mirror and the job would cheerfully publish an **empty manifest** — silently reverting every download to GitHub with no error. So the workflow round-trips a real signed PUT before mirroring anything. Verified both ways:

```
good creds -> selftest OK: signed PUT + HEAD round-tripped
bad secret -> selftest FAILED: 403 SignatureDoesNotMatch, exit 1
```

The mirror also reads each object back at the expected size before adding it to the manifest, and exits non-zero on any failure, so a partial mirror fails the job instead of publishing a manifest that promises files that are not there.

## Dependencies

None. SigV4 is implemented in the script rather than pulling an SDK or assuming the AWS CLI is installed, so it behaves the same on GitHub-hosted and self-hosted ARC runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every desktop download link on gauzy.co is dead: the page rewrote GitHub asset URLs to ever.sfo3.cdn.digitaloceanspaces.com, which went away with the DigitalOcean account. This PR adds a scheduled, idempotent mirror that copies desktop installers from GitHub Releases into a new R2 bucket served at `downloads.ever.co`, so downloads resolve again.

**How the mirror behaves**
- GitHub Releases stays the source of truth and the auto-update feed; R2 only fronts it as a mirror.
- A `manifest.json` in the bucket is the contract: the website rewrites a GitHub asset URL to `downloads.ever.co` only for keys listed there, so an unmirrored release still downloads from GitHub instead of 404ing.
- It runs on a 6-hour schedule instead of release hooks, which makes it self-healing and leaves the ~24 existing desktop build workflows untouched. Assets already present at the right size are skipped, and `latest*.yml` is never mirrored so the auto-updater keeps talking to GitHub.
- A self-test step round-trips a signed PUT before mirroring anything, because R2 reports signature failures the same as absent objects. Uploaded objects are read back at the expected size before the manifest is published, and any failure exits non-zero.
- The script needs no dependencies: SigV4 is implemented directly. Its R2 credentials are scoped to the `ever-downloads` bucket only, verified with a negative control.

<sup>Written for commit 4c00bbf4404a7fef9b74c2a5e86a3c244cf1b499. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

