### PR TITLE
Fix Time Log: await report filters before executing the query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,6 @@ apps/server-api/src/assets/icons/menu
 !**/certs/**/README.md
 !**/certs/**/.gitkeep
 
+/graphify-out
+
 /Tempnx-console-tmp**/**

--- a/packages/core/src/lib/time-tracking/testing/recording-query-builder.ts
+++ b/packages/core/src/lib/time-tracking/testing/recording-query-builder.ts
@@ -1,0 +1,90 @@
+import { IUser, PermissionsEnum } from '@gauzy/contracts';
+import { RequestContext } from '../../core/context';
+
+export type RecordedClause = { condition: unknown; parameters?: Record<string, unknown> };
+
+/**
+ * Stand-in for TypeORM's SelectQueryBuilder that keeps only what the time-tracking specs depend
+ * on: `where(callback)` clears the clause list and runs the callback synchronously (typeorm
+ * `SelectQueryBuilder.where` -> `QueryBuilder.getWhereCondition`), and the terminal calls render
+ * whatever clauses exist at that instant. A filter added by a promise still pending when the
+ * query executes never reaches the SQL, which is the defect these specs guard against.
+ */
+export class RecordingQueryBuilder {
+	/** Clauses present when the query executed, i.e. the ones that would have reached the SQL. */
+	executedClauses: RecordedClause[] | null = null;
+	private clauses: RecordedClause[] = [];
+
+	constructor(readonly alias: string) {}
+
+	innerJoin(): this {
+		return this;
+	}
+
+	setFindOptions(): this {
+		return this;
+	}
+
+	where(where: unknown, parameters?: Record<string, unknown>): this {
+		this.clauses = [];
+		if (typeof where === 'function') {
+			where(this);
+		} else {
+			this.clauses.push({ condition: where, parameters });
+		}
+		return this;
+	}
+
+	andWhere(condition: unknown, parameters?: Record<string, unknown>): this {
+		this.clauses.push({ condition, parameters });
+		return this;
+	}
+
+	async getCount(): Promise<number> {
+		this.executedClauses = [...this.clauses];
+		return 0;
+	}
+
+	async getMany(): Promise<never[]> {
+		this.executedClauses = [...this.clauses];
+		return [];
+	}
+}
+
+/**
+ * Clauses and merged parameters in place when the query executed. String conditions are
+ * normalised to double quotes so the assertions hold whatever quoting the database helper
+ * applied; other conditions (e.g. `Brackets`) are reported by their class name.
+ */
+export function executedFilters(builder: RecordingQueryBuilder): {
+	conditions: string[];
+	parameters: Record<string, unknown>;
+} {
+	if (!builder.executedClauses) {
+		throw new Error('The query was never executed');
+	}
+	return {
+		conditions: builder.executedClauses.map(({ condition }) =>
+			typeof condition === 'string' ? condition.replace(/`/g, '"') : (condition as object).constructor.name
+		),
+		parameters: Object.assign({}, ...builder.executedClauses.map(({ parameters }) => parameters ?? {}))
+	};
+}
+
+/** Spies the RequestContext statics the filter helpers read: tenant, current user and permission check. */
+export function mockRequestContext(caller: {
+	tenantId: string;
+	user: Pick<IUser, 'id' | 'employeeId'>;
+	canChangeSelectedEmployee: boolean;
+}): void {
+	jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue(caller.tenantId);
+	jest.spyOn(RequestContext, 'currentUser').mockReturnValue(caller.user as IUser);
+	jest.spyOn(RequestContext, 'hasPermission').mockImplementation(
+		(permission) => caller.canChangeSelectedEmployee && permission === PermissionsEnum.CHANGE_SELECTED_EMPLOYEE
+	);
+}
+
+/** Resolves on a later macrotask, like a repository round-trip, to place an async boundary inside a mocked call. */
+export function nextMacrotask(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}

--- a/packages/core/src/lib/time-tracking/testing/recording-query-builder.ts
+++ b/packages/core/src/lib/time-tracking/testing/recording-query-builder.ts
@@ -1,12 +1,19 @@
+import { Brackets, WhereExpressionBuilder } from 'typeorm';
 import { IUser, PermissionsEnum } from '@gauzy/contracts';
 import { RequestContext } from '../../core/context';
 
-export type RecordedClause = { condition: unknown; parameters?: Record<string, unknown> };
+export type RecordedClause = {
+	condition: unknown;
+	parameters?: Record<string, unknown>;
+	/** Predicates a `Brackets` factory attached, captured when the brackets were added. */
+	nested?: RecordedClause[];
+};
 
 /**
  * Stand-in for TypeORM's SelectQueryBuilder that keeps only what the time-tracking specs depend
  * on: `where(callback)` clears the clause list and runs the callback synchronously (typeorm
- * `SelectQueryBuilder.where` -> `QueryBuilder.getWhereCondition`), and the terminal calls render
+ * `SelectQueryBuilder.where` -> `QueryBuilder.getWhereCondition`), a `Brackets` factory runs
+ * against a nested builder as soon as the brackets are added, and the terminal calls render
  * whatever clauses exist at that instant. A filter added by a promise still pending when the
  * query executes never reaches the SQL, which is the defect these specs guard against.
  */
@@ -30,13 +37,13 @@ export class RecordingQueryBuilder {
 		if (typeof where === 'function') {
 			where(this);
 		} else {
-			this.clauses.push({ condition: where, parameters });
+			this.clauses.push(this.record(where, parameters));
 		}
 		return this;
 	}
 
 	andWhere(condition: unknown, parameters?: Record<string, unknown>): this {
-		this.clauses.push({ condition, parameters });
+		this.clauses.push(this.record(condition, parameters));
 		return this;
 	}
 
@@ -49,25 +56,41 @@ export class RecordingQueryBuilder {
 		this.executedClauses = [...this.clauses];
 		return [];
 	}
+
+	private record(condition: unknown, parameters?: Record<string, unknown>): RecordedClause {
+		if (condition instanceof Brackets) {
+			const nested = new RecordingQueryBuilder(this.alias);
+			// The double only implements the where/andWhere subset the factories use.
+			condition.whereFactory(nested as unknown as WhereExpressionBuilder);
+			return { condition, nested: nested.clauses };
+		}
+		return { condition, parameters };
+	}
 }
 
 /**
- * Clauses and merged parameters in place when the query executed. String conditions are
- * normalised to double quotes so the assertions hold whatever quoting the database helper
- * applied; other conditions (e.g. `Brackets`) are reported by their class name.
+ * Clauses in place when the query executed, with the predicates of every `Brackets` flattened in
+ * after their brackets. String conditions are normalised to double quotes so the assertions hold
+ * whatever quoting the database helper applied; other conditions (e.g. `Brackets`) are reported
+ * by their class name. `clauses` keeps the raw entries for object-literal predicates.
  */
 export function executedFilters(builder: RecordingQueryBuilder): {
 	conditions: string[];
 	parameters: Record<string, unknown>;
+	clauses: RecordedClause[];
 } {
 	if (!builder.executedClauses) {
 		throw new Error('The query was never executed');
 	}
+	const flatten = (clauses: RecordedClause[]): RecordedClause[] =>
+		clauses.flatMap((clause) => (clause.nested ? [clause, ...flatten(clause.nested)] : [clause]));
+	const clauses = flatten(builder.executedClauses);
 	return {
-		conditions: builder.executedClauses.map(({ condition }) =>
+		conditions: clauses.map(({ condition }) =>
 			typeof condition === 'string' ? condition.replace(/`/g, '"') : (condition as object).constructor.name
 		),
-		parameters: Object.assign({}, ...builder.executedClauses.map(({ parameters }) => parameters ?? {}))
+		parameters: Object.assign({}, ...clauses.map(({ parameters }) => parameters ?? {})),
+		clauses
 	};
 }
 

