### PR TITLE
fix(employees): put the Time & Activity filters on the trailing edge

### DIFF
--- a/apps/gauzy/src/app/pages/employees/activity/screenshot/screenshot/screenshot.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/screenshot/screenshot/screenshot.component.scss
@@ -112,8 +112,13 @@
     min-width: 0;
   }
 
+  // Restated from `time-activities.component.scss`, which this file forwards:
+  // that block declares the same `.header-bar`, so the copy below wins and has
+  // to carry the end-alignment too. The filter row itself is ended by the
+  // forwarded `ngx-gauzy-filters .main-wrapper` rule.
   .header-filters {
-    display: block;
+    display: flex;
+    justify-content: flex-end;
     flex: 1 1 auto;
     min-width: 0;
   }

--- a/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
@@ -36,11 +36,14 @@
   gap: 0.75rem 1rem;
   flex: 0 0 auto;
   // The table below ends at a 16px inset: the scroll container is held 11px off
-  // the card's edge and the 5px scrollbar sits inside that. This row reaches the
-  // same 16px as 8px here plus the 8px the filter row's own wrapper adds, so the
-  // two end on one line.
-  @include nb-ltr(padding-right, 0.5rem);
-  @include nb-rtl(padding-left, 0.5rem);
+  // the card's edge and the 5px scrollbar sits inside that. The filter row does
+  // not end there on its own — `.filter-item-list` is a bootstrap `.row` whose
+  // negative gutters are never reset, so its trailing item overhangs the wrapper
+  // it sits in. Carry the difference here instead; the value is set against the
+  // rendered result rather than derived, since the overhang comes from gutters
+  // this page does not own.
+  @include nb-ltr(padding-right, 31px);
+  @include nb-rtl(padding-left, 31px);
 
   .header-statistics {
     flex: 0 0 auto;

--- a/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
@@ -199,15 +199,66 @@
   }
 }
 
