### PR TITLE
Fix: collapse the duplicated transformIgnorePatterns key in packages/core/jest.config.ts

### DIFF
--- a/packages/core/jest.config.ts
+++ b/packages/core/jest.config.ts
@@ -5,13 +5,6 @@ module.exports = {
 	transform: {
 		'^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }]
 	},
-	// Several dependencies now ship ESM only. Jest's default here is ["/node_modules/"], i.e.
-	// transform nothing under node_modules, so the bare `export` in those packages reached the
-	// CommonJS loader and every suite that transitively imported one died at import time with
-	// "SyntaxError: Unexpected token 'export'" — 14 of 15 suites, silently, since no CI job runs
-	// this project. Listing them explicitly (rather than transforming all of node_modules) keeps
-	// the run fast. Add to this list when a dependency goes ESM-only.
-	transformIgnorePatterns: ['node_modules/(?!(.*/)?(uuid|camelcase|nanoid|@gauzy)/)'],
 	moduleFileExtensions: ['ts', 'js', 'html'],
 	// Dependencies that ship ESM-only builds Jest cannot `require`. A suite that reaches one of
 	// them fails to LOAD rather than failing an assertion — Jest reports that as a suite error,
@@ -26,6 +19,16 @@ module.exports = {
 	//   camelcase                        -> time-tracking suites
 	//   @faker-js/faker                  -> reached through the entity graph (core/seeds)
 	//   @nestjs/axios                    -> ships a raw `index.ts` that re-exports `./dist`
+	// Listing packages explicitly, rather than transforming all of node_modules, is what keeps the
+	// run fast.
+	//
+	// Two things this list depends on that are easy to break from elsewhere:
+	//   - `allowJs: true` in tsconfig.spec.json — ts-jest hands a `.js` file back UNCHANGED when
+	//     allowJs is false, so without it every exception here silently stops working.
+	//   - `@gauzy/*` is deliberately absent, and adding it would do nothing. Jest resolves
+	//     workspace packages to their real source path (`packages/<pkg>/src/index.ts`), which has
+	//     no `node_modules/` segment, so this pattern is never consulted for them. A second, older
+	//     copy of this key used to list `@gauzy`; it was inert there too.
 	transformIgnorePatterns: [
 		'node_modules/(?!(?:.*/)?(sanitize-html|htmlparser2|domelementtype|domhandler|domutils|dom-serializer|entities|nanoid|parse-srcset|uuid|camelcase|@faker-js|@nestjs/axios)/)'
 	],


### PR DESCRIPTION
## Summary

`packages/core/jest.config.ts` declared `transformIgnorePatterns` **twice** in one object literal. The later key wins, so the first was dead code, and TypeScript flagged the file with `TS1117`.

**This is not cosmetic.** `jest-config` only parses a TypeScript config through ts-node when `process.features.typescript` is unset. Node 24 reports `"strip"`, so native type-stripping hides the error. Take that away — Node ≤ 22.5, `--no-experimental-strip-types`, or any tooling that disables stripping — and Jest dies before loading anything:

```
Error: Jest: Failed to parse the TypeScript config file .../packages/core/jest.config.ts
  TSError: Unable to compile TypeScript:
  packages/core/jest.config.ts(29,2): error TS1117
```

Zero suites, zero tests — masked today by a single version floor (`.nvmrc` 24.17.0 / `engines.node >= 24`). Verified both ways: that command fails on the parent commit and passes on this branch.

## How it got there

Not a decision anyone made. At each of the three commits that touched this file it had exactly **one** key. Both sides of merge commit `626acc2219` (#9921) had one each, on branches that diverged at `9d37687d89`, and git's line-based merge concatenated the two insertions with no conflict. No human ever chose between the lists.

## Why `@gauzy` is not carried forward

The dead list contained `@gauzy`; the live one does not. That entry could never have done anything: Jest resolves workspace packages to their **real source path** under `packages/`, which has no `node_modules/` segment, so this pattern is never consulted for them.

Checked three independent ways:
1. An instrumented resolver logging every resolution — all `@gauzy/*` land on `…\packages\<pkg>\src\index.ts`, never under `node_modules`.
2. A counterfactual adding `packages/contracts/` to the pattern, which *does* break the suite and names `packages\contracts\src\index.ts` as the gated file — proving the transform decision is evaluated against the realpath.
3. An A/B run with `|@gauzy` spliced back into the live pattern — identical results.

It was inert in the older key too, so nothing was lost when the merge dropped it.

## Comment handling

The dead block's comment is **dropped rather than merged**, because two of its three claims are now false: jest 30's default is not `["/node_modules/"]`, and *"14 of 15 suites, since no CI job runs this project"* is stale — there are 56 spec files, and `test-unit.yml` does run them on pushes to `stage` (non-blocking ≠ absent).

Its one unique, true point — that an explicit list is what keeps the run fast — is salvaged into the surviving comment, along with two dependencies that are load-bearing but live in other files:
- `allowJs: true` in `tsconfig.spec.json`, without which ts-jest returns `.js` untouched and **every** exception here silently stops working;
- why `@gauzy` is absent, so it doesn't get "restored".

## Verification

| Check | Before | After |
|---|---|---|
| `tsc -p packages/core/tsconfig.spec.json --noEmit` | 1 error (TS1117) | **0 errors** |
| Full core suite | 56/56 suites, 612/612 tests | **56/56, 612/612** |
| `node --no-experimental-strip-types … jest` | hard parse failure, 0 suites | **passes** |
| `jest --showConfig` | — | identical apart from the per-run random `seed` |

On Node 24 the effective config is unchanged — this only removes dead code and a latent failure mode.

## Not addressed here

Deliberately out of scope, found while investigating:
- Both guardrails for this bug class are dead: ESLint cannot run at all (`Cannot find module 'nx/src/utils/typescript'`; `@typescript-eslint/parser` isn't installed), and there is no `typecheck` target anywhere.
- Three of the 13 live entries (`sanitize-html`, `parse-srcset`, `nanoid`) no longer need transforming.
- The `(?:.*/)?` prefix is over-broad — it un-ignores `@smithy/uuid`, `typeorm/browser/entities`, etc. A perf tax, not a correctness bug.

Each of those is a behaviour change; this PR keeps the effective config byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses a duplicated `transformIgnorePatterns` key in `packages/core/jest.config.ts`. The later key already won, so the first was dead code, but TypeScript flagged the file with TS1117 — and Jest fails to parse the config entirely when native type stripping is off (Node ≤ 22.5 or `--no-experimental-strip-types`), so no tests run.

- The duplicate came from a merge that concatenated both sides without conflict.
- The dead list's `@gauzy` entry is dropped: Jest resolves workspace packages to their real path under `packages/`, so the pattern never applied to them.
- The surviving comment now documents `allowJs: true` in `tsconfig.spec.json` as a prerequisite and why `@gauzy` is absent.
- On Node 24 the effective config is unchanged; the core suite still passes (56/56 suites, 612/612 tests).

<sup>Written for commit 042ac9c02ae4eabe1f4f9a7ee5f1b6df878aedd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