--- a/packages/core/src/lib/time-tracking/time-log/time-log.service.spec.ts
+++ b/packages/core/src/lib/time-tracking/time-log/time-log.service.spec.ts
@@ -11,24 +11,216 @@
  */
 import '../../core/entities/internal';
 import { Test, TestingModule } from '@nestjs/testing';
+import { CommandBus } from '@nestjs/cqrs';
+import { IGetTimeLogReportInput, IUser, PermissionsEnum } from '@gauzy/contracts';
+import { RequestContext } from '../../core/context';
+import { MultiORMEnum } from '../../core/utils';
+import { ManagedEmployeeService } from '../../employee/managed-employee.service';
+import { TypeOrmTimeLogRepository } from './repository/type-orm-time-log.repository';
 import { TimeLogService } from './time-log.service';
+
+const TENANT_ID = '5a1c2f0e-6d3b-4c8a-9e2f-1b7d4a6c8e90';
+const ORGANIZATION_ID = '0f9e8d7c-6b5a-4c3d-8e2f-1a0b9c8d7e6f';
+const USER_ID = 'c3b2a190-8f7e-4d6c-9b5a-4e3d2c1b0a9f';
+const CURRENT_EMPLOYEE_ID = '7e6d5c4b-3a29-4180-9f8e-7d6c5b4a3928';
+const TARGET_EMPLOYEE_ID = '1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d';
+
+type RecordedClause = { condition: unknown; parameters?: Record<string, unknown> };
+
+/**
+ * Stand-in for TypeORM's SelectQueryBuilder that keeps only what the regression depends on:
+ * `where(callback)` clears the clause list and runs the callback synchronously (typeorm
+ * `SelectQueryBuilder.where` -> `QueryBuilder.getWhereCondition`), and `getMany()` renders whatever
+ * clauses exist at that instant. A filter added by a promise still pending when `getMany()` runs
+ * never reaches the SQL, which is the defect this suite guards against.
+ */
+class RecordingQueryBuilder {
+	readonly alias = 'time_log';
+	/** Clauses present when `getMany()` ran, i.e. the ones that would have reached the SQL. */
+	executedClauses: RecordedClause[] | null = null;
+	private clauses: RecordedClause[] = [];
+
+	innerJoin(): this {
+		return this;
+	}
+
+	setFindOptions(): this {
+		return this;
+	}
+
+	where(where: unknown, parameters?: Record<string, unknown>): this {
+		this.clauses = [];
+		if (typeof where === 'function') {
+			where(this);
+		} else {
+			this.clauses.push({ condition: where, parameters });
+		}
+		return this;
+	}
+
+	andWhere(condition: unknown, parameters?: Record<string, unknown>): this {
+		this.clauses.push({ condition, parameters });
+		return this;
+	}
+
+	async getMany(): Promise<never[]> {
+		this.executedClauses = [...this.clauses];
+		return [];
+	}
+}
+
 describe('TimeLogService', () => {
 	let service: TimeLogService;
+	let builder: RecordingQueryBuilder;
+	let canManageEmployees: jest.Mock;
+
 	beforeEach(async () => {
+		builder = new RecordingQueryBuilder();
+		canManageEmployees = jest.fn();
+
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [TimeLogService]
 		})
 			/**
-			 * The original scaffold listed the subject with NO dependencies provided, so this suite
-			 * could never have passed even once it loaded — it would have died on
-			 * `Nest can't resolve dependencies`. Automocking every token keeps the suite honest
-			 * about what it actually checks: that the class is constructible and its wiring holds.
+			 * Every dependency is automocked to an empty object, except the three the report
+			 * methods actually touch: the TypeORM repository (hands out the recording builder),
+			 * the manager check, and the command bus used by `getDailyReport` to group results.
 			 */
-			.useMocker(() => ({}))
+			.useMocker((token) => {
+				if (token === TypeOrmTimeLogRepository) {
+					return { metadata: { tableName: 'time_log' }, createQueryBuilder: () => builder };
+				}
+				if (token === ManagedEmployeeService) {
+					return { canManageEmployees };
+				}
+				if (token === CommandBus) {
+					return { execute: jest.fn().mockResolvedValue([]) };
+				}
+				return {};
+			})
 			.compile();
+
 		service = module.get<TimeLogService>(TimeLogService);
+		// The ORM switch is resolved from DB_ORM at module load; pin it so the suite ignores the local .env.
+		Object.defineProperty(service, 'ormType', { value: MultiORMEnum.TypeORM });
 	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	it('should be defined', () => {
 		expect(service).toBeDefined();
+	});
+
+	describe('report queries', () => {
+		const request: IGetTimeLogReportInput = {
+			organizationId: ORGANIZATION_ID,
+			employeeIds: [TARGET_EMPLOYEE_ID],
+			startDate: '2026-01-05T00:00:00.000Z',
+			endDate: '2026-01-12T00:00:00.000Z',
+			timeZone: 'UTC'
+		};
+
+		// The `Brackets` entry is the startedAt date range.
+		const scopingConditions = [
+			'"time_log"."tenantId" = :tenantId',
+			'"time_log"."organizationId" = :organizationId',
+			'"time_log"."employeeId" IN (:...employeeIds)',
+			'Brackets'
+		];
+
+		const reportMethods: Array<[string, (input: IGetTimeLogReportInput) => Promise<unknown>]> = [
+			['getTimeLogs', (input) => service.getTimeLogs(input)],
+			['getWeeklyReport', (input) => service.getWeeklyReport(input)],
+			['getDailyReportCharts', (input) => service.getDailyReportCharts(input)],
+			['getDailyReport', (input) => service.getDailyReport(input)],
+			['getOwedAmountReport', (input) => service.getOwedAmountReport(input)],
+			['getOwedAmountReportCharts', (input) => service.getOwedAmountReportCharts(input)],
+			['getTimeLimit', (input) => service.getTimeLimit({ ...input, duration: 'day' })]
+		];
+
+		const actAs = (caller: { canChangeSelectedEmployee: boolean }) => {
+			jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue(TENANT_ID);
+			jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+				id: USER_ID,
+				employeeId: CURRENT_EMPLOYEE_ID
+			} as IUser);
+			jest.spyOn(RequestContext, 'hasPermission').mockImplementation(
+				(permission) =>
+					caller.canChangeSelectedEmployee && permission === PermissionsEnum.CHANGE_SELECTED_EMPLOYEE
+			);
+		};
+
+		/** Resolves on a later macrotask, like the repository round-trip behind the real manager check. */
+		const resolveLater = (value: boolean) => () =>
+			new Promise<boolean>((resolve) => setImmediate(() => resolve(value)));
+
+		const executedFilters = () => {
+			expect(builder.executedClauses).not.toBeNull();
+			const clauses = builder.executedClauses as RecordedClause[];
+			return {
+				conditions: clauses.map(({ condition }) =>
+					typeof condition === 'string'
+						? condition.replace(/`/g, '"')
+						: (condition as object).constructor.name
+				),
+				parameters: Object.assign({}, ...clauses.map(({ parameters }) => parameters ?? {}))
+			};
+		};
+
+		it.each<[string, (input: IGetTimeLogReportInput) => Promise<unknown>]>(reportMethods)(
+			'%s applies the tenant, organization, employee and date filters before executing for a manager',
+			async (_name, run) => {
+				actAs({ canChangeSelectedEmployee: false });
+				canManageEmployees.mockImplementation(resolveLater(true));
+
+				await run(request);
+
+				expect(canManageEmployees).toHaveBeenCalledWith([TARGET_EMPLOYEE_ID], []);
+				const { conditions, parameters } = executedFilters();
+				expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
+				expect(parameters).toEqual(
+					expect.objectContaining({
+						tenantId: TENANT_ID,
+						organizationId: ORGANIZATION_ID,
+						employeeIds: [TARGET_EMPLOYEE_ID]
+					})
+				);
+			}
+		);
+
+		it('narrows a caller who does not manage the requested employees to their own logs', async () => {
+			actAs({ canChangeSelectedEmployee: false });
+			canManageEmployees.mockImplementation(resolveLater(false));
+
+			await service.getDailyReport(request);
+
+			const { conditions, parameters } = executedFilters();
+			expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
+			expect(parameters).toEqual(expect.objectContaining({ employeeIds: [CURRENT_EMPLOYEE_ID] }));
+		});
+
+		it('keeps the requested employees for a caller with CHANGE_SELECTED_EMPLOYEE', async () => {
+			actAs({ canChangeSelectedEmployee: true });
+
+			await service.getDailyReport(request);
+
+			expect(canManageEmployees).not.toHaveBeenCalled();
+			const { conditions, parameters } = executedFilters();
+			expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
+			expect(parameters).toEqual(expect.objectContaining({ employeeIds: [TARGET_EMPLOYEE_ID] }));
+		});
+
+		it('honours onlyMe without consulting the manager check', async () => {
+			actAs({ canChangeSelectedEmployee: false });
+
+			await service.getDailyReport({ ...request, onlyMe: true });
+
+			expect(canManageEmployees).not.toHaveBeenCalled();
+			const { conditions, parameters } = executedFilters();
+			expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
+			expect(parameters).toEqual(expect.objectContaining({ employeeIds: [CURRENT_EMPLOYEE_ID] }));
+		});
 	});
 });

--- a/packages/core/src/lib/time-tracking/time-log/time-log.service.spec.ts
+++ b/packages/core/src/lib/time-tracking/time-log/time-log.service.spec.ts
@@ -12,10 +12,15 @@
 import '../../core/entities/internal';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CommandBus } from '@nestjs/cqrs';
-import { IGetTimeLogReportInput, IUser, PermissionsEnum } from '@gauzy/contracts';
-import { RequestContext } from '../../core/context';
+import { IGetTimeLogReportInput } from '@gauzy/contracts';
 import { MultiORMEnum } from '../../core/utils';
 import { ManagedEmployeeService } from '../../employee/managed-employee.service';
+import {
+	executedFilters,
+	mockRequestContext,
+	nextMacrotask,
+	RecordingQueryBuilder
+} from '../testing/recording-query-builder';
 import { TypeOrmTimeLogRepository } from './repository/type-orm-time-log.repository';
 import { TimeLogService } from './time-log.service';
 
@@ -25,66 +30,22 @@ const USER_ID = 'c3b2a190-8f7e-4d6c-9b5a-4e3d2c1b0a9f';
 const CURRENT_EMPLOYEE_ID = '7e6d5c4b-3a29-4180-9f8e-7d6c5b4a3928';
 const TARGET_EMPLOYEE_ID = '1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d';
 
-type RecordedClause = { condition: unknown; parameters?: Record<string, unknown> };
-
-/**
- * Stand-in for TypeORM's SelectQueryBuilder that keeps only what the regression depends on:
- * `where(callback)` clears the clause list and runs the callback synchronously (typeorm
- * `SelectQueryBuilder.where` -> `QueryBuilder.getWhereCondition`), and `getMany()` renders whatever
- * clauses exist at that instant. A filter added by a promise still pending when `getMany()` runs
- * never reaches the SQL, which is the defect this suite guards against.
- */
-class RecordingQueryBuilder {
-	readonly alias = 'time_log';
-	/** Clauses present when `getMany()` ran, i.e. the ones that would have reached the SQL. */
-	executedClauses: RecordedClause[] | null = null;
-	private clauses: RecordedClause[] = [];
-
-	innerJoin(): this {
-		return this;
-	}
-
-	setFindOptions(): this {
-		return this;
-	}
-
-	where(where: unknown, parameters?: Record<string, unknown>): this {
-		this.clauses = [];
-		if (typeof where === 'function') {
-			where(this);
-		} else {
-			this.clauses.push({ condition: where, parameters });
-		}
-		return this;
-	}
-
-	andWhere(condition: unknown, parameters?: Record<string, unknown>): this {
-		this.clauses.push({ condition, parameters });
-		return this;
-	}
-
-	async getMany(): Promise<never[]> {
-		this.executedClauses = [...this.clauses];
-		return [];
-	}
-}
-
 describe('TimeLogService', () => {
 	let service: TimeLogService;
 	let builder: RecordingQueryBuilder;
 	let canManageEmployees: jest.Mock;
 
 	beforeEach(async () => {
-		builder = new RecordingQueryBuilder();
+		builder = new RecordingQueryBuilder('time_log');
 		canManageEmployees = jest.fn();
 
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [TimeLogService]
 		})
 			/**
-			 * Every dependency is automocked to an empty object, except the three the report
-			 * methods actually touch: the TypeORM repository (hands out the recording builder),
-			 * the manager check, and the command bus used by `getDailyReport` to group results.
+			 * Every dependency is mocked to an empty object, except the three the report methods
+			 * actually touch: the TypeORM repository (hands out the recording builder), the
+			 * manager check, and the command bus used by `getDailyReport` to group results.
 			 */
 			.useMocker((token) => {
 				if (token === TypeOrmTimeLogRepository) {
@@ -140,33 +101,17 @@ describe('TimeLogService', () => {
 			['getTimeLimit', (input) => service.getTimeLimit({ ...input, duration: 'day' })]
 		];
 
-		const actAs = (caller: { canChangeSelectedEmployee: boolean }) => {
-			jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue(TENANT_ID);
-			jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
-				id: USER_ID,
-				employeeId: CURRENT_EMPLOYEE_ID
-			} as IUser);
-			jest.spyOn(RequestContext, 'hasPermission').mockImplementation(
-				(permission) =>
-					caller.canChangeSelectedEmployee && permission === PermissionsEnum.CHANGE_SELECTED_EMPLOYEE
-			);
-		};
+		const actAs = (caller: { canChangeSelectedEmployee: boolean }) =>
+			mockRequestContext({
+				tenantId: TENANT_ID,
+				user: { id: USER_ID, employeeId: CURRENT_EMPLOYEE_ID },
+				canChangeSelectedEmployee: caller.canChangeSelectedEmployee
+			});
 
-		/** Resolves on a later macrotask, like the repository round-trip behind the real manager check. */
-		const resolveLater = (value: boolean) => () =>
-			new Promise<boolean>((resolve) => setImmediate(() => resolve(value)));
-
-		const executedFilters = () => {
-			expect(builder.executedClauses).not.toBeNull();
-			const clauses = builder.executedClauses as RecordedClause[];
-			return {
-				conditions: clauses.map(({ condition }) =>
-					typeof condition === 'string'
-						? condition.replace(/`/g, '"')
-						: (condition as object).constructor.name
-				),
-				parameters: Object.assign({}, ...clauses.map(({ parameters }) => parameters ?? {}))
-			};
+		// Resolves on a later macrotask, like the repository round-trip behind the real manager check.
+		const resolveLater = (value: boolean) => async () => {
+			await nextMacrotask();
+			return value;
 		};
 
 		it.each<[string, (input: IGetTimeLogReportInput) => Promise<unknown>]>(reportMethods)(
@@ -178,7 +123,7 @@ describe('TimeLogService', () => {
 				await run(request);
 
 				expect(canManageEmployees).toHaveBeenCalledWith([TARGET_EMPLOYEE_ID], []);
-				const { conditions, parameters } = executedFilters();
+				const { conditions, parameters } = executedFilters(builder);
 				expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
 				expect(parameters).toEqual(
 					expect.objectContaining({
@@ -196,7 +141,7 @@ describe('TimeLogService', () => {
 
 			await service.getDailyReport(request);
 
-			const { conditions, parameters } = executedFilters();
+			const { conditions, parameters } = executedFilters(builder);
 			expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
 			expect(parameters).toEqual(expect.objectContaining({ employeeIds: [CURRENT_EMPLOYEE_ID] }));
 		});
@@ -207,7 +152,7 @@ describe('TimeLogService', () => {
 			await service.getDailyReport(request);
 
 			expect(canManageEmployees).not.toHaveBeenCalled();
-			const { conditions, parameters } = executedFilters();
+			const { conditions, parameters } = executedFilters(builder);
 			expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
 			expect(parameters).toEqual(expect.objectContaining({ employeeIds: [TARGET_EMPLOYEE_ID] }));
 		});
@@ -218,7 +163,7 @@ describe('TimeLogService', () => {
 			await service.getDailyReport({ ...request, onlyMe: true });
 
 			expect(canManageEmployees).not.toHaveBeenCalled();
-			const { conditions, parameters } = executedFilters();
+			const { conditions, parameters } = executedFilters(builder);
 			expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
 			expect(parameters).toEqual(expect.objectContaining({ employeeIds: [CURRENT_EMPLOYEE_ID] }));
 		});

--- a/packages/core/src/lib/time-tracking/time-log/time-log.service.spec.ts
+++ b/packages/core/src/lib/time-tracking/time-log/time-log.service.spec.ts
@@ -13,7 +13,8 @@ import '../../core/entities/internal';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CommandBus } from '@nestjs/cqrs';
 import { IGetTimeLogReportInput } from '@gauzy/contracts';
-import { MultiORMEnum } from '../../core/utils';
+import { moment } from '../../core/moment-extend';
+import { getDateRangeFormat, MultiORMEnum } from '../../core/utils';
 import { ManagedEmployeeService } from '../../employee/managed-employee.service';
 import {
 	executedFilters,
@@ -83,12 +84,15 @@ describe('TimeLogService', () => {
 			timeZone: 'UTC'
 		};
 
-		// The `Brackets` entry is the startedAt date range.
+		// The date range is the pair of startedAt predicates inside the `Brackets`.
+		const { start, end } = getDateRangeFormat(moment.utc(request.startDate), moment.utc(request.endDate));
 		const scopingConditions = [
 			'"time_log"."tenantId" = :tenantId',
 			'"time_log"."organizationId" = :organizationId',
 			'"time_log"."employeeId" IN (:...employeeIds)',
-			'Brackets'
+			'Brackets',
+			'"time_log"."startedAt" >= :startDate',
+			'"time_log"."startedAt" < :endDate'
 		];
 
 		const reportMethods: Array<[string, (input: IGetTimeLogReportInput) => Promise<unknown>]> = [
@@ -129,7 +133,9 @@ describe('TimeLogService', () => {
 					expect.objectContaining({
 						tenantId: TENANT_ID,
 						organizationId: ORGANIZATION_ID,
-						employeeIds: [TARGET_EMPLOYEE_ID]
+						employeeIds: [TARGET_EMPLOYEE_ID],
+						startDate: start,
+						endDate: end
 					})
 				);
 			}

--- a/packages/core/src/lib/time-tracking/time-log/time-log.service.ts
+++ b/packages/core/src/lib/time-tracking/time-log/time-log.service.ts
@@ -294,9 +294,7 @@ export class TimeLogService extends TenantAwareCrudService<TimeLog> {
 					}
 				});
 				// Apply additional conditions to the query based on request filters
-				query.where((qb: SelectQueryBuilder<TimeLog>) => {
-					this.getFilterTimeLogQuery(qb, request);
-				});
+				await this.getFilterTimeLogQuery(query, request);
 
 				// Execute the query and retrieve time logs
 				logs = await query.getMany();
@@ -448,9 +446,7 @@ export class TimeLogService extends TenantAwareCrudService<TimeLog> {
 					}
 				});
 				// Apply additional conditions to the query based on request filters
-				query.where((qb: SelectQueryBuilder<TimeLog>) => {
-					this.getFilterTimeLogQuery(qb, request);
-				});
+				await this.getFilterTimeLogQuery(query, request);
 
 				// Execute the query and retrieve time logs
 				logs = await query.getMany();
@@ -539,9 +535,7 @@ export class TimeLogService extends TenantAwareCrudService<TimeLog> {
 				});
 
 				// Apply additional conditions to the query based on request filters
-				query.where((qb: SelectQueryBuilder<TimeLog>) => {
-					this.getFilterTimeLogQuery(qb, request);
-				});
+				await this.getFilterTimeLogQuery(query, request);
 
 				// Execute the query and retrieve time logs
 				timeLogs = await query.getMany();
@@ -636,9 +630,7 @@ export class TimeLogService extends TenantAwareCrudService<TimeLog> {
 					}
 				});
 				// Apply additional conditions to the query based on request filters
-				query.where((qb: SelectQueryBuilder<TimeLog>) => {
-					this.getFilterTimeLogQuery(qb, request);
-				});
+				await this.getFilterTimeLogQuery(query, request);
 
 				// Execute the query and retrieve time logs
 				timeLogs = await query.getMany();
@@ -753,9 +745,7 @@ export class TimeLogService extends TenantAwareCrudService<TimeLog> {
 					}
 				});
 				// Apply additional conditions to the query based on request filters
-				query.where((qb: SelectQueryBuilder<TimeLog>) => {
-					this.getFilterTimeLogQuery(qb, request);
-				});
+				await this.getFilterTimeLogQuery(query, request);
 
 				// Execute the query and retrieve time logs
 				timeLogs = await query.getMany();

--- a/packages/core/src/lib/time-tracking/timesheet/timesheet.service.spec.ts
+++ b/packages/core/src/lib/time-tracking/timesheet/timesheet.service.spec.ts
@@ -11,8 +11,10 @@
  */
 import '../../core/entities/internal';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Between, In } from 'typeorm';
+import * as moment from 'moment';
 import { IGetTimesheetInput } from '@gauzy/contracts';
-import { MultiORMEnum } from '../../core/utils';
+import { getDateRangeFormat, MultiORMEnum } from '../../core/utils';
 import {
 	executedFilters,
 	mockRequestContext,
@@ -70,7 +72,8 @@ describe('TimeSheetService', () => {
 			endDate: '2026-01-31T23:59:59.999Z'
 		};
 
-		// The `Brackets` entry carries the startedAt range together with the status and employee predicates.
+		// The startedAt range and the employee predicate live in the object literal inside the `Brackets`.
+		const { start, end } = getDateRangeFormat(moment.utc(request.startDate), moment.utc(request.endDate));
 		const scopingConditions = [
 			'Brackets',
 			'"timesheet"."tenantId" = :tenantId',
@@ -108,10 +111,19 @@ describe('TimeSheetService', () => {
 
 				await run(request);
 
-				const { conditions, parameters } = executedFilters(builder);
+				const { conditions, parameters, clauses } = executedFilters(builder);
 				expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
 				expect(parameters).toEqual(
 					expect.objectContaining({ tenantId: TENANT_ID, organizationId: ORGANIZATION_ID })
+				);
+				// A caller without CHANGE_SELECTED_EMPLOYEE is narrowed to their own employee id.
+				expect(clauses.map(({ condition }) => condition)).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							startedAt: Between(start, end),
+							employeeId: In([CURRENT_EMPLOYEE_ID])
+						})
+					])
 				);
 			}
 		);