-// Time & Activities grid. The table body carries no font-size of its own, so it
-// inherited the 0.875rem paragraph size; setting the container caps every cell
-// that does not override it, and the three that do are listed alongside.
-:host ga-daily-grid ::ng-deep {
+// ---------------------------------------------------------------------------
+// Time & Activities grid — the whole `.grid-container` runs at the table-header
+// scale (0.75rem / 12px).
+//
+// Most of the table carries no size of its own, so the declaration on the
+// container inherits down and does the bulk of the work. Everything listed
+// under it is an element that DOES declare a size and would otherwise ignore
+// the container: the shared `report.scss` chrome, and the nested cell
+// components, each of which ships its own scale.
+//
+// The size is taken from `gauzy-table-header-font-size` rather than written as
+// a literal, so the grid tracks the same scale as the group-by label and the
+// stat-strip labels capped above.
+//
+// Line-height is restated wherever the size is, because these components pair a
+// px size with a px leading — dropping the size alone would leave leading set
+// for larger text and the rows would read as loosely set.
+// ---------------------------------------------------------------------------
+:host .grid-container {
+  font-size: nb-theme(gauzy-table-header-font-size);
+  line-height: nb-theme(gauzy-table-header-line-height);
+}
+
+:host .grid-container ga-daily-grid ::ng-deep {
+  // `report.scss` chrome: the column-heading strip, the activity badge (14px),
+  // and the header the mobile breakpoint switches on (16px).
   .day-grid-container,
+  .columns-header,
   .responsive-table-header,
+  .responsive-table-content,
   nb-accordion-item-header,
   nb-badge {
     font-size: nb-theme(gauzy-table-header-font-size);
+    line-height: nb-theme(gauzy-table-header-line-height);
+  }
+
+  // Nested cell components. Each sets a px size on its own inner text, so the
+  // container's inheritance stops at their host element.
+  ngx-avatar {
+    .link-text,
+    .caption {
+      font-size: nb-theme(gauzy-table-header-font-size);
+      line-height: nb-theme(gauzy-table-header-line-height);
+    }
+  }
+
+  ga-project-column-view {
+    .main-header,
+    .employees-count {
+      font-size: nb-theme(gauzy-table-header-font-size);
+      line-height: nb-theme(gauzy-table-header-line-height);
+    }
+  }
+
+  // The client cell. Its `.link-text` carries the size, so the host declaration
+  // alone would not reach it. The 8px counter chip further in is left alone —
+  // it is a count badge rather than body text.
+  ngx-contact-links .link-text {
+    font-size: nb-theme(gauzy-table-header-font-size);
+    line-height: nb-theme(gauzy-table-header-line-height);
   }
 
   // Durations move off the near-white `--gauzy-text-color-1` onto the muted

--- a/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
@@ -14,7 +14,12 @@
   .custom-card-body {
     overflow-y: overlay;
     overflow-x: hidden;
-    padding-right: 11px;
+    // The scrollbar draws on this element's own trailing edge, so the way to move
+    // it off the card's edge is to narrow the element rather than pad its content.
+    // Inset by 11px and the 5px bar sits inside that, putting the table's trailing
+    // edge on the same 16px inset the filter row above uses.
+    @include nb-ltr(margin-right, 11px);
+    @include nb-rtl(margin-left, 11px);
     flex: 1 1 auto;
     min-height: 0;
   }
@@ -30,6 +35,10 @@
   flex-wrap: nowrap;
   gap: 0.75rem 1rem;
   flex: 0 0 auto;
+  // The table below ends at a 16px inset: the scroll container is held 11px off
+  // the card's edge and the 5px scrollbar sits inside that. This row reaches the
+  // same 16px as 8px here plus the 8px the filter row's own wrapper adds, so the
+  // two end on one line.
   @include nb-ltr(padding-right, 0.5rem);
   @include nb-rtl(padding-left, 0.5rem);
 

--- a/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
@@ -38,8 +38,11 @@
     min-width: 0;
   }
 
+  // A flex slot that ends its content, so the filter row lands on the trailing
+  // edge of the header rather than starting wherever its box happens to begin.
   .header-filters {
-    display: block;
+    display: flex;
+    justify-content: flex-end;
     flex: 1 1 auto;
     min-width: 0;
   }
@@ -75,6 +78,12 @@
   .main-wrapper {
     margin: 0;
     flex-wrap: nowrap;
+    // The bar is authored as `space-between` plus an `ml-auto` push on its inner
+    // column — and the `.col-auto.ml-auto` reset below drops that push, since the
+    // negative gutters it went with are gone. So the row has to be ended here
+    // instead: full width of its slot, contents flush to the trailing edge.
+    width: 100%;
+    justify-content: flex-end;
   }
 
   // `align-items-end` on the filter list is a bootstrap utility (`!important`), so

--- a/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
@@ -42,8 +42,8 @@
   // it sits in. Carry the difference here instead; the value is set against the
   // rendered result rather than derived, since the overhang comes from gutters
   // this page does not own.
-  @include nb-ltr(padding-right, 31px);
-  @include nb-rtl(padding-left, 31px);
+  @include nb-ltr(padding-right, 27px);
+  @include nb-rtl(padding-left, 27px);
 
   .header-statistics {
     flex: 0 0 auto;

--- a/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
+++ b/apps/gauzy/src/app/pages/employees/activity/time-activities/time-activities/time-activities.component.scss
@@ -261,6 +261,18 @@
     line-height: nb-theme(gauzy-table-header-line-height);
   }
 
+  // `report.scss` gives every row a fixed 86px box, pads it 10px/20px and pins
+  // the content to the top. That was sized for the old scale; at the table-header
+  // size the single `.table-inner-wrapper` fills a little over half of it and the
+  // rest reads as a gap under each row. Let the content set the height and pad it
+  // evenly, so the row is only as tall as what it holds.
+  .table-row {
+    height: auto;
+    justify-content: center;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
   // Durations move off the near-white `--gauzy-text-color-1` onto the muted
   // numeric colour, so a row reads as one line with the badge carrying the
   // emphasis rather than as a block of white.

--- a/packages/plugins/videos-ui/src/lib/pages/video-page/video-page.component.scss
+++ b/packages/plugins/videos-ui/src/lib/pages/video-page/video-page.component.scss
@@ -30,6 +30,36 @@
   }
 }
 