--- a/packages/core/src/lib/time-tracking/timesheet/timesheet.service.spec.ts
+++ b/packages/core/src/lib/time-tracking/timesheet/timesheet.service.spec.ts
@@ -11,9 +11,14 @@
  */
 import '../../core/entities/internal';
 import { Test, TestingModule } from '@nestjs/testing';
-import { IGetTimesheetInput, IUser, PermissionsEnum } from '@gauzy/contracts';
-import { RequestContext } from '../../core/context';
+import { IGetTimesheetInput } from '@gauzy/contracts';
 import { MultiORMEnum } from '../../core/utils';
+import {
+	executedFilters,
+	mockRequestContext,
+	nextMacrotask,
+	RecordingQueryBuilder
+} from '../testing/recording-query-builder';
 import { TypeOrmTimesheetRepository } from './repository/type-orm-timesheet.repository';
 import { TimeSheetService } from './timesheet.service';
 
@@ -23,65 +28,17 @@ const USER_ID = 'd4c3b2a1-0f9e-4d8c-7b6a-5f4e3d2c1b0a';
 const CURRENT_EMPLOYEE_ID = '6f5e4d3c-2b1a-4098-8f7e-6d5c4b3a2918';
 const TARGET_EMPLOYEE_ID = '3a4b5c6d-7e8f-4a9b-8c0d-1e2f3a4b5c6d';
 