+// Filters on the trailing edge, matching the other Time & Activity tabs. This
+// file does not forward `time-activities.component`, so the alignment those tabs
+// share is restated here: the bar is authored as a bootstrap `.row.col-auto`
+// with `space-between` and negative gutters, so end its row explicitly and drop
+// the gutters — otherwise it hangs past the card's padding edge.
+:host .custom-card-header {
+  display: flex;
+  justify-content: flex-end;
+  // Matches `.custom-card-body`'s inset, so the controls line up with the video
+  // grid below them rather than sitting proud of it. Logical, so it follows the
+  // trailing edge under RTL the way `flex-end` above already does.
+  padding-inline-end: 1rem;
+
+  ::ng-deep ngx-gauzy-filters {
+    .main-wrapper {
+      width: 100%;
+      margin: 0;
+      justify-content: flex-end;
+    }
+
+    // The negative gutters this column's padding cancelled are gone with the
+    // row's margin, so the padding would now read as a real 15px inset off the
+    // trailing edge. Its `ml-auto` is left alone — bootstrap sets it
+    // `!important` and it pushes the same way `flex-end` already does.
+    .col-auto.ml-auto {
+      padding: 0;
+    }
+  }
+}
+
 // Videos tab — the same cap the other Time & Activity tabs get. The duration
 // chip keeps its white-on-black: it sits over a thumbnail, where the contrast
 // is doing legibility work rather than drawing attention.

--- a/packages/ui-core/shared/src/lib/report/daily-grid/daily-grid.component.html
+++ b/packages/ui-core/shared/src/lib/report/daily-grid/daily-grid.component.html
@@ -42,7 +42,8 @@
 								</div>
 								<div class="responsive-table-row project-column"></div>
 								<div class="responsive-table-row project-column"></div>
-								<div class="responsive-table-row todo-column header"></div>
+								<div class="responsive-table-row todo-column"></div>
+								<div class="responsive-table-row todo-column"></div>
 								<div class="responsive-table-row time-column">
 									<span>{{ day?.sum | durationFormat }}</span>
 								</div>
@@ -62,7 +63,8 @@
 								</div>
 								<div class="responsive-table-row project-column"></div>
 								<div class="responsive-table-row project-column"></div>
-								<div class="responsive-table-row todo-column header"></div>
+								<div class="responsive-table-row todo-column"></div>
+								<div class="responsive-table-row todo-column"></div>
 								<div class="responsive-table-row time-column">
 									<span>{{ day?.sum | durationFormat }}</span>
 								</div>
@@ -82,7 +84,8 @@
 								</div>
 								<div class="responsive-table-row project-column"></div>
 								<div class="responsive-table-row project-column"></div>
-								<div class="responsive-table-row todo-column header client"></div>
+								<div class="responsive-table-row todo-column"></div>
+								<div class="responsive-table-row todo-column"></div>
 								<div class="responsive-table-row time-column">
 									<span>{{ day?.sum | durationFormat }}</span>
 								</div>
@@ -104,7 +107,8 @@
 								</div>
 								<div class="responsive-table-row project-column"></div>
 								<div class="responsive-table-row project-column"></div>
-								<div class="responsive-table-row todo-column header"></div>
+								<div class="responsive-table-row todo-column"></div>
+								<div class="responsive-table-row todo-column"></div>
 								<div class="responsive-table-row time-column">
 									<span>{{ day?.sum | durationFormat }}</span>
 								</div>