-type RecordedClause = { condition: unknown; parameters?: Record<string, unknown> };
-
-/**
- * Stand-in for TypeORM's SelectQueryBuilder that keeps only what matters here: `where(callback)`
- * clears the clause list and runs the callback synchronously, and the terminal calls render
- * whatever clauses exist at that instant. Same double as in time-log.service.spec.ts, since both
- * services attach their tenant scoping through the same filter-helper pattern.
- */
-class RecordingQueryBuilder {
-	readonly alias = 'timesheet';
-	/** Clauses present when the query executed, i.e. the ones that would have reached the SQL. */
-	executedClauses: RecordedClause[] | null = null;
-	private clauses: RecordedClause[] = [];
-
-	innerJoin(): this {
-		return this;
-	}
-
-	setFindOptions(): this {
-		return this;
-	}
-
-	where(where: unknown, parameters?: Record<string, unknown>): this {
-		this.clauses = [];
-		if (typeof where === 'function') {
-			where(this);
-		} else {
-			this.clauses.push({ condition: where, parameters });
-		}
-		return this;
-	}
-
-	andWhere(condition: unknown, parameters?: Record<string, unknown>): this {
-		this.clauses.push({ condition, parameters });
-		return this;
-	}
-
-	async getCount(): Promise<number> {
-		this.executedClauses = [...this.clauses];
-		return 0;
-	}
-
-	async getMany(): Promise<never[]> {
-		this.executedClauses = [...this.clauses];
-		return [];
-	}
-}
-
 describe('TimeSheetService', () => {
 	let service: TimeSheetService;
 	let builder: RecordingQueryBuilder;
 
 	beforeEach(async () => {
-		builder = new RecordingQueryBuilder();
+		builder = new RecordingQueryBuilder('timesheet');
 
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [TimeSheetService]
 		})
-			// Every dependency is automocked except the TypeORM repository, which hands out the recording builder.
+			// Every dependency is mocked to an empty object, except the TypeORM repository, which hands out the recording builder.
 			.useMocker((token) =>
 				token === TypeOrmTimesheetRepository
 					? { metadata: { tableName: 'timesheet' }, createQueryBuilder: () => builder }
@@ -94,7 +51,10 @@ describe('TimeSheetService', () => {
 		Object.defineProperty(service, 'ormType', { value: MultiORMEnum.TypeORM });
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
+		// Let a helper left dangling by an un-awaited call settle while the context mocks are still in
+		// place, so a regression fails on the assertions instead of crashing the worker.
+		await nextMacrotask();
 		jest.restoreAllMocks();
 	});
 
@@ -122,33 +82,35 @@ describe('TimeSheetService', () => {
 			['getTimeSheets', (input) => service.getTimeSheets(input)]
 		];
 
-		const actAsEmployee = () => {
-			jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue(TENANT_ID);
-			jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
-				id: USER_ID,
-				employeeId: CURRENT_EMPLOYEE_ID
-			} as IUser);
-			jest.spyOn(RequestContext, 'hasPermission').mockImplementation(
-				(permission) => permission !== PermissionsEnum.CHANGE_SELECTED_EMPLOYEE
-			);
+		/**
+		 * getFilterTimesheetQuery has no awaited operation today, so calling it inside a
+		 * synchronous `where(callback)` would still attach every clause in time. Suspend it before
+		 * it runs, the way the first await added to it would, so the suite fails as soon as the
+		 * helper is called without being awaited again.
+		 */
+		const suspendFilterHelper = () => {
+			const original = TimeSheetService.prototype.getFilterTimesheetQuery;
+			jest.spyOn(service, 'getFilterTimesheetQuery').mockImplementation(async (qb, input) => {
+				await nextMacrotask();
+				return original.call(service, qb, input);
+			});
 		};
 
 		it.each<[string, (input: IGetTimesheetInput) => Promise<unknown>]>(queries)(
 			'%s applies the tenant, organization and date filters before executing',
 			async (_name, run) => {
-				actAsEmployee();
+				mockRequestContext({
+					tenantId: TENANT_ID,
+					user: { id: USER_ID, employeeId: CURRENT_EMPLOYEE_ID },
+					canChangeSelectedEmployee: false
+				});
+				suspendFilterHelper();
 
 				await run(request);
 
-				expect(builder.executedClauses).not.toBeNull();
-				const clauses = builder.executedClauses as RecordedClause[];
-				const conditions = clauses.map(({ condition }) =>
-					typeof condition === 'string'
-						? condition.replace(/`/g, '"')
-						: (condition as object).constructor.name
-				);
+				const { conditions, parameters } = executedFilters(builder);
 				expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
-				expect(Object.assign({}, ...clauses.map(({ parameters }) => parameters ?? {}))).toEqual(
+				expect(parameters).toEqual(
 					expect.objectContaining({ tenantId: TENANT_ID, organizationId: ORGANIZATION_ID })
 				);
 			}

--- a/packages/core/src/lib/time-tracking/timesheet/timesheet.service.spec.ts
+++ b/packages/core/src/lib/time-tracking/timesheet/timesheet.service.spec.ts
@@ -11,24 +11,147 @@
  */
 import '../../core/entities/internal';
 import { Test, TestingModule } from '@nestjs/testing';
+import { IGetTimesheetInput, IUser, PermissionsEnum } from '@gauzy/contracts';
+import { RequestContext } from '../../core/context';
+import { MultiORMEnum } from '../../core/utils';
+import { TypeOrmTimesheetRepository } from './repository/type-orm-timesheet.repository';
 import { TimeSheetService } from './timesheet.service';
+
+const TENANT_ID = '9b8a7c6d-5e4f-4a3b-8c2d-1e0f9a8b7c6d';
+const ORGANIZATION_ID = '2c3d4e5f-6a7b-4c8d-9e0f-1a2b3c4d5e6f';
+const USER_ID = 'd4c3b2a1-0f9e-4d8c-7b6a-5f4e3d2c1b0a';
+const CURRENT_EMPLOYEE_ID = '6f5e4d3c-2b1a-4098-8f7e-6d5c4b3a2918';
+const TARGET_EMPLOYEE_ID = '3a4b5c6d-7e8f-4a9b-8c0d-1e2f3a4b5c6d';
+
+type RecordedClause = { condition: unknown; parameters?: Record<string, unknown> };
+
+/**
+ * Stand-in for TypeORM's SelectQueryBuilder that keeps only what matters here: `where(callback)`
+ * clears the clause list and runs the callback synchronously, and the terminal calls render
+ * whatever clauses exist at that instant. Same double as in time-log.service.spec.ts, since both
+ * services attach their tenant scoping through the same filter-helper pattern.
+ */
+class RecordingQueryBuilder {
+	readonly alias = 'timesheet';
+	/** Clauses present when the query executed, i.e. the ones that would have reached the SQL. */
+	executedClauses: RecordedClause[] | null = null;
+	private clauses: RecordedClause[] = [];
+
+	innerJoin(): this {
+		return this;
+	}
+
+	setFindOptions(): this {
+		return this;
+	}
+
+	where(where: unknown, parameters?: Record<string, unknown>): this {
+		this.clauses = [];
+		if (typeof where === 'function') {
+			where(this);
+		} else {
+			this.clauses.push({ condition: where, parameters });
+		}
+		return this;
+	}
+
+	andWhere(condition: unknown, parameters?: Record<string, unknown>): this {
+		this.clauses.push({ condition, parameters });
+		return this;
+	}
+
+	async getCount(): Promise<number> {
+		this.executedClauses = [...this.clauses];
+		return 0;
+	}
+
+	async getMany(): Promise<never[]> {
+		this.executedClauses = [...this.clauses];
+		return [];
+	}
+}
+
 describe('TimeSheetService', () => {
 	let service: TimeSheetService;
+	let builder: RecordingQueryBuilder;
+
 	beforeEach(async () => {
+		builder = new RecordingQueryBuilder();
+
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [TimeSheetService]
 		})
-			/**
-			 * The original scaffold listed the subject with NO dependencies provided, so this suite
-			 * could never have passed even once it loaded — it would have died on
-			 * `Nest can't resolve dependencies`. Automocking every token keeps the suite honest
-			 * about what it actually checks: that the class is constructible and its wiring holds.
-			 */
-			.useMocker(() => ({}))
+			// Every dependency is automocked except the TypeORM repository, which hands out the recording builder.
+			.useMocker((token) =>
+				token === TypeOrmTimesheetRepository
+					? { metadata: { tableName: 'timesheet' }, createQueryBuilder: () => builder }
+					: {}
+			)
 			.compile();
+
 		service = module.get<TimeSheetService>(TimeSheetService);
+		// The ORM switch is resolved from DB_ORM at module load; pin it so the suite ignores the local .env.
+		Object.defineProperty(service, 'ormType', { value: MultiORMEnum.TypeORM });
 	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	it('should be defined', () => {
 		expect(service).toBeDefined();
+	});
+
+	describe('timesheet queries', () => {
+		const request: IGetTimesheetInput = {
+			organizationId: ORGANIZATION_ID,
+			employeeIds: [TARGET_EMPLOYEE_ID],
+			startDate: '2026-01-01T00:00:00.000Z',
+			endDate: '2026-01-31T23:59:59.999Z'
+		};
+
+		// The `Brackets` entry carries the startedAt range together with the status and employee predicates.
+		const scopingConditions = [
+			'Brackets',
+			'"timesheet"."tenantId" = :tenantId',
+			'"timesheet"."organizationId" = :organizationId'
+		];
+
+		const queries: Array<[string, (input: IGetTimesheetInput) => Promise<unknown>]> = [
+			['getTimeSheetCount', (input) => service.getTimeSheetCount(input)],
+			['getTimeSheets', (input) => service.getTimeSheets(input)]
+		];
+
+		const actAsEmployee = () => {
+			jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue(TENANT_ID);
+			jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+				id: USER_ID,
+				employeeId: CURRENT_EMPLOYEE_ID
+			} as IUser);
+			jest.spyOn(RequestContext, 'hasPermission').mockImplementation(
+				(permission) => permission !== PermissionsEnum.CHANGE_SELECTED_EMPLOYEE
+			);
+		};
+
+		it.each<[string, (input: IGetTimesheetInput) => Promise<unknown>]>(queries)(
+			'%s applies the tenant, organization and date filters before executing',
+			async (_name, run) => {
+				actAsEmployee();
+
+				await run(request);
+
+				expect(builder.executedClauses).not.toBeNull();
+				const clauses = builder.executedClauses as RecordedClause[];
+				const conditions = clauses.map(({ condition }) =>
+					typeof condition === 'string'
+						? condition.replace(/`/g, '"')
+						: (condition as object).constructor.name
+				);
+				expect(conditions).toEqual(expect.arrayContaining(scopingConditions));
+				expect(Object.assign({}, ...clauses.map(({ parameters }) => parameters ?? {}))).toEqual(
+					expect.objectContaining({ tenantId: TENANT_ID, organizationId: ORGANIZATION_ID })
+				);
+			}
+		);
 	});
 });

--- a/packages/core/src/lib/time-tracking/timesheet/timesheet.service.ts
+++ b/packages/core/src/lib/time-tracking/timesheet/timesheet.service.ts
@@ -137,7 +137,7 @@ export class TimeSheetService extends TenantAwareCrudService<Timesheet> {
 							brandColor: true
 						}
 					},
-					...(request?.relations ? { relations: parseFindOptionsRelations(request.relations) } : {})
+					...(request.relations ? { relations: parseFindOptionsRelations(request.relations) } : {})
 				});
 
 				// Apply filters to the query

--- a/packages/core/src/lib/time-tracking/timesheet/timesheet.service.ts
+++ b/packages/core/src/lib/time-tracking/timesheet/timesheet.service.ts
@@ -65,9 +65,7 @@ export class TimeSheetService extends TenantAwareCrudService<Timesheet> {
 				query.innerJoin(`${query.alias}.employee`, 'employee');
 
 				// Apply filters to the query
-				query.where((query: SelectQueryBuilder<Timesheet>) => {
-					this.getFilterTimesheetQuery(query, request);
-				});
+				await this.getFilterTimesheetQuery(query, request);
 
 				// Return the total count of timesheets
 				return query.getCount();
@@ -143,9 +141,7 @@ export class TimeSheetService extends TenantAwareCrudService<Timesheet> {
 				});
 
 				// Apply filters to the query
-				query.where((query: SelectQueryBuilder<Timesheet>) => {
-					this.getFilterTimesheetQuery(query, request);
-				});
+				await this.getFilterTimesheetQuery(query, request);
 
 				// Return the list of timesheets
 				return await query.getMany();

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -13,5 +13,5 @@
 		"noFallthroughCasesInSwitch": false
 	},
 	"include": ["src/**/*.ts"],
-	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/testing/**"]
 }

--- a/packages/core/tsconfig.spec.json
+++ b/packages/core/tsconfig.spec.json
@@ -11,5 +11,5 @@
 		"allowJs": true,
 		"types": ["jest", "node"]
 	},
-	"include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+	"include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/testing/**/*.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
# Fix Time Log: await report filters before executing the query

- [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever-gauzy/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value?

---

## Problem

`TimeLogService.getFilterTimeLogQuery` is `async` (it awaits `ManagedEmployeeService.canManageEmployees`), but five report methods still called it inside a synchronous TypeORM `where()` callback without awaiting it:

- `getDailyReportCharts` (`GET /timesheet/time-log/report/daily-chart`)
- `getDailyReport` (`GET /timesheet/time-log/report/daily`)
- `getOwedAmountReport` (`GET /timesheet/time-log/report/owed-report`)
- `getOwedAmountReportCharts` (`GET /timesheet/time-log/report/owed-charts`)
- `getTimeLimit` (`GET /timesheet/time-log/time-limit`)

With TypeORM 0.3.28, `where(callback)` resets the clause list and runs the callback synchronously. As soon as the manager check is reached (a caller without `CHANGE_SELECTED_EMPLOYEE` sending `employeeIds`), the helper suspends before any `andWhere`, the callback returns, and `getMany()` builds the SQL with no `WHERE` clause at all. Tenant, organization, employee and date filters are all dropped, so the endpoint can return time logs from other tenants.

## Fix

Call the helper directly with `await` before `getMany()`, as `getTimeLogs` and `getWeeklyReport` already do. None of the five methods had a clause before that call (only `innerJoin` and `setFindOptions`), so the synchronous paths (`CHANGE_SELECTED_EMPLOYEE`, `onlyMe`, no `employeeIds`) produce the same SQL as before. The filters themselves are unchanged.

The second commit applies the same pattern to `TimeSheetService.getFilterTimesheetQuery`, which is declared `async` and was also invoked inside a `where()` callback. It contains no `await` today, so nothing is broken there yet, but the first `await` added to it would drop every filter the same way.

## Tests

- `time-log.service.spec.ts`: drives all seven query methods through a query-builder double that mirrors TypeORM's synchronous `where(callback)` semantics, with the manager check resolving on a later tick. It asserts the tenant, organization, employee and date clauses are present when the query executes, and covers the manager-refused, admin and `onlyMe` paths. On the previous code the five report methods fail with an empty clause list; the admin and `onlyMe` paths pass on both versions.
- `timesheet.service.spec.ts`: same check for `getTimeSheetCount` and `getTimeSheets`.

```
npx jest -c packages/core/jest.config.ts packages/core/src/lib/time-tracking/time-log packages/core/src/lib/time-tracking/timesheet
```

14 tests pass. `tsc --noEmit -p packages/core/tsconfig.lib.json` reports no errors.

## Consumers

These endpoints are used by the Angular UI (`packages/ui-core` timesheet service) and by Ever Teams. The change only restores the intended filtering; no client relies on the missing clauses.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes time-log report queries silently dropping all filters, which could return time logs from other tenants. `getFilterTimeLogQuery` is async but five report methods invoked it inside a synchronous TypeORM `where()` callback without awaiting it; once the manager check suspended, the callback returned before any `andWhere` ran and `getMany()` built the SQL with no WHERE clause. The helper is now awaited directly before `getMany()`, as `getTimeLogs` and `getWeeklyReport` already do, so tenant, organization, employee, and date filters are restored. Synchronous paths (`CHANGE_SELECTED_EMPLOYEE`, `onlyMe`, no `employeeIds`) build the same SQL as before.

The same fix is applied to `TimeSheetService.getFilterTimesheetQuery`, which is async and was also invoked inside a `where()` callback. It contains no `await` today, but the first `await` added would drop every filter the same way. Also ignores the local `graphify-out/` directory and drops a stray `request?.relations` optional chain in `getTimeSheets`.

**Tests**
- Adds a shared query-builder double in `time-tracking/testing/` that mirrors TypeORM's synchronous `where(callback)` semantics, evaluates `Brackets`, and asserts scoping clauses are present when the query executes.
- The time-log spec fails on the previous code for the five report methods; admin and `onlyMe` paths pass on both versions.
- The timesheet spec suspends the filter helper, so restoring the `where()` callback makes the tests fail.

<sup>Written for commit 4b113456e53934065ed741732d6b632edaef900b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-gauzy/pull/10120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