--- a/packages/ui-core/shared/src/lib/report/daily-grid/daily-grid.component.scss
+++ b/packages/ui-core/shared/src/lib/report/daily-grid/daily-grid.component.scss
@@ -53,11 +53,13 @@
 // while the header sits in the card and carries the expand chevron as an extra
 // flex item after the last column. Both leave the header's columns ending
 // further along than the rows', so its Time and Activity read as pushed right.
-// Inset the trailing edge by the chevron's width to bring them back onto the
-// columns the table below uses.
+// Inset the trailing edge to bring them back towards the columns the table below
+// uses. The value is set against the rendered result rather than derived: the two
+// boxes differ by the body's inset and the chevron both, so no single figure
+// follows from the stylesheet alone.
 :host ::ng-deep nb-accordion-item-header {
-  @include nb-ltr(padding-right, 44px);
-  @include nb-rtl(padding-left, 44px);
+  @include nb-ltr(padding-right, 40px);
+  @include nb-rtl(padding-left, 40px);
 }
 
 @include respond(lg) {

--- a/packages/ui-core/shared/src/lib/report/daily-grid/daily-grid.component.scss
+++ b/packages/ui-core/shared/src/lib/report/daily-grid/daily-grid.component.scss
@@ -34,20 +34,30 @@
   width: 20%;
   min-width: 20%;
 }
+// Matches the two 30% columns the data rows carry (To Do and Notes). The
+// accordion header repeats the same pair as empty spacers, so both rows sum to
+// the same width and shrink by the same ratio — which is what keeps Time and
+// Activity in the header aligned with their columns in the table below.
 .todo-column {
   width: 30%;
-  &.header {
-    width: 28%;
-    &.client {
-      width: 22%;
-    }
-  }
 }
 .time-column {
   width: 15%;
 }
 .activity-column {
   width: 15%;
+}
+
+// The header and the data rows carry the same columns, but they resolve inside
+// different boxes: the rows sit inside `nb-accordion-item-body` and its inset,
+// while the header sits in the card and carries the expand chevron as an extra
+// flex item after the last column. Both leave the header's columns ending
+// further along than the rows', so its Time and Activity read as pushed right.
+// Inset the trailing edge by the chevron's width to bring them back onto the
+// columns the table below uses.
+:host ::ng-deep nb-accordion-item-header {
+  @include nb-ltr(padding-right, 44px);
+  @include nb-rtl(padding-left, 44px);
 }
 
 @include respond(lg) {

--- a/packages/ui-core/shared/src/lib/report/project-column-view/project-column-view.component.scss
+++ b/packages/ui-core/shared/src/lib/report/project-column-view/project-column-view.component.scss
@@ -31,10 +31,10 @@
             overflow: hidden;
 
             .main-header {
-                font-size: 14px;
+                font-size: 12px;
                 font-style: normal;
                 font-weight: 600;
-                line-height: 17px;
+                line-height: 15px;
                 letter-spacing: 0em;
                 white-space: nowrap;
                 overflow: hidden;

--- a/packages/ui-core/shared/src/lib/report/project-column-view/project-column-view.component.scss
+++ b/packages/ui-core/shared/src/lib/report/project-column-view/project-column-view.component.scss
@@ -9,10 +9,10 @@
         padding-top: 5px;
 
         .logo-wrapper {
-            min-width: 28px;
-            min-height: 28px;
-            width: 28px;
-            height: 28px;
+            min-width: 24px;
+            min-height: 24px;
+            width: 24px;
+            height: 24px;
             @include nb-rtl(margin-left, 10px);
             @include nb-ltr(margin-right, 10px);
 


### PR DESCRIPTION
- [ ] Before

<img width="1914" height="867" alt="Screenshot 2026-09-04 191053" src="https://github.com/user-attachments/assets/471d1478-6b83-4be0-97a9-38277c926a93" />

- [ ] After

<img width="1916" height="860" alt="Screenshot 2026-09-04 194454" src="https://github.com/user-attachments/assets/09140694-c816-4475-ac8f-ebd98eff6b10" />



